### PR TITLE
docs: make prose more natural

### DIFF
--- a/docs/contributing/codebase-structure.rst
+++ b/docs/contributing/codebase-structure.rst
@@ -7,9 +7,9 @@ This page says which package should own a change.
 Choose a destination
 --------------------
 
-``reef/`` holds every shared mechanism. Each bundled method is one package
-beside it — ``recipes/sao/``, ``recipes/tttd/``, ``recipes/openclawrl/``,
-``recipes/harness_evolve/`` — with that method's recipe, processor, step
+``reef/`` holds every shared mechanism. Each bundled method lives in one
+package under ``recipes/`` (``sao``, ``tttd``, ``openclawrl``, or
+``harness_evolve``) with that method's recipe, processor, step
 preparer, and, for weight methods, the ``slime/`` subpackage only the training
 plane imports. Nothing under ``reef/`` imports a method package.
 

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -14,7 +14,7 @@ Run the full suite
 Run it in the supported container environment. Many torch-dependent tests use
 ``pytest.importorskip`` and skip when torch is unavailable. Others, including
 ``tests/reef_service/test_slime_bridge.py``, import Slime and torch during
-collection — without the training dependencies, pytest cannot collect the full
+collection. Without the training dependencies, pytest cannot collect the full
 suite.
 
 Run one area

--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -59,5 +59,5 @@ adapter-specific: ``config`` node contents follow each adapter's schema.
 See also
 --------
 
-- `Evolve your harness <../user-guide/evolve-your-harness.rst>`__ — the loop that produces the tree.
-- `harness_evolve <../user-guide/recipes/harness-evolve.rst>`__ — the recipe's configuration.
+- `Evolve your harness <../user-guide/evolve-your-harness.rst>`__: the loop that produces the tree.
+- `harness_evolve <../user-guide/recipes/harness-evolve.rst>`__: the recipe's configuration.

--- a/docs/developer-guide/loss-families.rst
+++ b/docs/developer-guide/loss-families.rst
@@ -77,18 +77,18 @@ The spec
 ``loss_family``, ``loss_type``, and ``validate_specific_args`` are required. The
 rest has defaults. The overrides, in the order the pipeline reaches them:
 
-- ``parse_specific_options`` and ``apply_driver_options`` — family flags on
+- ``parse_specific_options`` and ``apply_driver_options``: family flags on
   the driver's argv (``--<name>-*``), stripped before Slime's parser sees them
   and stamped onto ``args``.
-- ``configure_backend_args`` — derive backend settings once ``loss_family`` is
+- ``configure_backend_args``: derive backend settings once ``loss_family`` is
   stamped. SAO turns Slime's advantage pass on here.
-- ``shape_sample_row`` and ``build_rollout_data`` — a custom wire row. The
+- ``shape_sample_row`` and ``build_rollout_data``: a custom wire row. The
   default row is ``[source_id, tokens, loss_mask, rollout_log_probs, reward]``;
   a family appends its own columns and reads them back.
-- ``prepare_rollout`` — driver-side work before a step.
-- ``bind`` — a per-run instance carrying state such as a critic schedule.
-- ``train`` — critic and actor orchestration; the default is one actor step.
-- ``provenance_metrics`` — telemetry after the step.
+- ``prepare_rollout``: driver-side work before a step.
+- ``bind``: a per-run instance carrying state such as a critic schedule.
+- ``train``: critic and actor orchestration; the default is one actor step.
+- ``provenance_metrics``: telemetry after the step.
 
 Two loss lanes
 --------------
@@ -108,12 +108,12 @@ every declared channel is present, and projects the dotted paths onto ``args``.
 A missing module or hook stops the worker; nothing falls back to Slime's default
 loss.
 
-- ``custom_loss_function_path`` — ``<name>_loss(args, batch, logits, sum_of_sample_mean)``
-- ``custom_pg_loss_function_path`` — ``<name>_loss(args, ppo_kl, log_probs, advantages)``
-- ``custom_advantage_function_path`` — ``<name>_advantages(args, rollout_data)``
-- ``reef_actor_init_hook_path`` — ``<name>_actor_init(actor)``, once, after the
+- ``custom_loss_function_path``: ``<name>_loss(args, batch, logits, sum_of_sample_mean)``
+- ``custom_pg_loss_function_path``: ``<name>_loss(args, ppo_kl, log_probs, advantages)``
+- ``custom_advantage_function_path``: ``<name>_advantages(args, rollout_data)``
+- ``reef_actor_init_hook_path``: ``<name>_actor_init(actor)``, once, after the
   actor has loaded its weights
-- ``reef_actor_pre_train_hook_path`` — ``<name>_actor_pre_train(actor, rollout_data)``,
+- ``reef_actor_pre_train_hook_path``: ``<name>_actor_pre_train(actor, rollout_data)``,
   before every training step
 
 ``tests/reef_service/test_slime_algorithm_contract.py`` enforces the entry point
@@ -126,18 +126,18 @@ Wire declarations
 
 A family that ships more than the five policy columns declares them on the spec.
 
-- ``rollout_data_keys`` — per-sample payload keys the rollout manager
+- ``rollout_data_keys``: per-sample payload keys the rollout manager
   partitions across data-parallel ranks.
-- ``rollout_tensor_dtypes`` — which of those become tensors, and as what
+- ``rollout_tensor_dtypes``: which of those become tensors, and as what
   (``"int"``, ``"long"``, ``"float32"``). Ragged fields stay undeclared and
   pass through as lists.
-- ``response_aligned_keys`` — tensors laid out per response token; the worker
+- ``response_aligned_keys``: tensors laid out per response token; the worker
   slices them for context parallelism the way it slices advantages.
-- ``external_batch_keys`` — keys the worker forwards through ``get_batch``
+- ``external_batch_keys``: keys the worker forwards through ``get_batch``
   into the microbatch.
-- ``rollout_log_skip_keys`` — non-scalar keys hidden from Slime's numeric
+- ``rollout_log_skip_keys``: non-scalar keys hidden from Slime's numeric
   rollout logger.
-- ``critic_value_head_zero_init`` and ``critic_value_mask_key`` — critic
+- ``critic_value_head_zero_init`` and ``critic_value_mask_key``: critic
   families only.
 
 Bundled families worth reading: ``recipes/tttd/slime/`` (two hooks, the default
@@ -148,5 +148,5 @@ frozen Megatron teacher).
 See also
 --------
 
-- `Python API <../reference/python-api.rst#step-preparer>`__ — the signal side of the pair.
-- `Write a recipe <write-a-recipe.rst>`__ — binding a family to a method.
+- `Python API <../reference/python-api.rst#step-preparer>`__: the signal side of the pair.
+- `Write a recipe <write-a-recipe.rst>`__: binding a family to a method.

--- a/docs/developer-guide/processors.rst
+++ b/docs/developer-guide/processors.rst
@@ -2,9 +2,9 @@ Processors
 ==========
 
 A processor is a scenario's batch builder: records in, one typed training
-batch out, plus the answer to what the record store may delete. This page is
-the design behind the two engines a recipe subclasses — why there are two,
-what each owns, and the path a record takes to a batch.
+batch out, plus the answer to what the record store may delete. This page
+explains the two engines a recipe can subclass, what each owns, and the path a
+record takes to a batch.
 
 .. page::
    :for: recipe authors choosing an engine, and anyone reading ``reef/train/processors/``
@@ -17,16 +17,17 @@ The contract
 The trainer drives four mutating methods on its own thread, under its lock;
 none may block:
 
-- ``ingest(record)`` — one record arrives;
-- ``ready()`` — is a batch available;
-- ``build_batch()`` — produce it (the trainer validates it against ``output_schema``);
-- ``acknowledge(batch_id)`` — the training step consumed that batch; returns
+- ``ingest(record)``: one record arrives;
+- ``ready()``: is a batch available;
+- ``build_batch()``: produce it (the trainer validates it against ``output_schema``);
+- ``acknowledge(batch_id)``: the training step consumed that batch; returns
   the consumed record ids, which the commit record persists so recovery never
   re-ingests them.
 
-Retention rides along: the trainer reads ``retention_decision()`` (protected
-vs releasable ids) and reports deletions back through ``compaction_applied()``.
-Nothing numeric lives here — advantages and the loss family are the step
+The processor also controls retention. The trainer reads
+``retention_decision()`` (protected vs releasable ids) and reports deletions
+back through ``compaction_applied()``.
+Nothing numeric lives here. Advantages and the loss family are the step
 preparer's. The read-only ``status()`` hook is empty by default; a processor
 uses it only when a terminal outcome cannot become a batch and an external
 runner must stop waiting (TTTD reports a complete mixed-artifact step as an
@@ -61,7 +62,7 @@ Why there are two
 
 Everything else, including the ``async``, follows from that one question.
 
-A report *arrives knowing what it judges* — it names its inference records.
+A report *arrives knowing what it judges*: it names its inference records.
 The decision is then a comparison on data already in hand: cheap,
 synchronous, and possible the moment the last referenced record lands. What
 it costs is bookkeeping about the reference: an index of reports waiting on
@@ -70,20 +71,20 @@ dedup for a grader that retries its POST, and a barrier for recipes whose
 unit is a whole group.
 
 A computed-feedback recipe has no report. Its signal does not exist until
-later traffic completes an earlier record, and judging it calls a model —
-seconds to minutes the trainer's thread cannot spend without stalling
-serving. So judgment moves to a worker, and the bookkeeping is a different
-set: which records still wait, a TTL for the ones whose completion never
-comes, and absorption for judgments that land without a record to trigger
-them.
+later traffic completes an earlier record, and judging it calls a model.
+Judgment can take seconds or minutes, which would stall serving if it ran on
+the trainer's thread. It moves to a worker instead, with different
+bookkeeping: which records still wait, a TTL for the ones whose completion
+never comes, and absorption for judgments that land without a record to
+trigger them.
 
 Neither set follows from ``async``. Making the reported judge asynchronous
-would buy uniform timing while keeping every structure above, and would make
+would make timing uniform while keeping every structure above, and would make
 every reported recipe's readiness eventually consistent and expose it to
-losing an in-flight judgment on a crash — an exposure only the computed path
+losing an in-flight judgment on a crash, an exposure only the computed path
 carries today. The engines differ because the questions differ. What they
-share — hold a pending batch, be ready while it exists or once enough units
-are held, release what it consumed — is defined once in ``base.py``; each
+share (hold a pending batch, be ready while it exists or once enough units
+are held, and release what it consumed) is defined once in ``base.py``. Each
 engine fills in ``_ready_count``, ``_make_pending``, and ``_consume_pending``.
 
 What a recipe writes
@@ -93,12 +94,12 @@ What a recipe writes
 groups, plus the class attributes ``output_schema``, ``exclusive_sources``,
 ``ordered_groups``.
 
-**Computed feedback:** ``ingest`` — the correlation *is* the method, written
-with the engine's ``catch_up`` / ``dispatch`` / ``track`` / ``retire`` verbs —
-plus ``judge``, ``make_sample``, ``make_batch``, and ``expire`` for tracked
+**Computed feedback:** In ``ingest``, the correlation *is* the method. It uses
+the engine's ``catch_up`` / ``dispatch`` / ``track`` / ``retire`` verbs, as
+well as ``judge``, ``make_sample``, ``make_batch``, and ``expire`` for tracked
 records that time out.
 
-Nothing else on either tier: no retention, lifecycle, or recovery code.
+Neither tier contains retention, lifecycle, or recovery code.
 
 A record's path to a batch
 --------------------------
@@ -119,8 +120,8 @@ Where a processor lives
 
 Every file under ``reef/train/processors/`` is framework: ``base``,
 ``reported``, ``computed``, and ``common`` (shared report readers and sample
-builders). A method's processor is ``recipes/<name>/processor.py`` — its data
-story, read top to bottom. Machinery beyond that file's job sits beside it as
+builders). A method's processor is ``recipes/<name>/processor.py`` and should
+show its data flow from top to bottom. Machinery beyond that file's job sits beside it as
 modules named by concern (``recipes/openclawrl/``: ``sessions``, ``turns``,
 ``prm``), never in the processor file and never in a ``utils`` grab-bag.
 
@@ -154,5 +155,5 @@ The bundled processors
 See also
 --------
 
-- `Write a recipe <write-a-recipe.rst>`__ — a processor in a complete recipe.
-- `Loss families <loss-families.rst>`__ — the numeric side, which lives in the preparer.
+- `Write a recipe <write-a-recipe.rst>`__: a processor in a complete recipe.
+- `Loss families <loss-families.rst>`__: the numeric side, which lives in the preparer.

--- a/docs/developer-guide/surface.rst
+++ b/docs/developer-guide/surface.rst
@@ -30,7 +30,7 @@ caches. Those live in ``train/``, ``artifact/``, ``scenario/``,
 Admission is deliberately adjacent rather than a field on ``Surface``. A
 recipe selects it through ``build_artifact_validator()``, the scenario factory
 freezes it on ``ScenarioBinding.artifact_validator``, and the commit protocol
-runs it before publication and rollback — so the decision stays in the commit
+runs it before publication and rollback, so the decision stays in the commit
 path instead of looking like a serving capability.
 
 Capabilities and call sites
@@ -99,7 +99,7 @@ transaction; the surface does not repeat that step.
 **Per-scenario adapters.** When a runtime trains one LoRA adapter per
 scenario, ``create_weight_surface(scenario=...)`` puts that scenario's frozen
 adapter revision on every request. ``reef.surface.adapter`` holds only the
-naming contract — ``adapter_name(scenario, version)`` and its inverse — so a
+naming contract (``adapter_name(scenario, version)`` and its inverse), so a
 recorded ``lora_path`` names exactly one (scenario, revision). Residency is
 engine-global, not per surface: the training bridge owns one
 ``AdapterResidencyManager`` per engine, and the surface never touches it.
@@ -154,5 +154,5 @@ protocols, and never imports a concrete one.
 See also
 --------
 
-- `Write a recipe <write-a-recipe.rst>`__ — where ``build_surface`` fits.
-- `Harness adapters <harness-adapters.rst>`__ — the client side of a file tree.
+- `Write a recipe <write-a-recipe.rst>`__: where ``build_surface`` fits.
+- `Harness adapters <harness-adapters.rst>`__: the client side of a file tree.

--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -2,7 +2,7 @@ Write a harness method
 ======================
 
 A harness method is the part you write: what edit to try, and how an episode
-scored. Reef runs the loop around it — snapshot, apply, run the paired episodes,
+scored. Reef runs the loop around it: snapshot, apply, run the paired episodes,
 record, publish or revert.
 
 `Evolve your harness <../user-guide/evolve-your-harness.rst>`__ is the mechanism this plugs
@@ -19,17 +19,18 @@ A method fills three slots:
 
 ``propose`` sees the tree as ``(kind, config)`` pairs, the batch of
 ``TraceSample`` records (recorded request payload, score, source receipt), and
-``models``, its only path to a model — ``models.served`` is the model under
-test, ``models["teacher"]`` comes from ``evolution.models``. Each binding is
-called as ``binding.chat(messages, *, timeout_s=None, **params) -> str`` —
-OpenAI-shaped ``messages`` whatever the endpoint's dialect, returning the
-assistant text. It returns one ``Mutation`` (``create``, ``update``, or
+``models``, its only path to a model. ``models.served`` is the model under
+test, ``models["teacher"]`` comes from ``evolution.models``. Call each binding
+as ``binding.chat(messages, *, timeout_s=None, **params) -> str``. The
+``messages`` are OpenAI-shaped regardless of the endpoint's dialect, and the
+binding returns the assistant text. ``propose`` returns one ``Mutation``
+(``create``, ``update``, or
 ``remove`` on one root-level entry), a sequence applied as one composite
 proposal under one verdict, or ``None`` to skip. An optional keyword-only
 ``manifest`` argument receives the previous step's ``FailureManifest``.
 
-``evaluate`` grades one finished episode — both sides of every pair. ``result``
-carries the exit code, stdout, stderr, and the parsed ``trajectory``. Episodes
+``evaluate`` grades one finished episode. Reef calls it for both sides of every
+pair. ``result`` carries the exit code, stdout, stderr, and the parsed ``trajectory``. Episodes
 that could not run never reach it.
 
 ``selection`` defaults to ``score_comparison``: select when the candidate wins
@@ -39,7 +40,7 @@ more task comparisons than it loses. ``always`` selects every applied mutation.
 
    The tree refuses credentials outright. A config node holding a literal
    credential (``apiKey``, ``token``, plural and list forms) fails admission at
-   seed boot, at every proposal, and when recovered state loads — tree state
+   seed boot, at every proposal, and when recovered state loads. Tree state
    persists into the commit log, the snapshot metadata, and the published
    artifact. If a workdir from before this gate already holds a key, resuming
    fails and names the field: rotate the key, then edit the entry out of the
@@ -48,7 +49,7 @@ more task comparisons than it loses. ``always`` selects every applied mutation.
 A complete method
 ~~~~~~~~~~~~~~~~~
 
-Each task string starts with a tag — ``[fib]`` in the config below — and
+Each task string starts with a tag, such as ``[fib]`` in the config below, and
 ``evaluate`` uses it to look up that task's expected answer. The tag convention
 is the method's own; Reef passes the task string through unchanged.
 
@@ -120,7 +121,7 @@ The recipe config names the callables, the tasks, and the first-boot tree:
 Preset YAML is read as-is: ``${VAR}`` is **not** interpolated in a preset, only
 in a deployment config. Write literal values.
 
-That file is a preset, not a deployment config — it has no ``services`` and no
+That file is a preset, not a deployment config. It has no ``services`` and no
 ``reef`` section, so ``reef serve -c`` cannot read it. Save it as
 ``recipes/<name>.yaml`` and ``export REEF_RECIPE_CONFIG_DIR=$PWD/recipes``;
 there is no default directory. The deployment config is the file ``reef serve
@@ -144,7 +145,7 @@ the one to copy:
 See `Recipe configuration <../reference/configuration.rst#recipe-configuration>`__.
 ``recipes/harness_evolve/examples/harness_evolve/run.sh`` does exactly this.
 
-Keep ``tasks`` short — it sets each step's cost. Start Reef where the method
+Keep the ``tasks`` list short because it sets each step's cost. Start Reef where the method
 package is importable, and give ``-c`` an absolute path: Reef resolves a
 relative ``-c`` against its own repo root, not your working directory. Recovered
 tree state always wins over ``seed``. The full field list is in `harness_evolve
@@ -189,4 +190,4 @@ candidate selection breaks revert.
 See also
 --------
 
-- `Python API <../reference/python-api.rst#harness-method>`__ — the contract as a table.
+- `Python API <../reference/python-api.rst#harness-method>`__: the contract as a table.

--- a/docs/developer-guide/write-a-recipe.rst
+++ b/docs/developer-guide/write-a-recipe.rst
@@ -11,9 +11,9 @@ Accepting records, replaying them after a restart, holding a batch until it is
 acknowledged, committing algorithm state, running the backend, and publishing
 the next version are Reef's job, not the method's.
 
-This page writes a **weight** recipe. To write a harness-evolution method —
-``propose``, ``evaluate``, and a selection policy against a fixed model — see
-`Evolve your harness <../user-guide/evolve-your-harness.rst#write-a-method>`__ instead.
+This page covers a **weight** recipe. For a harness-evolution method with
+``propose``, ``evaluate``, and a selection policy against a fixed model, see
+`Evolve your harness <../user-guide/evolve-your-harness.rst#write-a-method>`__.
 
 .. code:: mermaid
 
@@ -52,8 +52,9 @@ This page writes a **weight** recipe. To write a harness-evolution method —
        RESOLVE -->|"typed batch"| EVOLVE
        class JUDGE,BATCH,PREP,EVAL,SELECT user-owned
 
-The shaded steps are the method's. A processor *judges* each resolved unit — one
-record plus the reports that reference it: ``TRAIN`` batches it, ``WAIT`` holds
+The shaded steps are the method's. A processor *judges* each resolved unit. A
+unit consists of one record plus the reports that reference it. ``TRAIN``
+batches it, ``WAIT`` holds
 it until its remaining references land, ``NEVER`` drops it. After the backend
 runs, the method's evaluator measures the candidate and its selector decides
 whether it is published.
@@ -78,10 +79,10 @@ A weight recipe is four pieces plus the class that binds them.
    candidate evaluation | measures the checkpoint the backend exported and decides select or reject. Every recipe carries one; the default selects whatever the backend produced
    recipe class | a frozen dataclass whose ``training_spec()`` names the processor, the preparer (by dotted path), and the loss family
 
-`Python API <../reference/python-api.rst>`__ is the contract for each. ``recipes/sao/`` is
-the smallest bundled implementation and the one to read alongside it — four
-files, under 200 lines: ``recipe.py``, ``processor.py``, ``preparer.py``, and
-the ``slime/`` loss family.
+`Python API <../reference/python-api.rst>`__ is the contract for each.
+``recipes/sao/`` is the smallest bundled implementation and the one to read
+alongside this page. Its four files total fewer than 200 lines: ``recipe.py``,
+``processor.py``, ``preparer.py``, and the ``slime/`` loss family.
 
 Configure it
 ~~~~~~~~~~~~
@@ -115,8 +116,9 @@ loss family requires (`the mapping
 Gate a candidate
 ~~~~~~~~~~~~~~~~
 
-A runtime finishes training by exporting a candidate, and the recipe's ``candidate_evaluation``
-decides what happens to it. A harness recipe builds its evaluator in code:
+A runtime finishes training by exporting a candidate. The recipe's
+``candidate_evaluation`` decides what happens to it. A harness recipe builds
+its evaluator in code:
 
 .. code:: yaml
 
@@ -127,13 +129,13 @@ decides what happens to it. A harness recipe builds its evaluator in code:
        threshold: 0.8
 
 Reef calls the factory once per scenario with that opaque ``config`` and the
-scenario's training runtime, and the trainer runs the plugin between the
-backend step and publication — evaluate, then decide, in that order. A
-rejection leaves the previous version serving. The plugin contract —
-``evaluate``, ``decide``, the fail-closed rule, and idempotency by
-``candidate.candidate_id`` — is in `Python API
-<../reference/python-api.rst#candidate-evaluation>`__, and the section fields
-are in `Configuration <../reference/configuration.rst#the-evaluation-section>`__.
+scenario's training runtime. The trainer runs the plugin between the backend
+step and publication, calling ``evaluate`` before ``decide``. A rejection
+leaves the previous version serving. `Python API
+<../reference/python-api.rst#candidate-evaluation>`__ documents the plugin
+contract: ``evaluate``, ``decide``, the fail-closed rule,
+and idempotency by ``candidate.candidate_id``. The section fields are in
+`Configuration <../reference/configuration.rst#the-evaluation-section>`__.
 
 Where the feedback comes from
 -----------------------------
@@ -146,4 +148,4 @@ none.
 See also
 --------
 
-- `Adding components <../contributing/adding-components.rst>`__ — bundling a recipe into Reef itself.
+- `Adding components <../contributing/adding-components.rst>`__: bundling a recipe into Reef itself.

--- a/docs/getting-started/architecture.rst
+++ b/docs/getting-started/architecture.rst
@@ -51,9 +51,9 @@ own process, with no GPU.
 The opening pull is for recipes whose artifact is the harness tree: the agent
 fetches the currently served tree (``GET /reef/harness``, or the install script
 built on it) and runs on that version, so the harness it uses is the one whose
-receipts it will later report against. Weight recipes skip it — the artifact
-lives in the inference runtime, and a request reaches the new version on its
-own.
+receipts it will later report against. Weight recipes skip this pull because
+their artifact lives in the inference runtime. Requests reach the new version
+there directly.
 
 The request path
 ----------------
@@ -82,7 +82,7 @@ Records
 -------
 
 Every inference and every report is an ``AgentRecord``: an id, a scenario, a
-request type, a payload, and — for inference — the frozen ``artifact_ref``. The
+request type, a payload, and the frozen ``artifact_ref`` for inference. The
 record id is the receipt.
 
 Appending the same id with different content returns a conflict rather than
@@ -109,8 +109,8 @@ when the recipe is constructed are fixed with it.
 A Reef process runs at most one scenario that trains full weights, on a single
 thread, so preparation, remote execution, and commit never interleave. It may
 run any number of scenarios that produce no updates or that update text
-artifacts in process — each grows and commits on its own background thread, so
-record acceptance never waits for artifact evolution.
+artifacts in process. Each one grows and commits on its own background thread,
+so record acceptance never waits for artifact evolution.
 
 Surfaces
 --------
@@ -176,7 +176,7 @@ weight files and a ``reef-artifact.json`` manifest in every version. Heads move
 only by compare-and-swap: ``advance_current`` requires the expected head,
 ``publish`` requires the expected parent, and the push carries a lease, so a
 stale publication conflicts instead of overwriting. Rollback does not rewrite
-history — it activates an earlier version and publishes the same bytes as a new
+history. It activates an earlier version and publishes the same bytes as a new
 commit, keeping step numbers monotonic.
 
 Durability
@@ -208,7 +208,7 @@ artifact and reloads from durable state, replaying the uncompacted records. Each
 scenario needs exactly one logical Reef writer, and external training operations
 must be idempotent or reconcilable after a crash.
 
-All of this assumes persistent storage — see `Configuration
+These guarantees require persistent storage. See `Configuration
 <../reference/configuration.rst>`__ for the paths.
 
 Evaluation

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -18,8 +18,8 @@ under LFS. This install runs the base ``recipe`` kind and ``harness_evolve``.
 Client only
 -----------
 
-A client that only talks to a Reef deployment needs neither the repository nor
-the install above — just the stdlib-only wire client:
+A client that only talks to a Reef deployment does not need the repository or
+the full install. Install the stdlib-only wire client instead:
 
 .. code:: bash
 

--- a/docs/getting-started/intro.rst
+++ b/docs/getting-started/intro.rst
@@ -44,7 +44,8 @@ Reef closes that loop in the serving lifecycle for continual learning.
    Learn* :: a recipe — the learning method the deployment runs — releases a candidate learned version
    Publish :: an accepted candidate becomes the version being served
 
-Existing solutions and infras do not yet close that loop:
+Existing inference engines and RL frameworks cover parts of that loop, but not
+the whole thing:
 
 +-------------------------------------+------------------------+----------------------------+----------+
 | Ability                             | Inference engine       | RL training framework      | **Reef** |
@@ -71,16 +72,16 @@ configure picks one (composite version is a feature in the roadmap).
 **Model weights.** Reef runs the training step and hot-swaps the result into the
 serving engine. See `Evolve your model <../user-guide/evolve-your-model.rst>`__.
 
-**The harness tree** — the agent's rules, prompts, skills, and config, versioned
-as one object. Reef proposes an edit, runs the agent both ways on your tasks,
-and keeps the winner. See `Evolve your harness
+**The harness tree** is the agent's rules, prompts, skills, and config, versioned
+as one object. Reef proposes an edit, runs the current and proposed versions on
+your tasks, and keeps the winner. See `Evolve your harness
 <../user-guide/evolve-your-harness.rst>`__.
 
 What a call looks like
 ----------------------
 
-A deployment names one recipe — the method it runs — in its config, and every
-scenario it creates binds to that recipe:
+A deployment names one recipe in its config. Every scenario it creates binds
+to that recipe:
 
 .. code:: yaml
 

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -23,8 +23,8 @@ with no GPU.
 
 .. steps::
 
-   #. **Install.** Follow `Installation <installation.rst>`__ — the laptop path
-      is enough.
+   #. **Install.** Follow the laptop path in `Installation
+      <installation.rst>`__.
 
    #. **Serve.** ``external-provider.yaml`` is one process that
       proxies an OpenAI-compatible provider and records what it serves.
@@ -36,10 +36,10 @@ with no GPU.
 
          reef serve -c recipes/basic/external-provider.yaml
 
-      The config carries every other value — the provider, the model, and a
-      ``.reef/`` state directory beside the checkout. Only these two stay in the
-      environment: the upstream key is a secret, and this file is a template to
-      copy rather than an example to run, so it ships no token of its own.
+      The config supplies the provider, the model, and a ``.reef/`` state
+      directory beside the checkout. Only the two secrets stay in the
+      environment: the upstream key and the Reef token. The file is a template
+      to copy, so it does not include a token.
 
       ``reef serve`` runs in the foreground and holds the terminal until
       Ctrl-C. Leave it running and open a second terminal for everything below.
@@ -51,8 +51,8 @@ with no GPU.
    #. **Send a request and report on it.** The body is the provider's;
       ``x-reef-scenario`` is the only thing Reef adds. The response header
       ``x-reef-agent-record-id`` carries the **receipt**, which names the
-      stored exchange. Any grader you already have — tests, a verifier, a
-      rubric, a thumbs-down — becomes feedback against it.
+      stored exchange. Tests, a verifier, a rubric, a thumbs-down, or any other
+      grader you already have can report feedback against it.
 
       .. code:: python
 
@@ -82,7 +82,7 @@ with no GPU.
       id. Only inference-record ids are receipts, and they appear only
       in ``references``.
 
-   #. **Or use the wire client.** ``reef-client`` is a stdlib-only client —
+   #. **Or use the wire client.** Install the stdlib-only ``reef-client`` with
       ``pip install reef-client``. It keeps the receipt for you.
 
       .. code:: python
@@ -129,16 +129,16 @@ with no GPU.
       One version, and it will stay at one: this deployment's recipe is the
       base ``recipe`` kind, which records and trains nothing.
 
-To make the chain advance, bind a recipe that learns. Weight recipes are named
-directly — copy ``recipes/basic/external-provider.yaml``, set
-``reef.recipe: sao``, serve that — but they need GPUs (`Evolve your model
+To make the chain advance, bind a recipe that learns. To use a weight recipe,
+copy ``recipes/basic/external-provider.yaml``, set ``reef.recipe: sao``, and
+serve the new config. Weight recipes need GPUs (`Evolve your model
 <../user-guide/evolve-your-model.rst>`__).
 
 The one that runs on a laptop is ``harness_evolve``, and it takes a second file:
 a **preset** naming your ``propose`` and ``evaluate`` callables and the tasks to
-evaluate on. ``recipes/harness_evolve/examples/harness_evolve/run.sh`` is that
-whole loop already wired — run it, then `Evolve your harness
-<../user-guide/evolve-your-harness.rst>`__ explains each piece.
+evaluate on. ``recipes/harness_evolve/examples/harness_evolve/run.sh`` wires the
+whole loop together. Run it, then read `Evolve your harness
+<../user-guide/evolve-your-harness.rst>`__ for an explanation of each piece.
 
 
 
@@ -163,9 +163,10 @@ Receipt
 Every recorded exchange gets an id, and that id is the receipt. It identifies
 the request, the response, and the artifact version that produced it.
 
-The receipt arrives in the ``x-reef-agent-record-id`` response header, or in the
-terminal SSE metadata for a stream — `HTTP API <../reference/http-api.rst#inference>`__ has
-the exact field per dialect. A stream carries it only once the record is stored.
+The receipt arrives in the ``x-reef-agent-record-id`` response header or in the
+terminal SSE metadata for a stream. `HTTP API
+<../reference/http-api.rst#inference>`__ lists the exact field for each dialect.
+A stream carries it only after the record is stored.
 
 Report
 ------
@@ -174,9 +175,9 @@ A report is feedback that quotes receipts. It carries ``score``, ``feedback``,
 ``references``, and ``metadata``; `HTTP API <../reference/http-api.rst#report>`__ gives the
 types and the rules.
 
-Whatever already decides whether your agent did well — a test suite, a verifier,
-a human — stays in your harness. Reports are consumed at most once, so a retry
-or a late arrival is never counted twice.
+Whatever already decides whether your agent did well stays in your harness.
+That may be a test suite, a verifier, or a human. Reports are consumed at most
+once, so a retry or late arrival is never counted twice.
 
 Version chain
 -------------

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -45,10 +45,10 @@ Where it writes
 ---------------
 
 Each service gets a log and a PID file under ``run_dir``, which defaults to
-``/tmp/reef-stack``. Reef's own state — records, commit logs, and the Git-backed
-version chain — goes to the ``reef.*_dir`` paths in the config, not here.
+``/tmp/reef-stack``. Reef writes its own state, including records, commit logs,
+and the Git-backed version chain, to the ``reef.*_dir`` paths in the config.
 
 See also
 --------
 
-- `Configuration <configuration.rst>`__ — what goes in the file this reads.
+- `Configuration <configuration.rst>`__: what goes in the file this reads.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -85,8 +85,9 @@ to ``/var/lib/reef``. Point them somewhere persistent.
    On ephemeral storage, a restart loses the record store, the commit logs, and
    every version.
 
-Recipe settings sit beside these in the same section — ``batch_size``,
-``min_score``, and whatever else the recipe declares with ``config_field``. Keys
+Recipe settings such as ``batch_size`` and ``min_score`` sit beside these in
+the same section, along with any others the recipe declares with
+``config_field``. Keys
 the service does not recognize are handed to the recipe.
 
 Recipe configuration
@@ -94,17 +95,17 @@ Recipe configuration
 
 A recipe is named three ways:
 
-- **A bundled kind** — ``recipe: sao``
-- **A dotted class** — ``recipe: "my_pkg.my_method:MyMethodRecipe"``
-- **A named preset** — ``recipe: my-preset``, resolved to ``my-preset.yaml``
+- **A bundled kind:** ``recipe: sao``
+- **A dotted class:** ``recipe: "my_pkg.my_method:MyMethodRecipe"``
+- **A named preset:** ``recipe: my-preset``, resolved to ``my-preset.yaml``
   under ``REEF_RECIPE_CONFIG_DIR``
 
 ``REEF_RECIPE_CONFIG_DIR`` is the directory preset YAML is read from, and it has
 **no default**: a bare recipe name resolves to a preset only when it is set.
 
-A preset is read as-is — ``${VAR}`` interpolates in a deployment config, never
-in a preset. A preset carries its own ``kind``, ``model``, ``data``, and — for
-harness evolution — ``evolution`` sections:
+A preset is read as-is. ``${VAR}`` interpolates in a deployment config, never
+in a preset. A preset carries its own ``kind``, ``model``, and ``data``
+sections. Harness-evolution presets also carry an ``evolution`` section:
 
 .. code:: yaml
 
@@ -154,8 +155,8 @@ Read by the weight-training stack. See `Evolve your model
    training.checkpoint_retention | storage-fraction bounds and the retention policy
    training.slime_flags | GPU layout, optimizer, sequence length, and loss settings, as one literal string
 
-Architecture flags — layer counts, hidden sizes — are auto-filled by Slime from
-``reef.model_path`` and do not belong in the config.
+Slime fills architecture flags such as layer counts and hidden sizes from
+``reef.model_path``. Do not put them in the config.
 
 The ``evaluation`` section
 --------------------------
@@ -215,7 +216,7 @@ store on the cluster.
 writes syncable data below ``directory`` for a later ``wandb sync``.
 ``disabled`` makes no calls even when ``enabled`` is true.
 
-Each scenario maps to one group — the scenario name, or
+Each scenario maps to a group named after the scenario or
 ``<group_prefix>/<scenario>``. Within it, Reef opens one run when the scenario
 binds and another after each rollback. The deterministic run id includes those
 identities, so restarting resumes the same run with ``resume=allow``. A rollback
@@ -234,8 +235,8 @@ Those become ``recipe/*`` and ``processor/*``, each namespace on its own
 ``<namespace>/event`` axis. Only finite numeric values are sent.
 
 Durable commit metrics carry ``experiment/provider``, ``experiment/project``,
-``experiment/group``, and ``experiment/run_id`` — use them to open the run from
-a Reef version, and the run's ``reef/training_job_id`` to go the other way.
+``experiment/group``, and ``experiment/run_id``. Use them to open the run from
+a Reef version, and use the run's ``reef/training_job_id`` to go the other way.
 Checkpoint paths are metadata only unless ``upload_checkpoints: true``.
 
 Import, initialization, logging, summary, and upload failures are reported in
@@ -244,4 +245,4 @@ the service log and never fail a training step or its commit.
 See also
 --------
 
-- `Choosing a recipe <../user-guide/recipes.rst>`__ — what to put in ``reef.recipe``.
+- `Choosing a recipe <../user-guide/recipes.rst>`__: what to put in ``reef.recipe``.

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -9,13 +9,13 @@ Scenario
 
 One workload: its records, training state, and version chain, isolated from
 every other scenario. The first request carrying a new ``x-reef-scenario``
-creates it and binds its recipe — and optionally a starting artifact version —
-permanently.
+creates it and permanently binds its recipe. The request may also bind a
+starting artifact version.
 
 Agent record
 ------------
 
-One stored exchange — an inference call or a report — with its id, scenario,
+One stored exchange, either an inference call or a report, with its id, scenario,
 request type, payload, and, for inference, the artifact version that served it.
 The record store lives under ``agent_record_dir``.
 
@@ -77,9 +77,9 @@ Candidate selection
 The decision whether a produced update should replace the current served
 version. A ``CandidateEvaluator`` measures the candidate, a
 ``CandidateSelector`` makes the select-or-reject decision, and a
-``CandidateEvaluationPlugin`` implements both. Also called the gate. It is
-part of the recipe — every recipe carries its plugin as ``candidate_evaluation``
-— and is independent of checkpoint cadence and of retention.
+``CandidateEvaluationPlugin`` implements both. The docs also call this the
+gate. Every recipe carries the plugin as ``candidate_evaluation``. It is
+independent of checkpoint cadence and retention.
 
 Surface
 -------
@@ -91,17 +91,19 @@ hooks, and an optional client-pulled file tree, composed as fields on one
 Processor
 ---------
 
-The method's data-side component. It judges each resolved unit — one record plus
-the reports referencing it — as ``TRAIN``, ``WAIT``, or ``NEVER``, and assembles
+The method's data-side component. It judges each resolved unit, consisting of
+one record plus the reports referencing it, as ``TRAIN``, ``WAIT``, or
+``NEVER``, and assembles
 the accepted units into one typed batch. Reported and computed feedback pick
 different engines.
 
 Preparer
 --------
 
-The function that converts a reserved batch into a ``StepSignal`` — loss family,
-advantages, next algorithm state. Backend-neutral, importing no training stack.
-A recipe names it by registered name or dotted path.
+The function that converts a reserved batch into a ``StepSignal`` containing
+the loss family, advantages, and next algorithm state. It is backend neutral
+and imports no training stack. A recipe names it by registered name or dotted
+path.
 
 Loss family
 -----------
@@ -115,9 +117,9 @@ Harness
 
 Two meanings, both in use here.
 
-1. **Your harness** — the agent program around the model, owning prompts,
+1. **Your harness:** the agent program around the model, owning prompts,
    conversations, tools, environments, and grading. It runs outside Reef.
-2. **The harness tree** — Reef's deliverable: a versioned artifact of config,
+2. **The harness tree:** Reef's deliverable, a versioned artifact of config,
    rules, prompt templates, skills, and extension code, served over
    ``GET /reef/harness``.
 
@@ -133,10 +135,10 @@ Runtime
 
 Two meanings.
 
-1. **The request-plane contract** — ``InferenceRuntime`` and
+1. **The request-plane contract:** ``InferenceRuntime`` and
    ``TrainingRuntime``: the external service that executes model work. Inference
    is always required; GPU training only for weight recipes.
-2. **A training backend integration** — a concrete implementation of that
+2. **A training backend integration:** a concrete implementation of that
    contract, such as Reef's Slime runtime.
 
 SAO

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -1,8 +1,8 @@
 HTTP API
 ========
 
-Reef serves the provider's own inference routes — OpenAI at
-``/v1/chat/completions``, Anthropic at ``/v1/messages`` — and forwards each
+Reef serves the provider's own inference routes: OpenAI at
+``/v1/chat/completions`` and Anthropic at ``/v1/messages``. It forwards each
 request to the runtime unchanged. It adds a small set of ``/reef/*`` routes for
 feedback, scenarios, artifacts, and status.
 
@@ -155,10 +155,10 @@ It answers ``{agent_record_id, scenario, request_type}``.
 The optional top-level ``agent_record_id`` makes posting retry-safe: Reef uses
 it as the report's own record id, so an identical resend returns the stored
 record instead of reprocessing it, while the same id with different content is
-HTTP 409. It is not a receipt — receipts go in ``references``.
+HTTP 409. It is not a receipt. Receipts go in ``references``.
 
-A recipe may declare a report schema — `tttd
-<../user-guide/recipes/tttd.rst#the-report-contract>`__ declares one — in which case Reef
+A recipe may declare a report schema. `tttd
+<../user-guide/recipes/tttd.rst#the-report-contract>`__ declares one. In that case, Reef
 validates the declared ``score`` and ``metadata`` fields at ingress and answers
 HTTP 400 on a violation; ``feedback`` and undeclared ``metadata`` keys pass
 through unvalidated. To record a report but keep it out of training, send
@@ -236,7 +236,7 @@ an update is being trained or published.
 
 ``error`` and ``preload_errors`` report asynchronous training and preload
 failures. ``batch_ready`` says whether the processor has a batch waiting.
-``serving`` is runtime-wide and recipe-shaped — a LoRA deployment reports each
+``serving`` is runtime-wide but recipe-shaped. A LoRA deployment reports each
 scenario's ``adapter_weight_version`` under it.
 
 Status codes

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -64,8 +64,8 @@ behavior.
    └── HarnessEvolveRecipe      harness surface + backend   reef.harness_evolve
 
 Choose the narrowest class whose assumptions all hold. Inheriting ``Recipe``
-does not mean record-only — it means starting without a specialized base's extra
-contracts.
+starts without the extra contracts of a specialized base; it does not force the
+recipe to remain record-only.
 
 +---------------------------------+------------------------------------------------------+
 | What you are building           | Where to start                                       |
@@ -156,7 +156,7 @@ parser, and an optional environment fallback:
 Precedence is explicit configuration, then environment, then the default.
 ``from_environment()`` builds the recipe; ``service_config()`` forwards declared
 fields and shared artifact settings from the service configuration. Override
-``processor_config()`` when a processor needs renamed or derived keys — never
+``processor_config()`` when a processor needs renamed or derived keys. Never
 read deployment YAML from inside a processor.
 
 Report
@@ -291,7 +291,7 @@ Begin a score-based ``judge()`` with ``context.eligibility()``: it returns
 ``WAIT`` while a referenced inference is missing, ``NEVER`` for permanently
 ineligible input, and ``None`` when the method should decide. Use
 ``ReportDecision.never(reason)`` for a rejection an operator should be able to
-diagnose — the processor logs each new reason and counts repeats.
+diagnose. The processor logs each new reason and counts repeats.
 
 ``ReportDecision.train(value)`` creates a singleton candidate. Supply
 ``group_key`` and an idempotent ``slot`` when the training unit is a complete
@@ -365,7 +365,7 @@ depend on mutable external state.
 +------------------------+-------------------------------------------------+
 
 A ``PolicySample`` carries ``source_agent_record_id``, ``tokens``,
-``loss_mask``, ``rollout_log_probs``, ``reward``, and — when available —
+``loss_mask``, ``rollout_log_probs``, and ``reward``. When available, it also carries
 ``weight_version``, ``action_mask``, ``rollout_created_at``, ``turn_count``,
 ``topk_indices`` / ``topk_log_probs``, ``weight_version_spans``, and ``extras``,
 the field a processor uses for its own loss family. Use the shared assembly
@@ -427,7 +427,7 @@ A preparer owns method math and nothing else. It must not import a runtime, Ray,
 torch, or Slime; execute a training job; read deployment configuration; mutate
 the reserved batch; or commit state outside ``next_algorithm_state``. The
 recipe's loss family, the signal's loss family, the driver environment, and the
-backend flags must agree — Reef rejects a mismatch at startup or step
+backend flags must agree. Reef rejects a mismatch at startup or during step
 preparation.
 
 Use a ``StepPreparer`` subclass with ``@register_step_preparer`` only when
@@ -499,8 +499,8 @@ exact result it was given.
 
 A rejection leaves the previous artifact serving. An exception is fail-closed:
 Reef aborts the prepared candidate rather than publishing it. Make evaluations
-idempotent by ``candidate.candidate_id`` — recovery may repeat work whose result
-was not durably committed. The deployment names the factory in its
+idempotent by ``candidate.candidate_id`` because recovery may repeat work whose
+result was not durably committed. The deployment names the factory in its
 ``evaluation`` section (`Configuration
 <configuration.rst#the-evaluation-section>`__).
 

--- a/docs/rfcs/continual-opd.rst
+++ b/docs/rfcs/continual-opd.rst
@@ -1,14 +1,14 @@
 .. _continual-opd-on-reef--framework:
 
-Continual OPD on Reef — Framework
+Continual OPD on Reef: framework
 =================================
 
    A small model serves by default; a verifier flags tasks it handles poorly and
    escalates them to a large model; escalated trajectories are continually
    distilled back into the small model (hard distillation + soft on-policy
-   distillation, including cross-tokenizer). As the small model improves, the
-   escalation share narrows — the goals are a steadily falling cost per solved
-   task and escalation rate.
+   distillation, including cross-tokenizer). The intended result is a lower
+   escalation rate and a steadily falling cost per solved task as the small
+   model improves.
 
 .. _1-system-framework-four-components:
 
@@ -44,16 +44,16 @@ Continual OPD on Reef — Framework
       artifact version chain (one version per distillation step;
       probe-set regression → rollback)
 
-1. **Router** — v1 lives harness-side (~50 LoC). The student runs first; if the
-   verifier fails it, the task is retried on the teacher. This requires no
+1. **Router:** v1 lives on the harness side (~50 LoC). The student runs first;
+   if the verifier fails it, the task is retried on the teacher. This requires no
    Reef changes: two scenarios, each bound to its own recipe/upstream
    (multi-recipe deployments are natively supported).
-2. **Verifier** — it is the existing report score. v1 targets domains
+2. **Verifier:** the existing report score is the verifier. v1 targets domains
    where verification is free (code via unit tests, math via numeric checks).
-3. **Distillation** — layered, cheapest first (see §2). Triggering is free:
-   escalated samples filling a batch *is* Reef's native processor training
-   trigger.
-4. **Trust evolution** — track per-domain student pass rates; once a domain
+3. **Distillation:** layers run from cheapest to most expensive (see §2).
+   Escalated samples filling a batch provide the trigger, using Reef's native
+   processor training mechanism, so no separate trigger is needed.
+4. **Trust evolution:** track per-domain student pass rates; once a domain
    clears the bar, escalation is switched off there (keeping a small audit
    sample; dropping below the floor re-enables it). Thresholds and state
    eventually become versioned artifacts; v1 uses a simple EMA + fixed
@@ -102,29 +102,29 @@ Continual OPD on Reef — Framework
 |                 |                | needed)               |                   |
 +-----------------+----------------+-----------------------+-------------------+
 
-Key facts (verified in code): **slime already ships OPD** — teacher scoring,
-reverse-KL, an end-to-end ``teacher_log_probs`` pipeline, and frozen
-heterogeneous teacher engines all exist. The Reef↔slime bridge now carries it
+The code already provides the required OPD backend. Slime includes teacher
+scoring, reverse-KL, an end-to-end ``teacher_log_probs`` pipeline, and frozen
+heterogeneous teacher engines. The Reef↔slime bridge now carries it
 too: ``opd`` is in the bridge's algorithm whitelist, and after the bridge
 receives a batch it calls the teacher for scoring and directly constructs
 per-token advantages
 (``β·clip(RMSNorm(teacher_logp − rollout_logp), −c, c)``; optional centering
-happens before RMS normalization) shipped through the existing channel — it
-requires no slime-core changes and leaves the client contract unchanged.
+happens before RMS normalization) through the existing channel. This requires
+no slime-core changes and leaves the client contract unchanged.
 
 .. _3-roadmap:
 
 3. Roadmap
 ----------
 
-- **Phase 0 (no code changes — get the loop running)**: dual scenarios + harness
+- **Phase 0 (no code changes):** run the loop with dual scenarios, a harness
   router + verifier + the L0 hard-distillation loop. Deliverables: end-to-end
   engineering validation plus all baselines.
-- **Phase 1 (core development, shipped)**: L1 same-vocab OPD through the
-  bridge — landed in ``reef/train/slime_backend/reef_adapters/``
+- **Phase 1 (core development, shipped):** L1 same-vocab OPD through the
+  bridge, implemented in ``reef/train/slime_backend/reef_adapters/``
   plus one cookbook backend-preparer file (the removed ``examples/opd``
   prototype exercised this end to end; see git history).
-- **Phase 2**: cross-tokenizer alignment library + L2; automate trust
+- **Phase 2:** cross-tokenizer alignment library + L2; automate trust
   evolution and rollback.
 
 .. _4-first-experiments:

--- a/docs/rfcs/evolution-boundary.rst
+++ b/docs/rfcs/evolution-boundary.rst
@@ -1,11 +1,12 @@
 .. _the-evolution-boundary--what-reef-updates-and-what-it-doesnt:
 
-The evolution boundary — what Reef updates, and what it doesn't
+The evolution boundary: what Reef updates, and what it doesn't
 ===============================================================
 
-   Reef versions and updates **served artifacts** — model weights, skills,
-   harness trees, context playbooks. **Run state** — the bookkeeping a harness
-   produces while executing a fixed algorithm — stays harness-side. Whether an
+   Reef versions and updates **served artifacts** such as model weights, skills,
+   harness trees, and context playbooks. **Run state** is the bookkeeping a
+   harness produces while executing a fixed algorithm, and it stays on the
+   harness side. Whether an
    update is gated before publishing is a separate, per-backend risk policy, not
    what decides the boundary.
 
@@ -14,27 +15,28 @@ The evolution boundary — what Reef updates, and what it doesn't
 1. The question
 ---------------
 
-The same design question keeps arriving in different costumes:
+Several methods raise the same design question:
 
 - Should TTT-Discover's PUCT archive (visit counts, pruning, selection) move
   from `recipes/tttd/examples/tttd <../../recipes/tttd/examples/tttd/harness/search.py>`__ into a training backend?
 - ACE-style playbooks are updated every batch by incremental merges, with no
-  win/lose gate — is that Reef's job or the harness's?
-- GEPA evolves prompts by keeping a candidate frontier — Reef-side or external?
+  win/lose gate. Is that Reef's job or the harness's?
+- GEPA evolves prompts by keeping a candidate frontier. Should that live in
+  Reef or outside it?
 
-One early intuition — *"Reef owns the updates that might make things worse,
-because Reef has the gate"* — does not survive contact with the codebase:
-**no update is guaranteed an improvement**. A PPO step can regress; the
+The presence of a gate cannot determine this boundary because **no update is
+guaranteed to be an improvement**. A PPO step can regress. The
 ``openclawrl`` and ``sao`` algorithms
 publish every batch with no gate at all, and their safety net is not a gate but
-the version chain — every publish is a commit, receipts tie each outcome to the
-exact version that produced it, and rollback restores any earlier one. So
-gating cannot be the boundary criterion. Two orthogonal axes are.
+the version chain: every publish is a commit, receipts tie each outcome to the
+exact version that produced it, and rollback restores any earlier one. Gating
+therefore cannot be the boundary criterion. The boundary depends on two
+orthogonal axes.
 
 .. _2-axis-1--what-changes-this-decides-where-the-code-lives:
 
-2. Axis 1 — *what* changes. This decides where the code lives.
---------------------------------------------------------------
+2. Axis 1: *what* changes
+-------------------------
 
 **Served artifacts → Reef.** Anything that answers *"which version produced
 this response?"*: model weights, ``SKILL.md``, the harness tree's
@@ -44,30 +46,29 @@ version identity, receipts, stale-publish fencing, and rollback.
 Updating them is a training backend's job, and every update lands on the version chain.
 
 **Run state → harness.** State produced by *executing* a fixed rule: a PUCT
-archive's visit counts and prunes, the working memory of one search, one
+archive's visit counts and prunes, the working memory of one search, or one
 conversation's context. These updates are dense, order-dependent bookkeeping
-defined by the algorithm — not hypotheses to adjudicate. There is no
+defined by the algorithm, not hypotheses to adjudicate. There is no
 accept/reject decision to make about a visit-count increment, and gating one
 would break the algorithm's semantics. Their scope is one run or one problem
 instance. The harness owns them; Reef may at most persist snapshots (§5).
 
-The same rule holds from the artifact side: *learned state is runtime
-output, never committed to the evolved artifact*. The genome — the skill or
-policy text — evolves through Reef; the memory that text accumulates while
-running does not.
+The same rule holds from the artifact side: *learned state is runtime output,
+never committed to the evolved artifact*. The skill or policy text evolves
+through Reef; the memory it accumulates while running does not.
 
 Worked example: TTT-Discover
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The TTTD harness is the cleanest demonstration of the boundary: during a run its
-*code never changes* — only archive state does. So the search loop stays
+During a TTTD run, the harness code does not change; only the archive state
+does. The search loop therefore stays
 external (`recipes/tttd/examples/tttd <../../recipes/tttd/examples/tttd/README.md>`__), and the Reef side
 is exactly the part that needs the training backend: grouped advantage
 computation and the ``tttd`` loss
 (`recipes/tttd/slime/ <../../recipes/tttd/slime>`__).
-A litmus test that the archive is state rather than genome: its per-step
-updates cannot be replayed against each other as competing candidates — a
-gate has no place to stand.
+The archive is state rather than genome because its per-step updates cannot be
+replayed against each other as competing candidates. An accept-or-reject gate
+therefore does not apply.
 
 Conversely, the TTTD harness *does* contain genome that could evolve through
 Reef one day: the prompt template, the exploration constant, the
@@ -77,8 +78,8 @@ cross-run scores would be the same gated text-artifact loop
 
 .. _3-axis-2--how-changes-are-accepted-a-per-backend-policy:
 
-3. Axis 2 — *how* changes are accepted. A per-backend policy.
--------------------------------------------------------------
+3. Axis 2: *how* changes are accepted
+-------------------------------------
 
 Acceptance policies form a spectrum. All of them are Reef-side, and all land
 on the same version chain:
@@ -109,9 +110,10 @@ currently cannot is an implementation gap, not a principle (§5).
 4. Rule of thumb
 ----------------
 
-**Reef evolves the rules; harnesses run them.** State produced by running the
-rules gets persistence at most; changes to the rules themselves get versioned
-publishes — gated or not is the backend's call.
+Reef versions changes to the rules that a served artifact applies. The harness
+executes those rules and owns the resulting run state. Reef may persist that
+state, while changes to the rules are published as new versions. The backend
+decides whether to gate those publishes.
 
 +----------------+-----------------+----------------+----------------+
 | The thing      | Axis 1          | Axis 2         | Lives          |
@@ -140,20 +142,19 @@ The placement litmus is the direction of data flow, not how agent-like the
 code is:
 
 - Code whose input is a request or the environment and whose output is the
-  **next request** — task orchestration, grading, search loops such as TTTD's
-  PUCT selection — is a harness. It runs outside, however sophisticated.
+  **next request** is a harness. This includes task orchestration, grading, and
+  search loops such as TTTD's PUCT selection. It runs outside Reef.
 - Code whose input is the **record store** and whose output is a **publish on
-  the version chain** — a weight step, a skill edit, an ACE reflector/curator
-  pass — is a recipe backend. It runs inside Reef even when it calls an LLM
-  to do its thinking: it never answers a user request and never touches the
+  the version chain** is a recipe backend. Examples include a weight step, a
+  skill edit, and an ACE reflector/curator pass. It runs inside Reef even when
+  it calls an LLM: it never answers a user request and never touches the
   environment.
 
-That is why TTTD's harness stays external while skill evolution (and
-ACE on top of it) is built in, and the two placements are one rule, not an
-inconsistency: the TTTD search loop has both ends on the environment side;
-the evolution loop has both ends on Reef's side. One method can have both —
-TTTD's search harness outside, its grouped training step inside — and the
-seam between them is always the same pair: receipts out, reports in.
+TTTD's harness stays external because its search loop reads and writes
+environment-side state. Skill evolution, including ACE on top of it, stays in
+Reef because that loop reads records and publishes artifacts. One method can
+have both: TTTD's search harness runs outside while its grouped training step
+runs inside. They exchange receipts and reports.
 
 .. _5-what-the-boundary-unlocks:
 
@@ -164,8 +165,8 @@ seam between them is always the same pair: receipts out, reports in.
    `arXiv:2510.04618 <https://arxiv.org/abs/2510.04618>`__). Structurally
    identical to online weight training with the artifact in the weights'
    place: reflector/curator merge per batch → publish → the version chain as
-   the safety net. ACE's own failure mode — context collapse — is answered by
-   rollback;
+   the safety net. Rollback addresses ACE's own failure mode of context
+   collapse;
    a gate is optional hardening, not a prerequisite.
 2. **Population/Pareto acceptance** (unlocks GEPA,
    `arXiv:2507.19457 <https://arxiv.org/abs/2507.19457>`__). Generalize the gate
@@ -176,5 +177,5 @@ seam between them is always the same pair: receipts out, reports in.
 3. **Run-state snapshots on the version chain** (TTTD durability, optional).
    ``PUCTArchive.state_dict()`` is already JSON-ready; letting snapshots ride
    the version chain as attachments would keep a crashed harness's resume aligned
-   with the weight version it trained. Persistence only — selection logic
-   stays harness-side.
+   with the weight version it trained. This adds persistence only; selection
+   logic stays on the harness side.

--- a/docs/rfcs/method-integration.rst
+++ b/docs/rfcs/method-integration.rst
@@ -1,6 +1,6 @@
 .. _method-integration--one-method-one-trust-domain:
 
-Method integration — one method, one trust domain
+Method integration: one method, one trust domain
 =================================================
 
    **Status (2026-08): resolved, beyond M3.** The judging half moved all the
@@ -8,15 +8,15 @@ Method integration — one method, one trust domain
    sessions are reconstructed from recorded traffic by trace matching (no
    tags, no headers), PRM judging runs on a processor-private worker
    sanctioned by the ``DataProcessor`` contract, and verdicts become batch
-   candidates directly — no report round-trip at all. The grader proxy and
+   candidates directly, without a report round trip. The grader proxy and
    its ``x-reef-return-training`` opt-in are retired; agents point at Reef
    directly. File references below describe the pre-move layout and are kept
    as the record of why the move happened.
 
 ..
 
-   A bundled method's correctness-critical logic — grading orchestration,
-   session correlation, exclusion semantics — must live in **one** trust
+   A bundled method's correctness-critical logic, including grading orchestration,
+   session correlation, and exclusion semantics, must live in **one** trust
    domain, versioned and tested with the processor that consumes its reports.
    Reef's core capabilities (records, inference, dispatch) are **served to**
    method components through APIs, never **re-implemented by** them. The
@@ -30,44 +30,46 @@ Method integration — one method, one trust domain
 
 The ``openclawrl`` integration is our first method whose grading is itself part
 of the algorithm (a PRM judging next-state feedback). Making it work under the
-current rules — *no method-specific code in the request plane*, agent records have
-a write-only HTTP surface — produced a topology with four structural defects:
+current rules produced a topology with four structural defects. Those rules
+kept method-specific code out of the request plane while giving agent records
+a write-only HTTP surface.
 
 1. **Correctness split across trust domains.** The method's exclusion
    semantics (next-state presence, neutral drops, the at-least-one promotion)
    live in ``recipes/openclawrl/examples/openclawrl/sessions.py`` (since removed),
    while `OpenClawRLProcessor <../../recipes/openclawrl/processor.py>`__
    deliberately accepts *any* numeric score. The processor's docstring says
-   "the external grader owns the method's exclusion semantics" — load-bearing
-   training logic labeled as an example, outside CI's method tests, outside
-   the version chain.
+   "the external grader owns the method's exclusion semantics." Correctness
+   therefore depended on training logic labeled as an example, outside CI's
+   method tests and the version chain.
 2. **Core capabilities rebuilt outside, degraded.** The grader is a
    forwarding proxy that re-implements a miniature request plane
    (``grader.py`` ≈ ``service/`` +
    ``inference.py`` forwarding) and a miniature record store
    (``sessions.py`` ≈ ``records.py``,
-   but in-memory, TTL-swept, lost on crash). ``sessions.py`` says it plainly:
+   but in-memory, TTL-swept, lost on crash). ``sessions.py`` explains its origin:
    *"Adapted from the reef-internal coordinator on the openclaw branch."*
-   The coordinator was not designed outside — it was evicted.
+   The architecture moved the coordinator outside Reef even though it depended
+   on Reef's request-plane behavior.
 3. **Two unsynchronized failure domains.** The grader holds turns Reef has no
    verdict for; Reef holds records the grader may never judge (crash, TTL).
    Neither side can recover the other's state: the grader cannot re-read what
    Reef stored, and Reef cannot know a session ended.
 4. **A serving regression.** Because the grader must see complete responses,
-   it buffers upstream and synthesizes SSE all at once — every agent behind
-   this method loses true streaming, which Reef itself supports.
+   it buffers upstream and synthesizes SSE all at once. Every agent behind
+   this method loses the true streaming that Reef supports.
 
-None of these are bugs in the grader. They are forced moves given one missing
-capability, which is the actual root cause:
+These defects result from one missing capability rather than from isolated
+grader bugs:
 
 **Reef's agent-record surface is write-only.**
 `service/routes/records.py <../../reef/service/routes/records.py>`__
-registers ``POST /reef/report`` — nothing reads,
+registers ``POST /reef/report``, but nothing reads,
 queries, or subscribes. An external component that needs to see exchanges has
 exactly one option: sit on the traffic path and keep its own copy. Meanwhile
-the storage primitive for egress already exists —
+the storage primitive for egress already exists.
 `RecordStore.replay_page <../../reef/records.py>`__ is keyset-paginated and
-documented "for internal streaming consumers" — it simply has no HTTP surface.
+documented "for internal streaming consumers," but it has no HTTP surface.
 
 The same forces will apply to every future method whose grading is
 algorithmic (ACE's Reflector, ReasoningBank's distiller, OpenClaw-RL's
@@ -83,7 +85,7 @@ These are the standards new method integrations follow. Each traces to a
 defect above.
 
 - **P1 · One trust domain per method.** Everything that decides *what
-  trains* — grading orchestration, correlation, exclusion, promotion — ships
+  trains*, including grading orchestration, correlation, exclusion, and promotion, ships
   in one package with the processor that consumes its output, tested
   together. A processor may never delegate its acceptance semantics to an
   unversioned external component.
@@ -93,13 +95,13 @@ defect above.
   blocks review.
 - **P3 · Observe, don't carry.** Method components consume traffic from the
   egress surface (§3.1); they do not proxy the request path. The request
-  plane stays method-agnostic — that contract is kept, not weakened.
+  plane stays method-agnostic. This preserves the existing contract.
 - **P4 · Training-relevant state is durable.** Any state whose loss changes
   what trains (session tables, pending verdicts, retry queues) lives in
   Reef's store or is reconstructible from it by replay. Process memory is a
   cache, never the source of truth.
 - **P5 · No serving regressions.** A method integration may not degrade the
-  request path it observes — streaming stays end-to-end native. Buffered
+  request path it observes. Streaming stays end-to-end native. Buffered
   capture with synthesized SSE is disallowed.
 - **P6 · Reports carry the whole signal.** ``POST /reef/report`` already
   accepts structured ``feedback``; a method that produces more than a scalar
@@ -139,8 +141,8 @@ Egress is the inverse of ingress and reuses its auth. A consumer's position
 is its own cursor (``after_sequence``); Reef keeps no per-consumer state, so a
 crashed grader recovers by replaying from its last durable cursor. Compaction
 is safe unchanged: records are only compacted after training consumed them,
-which requires the method's own report — a record cannot be compacted before
-its grader has seen it, because the grader is what makes it trainable.
+which requires the method's own report. A record cannot be compacted before
+its grader has seen it because the grader is what makes it trainable.
 
 .. _32-request-tags:
 
@@ -164,15 +166,16 @@ A bundled method is one package under ``reef/<name>/`` (landed 2026-08 as
 ``recipe``/``processor``/``preparer``/``slime``) containing
 every correctness-critical part: the recipe, the processor, and any grading
 service (judge orchestration, PRM client, correlation). Grading services run
-as service entries in the deployment config — as the grader already does in
-``training-openclawrl.yaml`` — but from inside the package, on the egress API.
+as service entries in the deployment config, as the grader already does in
+``training-openclawrl.yaml``. They run from inside the package on the egress API.
 There are no re-exports: a method's names are imported from its package.
 
-The considered alternative — in-core observer hooks on the request path
-(a method plugin invoked post-serve) — is rejected for now: it breaks the
-method-agnostic request plane for a latency win no current method needs.
-Egress-with-replay gives the same visibility with a crash story the hook
-model lacks. Revisit only if a method demonstrably cannot tolerate
+The considered alternative is an in-core observer hook on the request path,
+implemented as a method plugin invoked after serving. It is rejected for now
+because it breaks the
+method-agnostic request plane for a latency benefit no current method needs.
+Egress with replay provides the same visibility and allows recovery after a
+crash, which the hook model does not. Revisit only if a method cannot tolerate
 observe-lag.
 
 .. _34-report-payload-conventions:
@@ -186,7 +189,7 @@ The report schema is already open (``score``, ``feedback``, ``references``,
 - ``score``: scalar consumed by scored-rollout processors, as today.
 - ``metadata.training.eligible: false``: the existing framework-neutral
   opt-out (`reported.py <../../reef/train/processors/reported.py>`__,
-  ``_report_is_trainable``) — how a method submits a record-keeping report
+  ``_report_is_trainable``): how a method submits a record-keeping report
   that must not train.
 - ``feedback.<method>.*``: structured method signal. For OpenClaw-RL's OPD
   half: ``feedback.openclawrl.hint`` (the selected directive hint) and
@@ -201,20 +204,20 @@ The report schema is already open (``score``, ``feedback``, ``references``,
 
 Milestones, each independently shippable:
 
-1. **M1 — egress + tags.** Add §3.1 and §3.2. No behavior change for
+1. **M1: egress + tags.** Add §3.1 and §3.2. No behavior change for
    existing methods.
-2. **M2 — grader off the data path.** Agents point at Reef directly (true
+2. **M2: grader off the data path.** Agents point at Reef directly (true
    streaming restored, P5). The grader becomes an egress consumer: replay →
    correlate by tags → judge with the PRM → ``POST /reef/report``. Its session
    table becomes derived state; the retry queue survives because report ids
    stay deterministic (``openclawrl:<receipt>``) and
    `records.py <../../reef/records.py>`__ dedup is unchanged.
-3. **M3 — graduate the package.** Move grader, sessions, and PRM client into
+3. **M3: graduate the package.** Move grader, sessions, and PRM client into
    ``reef/methods/openclawrl/`` beside the recipe and processor; CI runs the
    exclusion-semantics tests against the processor contract (P1, P7).
    ``recipes/openclawrl/examples/openclawrl/`` keeps the opencode plugin, workload, and launch
    config.
-4. **M4 — the OPD half.** With P6 conventions in place, the missing half of
+4. **M4: the OPD half.** With P6 conventions in place, the missing half of
    the paper lands as data, not new infrastructure: the grader extracts
    hints, runs the hint-augmented teacher forward as a non-trainable
    inference call, and reports ``score`` + ``feedback.openclawrl.*``; a
@@ -231,7 +234,7 @@ Milestones, each independently shippable:
   integrated today keep working unmodified; tags are optional.
 - **The evolution boundary.** This RFC moves *method* code, not *run state*.
   A grader's session table is derived bookkeeping over Reef-served traffic,
-  which is exactly why it belongs on Reef's store — the
+  which is why it belongs on Reef's store. The
   `evolution boundary <evolution-boundary.rst>`__ is about harness-owned search
   state, and is untouched.
 - **Recipe authorship.** Third-party methods still need only a recipe class
@@ -250,7 +253,7 @@ Before a method merges, its review answers yes to all of:
 - ☐ No component proxies the request path or re-implements a core module
   (P2, P3).
 - ☐ Killing any method component and restarting it loses no
-  training-relevant state — everything derives from replay (P4).
+  training-relevant state because everything derives from replay (P4).
 - ☐ An agent behind this method gets native streaming (P5).
 - ☐ Every training signal arrives through ``POST /reef/report`` under
   documented keys (P6).

--- a/docs/rfcs/stale-sample-training.rst
+++ b/docs/rfcs/stale-sample-training.rst
@@ -14,7 +14,7 @@ Bounded stale-sample training without giving up the version fence
 1. Where the gate lives today
 -----------------------------
 
-Three pieces conspire, each individually reasonable:
+Three independently reasonable mechanisms combine to produce this behavior:
 
 1. **Provenance becomes the fence.**
    `ray_runtime.prepare_training_step <../../reef/runtime/adapters/ray_runtime.py>`__
@@ -27,17 +27,17 @@ Three pieces conspire, each individually reasonable:
    version and returns ``outcome="stale"`` on any difference.
 3. **The dispatcher discards.** On ``stale``,
    `dispatcher._process <../../reef/dispatcher.py>`__ calls ``reject_pending()``:
-   the reserved rollouts are dropped, not retried — correctly, because a retry
-   would carry the same producing version and fail the same comparison.
+   the reserved rollouts are dropped rather than retried. A retry would carry
+   the same producing version and fail the same comparison.
 
-The composite effect: a rollout is trainable **only** while the weights that
+As a result, a rollout is trainable **only** while the weights that
 produced it are still serving. The moment a commit publishes a new version,
-every in-flight rollout becomes garbage.
+every in-flight rollout becomes ineligible.
 
 .. _2-why-that-is-the-wrong-resting-point:
 
-2. Why that is the wrong resting point
---------------------------------------
+2. Why exact matching is too restrictive
+----------------------------------------
 
 The training path already owns how a sample is consumed. Staleness admission
 should only bound *which* producing versions reach that path; it should not
@@ -50,8 +50,8 @@ fencing from freshness admission while keeping ``max_staleness: 0`` inert.
 
 .. _3-proposal--split-the-fence-from-the-freshness-policy:
 
-3. Proposal — split the fence from the freshness policy
--------------------------------------------------------
+3. Proposal: split the fence from the freshness policy
+------------------------------------------------------
 
 ``expected_weight_version`` currently answers two different questions with one
 comparison:
@@ -144,8 +144,8 @@ On clean restart the bridge republishes the recovered checkpoint under its
 recorded serving token, so lag remains comparable after recovery. A genuinely
 new serving incarnation never compares equal and all
 older samples are dropped as cross-incarnation. The recovery-pair invariant,
-checkpoint retention, and the critic checkpoint are unaffected — none of them
-consume provenance.
+checkpoint retention, and the critic checkpoint are unaffected because none of
+them consume provenance.
 
 .. _43-what-does-not-change:
 

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -108,7 +108,7 @@ when the model itself cannot do the task.
 Before you start
 ----------------
 
-- ``pip install reef-client`` — the loop driver imports it.
+- ``pip install reef-client``: the loop driver imports it.
 - An OpenAI-compatible endpoint serving the model under test, hosted or local.
   ``REEF_UPSTREAM_URL`` takes no ``/v1`` suffix.
 - The ``pi`` binary on ``PATH``, or named by ``REEF_PI_BINARY``
@@ -211,4 +211,4 @@ how to connect an agent that has no adapter yet.
 See also
 --------
 
-- `harness_evolve <recipes/harness-evolve.rst>`__ — the recipe's full configuration.
+- `harness_evolve <recipes/harness-evolve.rst>`__: the recipe's full configuration.

--- a/docs/user-guide/evolve-your-model.rst
+++ b/docs/user-guide/evolve-your-model.rst
@@ -135,7 +135,7 @@ publishes it to the engine, and records a new version.
 You are training when a new ``training`` entry appears, which happens once
 ``batch_size`` eligible records have arrived. Later requests use the current
 version without a restart. Keep ``checkpoint_every_n_versions`` at its default
-of ``1`` unless you want versions without durable checkpoints — between
+of ``1`` unless you want versions without durable checkpoints. Between
 checkpoints, weight bytes live only in engine memory and a restart falls back to
 the last checkpoint.
 
@@ -146,7 +146,7 @@ Gate a candidate
 ----------------
 
 By default a successful training step is published. To measure the exported
-checkpoint first, add an ``evaluation`` section — the fields are in
+checkpoint first, add an ``evaluation`` section. The fields are in
 `Configuration <../reference/configuration.rst#the-evaluation-section>`__, the plugin
 interface and a worked example in `Write a recipe
 <../developer-guide/write-a-recipe.rst#gate-a-candidate>`__.
@@ -171,12 +171,13 @@ between scenarios; each keeps its own adapter and optimizer state, and a restart
 recovers every one of them. ``/reef/status`` lists each scenario with its
 ``adapter_weight_version``.
 
-An adapter the scenario did not train — an offline SFT run — is admitted the
-same way: it enters the version chain only if ``adapter_config.json`` declares a
+An adapter the scenario did not train, such as one from an offline SFT run,
+is admitted the same way. It enters the version chain only if
+``adapter_config.json`` declares a
 ``peft_type``, the weights are present, and its base model matches the one the
 engine holds.
 
 See also
 --------
 
-- `Architecture <../getting-started/architecture.rst#the-version-chain>`__ — the update transaction and durability model.
+- `Architecture <../getting-started/architecture.rst#the-version-chain>`__: the update transaction and durability model.

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -42,7 +42,7 @@ How a recipe is selected
 
 A deployment serves exactly one recipe, named by ``reef.recipe`` in its config.
 Every scenario it creates binds to that recipe, permanently. Requests never name
-a recipe — the scenario header is the only routing a caller provides.
+a recipe. The scenario header is the only routing a caller provides.
 
 .. code:: yaml
 
@@ -50,8 +50,9 @@ a recipe — the scenario header is the only routing a caller provides.
      recipe: sao          # a bundled kind
      batch_size: 1
 
-Naming — bundled kind, dotted class, or preset — and the per-kind config shapes
-are in `Configuration <../reference/configuration.rst#recipe-configuration>`__.
+``reef.recipe`` accepts a bundled kind, dotted class, or preset. `Configuration
+<../reference/configuration.rst#recipe-configuration>`__ describes the config
+for each kind.
 
 Every recipe has a checkpoint strategy, defaulting to ``EveryNVersions(1)``.
 ``checkpoint_every_n_versions`` is the shorter spelling in deployment YAML.
@@ -61,4 +62,4 @@ See also
 
 - `tttd <recipes/tttd.rst>`__ includes the bundled TTT-Discover example,
   formal circle-packing results, and recovery details.
-- `Write a recipe <../developer-guide/write-a-recipe.rst>`__ — when none of them fits.
+- `Write a recipe <../developer-guide/write-a-recipe.rst>`__: when none of them fits.

--- a/docs/user-guide/recipes/harness-evolve.rst
+++ b/docs/user-guide/recipes/harness-evolve.rst
@@ -38,9 +38,9 @@ publishes as a new version, pulled through ``GET /reef/harness``.
 Configuration
 -------------
 
-This kind never reads the flat ``reef.*`` section. Its configuration lives in a
-preset — ``<name>.yaml`` under ``REEF_RECIPE_CONFIG_DIR``, named by
-``reef.recipe`` in the deployment config (`Recipe configuration
+This kind never reads the flat ``reef.*`` section. Its configuration lives in
+``<name>.yaml`` under ``REEF_RECIPE_CONFIG_DIR``. The deployment config names
+that preset with ``reef.recipe`` (`Recipe configuration
 <../../reference/configuration.rst#recipe-configuration>`__). ``batch_size`` and
 ``max_score`` go under ``data:``; the rest goes under ``evolution:``.
 
@@ -90,10 +90,10 @@ SkillClaw
 
 `examples/skillclaw
 <../../../recipes/harness_evolve/examples/skillclaw/README.md>`__ is the
-larger worked instance: a full method package on the same mechanism. ``propose``
-is one sealed night — one decision per skill group plus the no-skill bucket —
-mapped to a single composite mutation sequence, and ``selection: always``
-publishes every non-skip night.
+larger worked instance: a full method package on the same mechanism. Each night,
+``propose`` makes one decision per skill group plus the no-skill bucket and maps
+them to a single composite mutation sequence. ``selection: always`` publishes
+every night that produces a proposal.
 
 It also shows the one extension point beyond the three slots. Its skill catalog
 must reach the model on every live request, so its recipe overrides
@@ -104,4 +104,4 @@ request path (`skillclaw_recipe.py
 See also
 --------
 
-- `HTTP API <../../reference/http-api.rst#harness-artifacts>`__ — pulling, pinning, and installing a published tree.
+- `HTTP API <../../reference/http-api.rst#harness-artifacts>`__: pulling, pinning, and installing a published tree.

--- a/docs/user-guide/recipes/sao.rst
+++ b/docs/user-guide/recipes/sao.rst
@@ -97,11 +97,11 @@ convergence result; the README lists every protocol deviation from the paper.
 The committed smoke configuration has one recorded run of its own
 (``results/smoke-2026-08-30/``): all 18 scored rollouts became committed
 training steps with no stale drops, which is the acceptance criterion for the
-smoke. Every score is 0.0 — Qwen2.5-1.5B-Instruct does not solve these
-problems — so its value is the per-step training metrics, exported from an
+smoke. Every score is 0.0 because Qwen2.5-1.5B-Instruct does not solve these
+problems. The useful output is the per-step training metrics, exported from an
 offline W&B run.
 
 See also
 --------
 
-- `Evolve your model <../evolve-your-model.rst>`__ — running the deployment.
+- `Evolve your model <../evolve-your-model.rst>`__: running the deployment.


### PR DESCRIPTION
## Motivation

The RST documentation used repetitive, dash-heavy sentence structures in many user, developer, reference, and RFC pages. This made otherwise precise technical material harder to scan.

## Changes

- Audited all 35 RST documentation files and rewrote prose in 26 of them.
- Replaced formulaic phrasing with direct, neutral technical language.
- Preserved facts, code blocks, configuration, links, tables, and diagrams.
- Kept the changes limited to documentation prose.

## Compatibility and operational impact

None. This pull request changes documentation only.

## Verification

- npm run check:docs: passed; validated 109 Markdown files, 35 RST files, internal routes, port 8900, and 14 Reef routes.
- npm run build: passed; production documentation site built and generated all static pages.
- git diff --check origin/main...HEAD: passed.

## AI assistance

OpenAI Codex reviewed and rewrote the prose. The blader/humanizer v2.11.2 guidance supplied the style checks. The final diff and verification results were reviewed before submission.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the maintenance model for review and merge requirements.