### PR TITLE
feat: add per-request serve-only inference

### DIFF
--- a/docs/connect-your-harness.rst
+++ b/docs/connect-your-harness.rst
@@ -1,0 +1,241 @@
+Connect your harness
+====================
+
+Before connecting your harness, make sure a Reef deployment is running. If you
+operate Reef yourself, follow `Get started <get-started.rst>`__ to install and serve it.
+For example, the complete SAO deployment lives in
+``examples/sao/serve.yaml``; its README explains how to start it.
+
+Check the deployment before sending model traffic:
+
+.. code:: bash
+
+   export REEF_URL=http://127.0.0.1:8900  # or other port depending on your config
+   export REEF_TOKEN=reef-local
+   curl -f "$REEF_URL/healthz"
+   # {"ok": true}
+
+``GET /healthz`` is unauthenticated and reports whether the service process is
+ready to answer requests.
+
+The following sections explain the additional headers and requests a harness
+uses after Reef is running.
+
+Request headers
+---------------
+
+These are headers that a harness sends to Reef:
+
++-----------------------------------+----------------------+------------------------+
+| Header                            | Required for         | Purpose                |
++===================================+======================+========================+
+| ``x-reef-scenario``               | inference, report,   | identifies what the    |
+|                                   | harness manifest and | record belongs to.     |
+|                                   | versions; optional   | Each scenario manages  |
+|                                   | on harness install   | one set of artifacts.  |
++-----------------------------------+----------------------+------------------------+
+| ``Authorization: Bearer <token>`` | every route except   | authenticates the      |
+|                                   | ``/healthz``, when   | caller                 |
+|                                   | auth is configured   |                        |
++-----------------------------------+----------------------+------------------------+
+
+
+Create the scenario
+-------------------
+
+A new scenario is created by sending an inference
+request or report with a new ``x-reef-scenario`` value. The scenario binds to
+the recipe the deployment serves (``reef.recipe`` in its config), permanently.
+
+.. code:: bash
+
+   curl -sD - "$REEF_URL/v1/chat/completions" \
+     -H "Authorization: Bearer $REEF_TOKEN" \
+     -H "x-reef-scenario: code-repair" \
+     -H "content-type: application/json" \
+     -d '{"model": "m", "messages": [{"role": "user", "content": "fix it"}]}'
+
+If the deployment sets ``reef.allow_implicit_scenario_creation: false``, a
+request for an unknown scenario returns HTTP 404. Create the scenario
+explicitly before sending traffic:
+
++---------------------------------------------+---------------------------------------------+-----------------------------------------------------------+
+| Endpoint                                    | Request body                                | Response                                                  |
++=============================================+=============================================+===========================================================+
+| ``POST /reef/scenarios``                    | ``{"name", "recipe", "artifact_version"?}`` | ``{scenario, recipe, artifact_version}``, 201 when        |
+|                                             |                                             | created, 200 when it already existed                      |
++---------------------------------------------+---------------------------------------------+-----------------------------------------------------------+
+| ``GET /reef/scenarios``                     | none                                        | every known scenario, with its recipe and current         |
+|                                             |                                             | artifact version once loaded                              |
++---------------------------------------------+---------------------------------------------+-----------------------------------------------------------+
+| ``GET /reef/scenarios/{scenario}/contract`` | none                                        | ``{scenario, recipe, processor, required_request_types}`` |
++---------------------------------------------+---------------------------------------------+-----------------------------------------------------------+
+
+Inference
+---------
+
+Send OpenAI-format inference requests to ``POST /v1/chat/completions`` and
+Anthropic-format requests to ``POST /v1/messages``. Use the same request body
+you would send directly to the provider. Reef does not add or change sampling
+parameters. For streaming inference, set ``"stream": true`` and read the SSE response.
+Anthropic clients may use ``POST /v1/messages/count_tokens`` to count request
+tokens without creating an inference record.
+
+Set the Reef request header ``x-reef-capture: false`` for a serve-only call.
+Reef still resolves the scenario's current artifact and applies its normal
+inference safety checks, but it does not create an inference record or expose
+the call to the scenario's processor. The header accepts only ``true`` or
+``false`` (case-insensitive) and defaults to ``true`` when absent. Because it
+is a Reef transport control, it is not forwarded to the inference provider.
+
+Reef returns a receipt that identifies the stored inference record. A
+non-streaming response carries it in the ``x-reef-agent-record-id`` header. A
+streaming response carries it only after the record has been stored: OpenAI
+streams receive a final empty-``choices`` chunk containing
+``reef.agent_record_id`` immediately before ``data: [DONE]``; Anthropic streams
+carry the same field in ``message_stop``. Serve-only responses carry no
+receipt; their provider terminal event is forwarded unchanged. Capture only
+controls whether a record exists. For captured traffic, the recipe remains
+responsible for deciding whether and how the record trains.
+
+Report
+------
+
+Submit feedback with ``POST /reef/report``. Reef stores the following four
+fields and drops other top-level fields. Put harness-specific data inside
+``metadata`` or ``feedback``.
+
++----------------+------------------+----------------------------------+
+| Field          | Type             | Notes                            |
++================+==================+==================================+
+| ``score``      | number           | optional; a bool is not a number |
+|                |                  | and is rejected                  |
++----------------+------------------+----------------------------------+
+| ``feedback``   | string or object | opaque to Reef's core: a rubric, |
+|                |                  | judge output, plain text         |
++----------------+------------------+----------------------------------+
+| ``references`` | list of strings  | the receipts this report grades  |
++----------------+------------------+----------------------------------+
+| ``metadata``   | object           | opaque, except the training      |
+|                |                  | eligibility flag below           |
++----------------+------------------+----------------------------------+
+
+Suppose Reef returned the receipt ``abc123`` for a model response in scenario
+``code-repair``. The harness grades that call like this:
+
+.. code:: python
+
+   client.report("code-repair", {
+       "agent_record_id": "myharness:run42:trial7",
+       "score": 1.0,
+       "references": ["abc123"],
+       "metadata": {"harbor": {"trial_id": "run42:7"}},
+   })
+
+The optional top-level ``agent_record_id`` makes posting retry-safe. Reef
+strips it from the payload and uses it as the report's own record id, so an
+identical resend returns the stored record instead of reprocessing it, while
+the same id with different content is HTTP 409. It is distinct from the
+receipts in ``references``, which identify the inference records being graded.
+
+A recipe may declare a report schema, in which case Reef validates keys in
+``feedback`` and ``metadata`` at ingress and answers HTTP 400 on a violation.
+To keep a report out of the training data, send
+``"metadata": {"training": {"eligible": false}}``. The flag defaults to true.
+
+Receive an updated artifact
+---------------------------
+
+How a harness receives an update depends on the artifact type:
+
+- For weight-training scenarios, continue calling the same inference
+  endpoint. It automatically serves the latest published weights.
+- For harness-evolution scenarios, new harness installations are published on
+  the endpoint ``GET /reef/harness/install``. Reef's harness has a
+  self-contained wrapper that automatically checks for updates and prompts the
+  user to install them.
+
+The following endpoints expose a harness tree:
+
++--------------------------------+---------------------------------------------------------------+
+| Endpoint                       | Response                                                      |
++================================+===============================================================+
+| ``GET /reef/harness``          | the served tree:                                              |
+|                                | ``{artifact_version, parent_artifact_version, files, gate}``, |
+|                                | plus an ``x-reef-artifact-version`` response header           |
++--------------------------------+---------------------------------------------------------------+
+| ``GET /reef/harness/versions`` | ``{scenario, versions}``, the full catalog, oldest first,     |
+|                                | each training row carrying the gate metrics of the step that  |
+|                                | published it                                                  |
++--------------------------------+---------------------------------------------------------------+
+| ``GET /reef/harness/install``  | a self-contained POSIX shell script that installs the vendor  |
+|                                | binary and writes the tree                                    |
++--------------------------------+---------------------------------------------------------------+
+
+The manifest and version endpoints are read-only and require
+``x-reef-scenario``. The install endpoint is also read-only when the request
+names an existing scenario.
+
+If ``GET /reef/harness/install`` omits ``x-reef-scenario``, Reef creates a
+scenario with a generated ``harness-`` name and embeds that assignment in the
+wrapper script. When exactly one configured recipe serves harness files, Reef
+selects it automatically.
+
+Use ``?version=`` on the manifest or install endpoint to request a particular
+catalog version instead of the latest one. An unknown or unrestorable version
+returns HTTP 404. Installation also requires ``?adapter=``. The value may be
+``pi``, ``opencode``, or an external descriptor.
+
+Pulling an older version changes only the local copy. To roll back the version
+served by Reef, send ``POST /reef/scenarios/{scenario}/rollback`` with
+``{"artifact_version": "…"}``. Reef republishes the checkpoint as a new commit
+instead of rewinding history, which keeps step numbers monotonic.
+
+Use ``GET /reef/scenarios/{scenario}/versions`` to choose a rollback target.
+This endpoint lists versions **newest first**, while
+``GET /reef/harness/versions`` lists them oldest first. Only versions marked
+``restorable`` can be rolled back.
+
+Inspect deployment status
+-------------------------
+
+``GET /reef/status`` reports asynchronous training and preload failures,
+current weight versions, inference admission, processor state, and checkpoint
+storage state. It is useful when inference continues serving an older version
+while an update is being trained or published.
+
+Status codes
+------------
+
++--------+-------------------------------------------------------------+
+| Status | Cause                                                       |
++========+=============================================================+
+| 400    | a malformed body, a missing or empty ``x-reef-scenario`` on |
+|        | a scenario-scoped route, a report violating the recipe's    |
+|        | declared schema                                             |
++--------+-------------------------------------------------------------+
+| 401    | missing or wrong bearer token                               |
++--------+-------------------------------------------------------------+
+| 403    | a valid bearer token that does not own the scenario         |
++--------+-------------------------------------------------------------+
+| 404    | unknown scenario (with implicit creation off), unknown      |
+|        | artifact version, unknown adapter, no configured harness    |
+|        | recipe, or a scenario that serves no files                  |
++--------+-------------------------------------------------------------+
+| 409    | a recipe or base artifact conflicting with the binding, a   |
+|        | record id resent with different content, an engine that     |
+|        | reports no serving weight version                           |
++--------+-------------------------------------------------------------+
+| 502    | the upstream provider failed on its own account             |
++--------+-------------------------------------------------------------+
+| 503    | the artifact store is unreachable, or inference kept losing |
+|        | the weight-update race until its deadline                   |
++--------+-------------------------------------------------------------+
+
+Reef relays upstream 4xx responses with the provider's original message so an
+agent can use the details to repair its next request.
+
+Next, read `Write a recipe <define-a-recipe.rst>`__ to decide what Reef does
+with these records, or `Deploy and train <deploy-and-train.rst>`__ to configure
+the service and training driver. The `glossary <glossary.rst>`__ defines the
+terms used throughout the docs.

--- a/reef/core/headers.py
+++ b/reef/core/headers.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from reef.core.errors import ReefError
+from reef.core.records_types import RequestType
+
+SCENARIO_HEADER = "x-reef-scenario"
+ARTIFACT_VERSION_HEADER = "x-reef-artifact-version"
+CAPTURE_HEADER = "x-reef-capture"
+#: Harness-stamped side-channel context (method-integration RFC §3.2). The
+#: request plane never reads a tag's meaning — it carries the pair through to
+#: the INFERENCE record so a processor can correlate on it. Header-free
+#: correlation stays the fallback; a tag is what a harness offers when its
+#: agent does not resend the transcript it is continuing.
+TAG_HEADER_PREFIX = "x-reef-tag-"
+
+
+class HeaderError(ReefError):
+    """Raised when x-reef-* request headers are missing or invalid."""
+
+
+@dataclass(frozen=True)
+class RequestHeaders:
+    scenario: str
+    request_type: RequestType
+    artifact_version: str | None = None
+    #: ``x-reef-tag-<name>`` pairs, lowercased names, opaque values.
+    tags: Mapping[str, str] = field(default_factory=dict)
+    #: Whether an inference exchange becomes a durable record. Reports do not
+    #: use this transport control and always keep the default.
+    capture: bool = True
+
+
+def parse_request_headers(headers: Mapping[str, str], request_type: RequestType) -> RequestHeaders:
+    normalized = {key.lower(): value for key, value in headers.items()}
+    scenario = normalized.get(SCENARIO_HEADER, "").strip()
+    if not scenario:
+        raise HeaderError(f"missing or empty {SCENARIO_HEADER}")
+    artifact_version = normalized.get(ARTIFACT_VERSION_HEADER, "").strip() or None
+    capture = True
+    if request_type is RequestType.INFERENCE and CAPTURE_HEADER in normalized:
+        capture_value = normalized[CAPTURE_HEADER].strip().lower()
+        if capture_value not in ("true", "false"):
+            raise HeaderError(f"{CAPTURE_HEADER} must be 'true' or 'false'")
+        capture = capture_value == "true"
+
+    tags = {
+        key[len(TAG_HEADER_PREFIX) :]: value.strip()
+        for key, value in normalized.items()
+        if key.startswith(TAG_HEADER_PREFIX) and len(key) > len(TAG_HEADER_PREFIX) and value.strip()
+    }
+
+    return RequestHeaders(
+        scenario=scenario,
+        request_type=request_type,
+        artifact_version=artifact_version,
+        capture=capture,
+        tags=tags,
+    )

--- a/reef/service/README.md
+++ b/reef/service/README.md
@@ -1,0 +1,73 @@
+# Service
+
+`service/` is the request plane's front door: the aiohttp application that
+accepts a request, answers it through the scenario's runtime, and hands the
+exchange over as a record unless the caller selects serve-only inference with
+`x-reef-capture: false`. Everything HTTP lives here — and only the HTTP parts
+live in the HTTP layer: request handling itself is a transport-free object that
+the routes adapt.
+
+- [`request_service.py`](request_service.py) — `RequestService`, the
+  transport-independent core: parses `x-reef-*` headers, normalizes typed
+  report payloads, freezes the artifact version before every provider
+  call (so concurrent publication cannot change what gets served or recorded),
+  the scenario surface's inference `prepare_request`/`verify_response` hooks and
+  the capture decision, and applies the configured inference retry policy.
+- [`routes/`](routes) — thin aiohttp adapters over `RequestService`:
+  [`inference.py`](routes/inference.py) (`/v1/chat/completions`,
+  `/v1/messages`, including streaming, and `/v1/messages/count_tokens`),
+  [`records.py`](routes/records.py)
+  (`/reef/report`, with client-supplied `agent_record_id`
+  retry dedup), [`scenarios.py`](routes/scenarios.py) (list, create,
+  versions, rollback), [`system.py`](routes/system.py) (`/healthz`,
+  `/reef/harness` with its `version` query, `/reef/harness/versions`,
+  `/reef/status`).
+- [`errors.py`](errors.py) — `ERROR_STATUS_TABLE`, the single
+  Reef-error-to-HTTP-status table, ordered most-specific first and applied
+  as the `translate_errors` middleware. Routes raise domain errors and never
+  carry their own try/except tables.
+- [`auth.py`](auth.py) — bearer-token middleware over the accepted token
+  set (several may be accepted at once for rotation); constant-time digest
+  comparison. `/healthz` stays reachable without credentials so liveness
+  probes can run.
+- [`streaming.py`](streaming.py) — SSE capture for recorded streams:
+  `stream_record`, `aggregate_sse_text` (OpenAI and Anthropic shapes).
+- [`app.py`](app.py) — `create_app`: builds the `RequestService`, installs
+  the two middlewares, registers the routes, owns dispatcher cleanup.
+- [`assembly.py`](assembly.py) — composition logic: a `ServiceSettings` in,
+  a dispatcher and app out (`build_dispatcher`, `build_app`). It knows
+  nothing about the deployment config format.
+- [`deploy/`](deploy) — `reef serve`: [`config.py`](deploy/config.py)
+  (YAML loading with `${VAR}` and `${dotted.path}` interpolation),
+  [`settings.py`](deploy/settings.py) (the frozen `ServiceSettings`
+  dataclass and the internal HTTP child's `run_service` entrypoint),
+  [`orchestrator.py`](deploy/orchestrator.py) (start every declared process
+  in dependency order, probe readiness, tear down in reverse). `deploy/` is
+  a subpackage, not a sibling: its only job is starting this service.
+
+**Adding a route**: write a `register_*` function in a [`routes/`](routes)
+module and wire it into `register_routes` in
+[`routes/__init__.py`](routes/__init__.py). The handler raises domain errors
+and lets [`errors.py`](errors.py) translate them; if a new error type needs a
+status other than 400, it gets a row in `ERROR_STATUS_TABLE`, not a local
+try/except. The doc-contract script derives the route list from `routes/`
+sources, so the route reference in
+[Design](https://reefinfra.ai/docs/design/)
+must name every route.
+
+Boundaries this package holds:
+
+- `RequestService` is transport-free; `routes/` is the only place aiohttp
+  request/response types appear on the request path.
+- `ServiceSettings` is frozen, and recipe-specific config fields are not fields on
+  it: they ride in `recipe_settings` and each recipe extracts its own via
+  `WeightTrainingRecipe.service_config`, so defaults live with the recipe
+  ([`test_training_server.py`](../../tests/reef_service/test_training_server.py)
+  pins this).
+- Nothing here imports `reef.train.slime` at module scope
+  ([`test_dependency_boundaries.py`](../../tests/reef_service/test_dependency_boundaries.py)).
+- The service exposes no control route beyond the ones above
+  ([`test_reef_contracts.py`](../../tests/reef_service/test_reef_contracts.py)).
+
+The wire-level route reference is
+[Design](https://reefinfra.ai/docs/design/).

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -2,9 +2,9 @@
 
 ``RequestService`` normalizes typed Reef payloads, resolves the artifact
 version before every provider call so concurrent publication cannot change
-what gets recorded, stores each exchange as a record, and applies the
-scenario surface's request/response checks. No aiohttp types appear here;
-``reef.service.routes`` adapts these methods to HTTP.
+what gets served or recorded, optionally stores the exchange as a record, and
+applies the scenario surface's request/response checks. No aiohttp types appear
+here; ``reef.service.routes`` adapts these methods to HTTP.
 """
 
 from __future__ import annotations
@@ -88,7 +88,9 @@ class RequestPayloadNormalizer:
 
 @dataclass(frozen=True)
 class PendingInference:
-    item: AgentRecord
+    item: AgentRecord | None
+    payload: Mapping[str, Any]
+    scenario: str
     artifact_version: str | None
     admission: InferenceAdmissionHandle | None = None
     lease: InferenceLease | None = None
@@ -179,7 +181,7 @@ class RequestService:
         payload: dict[str, Any],
         path: str,
         backend: InferenceBackend | None = None,
-    ) -> tuple[dict[str, Any], AgentRecord]:
+    ) -> tuple[dict[str, Any], AgentRecord | None]:
         original_payload = dict(payload)
         retry_delay = self._retry_policy.initial_s
         loop = asyncio.get_running_loop()
@@ -217,6 +219,8 @@ class RequestService:
                     if prepared.surface.inference is not None:
                         prepared.surface.inference.verify_response(prepared.artifact, path, response)
                     self._stamp_durable_weight_version(prepared, payload, response)
+                    if not prepared.parsed.capture:
+                        return client_inference_response(response), None
                     item = await asyncio.to_thread(
                         self._accept,
                         prepared.parsed,
@@ -286,13 +290,20 @@ class RequestService:
                     if admission is not None:
                         admission.release()
             raise
+        record_payload = _with_tags(payload, prepared.parsed)
         pending = PendingInference(
-            item=AgentRecord.create(
-                scenario=prepared.parsed.scenario,
-                request_type=RequestType.INFERENCE,
-                payload=_with_tags(payload, prepared.parsed),
-                artifact_ref=prepared.artifact.ref,
+            item=(
+                AgentRecord.create(
+                    scenario=prepared.parsed.scenario,
+                    request_type=RequestType.INFERENCE,
+                    payload=record_payload,
+                    artifact_ref=prepared.artifact.ref,
+                )
+                if prepared.parsed.capture
+                else None
             ),
+            payload=record_payload,
+            scenario=prepared.parsed.scenario,
             artifact_version=prepared.parsed.artifact_version,
             admission=admission,
             lease=lease,
@@ -301,9 +312,10 @@ class RequestService:
         )
         return stream, pending
 
-    def record_stream(self, pending: PendingInference, response: Mapping[str, Any]) -> AgentRecord:
+    def record_stream(self, pending: PendingInference, response: Mapping[str, Any]) -> AgentRecord | None:
+        """Settle a stream and persist it only when capture is enabled."""
         try:
-            payload = dict(pending.item.payload)
+            payload = dict(pending.payload)
             # A token-native streaming backend fills record_response only when
             # the upstream generation finishes. Validate that final capture
             # here, after the route has drained the stream but before it can
@@ -320,6 +332,8 @@ class RequestService:
                         response,
                     )
                 self._stamp_durable_weight_version(pending.deferred_prepared, payload, response)
+            if pending.item is None:
+                return None
             item = replace(
                 pending.item,
                 payload={**payload, "response": dict(response)},
@@ -329,11 +343,12 @@ class RequestService:
                 artifact_version=pending.artifact_version,
             )
         except Exception:
-            logger.exception(
-                "dispatcher rejected the stream record for scenario %r (record %s)",
-                pending.item.scenario,
-                pending.item.agent_record_id,
-            )
+            if pending.item is not None:
+                logger.exception(
+                    "dispatcher rejected the stream record for scenario %r (record %s)",
+                    pending.scenario,
+                    pending.item.agent_record_id,
+                )
             raise
         finally:
             try:

--- a/reef/service/routes/inference.py
+++ b/reef/service/routes/inference.py
@@ -41,14 +41,14 @@ def register_inference_routes(
                 "",
             )
             is_sse = "text/event-stream" in content_type.lower()
-            if not is_sse:
+            if not is_sse and pending.item is not None:
                 response_headers["x-reef-agent-record-id"] = pending.item.agent_record_id
             response = web.StreamResponse(status=upstream.status, headers=response_headers)
             body = bytearray()
             chat_identity: dict[str, Any] = {}
             complete = False
             error = None
-            record_attempted = False
+            settled = False
             try:
                 await response.prepare(request)
                 if is_sse:
@@ -71,17 +71,22 @@ def register_inference_routes(
                             await response.write(remainder)
                         error = "upstream SSE ended without a terminal event"
                     else:
-                        record_attempted = True
+                        settled = True
                         item = request_service.record_stream(
                             pending,
                             stream_record(upstream, bytes(body), complete=True),
                         )
-                        for frame in receipt_sse_events(
-                            request.path,
-                            chat_identity,
-                            terminal,
-                            item.agent_record_id,
-                        ):
+                        terminal_events = (
+                            receipt_sse_events(
+                                request.path,
+                                chat_identity,
+                                terminal,
+                                item.agent_record_id,
+                            )
+                            if item is not None
+                            else (terminal,)
+                        )
+                        for frame in terminal_events:
                             await response.write(frame)
                         complete = True
                 else:
@@ -96,16 +101,19 @@ def register_inference_routes(
                 raise
             finally:
                 if error is not None:
+                    stream_context = (
+                        f"record {pending.item.agent_record_id}" if pending.item is not None else "serve-only request"
+                    )
                     logger.warning(
-                        "stream for %s (record %s) ended early: %s",
+                        "stream for %s (%s) ended early: %s",
                         request.path,
-                        pending.item.agent_record_id,
+                        stream_context,
                         error,
                     )
                 try:
                     await upstream.close()
                 finally:
-                    if not record_attempted:
+                    if not settled:
                         request_service.record_stream(
                             pending,
                             stream_record(upstream, bytes(body), complete=complete, error=error),
@@ -118,7 +126,8 @@ def register_inference_routes(
             request.path,
             inference_backend,
         )
-        return web.json_response(response_payload, headers={"x-reef-agent-record-id": item.agent_record_id})
+        response_headers = {} if item is None else {"x-reef-agent-record-id": item.agent_record_id}
+        return web.json_response(response_payload, headers=response_headers)
 
     app.router.add_post("/v1/chat/completions", inference)
     app.router.add_post("/v1/messages", inference)

--- a/tests/reef_service/test_ray_runtime.py
+++ b/tests/reef_service/test_ray_runtime.py
@@ -1356,7 +1356,21 @@ def test_stream_and_failure_release_their_inference_admission_handles() -> None:
         body = b"".join([chunk async for chunk in deferred.chunks])
         recorded = stream_record(deferred, body, complete=True)
         item = service.record_stream(deferred_pending, recorded)
+        assert item is not None
         assert item.payload["weight_version"] == "engine:0"
+        assert runtime.inference_admission_status == {"open": True, "active": 0}
+
+        serve_only, serve_only_pending = await service.start_stream(
+            {"x-reef-scenario": "math", "x-reef-capture": "false"},
+            {"stream": True},
+            "/v1/chat/completions",
+            DeferredStreamingBackend(),
+        )
+        assert serve_only_pending.item is None
+        assert runtime.inference_admission_status == {"open": True, "active": 1}
+        serve_only_body = b"".join([chunk async for chunk in serve_only.chunks])
+        serve_only_response = stream_record(serve_only, serve_only_body, complete=True)
+        assert service.record_stream(serve_only_pending, serve_only_response) is None
         assert runtime.inference_admission_status == {"open": True, "active": 0}
 
         with pytest.raises(WeightVersionMismatch, match="atomic record_response"):

--- a/tests/reef_service/test_reef_contracts.py
+++ b/tests/reef_service/test_reef_contracts.py
@@ -387,6 +387,66 @@ def test_http_app_records_inference_and_returns_backend_response() -> None:
 
 
 @pytest.mark.unit
+def test_http_app_serve_only_inference_skips_record_and_receipt() -> None:
+    async def run() -> None:
+        payload = {"model": "reef", "messages": [{"role": "user", "content": "hi"}]}
+
+        async def backend(artifact: Artifact, path: str, request_payload: dict) -> dict:
+            del artifact
+            assert path == "/v1/chat/completions"
+            assert request_payload == payload
+            return {"choices": [{"message": {"content": "hi"}}]}
+
+        dispatcher = build_default_dispatcher()
+        client = TestClient(TestServer(create_app(dispatcher, inference_backend=ContractInferenceBackend(backend))))
+        await client.start_server()
+        try:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"x-reef-scenario": "chat", "x-reef-capture": "false"},
+                json=payload,
+            )
+
+            assert response.status == 200
+            assert "x-reef-agent-record-id" not in response.headers
+            assert (await response.json())["choices"][0]["message"]["content"] == "hi"
+            assert dispatcher.get_or_create_scenario("chat").records.replay("chat") == ()
+        finally:
+            await client.close()
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
+def test_http_app_rejects_invalid_capture_header_before_inference() -> None:
+    async def run() -> None:
+        async def backend(artifact: Artifact, path: str, payload: dict) -> dict:
+            del artifact, path, payload
+            raise AssertionError("invalid capture control reached the backend")
+
+        dispatcher = build_default_dispatcher()
+        client = TestClient(TestServer(create_app(dispatcher, inference_backend=ContractInferenceBackend(backend))))
+        await client.start_server()
+        try:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"x-reef-scenario": "chat", "x-reef-capture": "sometimes"},
+                json={"model": "reef", "messages": []},
+            )
+
+            assert response.status == 400
+            assert await response.text() == "x-reef-capture must be 'true' or 'false'"
+        finally:
+            await client.close()
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
 def test_artifact_proxy_backend_forwards_native_payload_unchanged() -> None:
     async def run() -> None:
         received = {}
@@ -521,6 +581,66 @@ def test_http_app_forwards_inference_stream_before_upstream_finishes(tmp_path) -
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("path", "content", "terminal"),
+    [
+        (
+            "/v1/chat/completions",
+            b'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ),
+        (
+            "/v1/messages",
+            b'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"hello"}}\n\n',
+            b'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+        ),
+    ],
+)
+def test_serve_only_sse_forwards_provider_terminal_without_capture(tmp_path, path, content, terminal) -> None:
+    async def run() -> None:
+        from aiohttp import web
+
+        received = {}
+
+        async def upstream(request):
+            received["payload"] = await request.json()
+            response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await response.prepare(request)
+            await response.write(content)
+            await response.write(terminal)
+            return response
+
+        upstream_app = web.Application()
+        upstream_app.router.add_post(path, upstream)
+        upstream_server = TestServer(upstream_app)
+        await upstream_server.start_server()
+        dispatcher = build_default_dispatcher(local_artifact_dir=tmp_path / "local")
+        backend = HttpInferenceBackend(str(upstream_server.make_url("")).rstrip("/"))
+        client = TestClient(TestServer(create_app(dispatcher, inference_backend=backend)))
+        await client.start_server()
+        try:
+            payload = {"messages": [{"role": "user", "content": "hi"}], "stream": True}
+            response = await client.post(
+                path,
+                headers={"x-reef-scenario": "chat", "x-reef-capture": "false"},
+                json=payload,
+            )
+
+            assert response.status == 200
+            assert "x-reef-agent-record-id" not in response.headers
+            assert await response.read() == content + terminal
+            assert received["payload"] == payload
+            assert dispatcher.get_or_create_scenario("chat").records.replay("chat") == ()
+        finally:
+            await client.close()
+            await upstream_server.close()
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
 def test_anthropic_stream_attaches_receipt_only_after_record_is_stored(tmp_path) -> None:
     async def run() -> None:
         import asyncio
@@ -608,6 +728,15 @@ def test_sse_without_terminal_event_has_no_receipt_and_is_recorded_incomplete(tm
             [record] = dispatcher.get_or_create_scenario("chat").records.replay("chat")
             assert record.payload["response"]["complete"] is False
             assert record.payload["response"]["error"] == "upstream SSE ended without a terminal event"
+
+            serve_only = await client.post(
+                "/v1/chat/completions",
+                headers={"x-reef-scenario": "serve-only", "x-reef-capture": "false"},
+                json={"messages": [{"role": "user", "content": "hi"}], "stream": True},
+            )
+            assert "x-reef-agent-record-id" not in serve_only.headers
+            assert await serve_only.read() == content
+            assert dispatcher.get_or_create_scenario("serve-only").records.replay("serve-only") == ()
         finally:
             await client.close()
             await upstream_server.close()

--- a/tests/reef_service/test_reef_wire.py
+++ b/tests/reef_service/test_reef_wire.py
@@ -28,6 +28,26 @@ def test_parse_request_headers_is_case_insensitive_and_preserves_scenario() -> N
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(("value", "capture"), [("true", True), (" FALSE ", False), ("TrUe", True)])
+def test_parse_inference_capture_header(value: str, capture: bool) -> None:
+    parsed = parse_request_headers(
+        {"x-reef-scenario": "chat", "X-Reef-Capture": value},
+        RequestType.INFERENCE,
+    )
+
+    assert parsed.capture is capture
+
+
+@pytest.mark.unit
+def test_parse_inference_capture_header_rejects_unknown_values() -> None:
+    with pytest.raises(HeaderError, match="x-reef-capture must be 'true' or 'false'"):
+        parse_request_headers(
+            {"x-reef-scenario": "chat", "x-reef-capture": "no"},
+            RequestType.INFERENCE,
+        )
+
+
+@pytest.mark.unit
 def test_agent_record_preserves_native_inference_payload() -> None:
     payload = {"model": "reef", "messages": [{"role": "user", "content": "hi"}]}
 


### PR DESCRIPTION
> Migrated from [Human-Agent-Society/reef-archive#473](https://github.com/Human-Agent-Society/reef-archive/pull/473). Originally opened by @BobbyZhouZijian on 2026-08-25T07:46:00Z. The source branch conflicted with the latest `main`; the migration merged the new base and kept the PR side for conflicted paths. Author review is required.

## Motivation

Closes [#472](https://github.com/Human-Agent-Society/reef-archive/issues/472).

Some inference calls need Reef's scenario routing, live artifact, admission, retry, and version-safety path without becoming processor input. Today every served exchange is captured, so auxiliary calls either create unnecessary records or bypass Reef entirely.

## Changes

- add the case-insensitive `x-reef-capture` request header, defaulting to `true` and rejecting values other than `true` or `false`;
- keep serve-only calls on the normal inference path while skipping `AgentRecord` creation, dispatcher ingestion, and receipts;
- forward OpenAI and Anthropic terminal SSE events unchanged for serve-only streams and leave interrupted streams uncaptured;
- settle streaming admission handles in both capture modes;
- document the public header and the boundary that recipes own training decisions for captured records; and
- cover header parsing, non-streaming behavior, OpenAI/Anthropic SSE, incomplete streams, provider payloads, and training-runtime admission.

## Compatibility and operational impact

This adds an optional public request header. Existing clients remain capture-enabled when the header is absent or `true`; no persisted format, configuration, dependency, or deployment migration changes.

With `x-reef-capture: false`, the response intentionally has no `x-reef-agent-record-id`, streaming responses have no synthetic Reef receipt event, and the exchange is unavailable to replay, processors, and delivery diagnostics. The same authenticated clients that can invoke inference may select serve-only behavior. Reef consumes the header at its boundary and does not add it to provider payloads.

The concrete design and alternatives are recorded in [#472](https://github.com/Human-Agent-Society/reef-archive/issues/472). Per maintainer direction, this focused additive change proceeds without a separate RFC document.

## Verification

- `PYTHONPATH=/tmp/reef-serve-only-inference pytest -q tests/reef_service/test_reef_wire.py tests/reef_service/test_reef_contracts.py` — 54 passed.
- `PYTHONPATH=/tmp/reef-serve-only-inference pytest -q tests/reef_service/test_ray_runtime.py::test_stream_and_failure_release_their_inference_admission_handles` — 1 passed.
- `ruff check reef/core/headers.py reef/service/request_service.py reef/service/routes/inference.py tests/reef_service/test_reef_contracts.py tests/reef_service/test_reef_wire.py tests/reef_service/test_ray_runtime.py` — passed.
- `mypy reef` — passed, 195 source files.
- `pre-commit run --files docs/connect-your-harness.rst reef/service/README.md reef/core/headers.py reef/service/request_service.py reef/service/routes/inference.py tests/reef_service/test_reef_wire.py tests/reef_service/test_reef_contracts.py tests/reef_service/test_ray_runtime.py` — passed.

## AI assistance

OpenAI Codex was directed to inspect the request and streaming paths, draft the design comment in [#472](https://github.com/Human-Agent-Society/reef-archive/issues/472), implement the change, and run the reported checks. The author reviewed the submitted design, behavior, and test results and remains responsible for them.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.