### PR TITLE
docs: simplify diagram and table labels

### DIFF
--- a/docs/contributing/codebase-structure.rst
+++ b/docs/contributing/codebase-structure.rst
@@ -19,10 +19,10 @@ a change that needs to reach upward is in the wrong package:
 .. code:: mermaid
 
    flowchart TD
-       accTitle: Which layer depends on which
-       subgraph Methods["Methods — recipes/"]
+       accTitle: Dependency direction between package layers
+       subgraph Methods["Methods in recipes/"]
            direction LR
-           M["sao · tttd · openclawrl · harness_evolve<br/>recipe, processor, preparer"]
+           M["sao, tttd, openclawrl, harness_evolve<br/>recipe, processor, preparer"]
        end
        subgraph Orchestration["Orchestration"]
            direction LR
@@ -32,7 +32,7 @@ a change that needs to reach upward is in the wrong package:
        subgraph Contracts["Contracts"]
            direction LR
            Recipe["reef/recipe<br/>what a method implements"]
-           Runtime["reef/runtime<br/>inference + training"]
+           Runtime["reef/runtime<br/>inference and training"]
            Harness["reef/harness<br/>descriptors, episodes"]
        end
        subgraph Engines["Engines and storage"]
@@ -41,7 +41,7 @@ a change that needs to reach upward is in the wrong package:
            Surfaces["reef/surface<br/>delivery of an artifact"]
            Artifacts["reef/artifact<br/>bytes, repositories, versions"]
        end
-       Core["reef/core — value types, wire shapes, errors"]
+       Core["reef/core: value types, wire shapes, errors"]
        Methods --> Orchestration
        Orchestration --> Contracts
        Contracts --> Engines

--- a/docs/developer-guide/processors.rst
+++ b/docs/developer-guide/processors.rst
@@ -44,7 +44,7 @@ One question picks the engine: **does feedback arrive in a report, or must the
 method compute it?**
 
 +-----------------+---------------------------------------------+----------------------------------------------------+
-|                 | reported — ``ReportedFeedbackProcessor``    | computed — ``ComputedFeedbackProcessor``           |
+|                 | reported: ``ReportedFeedbackProcessor``     | computed: ``ComputedFeedbackProcessor``            |
 +=================+=============================================+====================================================+
 | feedback        | reports referencing inference records       | signal mined from the traffic itself               |
 | arrives as      |                                             |                                                    |

--- a/docs/developer-guide/surface.rst
+++ b/docs/developer-guide/surface.rst
@@ -76,17 +76,17 @@ Built-in surfaces
 +----------------------------------------+-------------------------+----------------------------------+------------------+
 | Surface                                | Loader                  | Inference                        | Files            |
 +========================================+=========================+==================================+==================+
-| ``Surface()``                          | —                       | —                                | —                |
+| ``Surface()``                          | none                    | none                             | none             |
 +----------------------------------------+-------------------------+----------------------------------+------------------+
-| ``create_weight_surface()``            | ``WeightLoader``        | ``WeightInferenceHooks``         | —                |
+| ``create_weight_surface()``            | ``WeightLoader``        | ``WeightInferenceHooks``         | none             |
 +----------------------------------------+-------------------------+----------------------------------+------------------+
-| ``create_weight_surface(scenario=...)``| ``WeightLoader``        | ``WeightInferenceHooks``         | —                |
+| ``create_weight_surface(scenario=...)``| ``WeightLoader``        | ``WeightInferenceHooks``         | none             |
 |                                        |                         | selecting that scenario's        |                  |
 |                                        |                         | adapter revision                 |                  |
 +----------------------------------------+-------------------------+----------------------------------+------------------+
-| ``create_harness_surface()``           | —                       | —                                | ``TextFileTree`` |
+| ``create_harness_surface()``           | none                    | none                             | ``TextFileTree`` |
 +----------------------------------------+-------------------------+----------------------------------+------------------+
-| ``create_skill_surface(...)``          | —                       | optional ``SkillInferenceHooks`` | ``TextFileTree`` |
+| ``create_skill_surface(...)``          | none                    | optional ``SkillInferenceHooks`` | ``TextFileTree`` |
 +----------------------------------------+-------------------------+----------------------------------+------------------+
 
 **Weights.** ``WeightLoader`` probes whether an in-memory live weight version

--- a/docs/developer-guide/write-a-recipe.rst
+++ b/docs/developer-guide/write-a-recipe.rst
@@ -18,31 +18,31 @@ This page covers a **weight** recipe. For a harness-evolution method with
 .. code:: mermaid
 
    flowchart TB
-       accTitle: Recipe lifecycle: collect, resolve and select, evolve and publish
-       subgraph COLLECT["1 · COLLECT"]
+       accTitle: How a recipe collects records and publishes an update
+       subgraph COLLECT["1. Collect"]
            direction LR
            REQ["Inference request"]
-           REP["Report<br/>or nothing"]
+           REP["Optional report"]
            STORE[("Records")]
            REQ --> STORE
            REP --> STORE
        end
-       subgraph RESOLVE["2 · RESOLVE & SELECT"]
+       subgraph RESOLVE["2. Resolve and select"]
            direction LR
-           ENG["Resolve feedback<br/>reported · computed"]
+           ENG["Resolve reported<br/>or computed feedback"]
            JUDGE["Judge"]
            BATCH["Make batch"]
            ENG -->|"resolved unit"| JUDGE
            JUDGE -->|TRAIN| BATCH
-           JUDGE -.->|"WAIT · NEVER"| ENG
+           JUDGE -.->|"WAIT or NEVER"| ENG
        end
-       subgraph EVOLVE["3 · EVOLVE & PUBLISH"]
+       subgraph EVOLVE["3. Update and publish"]
            direction LR
            PREP["Prepare step"]
-           BACK["Run backend<br/>driver · local"]
+           BACK["Run backend<br/>driver or local"]
            EVAL["Evaluate candidate"]
            SELECT["Select or reject"]
-           VER["New artifact version<br/>serves next round ↻"]
+           VER["New artifact version<br/>serves later requests ↻"]
            PREP -->|"step signal"| BACK
            BACK -->|"unpublished checkpoint"| EVAL
            EVAL --> SELECT

--- a/docs/getting-started/architecture.rst
+++ b/docs/getting-started/architecture.rst
@@ -15,7 +15,7 @@ The core loop
 .. code:: mermaid
 
    sequenceDiagram
-       accTitle: The core serve, record, train, publish loop
+       accTitle: How Reef serves, records, trains, and publishes
        autonumber
        participant H as Harness
        participant S as Scenario
@@ -24,17 +24,17 @@ The core loop
        participant G as Training*
 
        opt Harness recipe: pull the served tree
-         H->>S: GET /reef/harness + scenario
-         S-->>H: Harness tree + artifact version
+         H->>S: GET /reef/harness for scenario
+         S-->>H: Harness tree and artifact version
          Note over H: Agent runs on that tree
        end
        Note over H,I: Serve and record each request
-       H->>S: Inference request + scenario
+       H->>S: Inference request for scenario
        S->>S: Freeze current artifact version
        S->>I: Provider-native request
        I-->>S: Provider response
-       S->>S: Validate frozen version + store
-       S-->>H: Response + receipt
+       S->>S: Validate frozen version and store record
+       S-->>H: Response and receipt
        H->>S: Feedback quotes the receipt
        S->>T: Eligible record
        opt Processor has a batch
@@ -146,21 +146,21 @@ stored durably either way.
 .. code:: mermaid
 
    flowchart TB
-       accTitle: Version durability: start, stage, commit, recover
-       subgraph START["1 · DURABLE START"]
+       accTitle: When artifact versions become durable
+       subgraph START["1. Durable start"]
            direction LR
            C0[("Checkpoint r0")] -->|"scenario starts"| S0["Serving r0"]
        end
-       subgraph LIVE["2 · ENGINE MEMORY · RESTART RESTORES r0"]
+       subgraph LIVE["2. Engine memory (restart restores r0)"]
            direction LR
-           V1["Live v1"] -->|"step 2 · train + sync"| V2["Live v2"]
+           V1["Live v1"] -->|"step 2: train and sync"| V2["Live v2"]
        end
-       subgraph NEXT["3 · NEXT DURABLE VERSION"]
+       subgraph NEXT["3. Next durable version"]
            direction LR
            C1[("Checkpoint r1")] -->|"continue serving"| S1["Serving r1"]
        end
-       START -->|"step 1 · train + sync"| LIVE
-       LIVE -->|"step 3 · export + publish"| NEXT
+       START -->|"step 1: train and sync"| LIVE
+       LIVE -->|"step 3: export and publish"| NEXT
        class C0,C1 durable
        class V1,V2 volatile
 

--- a/docs/getting-started/intro.rst
+++ b/docs/getting-started/intro.rst
@@ -9,19 +9,19 @@ model weights or of the agent's harness.
 Nothing about the agent has to change except the base URL it sends requests to.
 
 .. diagram::
-   :caption: Reef serves the model and publishes both artifacts: new weights into the engine, a new harness tree back to the agent.
+   :caption: Reef serves the model, loads new weights into the engine, and sends a new harness tree to the agent.
 
    <div class="fig-lane">
      <div class="fig-node">Your agent<span class="fig-node-caption">runs the harness tree: prompts, skills, config</span></div>
      <div class="fig-edge">
-       <span>requests + feedback</span>
+       <span>requests and feedback</span>
        <svg class="fig-arrow fig-arrow-next" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h13"/><path d="m13 7 5 5-5 5"/></svg>
        <svg class="fig-arrow fig-arrow-back" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H6"/><path d="m11 7-5 5 5 5"/></svg>
-       <span>answers + <strong>new harness tree</strong></span>
+       <span>answers and a <strong>new harness tree</strong></span>
      </div>
-     <div class="fig-node fig-emphasis">Reef<span class="fig-node-caption">serves, records; trains weights and evolves the harness</span></div>
+     <div class="fig-node fig-emphasis">Reef<span class="fig-node-caption">serves requests, records results, trains weights, and evolves the harness</span></div>
      <div class="fig-edge">
-       <span>inference + <strong>new weights</strong></span>
+       <span>inference and <strong>new weights</strong></span>
        <svg class="fig-arrow fig-arrow-next" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h13"/><path d="m13 7 5 5-5 5"/></svg>
      </div>
      <div class="fig-node">The model<span class="fig-node-caption">runs the weights: local engine or hosted API</span></div>
@@ -39,10 +39,10 @@ Reef closes that loop in the serving lifecycle for continual learning.
 .. flow::
    :loop: the next request is served by the new version
 
-   Serve :: forward the request, keep the exchange
-   Record :: which version of the weights or harness produced this request + response
-   Learn* :: a recipe — the learning method the deployment runs — releases a candidate learned version
-   Publish :: an accepted candidate becomes the version being served
+   Serve :: forward the request and keep the exchange
+   Record :: store the artifact version that produced the response
+   Learn* :: the recipe uses records to create a candidate version
+   Publish :: an accepted candidate becomes the current version
 
 Existing inference engines and RL frameworks cover parts of that loop, but not
 the whole thing:

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -5,15 +5,15 @@ Reef adds four things to an ordinary inference endpoint: a scenario, a receipt,
 a report, and a version chain.
 
 Two more terms matter once you want it to learn: the **recipe** and the
-**artifact**, highlighted below.
+**artifact**, shown below.
 
 .. flow::
 
-   Request :: served under a scenario; the recorded exchange returns a receipt
+   Request :: serve under a scenario and return a receipt
    Report :: feedback that quotes receipts
    Recipe* :: the method that turns reports into the next artifact
-   Artifact* :: what gets versioned: weights, or a harness tree
-   Version chain :: the history of artifacts it served
+   Artifact* :: what gets versioned: weights or a harness tree
+   Version chain :: the history of served artifacts
 
 Run the loop
 ------------
@@ -191,7 +191,7 @@ served it.
 
    v0 :: the starting artifact
    v1 :: first accepted update
-   v2* :: current — what requests are served by now
+   v2* :: current version serving requests
 
 Durable versions are Git-backed and can be pinned or rolled back. Between
 checkpoints, weight versions live in engine memory; their bytes are not
@@ -211,10 +211,10 @@ and whether a candidate is good enough to publish. `Write a recipe
 
 .. flow::
 
-   Records :: everything the scenario served and was told
-   Batch :: what the recipe judged eligible
-   Candidate :: an unpublished new artifact
-   Version :: published, and serving
+   Records :: requests, responses, and reports for the scenario
+   Batch :: eligible records selected by the recipe
+   Candidate :: a new unpublished artifact
+   Version :: the published artifact now serving
 
 Pick a bundled recipe from `Choosing a recipe <../user-guide/recipes.rst>`__, or write one in
 `Write a recipe <../developer-guide/write-a-recipe.rst>`__.

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -250,19 +250,19 @@ Reported feedback
 .. code:: mermaid
 
    sequenceDiagram
-       accTitle: How the reported-feedback processor turns records into a typed batch
+       accTitle: How reported feedback becomes a typed batch
        participant Reef as Reported-feedback processor
        participant Method as Method processor
        Reef->>Method: judge(ReportContext)
        alt referenced inference is missing
-           Method-->>Reef: WAIT — park this report
+           Method-->>Reef: WAIT: park this report
        else report can never train
-           Method-->>Reef: NEVER — release this report
+           Method-->>Reef: NEVER: release this report
        else report is accepted
            Method-->>Reef: ReportDecision.train(value, ...)
            opt group_key supplied
                Reef->>Method: decide_group(key, candidates)
-               Method-->>Reef: GroupDecision<br/>INCOMPLETE · READY · DISCARD
+               Method-->>Reef: GroupDecision<br/>INCOMPLETE / READY / DISCARD
            end
            Reef->>Method: make_batch(ready units, batch_number)
        end

--- a/docs/rfcs/continual-opd.rst
+++ b/docs/rfcs/continual-opd.rst
@@ -76,7 +76,7 @@ Continual OPD on Reef: framework
 |                 |                |                       | plumbing          |
 +-----------------+----------------+-----------------------+-------------------+
 | L1 same-vocab   | Large Qwen →   | Teacher scores the    | **Backend         |
-| OPD             | small Qwen     | student's own sampled | shipped** — the   |
+| OPD             | small Qwen     | student's own sampled | shipped**: the   |
 |                 |                | tokens per-token;     | ``opd`` loss      |
 |                 |                | reverse-KL signal     | family            |
 |                 |                |                       | (slime-bridge     |
@@ -138,7 +138,7 @@ no slime-core changes and leaves the client contract unchanged.
 | E0 | Three baselines: student-only, | How big the gap is and whether |
 |    | **each teacher's pure-run      | it's worth pursuing; the       |
 |    | ceiling** (large Qwen,         | teacher-only lines are the     |
-|    | GLM/Kimi — one line each),     | ceiling denominator for every  |
+|    | GLM/Kimi (one line each),     | ceiling denominator for every  |
 |    | oracle-router                  | later experiment and the cost  |
 |    |                                | reference for "just use the    |
 |    |                                | big model"                     |

--- a/docs/rfcs/evolution-boundary.rst
+++ b/docs/rfcs/evolution-boundary.rst
@@ -87,17 +87,17 @@ on the same version chain:
 +----------------------+--------------------------+----------------------+
 | Policy               | Examples                 | Safety net           |
 +======================+==========================+======================+
-| Ungated continual —  | ``openclawrl`` · ``sao`` | version chain +      |
-| publish every batch  | (weights); ACE-style     | rollback + receipts  |
+| Ungated continual:   | ``openclawrl``, ``sao``  | version chain,       |
+| publish every batch  | (weights); ACE-style     | rollback, receipts   |
 |                      | playbook merges          |                      |
 |                      | (artifacts, §5)          |                      |
 +----------------------+--------------------------+----------------------+
 | Compare with current | ``HarnessEvolveBackend`` | the decision, then   |
-| — select when wins   |                          | the version chain    |
+| select when wins     |                          | the version chain    |
 | exceed losses        |                          |                      |
 +----------------------+--------------------------+----------------------+
 | Population / Pareto  | GEPA-style prompt        | the frontier, then   |
-| — keep a candidate   | evolution (§5)           | the version chain    |
+| keep a candidate     | evolution (§5)           | the version chain    |
 | frontier             |                          |                      |
 +----------------------+--------------------------+----------------------+
 
@@ -131,10 +131,10 @@ decides whether to gate those publishes.
 | a GEPA prompt  | served artifact | Pareto         | Reef backend   |
 | candidate      |                 | frontier       | (§5.2)         |
 +----------------+-----------------+----------------+----------------+
-| a PUCT archive | run state       | — (algorithm   | harness        |
-| update         |                 | bookkeeping)   |                |
+| a PUCT archive | run state       | algorithm      | harness        |
+| update         |                 | bookkeeping    |                |
 +----------------+-----------------+----------------+----------------+
-| one run's      | run state       | —              | harness        |
+| one run's      | run state       | not applicable | harness        |
 | working memory |                 |                |                |
 +----------------+-----------------+----------------+----------------+
 

--- a/docs/rfcs/reef-router.rst
+++ b/docs/rfcs/reef-router.rst
@@ -96,9 +96,9 @@ it.
    flowchart LR
        C[Client] --> G[Gateway authentication]
        G --> S{Bound scenario}
-       subgraph SR[One Semantic Router process]
-         RA[entrypoint A → SR recipe A]
-         RB[entrypoint B → SR recipe B]
+       subgraph SR[Shared Semantic Router process]
+         RA[Scenario A entrypoint and router recipe]
+         RB[Scenario B entrypoint and router recipe]
        end
        S -->|tenant A| RA
        S -->|tenant B| RB
@@ -132,13 +132,13 @@ Architecture
 
    flowchart LR
        C[Client] --> E[Envoy tenant route]
-       E <-->|ext_proc gRPC| SR[Scenario entrypoint + SR recipe]
-       SR -->|selected role + resolved model + routing version| E
+       E <-->|ext_proc gRPC| SR[Scenario entrypoint and router recipe]
+       SR -->|selected role, resolved model, and routing version| E
        E --> R[Reef routed ingress]
        R -->|validated provider model| G[Provider gateway]
        G --> W[Ready worker]
        W --> R
-       R -->|validated response + AgentRecord| C
+       R -->|persist AgentRecord, then return response| C
 
 .. list-table::
    :header-rows: 1
@@ -200,11 +200,11 @@ closed.
 .. code:: mermaid
 
    flowchart LR
-       T[Authenticated tenant] --> S[Scenario tenant-a]
-       S --> R[Router config for tenant-a]
+       T[Authenticated tenant] --> S[Scenario: tenant-a]
+       S --> R[Router configuration for tenant-a]
        Q[Request] --> R
-       R --> M[Selected alias tenant-a/student]
-       M --> P[Resolved model tenant-a/student-v7]
+       R --> M[Selected alias: tenant-a/student]
+       M --> P[Resolved model: tenant-a/student-v7]
        P --> A[Validate snapshot and admit]
 
 The resolved model must already be ready at the provider gateway. Reef never
@@ -260,16 +260,16 @@ itself; Replay lookup is scoped by scenario and routing version.
        participant R as Reef scenario
        participant B as Backend
 
-       C->>G: inference request + tenant credential
+       C->>G: inference request and tenant credential
        G->>G: authenticate; bind scenario
        G->>SR: request in scenario namespace
-       SR-->>G: qualified role alias + body model + version + replay ID
-       G->>R: fixed scenario + routed request
+       SR-->>G: role alias, body model, version, and replay ID
+       G->>R: fixed scenario and routed request
        R->>R: validate alias, body model, and snapshot
        R->>R: retain routed target; acquire serving state
        R->>B: unchanged resolved-model request
-       Note over R,B: pause/update may resume this same request
-       B-->>R: response + serving identity
+       Note over R,B: A pause or update may resume this request
+       B-->>R: response and serving identity
        R->>R: validate and append AgentRecord
        R-->>C: response through gateway
 
@@ -493,7 +493,7 @@ roles inside one tenant-bound scenario.
        V -->|yes| O[Return student answer]
        V -->|no| T[Escalate to teacher role]
        T --> O2[Return teacher answer]
-       T -. distill .-> S2[Next student version]
+       T -. distill teacher output .-> S2[Next student version]
 
 Both roles, their resolved models, and every resulting record stay in one
 scenario. The target is teacher-comparable task quality at lower average
@@ -699,7 +699,7 @@ Testing
        ID, or fallback are rejected.
    * - GPU smoke
      - Route between two roles bound to ready models in one scenario while a
-       second scenario remains isolated. #435 additionally reproduces
+       second scenario remains isolated. #435 also reproduces
        ``recipes/<method>/examples/opd_router/``.
 
 The RFC itself requires no GPU.

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -59,10 +59,10 @@ The loop
 .. flow::
    :loop: publish the winner, or restore the snapshot
 
-   Batch :: scored reports the score window kept
+   Batch :: scored reports retained by the score window
    ``propose`` :: one mutation, or ``None``
-   Episodes* :: candidate vs current, on your tasks
-   Verdict :: publish a new version, or revert
+   Episodes* :: run the candidate and current tree on the same tasks
+   Verdict :: publish the candidate or restore the snapshot
 
 No evolution runs while traffic flows. A report whose score is at or below
 ``max_score`` enters the *window*; the default for harness evolution keeps

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -4,16 +4,16 @@ Choosing a recipe
 A recipe is picked along two axes: **what it evolves**, and **how it learns**.
 
 +-------------------------+--------------------------------------------------+------------------------------------------+
-|                         | **Reactive** — learns from the traffic           | **Proactive** — generates its own        |
+|                         | **Reactive:** learns from the traffic            | **Proactive:** generates its own         |
 |                         | it already serves                                | attempts                                 |
 +=========================+==================================================+==========================================+
-| **Model weights**       | ``sao`` — feedback on each attempt over a stream | ``tttd`` — repeated attempts at one      |
+| **Model weights**       | ``sao``: feedback on each attempt over a stream  | ``tttd``: repeated attempts at one       |
 |                         | of tasks                                         | problem, at test time                    |
 |                         |                                                  |                                          |
-|                         | ``openclawrl`` — multi-turn traffic,             |                                          |
+|                         | ``openclawrl``: multi-turn traffic,              |                                          |
 |                         | reward read from the next state                  |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+
-| **Harness** — prompts,  | ``harness_evolve`` — proposes edits from         | —                                        |
+| **Harness:** prompts,   | ``harness_evolve``: proposes edits from          | not available                            |
 | rules, skills, config   | the failures in its own served traffic           |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+
 
@@ -28,13 +28,12 @@ Pick by the signal your workload can produce.
 | A fixed grid of sibling attempts at one       | `tttd <recipes/tttd.rst>`__                     | model weights | yes        |
 | problem                                       |                                                 |               |            |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
-| Nothing on the wire — just agent              | `openclawrl <recipes/openclawrl.rst>`__         | model weights | yes        |
-| conversations                                 |                                                 |               |            |
+| Agent conversations without reports           | `openclawrl <recipes/openclawrl.rst>`__         | model weights | yes        |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 | Feedback on individual requests, and failures | `harness_evolve <recipes/harness-evolve.rst>`__ | harness tree  | no         |
 | worth learning from                           |                                                 |               |            |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
-| None yet — you only want the records          | ``recipe``, the base kind                       | nothing       | no         |
+| No feedback yet; record only                  | ``recipe``, the base kind                       | nothing       | no         |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 
 How a recipe is selected

--- a/docs/user-guide/recipes/harness-evolve.rst
+++ b/docs/user-guide/recipes/harness-evolve.rst
@@ -9,7 +9,7 @@ publishes the edit only if it wins.
 runnable example.
 
 +-------------+------------------------------------------------------------+
-| Evolves     | the harness tree — config, rules, prompts, skills,         |
+| Evolves     | the harness tree: config, rules, prompts, skills,          |
 |             | extensions                                                 |
 +-------------+------------------------------------------------------------+
 | Signal      | one report with a finite ``score`` and exactly one         |
@@ -17,7 +17,7 @@ runnable example.
 +-------------+------------------------------------------------------------+
 | Package     | ``recipes/harness_evolve/``                                |
 +-------------+------------------------------------------------------------+
-| Loss family | — (no weight training)                                     |
+| Loss family | none (no weight training)                                  |
 +-------------+------------------------------------------------------------+
 | Processor   | reported feedback, producing a ``TraceBatch``              |
 +-------------+------------------------------------------------------------+

--- a/docs/user-guide/recipes/openclawrl.rst
+++ b/docs/user-guide/recipes/openclawrl.rst
@@ -34,10 +34,10 @@ set session headers, or run behind a proxy.
 .. flow::
    :loop: the next session is served by the updated weights
 
-   Traffic :: recorded requests and responses
-   Sessions :: rebuilt by trace matching
-   Judge* :: each turn scored by the state that followed it
-   Step :: judged turns train the policy
+   Traffic :: requests and responses recorded by Reef
+   Sessions :: sessions rebuilt by matching traces
+   Judge* :: score each turn from the state that followed it
+   Step :: train the policy on judged turns
 
 How Reef implements it
 ----------------------

--- a/docs/user-guide/recipes/sao.rst
+++ b/docs/user-guide/recipes/sao.rst
@@ -28,10 +28,10 @@ a rollout enters training the moment its feedback arrives.
 
 .. flow::
 
-   Rollout :: one attempt at one task
-   Feedback :: reported against its receipt
-   Step* :: immediately, on its own
-   Version :: the next task is served by the updated weights
+   Rollout :: one attempt at a task
+   Feedback :: a report that refers to the receipt
+   Step* :: train immediately on that rollout
+   Version :: updated weights serve the next task
 
 How Reef implements it
 ----------------------


### PR DESCRIPTION
## Motivation

Follow-up to #53. The first prose pass intentionally preserved structured content, leaving Mermaid labels, custom flow diagrams, HTML diagram captions, and table cells with the same formulaic punctuation and compressed phrasing.

## Changes

- Rewrote labels in Mermaid, custom flow, and HTML diagrams using direct technical language.
- Replaced dash-heavy and symbol-joined phrases with plain sentence structure.
- Changed all-caps phase labels to sentence case where they were ordinary prose.
- Replaced ambiguous table dash placeholders with explicit values such as none and not applicable.
- Preserved graph topology, request flow, routing rules, version constraints, code behavior, and link targets.

## Compatibility and operational impact

None. This pull request changes documentation only.

## Verification

- npm run check:docs: passed; validated 109 Markdown files, 35 RST files, internal routes, port 8900, and 14 Reef routes.
- npm run build: passed; production documentation site built and generated all static pages.
- git diff --check: passed.
- Humanizer watch scans found no remaining em/en dashes or watched stock phrases in RST documentation.

## AI assistance

OpenAI Codex reviewed and rewrote the structured documentation text. The blader/humanizer v2.11.2 guidance supplied the style checks. The final diff and verification results were reviewed before submission.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the maintenance model for review and merge requirements.