### PR TITLE
refactor: move W&B config under observability

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -190,7 +190,7 @@ recipe, the processor, backend results, and the commit lifecycle. Install
 
 .. code:: yaml
 
-   training:
+   observability:
      wandb:
        enabled: true
        project: reef

--- a/docs/user-guide/operate.rst
+++ b/docs/user-guide/operate.rst
@@ -61,7 +61,7 @@ On a training deployment, checkpoint retention runs under ``--reef-checkpoint-po
 Track experiments with W&B
 --------------------------
 
-Tracking is optional and off by default; ``training.wandb`` in `Configuration <../reference/configuration.rst#experiment-tracking>`__ lists every key. Export ``WANDB_API_KEY`` before starting the stack; there is no key field, and the Slime driver refuses ``--wandb-key`` so a credential never enters a command line or a run config.
+Tracking is optional and off by default; ``observability.wandb`` in `Configuration <../reference/configuration.rst#experiment-tracking>`__ lists every key. Export ``WANDB_API_KEY`` before starting the stack; there is no key field, and the Slime driver refuses ``--wandb-key`` so a credential never enters a command line or a run config.
 
 What you see in W&B: one group per scenario and one run per scenario, plus a new run after every rollback, so each post-rollback branch is its own curve. Every training result lands on the run-local ``train/step`` axis carrying the monotonic ``reef/step`` that joins it to the commit log, and the commit metrics record ``experiment/run_id``, so a Reef version leads to its run and the run's ``reef/training_job_id`` leads back. Tracking failures are logged and never fail a training step or its commit.
 

--- a/docs/user-guide/recipes/tttd.rst
+++ b/docs/user-guide/recipes/tttd.rst
@@ -305,12 +305,12 @@ Enable W&B tracking
 -------------------
 
 The example disables W&B in ``serve.yaml`` by default. Set
-``training.wandb.enabled`` to ``true`` before starting the stack, and provide a
+``observability.wandb.enabled`` to ``true`` before starting the stack, and provide a
 project and an optional entity:
 
 .. code:: yaml
 
-   training:
+   observability:
      wandb:
        enabled: true
        project: reef

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -43,7 +43,7 @@ Reports and training
 
 **409 on a report.** The client-chosen ``agent_record_id`` was sent before with different content. Use a new id, or resend identical content.
 
-**The training step fails and /reef/status reports an error.** The service log has the traceback. A driver rejecting ``--wandb-key`` or ``--use-wandb`` means tracking must be configured under ``training.wandb`` instead. A loss-family mismatch (``REEF_TRAINING_LOSS`` or the recipe's family against the Slime flags) is refused at startup by design.
+**The training step fails and /reef/status reports an error.** The service log has the traceback. A driver rejecting ``--wandb-key`` or ``--use-wandb`` means tracking must be configured under ``observability.wandb`` instead. A loss-family mismatch (``REEF_TRAINING_LOSS`` or the recipe's family against the Slime flags) is refused at startup by design.
 
 **After a restart the previous live weights are gone.** Weights between checkpoints exist only in engine memory; a restart restores the last checkpoint and the step counter continues from there. Keep ``checkpoint_every_n_versions`` at 1 unless you can afford to lose live versions. A ``RUNNING`` job marker left by a crash mid-step needs an operator to decide whether the job completed before the stack is restarted.
 

--- a/recipes/openclawrl/examples/openclawrl/README.md
+++ b/recipes/openclawrl/examples/openclawrl/README.md
@@ -160,7 +160,7 @@ The paths and names are constants at the top of `run.sh`: the models under
 tasks). For live W&B tracking, set the following:
 
 - `WANDB_API_KEY=...` is forwarded into the stack for live training curves
-  (also set `training.wandb.enabled: true` in `serve.yaml`) and starts
+  (also set `observability.wandb.enabled: true` in `serve.yaml`) and starts
   `results/learning_curve.py`, which logs the per-session verdicts into the same
   W&B group.
 

--- a/recipes/openclawrl/examples/openclawrl/serve.yaml
+++ b/recipes/openclawrl/examples/openclawrl/serve.yaml
@@ -95,6 +95,18 @@ user_llm:
   port: "30001"
   served_name: qwen3-32b-user-llm
 
+observability:
+  wandb:
+    enabled: false                     # omitted or false means no tracking
+    project: reef
+    # entity: your-team
+    # group_prefix: openclawrl        # produces group openclawrl/<scenario>
+    # name_prefix: openclawrl
+    tags: []
+    mode: online                       # online, offline, or disabled
+    directory: /var/lib/reef/wandb
+    upload_checkpoints: false
+
 training:
   num_gpus: 5                          # ray-head GPU total (actor + rollout)
   cuda_visible_devices: "1,2,3,4,5"
@@ -107,16 +119,6 @@ training:
     min_free_space_fraction: 0.10
     policy: latest
   global_batch_size: 16
-  wandb:
-    enabled: false                     # omitted or false means no tracking
-    project: reef
-    # entity: your-team
-    # group_prefix: openclawrl        # produces group openclawrl/<scenario>
-    # name_prefix: openclawrl
-    tags: []
-    mode: online                       # online, offline, or disabled
-    directory: /var/lib/reef/wandb
-    upload_checkpoints: false
   # openclawrl runs the verbatim upstream top-K select objective; architecture
   # Reef derives architecture flags from the HF config.
   # --padded-vocab-size + the rope/swiglu/norm/GQA flags below: the

--- a/recipes/sao/examples/sao/README.md
+++ b/recipes/sao/examples/sao/README.md
@@ -159,9 +159,9 @@ curl -s -H "Authorization: Bearer reef-local" \
 The runtime reports `pg_clipfrac` (the fraction of tokens the DIS mask
 removed), `critic/explained_variance`, actor and critic `grad_norm`, and the
 asynchrony telemetry `sao/policy_lag_*`, `sao/queue_age_s_*`, and
-`sao/effective_token_rate`. Set `training.wandb.enabled: true` in
+`sao/effective_token_rate`. Set `observability.wandb.enabled: true` in
 `serve.yaml` and export `WANDB_API_KEY` to keep them per committed step;
-`training.wandb.directory` is where the run files go.
+`observability.wandb.directory` is where the run files go.
 
 ### A larger model
 
@@ -246,7 +246,7 @@ batch is 128 over a full training run.
 
 The curve is the cumulative mean reward against scored rollouts, per arm,
 with the base rate as the dashed line. The runs predate Reef's experiment tracking, so no per-step W&B
-history exists for them. A new run with `training.wandb.enabled: true`
+history exists for them. A new run with `observability.wandb.enabled: true`
 records the step metrics that the TTT-Discover and OpenClaw-RL results keep
 (mean reward, response length, KL, step time).
 

--- a/recipes/sao/examples/sao/results/smoke-2026-08-30/README.md
+++ b/recipes/sao/examples/sao/results/smoke-2026-08-30/README.md
@@ -33,7 +33,7 @@ produced the queued rollouts — the gap the DIS ratio calibrates.
 Run the example as documented in its README (`./run.sh`). Two deviations from
 the committed defaults were used to record this result:
 
-- `training.wandb` set to `enabled: true, mode: offline` — offline mode needs
+- `observability.wandb` set to `enabled: true, mode: offline` — offline mode needs
   no W&B account; the run file lands under `work/wandb`.
 - The stack ran inside the `docker/Dockerfile.reef` image with this repository
   mounted, instead of a host install of the training dependencies.

--- a/recipes/sao/examples/sao/serve.yaml
+++ b/recipes/sao/examples/sao/serve.yaml
@@ -45,14 +45,7 @@ reef:
   artifact_cache_dir: work/artifact-cache
   agent_record_dir: work/agent-record
 
-training:
-  num_gpus: 2                          # ray-head GPU total (actor+critic colocated, rollout)
-  cuda_visible_devices: "0,1"
-  ray_port: 6379
-  ray_dashboard_port: 8265
-  sglang_port: "30000"
-  checkpoint_dir: work/checkpoints
-  global_batch_size: 1
+observability:
   wandb:
     enabled: false                     # omitted or false means no tracking
     project: reef
@@ -63,6 +56,15 @@ training:
     mode: online                       # online, offline, or disabled
     directory: work/wandb
     upload_checkpoints: false
+
+training:
+  num_gpus: 2                          # ray-head GPU total (actor+critic colocated, rollout)
+  cuda_visible_devices: "0,1"
+  ray_port: 6379
+  ray_dashboard_port: 8265
+  sglang_port: "30000"
+  checkpoint_dir: work/checkpoints
+  global_batch_size: 1
   # SAO objective as slime flags: --use-critic creates the value-model group;
   # the algorithm spec sets --custom-advantage-function-path (skip-observation
   # GAE) and --custom-pg-loss-function-path (hard-masked DIS calibration)

--- a/recipes/tttd/examples/guidance_ttt/serve.yaml
+++ b/recipes/tttd/examples/guidance_ttt/serve.yaml
@@ -26,6 +26,18 @@ reef:
   artifact_cache_dir: work/polyomino_packing/artifact-cache
   agent_record_dir: work/polyomino_packing/agent-record
 
+observability:
+  wandb:
+    enabled: false                     # omitted or false means no tracking
+    project: reef
+    # entity: your-team
+    # group_prefix: guidance-ttt      # produces group guidance-ttt/<scenario>
+    # name_prefix: guidance-ttt
+    tags: []
+    mode: online                       # online, offline, or disabled
+    directory: work/polyomino_packing/wandb
+    upload_checkpoints: false
+
 training:
   num_gpus: 2
   cuda_visible_devices: "0,1"
@@ -37,16 +49,6 @@ training:
   lora_rank: 32
   tensor_parallel_size: 2
   checkpoint_dir: work/polyomino_packing/checkpoints
-  wandb:
-    enabled: false                     # omitted or false means no tracking
-    project: reef
-    # entity: your-team
-    # group_prefix: guidance-ttt      # produces group guidance-ttt/<scenario>
-    # name_prefix: guidance-ttt
-    tags: []
-    mode: online                       # online, offline, or disabled
-    directory: work/polyomino_packing/wandb
-    upload_checkpoints: false
 
 services:
   - name: ray-head

--- a/recipes/tttd/examples/tttd/serve.yaml
+++ b/recipes/tttd/examples/tttd/serve.yaml
@@ -26,6 +26,12 @@ reef:
   artifact_cache_dir: ${TTTD_STATE_DIR}/artifact-cache
   agent_record_dir: ${TTTD_STATE_DIR}/agent-record
 
+observability:
+  wandb:
+    enabled: false
+    project: reef
+    directory: ${TTTD_STATE_DIR}/wandb
+
 training:
   num_gpus: 2
   # The grid and completion limit. harness/harbor_agent.py reads these same
@@ -38,10 +44,6 @@ training:
     max_storage_fraction: 0.8
     min_free_space_fraction: 0.1
     policy: latest
-  wandb:
-    enabled: false
-    project: reef
-    directory: ${TTTD_STATE_DIR}/wandb
 
 services:
   - name: ray-head

--- a/reef/observability/wandb.py
+++ b/reef/observability/wandb.py
@@ -43,7 +43,7 @@ _METRIC_NAMESPACE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]*$")
 
 @dataclass(frozen=True, slots=True)
 class WandbConfig:
-    """Validated first-class ``training.wandb`` configuration."""
+    """Validated first-class ``observability.wandb`` configuration."""
 
     enabled: bool = False
     project: str = "reef"
@@ -60,7 +60,7 @@ class WandbConfig:
         if value is None:
             return cls()
         if not isinstance(value, Mapping):
-            raise ValueError("training.wandb must be a mapping")
+            raise ValueError("observability.wandb must be a mapping")
         allowed = {
             "enabled",
             "project",
@@ -74,24 +74,24 @@ class WandbConfig:
         }
         unknown = sorted(str(key) for key in value if key not in allowed)
         if unknown:
-            raise ValueError(f"unknown training.wandb settings: {', '.join(unknown)}")
+            raise ValueError(f"unknown observability.wandb settings: {', '.join(unknown)}")
 
-        enabled = _boolean(value.get("enabled", False), "training.wandb.enabled")
-        mode = _optional_string(value.get("mode"), "training.wandb.mode") or ("online" if enabled else "disabled")
+        enabled = _boolean(value.get("enabled", False), "observability.wandb.enabled")
+        mode = _optional_string(value.get("mode"), "observability.wandb.mode") or ("online" if enabled else "disabled")
         if mode not in {"online", "offline", "disabled"}:
-            raise ValueError("training.wandb.mode must be online, offline, or disabled")
+            raise ValueError("observability.wandb.mode must be online, offline, or disabled")
         return cls(
             enabled=enabled,
-            project=_optional_string(value.get("project"), "training.wandb.project") or "reef",
-            entity=_optional_string(value.get("entity"), "training.wandb.entity"),
-            group_prefix=_optional_string(value.get("group_prefix"), "training.wandb.group_prefix"),
-            name_prefix=_optional_string(value.get("name_prefix"), "training.wandb.name_prefix"),
+            project=_optional_string(value.get("project"), "observability.wandb.project") or "reef",
+            entity=_optional_string(value.get("entity"), "observability.wandb.entity"),
+            group_prefix=_optional_string(value.get("group_prefix"), "observability.wandb.group_prefix"),
+            name_prefix=_optional_string(value.get("name_prefix"), "observability.wandb.name_prefix"),
             tags=_tags(value.get("tags", ())),
             mode=mode,  # type: ignore[arg-type]
-            directory=_optional_string(value.get("directory"), "training.wandb.directory"),
+            directory=_optional_string(value.get("directory"), "observability.wandb.directory"),
             upload_checkpoints=_boolean(
                 value.get("upload_checkpoints", False),
-                "training.wandb.upload_checkpoints",
+                "observability.wandb.upload_checkpoints",
             ),
         )
 
@@ -584,11 +584,11 @@ def _optional_string(value: object, field: str) -> str | None:
 
 def _tags(value: object) -> tuple[str, ...]:
     if isinstance(value, str) or not isinstance(value, Sequence):
-        raise ValueError("training.wandb.tags must be a list of strings")
+        raise ValueError("observability.wandb.tags must be a list of strings")
     tags: list[str] = []
     for item in value:
         if not isinstance(item, str) or not item.strip():
-            raise ValueError("training.wandb.tags must be a list of non-empty strings")
+            raise ValueError("observability.wandb.tags must be a list of non-empty strings")
         tags.append(item.strip())
     return tuple(dict.fromkeys(tags))
 

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -100,8 +100,8 @@ class ServiceSettings:
     artifact_cache_dir: str = ".reef/artifact-cache"
     agent_record_dir: str = ".reef/agent-record"
     allow_implicit_scenario_creation: bool = True
-    #: Deployment-level experiment provider settings. These are sourced from
-    #: ``training.wandb`` rather than the recipe-owned ``reef`` section.
+    #: Deployment-level experiment provider settings, sourced from
+    #: ``observability.wandb``.
     wandb_config: Mapping[str, Any] = field(default_factory=dict)
     training_settings: Mapping[str, Any] = field(default_factory=dict)
     #: Optional pre-publication checkpoint evaluator and selection plugin.
@@ -262,7 +262,7 @@ def service_settings_from_config(config: Mapping[str, Any]) -> ServiceSettings:
         allow_implicit_scenario_creation=bool(
             _config_service_value(config, "reef", "allow_implicit_scenario_creation", default=True)
         ),
-        wandb_config=_config_service_mapping(config, "training", "wandb"),
+        wandb_config=_config_service_mapping(config, "observability", "wandb"),
         training_settings=_config_service_mapping(config, "training"),
         evaluation_settings=_config_optional_mapping(config, "evaluation"),
         recipe_settings=_reef_section(config),

--- a/reef/train/slime_backend/reef_adapters/driver.py
+++ b/reef/train/slime_backend/reef_adapters/driver.py
@@ -210,7 +210,7 @@ def _validate_tracking_args(args: Any) -> None:
         raise RuntimeError("--wandb-key is not supported; use WANDB_API_KEY or the W&B credential store")
     if getattr(args, "use_wandb", False):
         raise RuntimeError(
-            "--use-wandb in training.slime_flags is not supported; use Reef's generic training.wandb config"
+            "--use-wandb in training.slime_flags is not supported; use Reef's observability.wandb config"
         )
 
 

--- a/tests/reef_service/test_slime_bridge.py
+++ b/tests/reef_service/test_slime_bridge.py
@@ -1322,7 +1322,7 @@ def test_slime_rejects_its_legacy_raw_wandb_flags() -> None:
     from reef.train.slime_backend.reef_adapters.driver import _validate_tracking_args
 
     _validate_tracking_args(SimpleNamespace(use_wandb=False, wandb_key=None))
-    with pytest.raises(RuntimeError, match=r"generic training\.wandb"):
+    with pytest.raises(RuntimeError, match=r"observability\.wandb"):
         _validate_tracking_args(SimpleNamespace(use_wandb=True, wandb_key=None))
     with pytest.raises(RuntimeError, match="WANDB_API_KEY"):
         _validate_tracking_args(SimpleNamespace(use_wandb=False, wandb_key="secret"))

--- a/tests/reef_service/test_wandb_tracking.py
+++ b/tests/reef_service/test_wandb_tracking.py
@@ -319,7 +319,7 @@ def test_config_surface_is_generic_and_rejects_credentials() -> None:
     settings = service_settings_from_config(
         {
             "reef": {"recipe": "pg"},
-            "training": {
+            "observability": {
                 "wandb": {
                     "enabled": True,
                     "project": "reef-smoke",
@@ -334,9 +334,9 @@ def test_config_surface_is_generic_and_rejects_credentials() -> None:
     assert config.tags == ("baseline", "cpu")
     assert config.active is True
 
-    with pytest.raises(ValueError, match=r"unknown training\.wandb settings"):
+    with pytest.raises(ValueError, match=r"unknown observability\.wandb settings"):
         WandbConfig.from_mapping({"enabled": True, "api_key": "must-not-be-accepted"})
-    with pytest.raises(ValueError, match=r"unknown training\.wandb settings: group, name"):
+    with pytest.raises(ValueError, match=r"unknown observability\.wandb settings: group, name"):
         WandbConfig.from_mapping({"group": "legacy", "name": "legacy"})
 
 


### PR DESCRIPTION
## Motivation

W&B is a deployment-level observability provider shared by recipes, processors, backend results, and the scenario commit lifecycle. Keeping its configuration under `training` incorrectly makes it look like a training-backend setting and diverges from the provider grouping used by other observability integrations.

## Changes

- Move the service configuration source from `training.wandb` to `observability.wandb` without a legacy compatibility path.
- Update W&B validation errors and the Slime raw-flag guidance to use the new path.
- Migrate all bundled deployment examples and related user/reference documentation.
- Update configuration and Slime contract tests for the new canonical location.

## Compatibility and operational impact

This is a breaking deployment configuration change: `training.wandb` is no longer consumed. Deployments that enable W&B must move the existing mapping to `observability.wandb`. W&B runtime behavior, credentials, run identity, metrics, and persisted Reef data are unchanged.

## Verification

- `uvx pre-commit run --all-files --show-diff-on-failure` — passed.
- `python -m pytest -q tests/reef_service/test_wandb_tracking.py tests/reef_service/test_slime_bridge.py tests/reef_service/test_sao_configs.py tests/reef_service/test_training_server.py` — 158 passed.
- `python -m mypy reef/observability/wandb.py reef/service/deploy/settings.py reef/train/slime_backend/reef_adapters/driver.py` — passed.
- `git diff --check` — passed.

## AI assistance

OpenAI Codex was used to separate this change from the LangSmith implementation, update the configuration surface and examples, and run the verification commands listed above. The author remains responsible for the submitted changes and claims.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
