### PR TITLE
refactor: decouple Reef from cookbook recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,10 @@ jobs:
       # import the slime package (the wheel does not bundle it) or Slime's
       # optional dependencies.
       - run: python -m pip install pytest
+      # Exercise the repository cookbook as an external consumer of the
+      # installed Reef wheel. Linking only recipes/ keeps the source reef/
+      # package off sys.path, so it cannot shadow the wheel under test.
+      - run: ln -s "${{ github.workspace }}/recipes" "${{ runner.temp }}/recipes"
       - run: >
           python -m pytest ${{ github.workspace }}/tests/reef_service
           --ignore=${{ github.workspace }}/tests/reef_service/test_slime_bridge.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,20 +201,24 @@ jobs:
           assert expected_backend_files <= installed_files
           PY
       # Run outside the repo so `import reef` resolves to the installed wheel,
-      # not the source tree. Proves the wheel is complete: modules import,
-      # bundled recipes register, no named configs ship, entrypoint answers.
+      # not the source tree. Proves the wheel is complete: core modules import,
+      # cookbook methods and named configs do not ship, entrypoint answers.
       - run: |
           python -c "
           import importlib.util, pathlib
           import reef, reef.service.deploy
           import reef_client
           import reef.recipe as rp
-          from reef.recipe.registry import recipe_kinds
+          from reef.recipe import Recipe
+          from reef.recipe.registry import recipe_class_for
           assert importlib.util.find_spec('reef.train.slime_backend') is not None
-          assert recipe_kinds(), 'no bundled recipes registered'
+          assert importlib.util.find_spec('recipes') is None
+          assert not hasattr(rp, 'register_kind')
+          assert recipe_class_for('recipe') is Recipe
+          assert recipe_class_for('sao') is None
           leftover = sorted(p.name for p in (pathlib.Path(rp.__file__).parent / 'configs').glob('*.yaml'))
           assert not leftover, f'named recipe configs are deployment data and must not ship: {leftover}'
-          print('recipe kinds:', recipe_kinds())
+          print('core recipe:', recipe_class_for('recipe'))
           "
           reef --help
         working-directory: ${{ runner.temp }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Use the structured template that matches the work:
 - **Example** for a runnable user-facing recipe or reference deployment with a
   documented setup and expected result.
 - **RFC proposal** when the change may affect public interfaces,
-  persistence, trust boundaries, topology, bundled recipes, training
+  persistence, trust boundaries, topology, recipe extension contracts, training
   backends, or project-wide policy.
 - **Maintainer task** for scoped implementation, refactoring, cleanup, or
   project work that a maintainer has created or approved.
@@ -93,7 +93,7 @@ invitation to submit competing pull requests without coordination.
 Write an RFC before implementing a change that:
 
 - adds a new top-level package under `reef`;
-- adds a bundled recipe, learning method, or training backend;
+- adds a shared training backend or changes the recipe extension contract;
 - makes a significant or backwards-incompatible public interface change;
 - changes a persisted format, wire contract, trust boundary, or service
   topology; or

--- a/README.md
+++ b/README.md
@@ -189,10 +189,12 @@ the next time it starts. The [harness evolution guide](https://reefinfra.ai/docs
 describes the proposal, evaluation, and publication process.
 
 
-## Bundled recipes
+## Cookbook recipes
 
 Choose a recipe based on the feedback available from the workload and the
-artifact that should be updated.
+artifact that should be updated. These implementations live in this
+repository's `recipes/` cookbook; they are selected by dotted class reference
+and do not ship in the Reef wheel.
 
 | Workload | Method and recipe | Updated artifact | Documentation |
 |---|---|---|---|
@@ -225,7 +227,7 @@ The [documentation](https://reefinfra.ai/docs/) is organized in the following or
 - [Evolve your harness](https://reefinfra.ai/docs/user-guide/evolve-your-harness/): evolve a harness instead of model weights
 - [Evolve your model](https://reefinfra.ai/docs/user-guide/evolve-your-model/): configure and operate a training deployment
 - [Recipes](https://reefinfra.ai/docs/user-guide/recipes/): additional references on
-  the recipes already implemented in the official Reef installation
+  the cookbook implementations in this repository
 - [Architecture](https://reefinfra.ai/docs/getting-started/architecture/): Overall architecture of Reef
 - [Glossary](https://reefinfra.ai/docs/reference/glossary/): Explanation of the terminologies used
 

--- a/docs/contributing/adding-components.rst
+++ b/docs/contributing/adding-components.rst
@@ -40,8 +40,7 @@ Implementation
   construction belongs to the concrete integration.
 - A method with its own tensor objective adds a loss family in
   ``<method-package>/slime/`` (spec in ``__init__.py``, hooks in
-  ``objective.py``) and names it for the training driver through
-  ``REEF_TRAINING_LOSS`` as a dotted reference;
+  ``objective.py``) and names it in the recipe's ``training_spec()``;
   the `Loss families
   <../developer-guide/loss-families.rst>`__ lists what a family declares.
 - Override ``build_surface`` only when the produced artifact needs delivery

--- a/docs/contributing/adding-components.rst
+++ b/docs/contributing/adding-components.rst
@@ -4,11 +4,12 @@ Adding components
 First use the `Codebase structure <codebase-structure.rst>`__ to choose the
 owner, then use the matching playbook below.
 
-Bundled and external extensions
--------------------------------
+Core and external extensions
+----------------------------
 
-Prefer a dotted recipe or runtime reference while experimenting. Bundling a
-recipe, learning method, or training backend starts with an `RFC issue
+Recipes and learning methods are external packages selected by dotted
+reference; Reef does not bundle or register them. Changes to shared runtime or
+training machinery start with an `RFC issue
 <https://github.com/Human-Agent-Society/reef/issues/new?template=rfc.yml>`__.
 A new top-level package, persisted format, wire contract, or incompatible
 public API also requires an RFC.
@@ -23,26 +24,25 @@ runtime execution, and artifact delivery. Read `Write a recipe
 Implementation
 ~~~~~~~~~~~~~~
 
-- Keep an experiment recipe with its experiment and configure its kind as
-  ``package.module:ClassName``.
-- For an accepted bundled method, add the package ``reef/<name>/``:
-  ``recipe.py`` holds the frozen recipe dataclass decorated with
-  ``@register_kind("<name>")``, and the package's ``__init__`` is imported
-  from ``reef/__init__.py`` so registration happens at boot. The contract it implements is ``reef/recipe/``.
+- Keep a recipe with its method package and select its frozen recipe dataclass
+  as ``package.module:ClassName``. There is no ``register_kind`` step and no
+  import from ``reef/__init__.py``. The contract it implements is
+  ``reef/recipe/``.
 - Declare recipe-owned settings with ``config_field``. Do not parse those
   settings again in ``reef/service/``.
 - Put the method's record-to-batch behavior in
-  ``reef/<name>/processor.py``, subclassing a processor contract
+  ``<method-package>/processor.py``, subclassing a processor contract
   from ``reef/train/processors/``; extend those contracts only when they do
   not already express it.
 - Put the method's backend-neutral step preparer in
-  ``reef/<name>/preparer.py`` (``reef/train/algos/`` holds the
+  ``<method-package>/preparer.py`` (``reef/train/algos/`` holds the
   contract). Backend-specific payload
   construction belongs to the concrete integration.
 - A method with its own tensor objective adds a loss family in
-  ``reef/<name>/slime/`` (spec in ``__init__.py``, hooks in
-  ``objective.py``) and imports it from
-  ``reef/train/slime_backend/loss_families.py``; the `Loss families
+  ``<method-package>/slime/`` (spec in ``__init__.py``, hooks in
+  ``objective.py``) and names it for the training driver through
+  ``REEF_TRAINING_LOSS`` as a dotted reference;
+  the `Loss families
   <../developer-guide/loss-families.rst>`__ lists what a family declares.
 - Override ``build_surface`` only when the produced artifact needs delivery
   behavior beyond the existing surfaces.
@@ -50,7 +50,7 @@ Implementation
 Surrounding changes
 ~~~~~~~~~~~~~~~~~~~
 
-- Add registry and configuration tests in
+- Add dotted-resolution and configuration tests in
   ``tests/reef_service/test_reef_recipes.py`` and
   ``tests/reef_service/test_recipe_config_fields.py``.
 - Add method behavior tests under ``tests/reef_service/``. Add an integration
@@ -58,8 +58,8 @@ Surrounding changes
 - Put every runnable configuration beside its method under
   ``recipes/<name>/examples/``; only a stack that binds no method belongs in
   ``recipes/basic/``.
-- Add ``docs/user-guide/recipes/<name>.rst`` and update the public README recipe table when the
-  method is bundled. Update the relevant processor, preparer, or surface
+- Add ``docs/user-guide/recipes/<name>.rst`` and update the public README recipe
+  table when the cookbook carries the method. Update the relevant processor, preparer, or surface
   reference if its public contract changes.
 
 Add a training integration

--- a/docs/contributing/codebase-structure.rst
+++ b/docs/contributing/codebase-structure.rst
@@ -7,8 +7,8 @@ This page says which package should own a change.
 Choose a destination
 --------------------
 
-``reef/`` holds every shared mechanism. Each bundled method lives in one
-package under ``recipes/`` (``sao``, ``tttd``, ``openclawrl``, or
+``reef/`` holds every shared mechanism. Cookbook methods live in separate
+packages under ``recipes/`` (``sao``, ``tttd``, ``openclawrl``, or
 ``harness_evolve``) with that method's recipe, processor, step
 preparer, and, for weight methods, the ``slime/`` subpackage only the training
 plane imports. Nothing under ``reef/`` imports a method package.
@@ -66,8 +66,8 @@ import a concrete integration.
 | ``reef/scenario/``   | scenario binding, commit ordering,                       | training algorithms, repository            |
 |                      | recovery, checkpoint policy                              | implementations                            |
 +----------------------+----------------------------------------------------------+--------------------------------------------+
-| ``reef/recipe/``     | the contract a method implements, and                    | any particular method                      |
-|                      | kind registration                                        |                                            |
+| ``reef/recipe/``     | the contract a method implements, dotted                 | any particular method                      |
+|                      | class resolution, and runtime instance binding           |                                            |
 +----------------------+----------------------------------------------------------+--------------------------------------------+
 | ``reef/train/``      | the trainer loop, processor engines, batch               | HTTP endpoints, deployment                 |
 |                      | types, backend integrations                              | configuration parsing                      |
@@ -145,7 +145,7 @@ two packages that need more than a docstring are `Surfaces
 <../developer-guide/processors.rst>`__; the extension points every package
 exposes are in `Python API <../reference/python-api.rst>`__, and the public
 harness wire contract is `HTTP API <../reference/http-api.rst>`__. The
-`top-level README <../../README.md>`__ shows how the bundled methods sit
+`top-level README <../../README.md>`__ shows how the cookbook methods sit
 beside ``reef/``.
 
 Adding a new subpackage under ``reef/`` or a new method under ``recipes/``

--- a/docs/developer-guide/loss-families.rst
+++ b/docs/developer-guide/loss-families.rst
@@ -28,11 +28,11 @@ Layout
      utils/          driver-side helpers, only when the wire row is custom
 
 A package ``__init__`` registers its family by reference
-(``register_loss_family_ref("<name>", "reef.<name>.slime:<Pkg>Algorithm")``);
+(``register_loss_family_ref("<name>", "my_pkg.slime:MyAlgorithm")``);
 ``loss_families.py`` imports the reference on first resolve so
 ``@register_loss_family`` runs at boot. An external family decorates its class
-the same way and is named as ``package.module:ClassName`` wherever a family is
-named (``REEF_TRAINING_LOSS``, a recipe's ``loss_family``). Resolving the
+the same way. The recipe names it in ``training_spec().loss_family``; the
+driver reads that binding after importing the configured recipe class. Resolving the
 reference imports the module, which registers the family; the driver also keeps
 the reference on ``args.loss_family_ref`` so each Megatron worker, whose
 registry starts empty, can import it too.

--- a/docs/developer-guide/processors.rst
+++ b/docs/developer-guide/processors.rst
@@ -130,8 +130,8 @@ serving; delete one and a documented failure returns. The list, naming the
 attribute each requirement forces, is in the module docstrings of
 ``reported.py`` and ``computed.py``.
 
-The bundled processors
-----------------------
+Cookbook processors
+-------------------
 
 +---------------------------------------+----------+------------------------------------------------------------------+------------------------+
 | File                                  | Tier     | What its ``judge`` accepts                                       | Batch                  |
@@ -140,8 +140,8 @@ The bundled processors
 |                                       |          | inference whose assembled sample passes the action-mask check;   |                        |
 |                                       |          | one rollout, one unit                                            |                        |
 +---------------------------------------+----------+------------------------------------------------------------------+------------------------+
-| ``recipes/tttd/processor.py``         | reported | a report parsing as ``GroupedRolloutReport`` on this scenario's  | ``GroupedPolicyBatch`` |
-|                                       |          | grid; the step is the group, ready only when every               |                        |
+| ``recipes/tttd/processor.py``         | reported | a report parsing as ``TTTDGroupedRolloutReport`` on this         | ``GroupedPolicyBatch`` |
+|                                       |          | scenario's grid; the step is the group, ready only when every    |                        |
 |                                       |          | ``groups_per_step`` × ``rollouts_per_group`` slot is filled      |                        |
 +---------------------------------------+----------+------------------------------------------------------------------+------------------------+
 | ``recipes/harness_evolve/processor.py``| reported | a trainable, finitely scored report with exactly one reference   | ``TraceBatch``         |

--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -92,7 +92,7 @@ The recipe config names the callables, the tasks, and the first-boot tree:
 
 .. code:: yaml
 
-   kind: harness_evolve
+   implementation: my_pkg.harness_evolve:HarnessEvolveRecipe
 
    model:
      path: qwen3-8b

--- a/docs/developer-guide/write-a-recipe.rst
+++ b/docs/developer-guide/write-a-recipe.rst
@@ -103,21 +103,15 @@ Copy a weight-training config as described in `Evolve your model
      recipe: "my_pkg.my_method:MyMethodRecipe"
      batch_size: 4
 
-   services:
-     - name: slime-driver
-       # ...command, readiness, and other environment settings...
-       env:
-         REEF_TRAINING_RECIPE: ${reef.recipe}  # label only
-         REEF_TRAINING_LOSS: my_pkg.my_method.loss:MyLossAlgorithm
-
 This fragment shows only the new keys; keep the model, storage, runtime, and
 ``services`` settings from the config you copied. Set
 ``training.global_batch_size`` to the same value, and add the driver flags your
 loss family requires (`the mapping
 <loss-families.rst#family-to-driver-flags>`__).
-``REEF_TRAINING_LOSS`` is required: use a dotted reference so the driver and
-fresh workers import your loss implementation explicitly. Reference the recipe
-class directly; Reef has no global implementation registry.
+The driver reads the same ``reef.recipe`` value from the deployment config and
+gets the loss family from the class's ``training_spec()``. Do not repeat either
+value in the driver environment. Reef has no global recipe-implementation
+registry.
 
 .. code:: bash
 

--- a/docs/developer-guide/write-a-recipe.rst
+++ b/docs/developer-guide/write-a-recipe.rst
@@ -80,7 +80,7 @@ A weight recipe is four pieces plus the class that binds them.
    recipe class | a frozen dataclass whose ``training_spec()`` names the processor, the preparer (by dotted path), and the loss family
 
 `Python API <../reference/python-api.rst>`__ is the contract for each.
-``recipes/sao/`` is the smallest bundled implementation and the one to read
+``recipes/sao/`` is the smallest cookbook implementation and the one to read
 alongside this page. Its four files total fewer than 200 lines: ``recipe.py``,
 ``processor.py``, ``preparer.py``, and the ``slime/`` loss family.
 
@@ -103,11 +103,21 @@ Copy a weight-training config as described in `Evolve your model
      recipe: "my_pkg.my_method:MyMethodRecipe"
      batch_size: 4
 
+   services:
+     - name: slime-driver
+       # ...command, readiness, and other environment settings...
+       env:
+         REEF_TRAINING_RECIPE: ${reef.recipe}  # label only
+         REEF_TRAINING_LOSS: my_pkg.my_method.loss:MyLossAlgorithm
+
 This fragment shows only the new keys; keep the model, storage, runtime, and
 ``services`` settings from the config you copied. Set
 ``training.global_batch_size`` to the same value, and add the driver flags your
 loss family requires (`the mapping
 <loss-families.rst#family-to-driver-flags>`__).
+``REEF_TRAINING_LOSS`` is required: use a dotted reference so the driver and
+fresh workers import your loss implementation explicitly. Reference the recipe
+class directly; Reef has no global implementation registry.
 
 .. code:: bash
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -13,7 +13,8 @@ Enough to serve, record, report, and evolve a harness against a hosted model.
    git lfs install
 
 ``git lfs`` is required: Reef keeps version history in Git, with weight files
-under LFS. This install runs the base ``recipe`` kind and ``harness_evolve``.
+under LFS. The checkout includes the core ``recipe`` example and the
+``harness_evolve`` cookbook method.
 
 Client only
 -----------

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -127,11 +127,12 @@ with no GPU.
          # {"scenario": "hello-reef", "versions": [{"artifact_version": "...", "step": 0, ...}]}
 
       One version, and it will stay at one: this deployment's recipe is the
-      base ``recipe`` kind, which records and trains nothing.
+      core ``recipe``, which records and trains nothing.
 
 To make the chain advance, bind a recipe that learns. To use a weight recipe,
-copy ``recipes/basic/external-provider.yaml``, set ``reef.recipe: sao``, and
-serve the new config. Weight recipes need GPUs (`Evolve your model
+copy ``recipes/basic/external-provider.yaml``, set
+``reef.recipe: recipes.sao.recipe:SAORecipe``, and serve the new config.
+Weight recipes need GPUs (`Evolve your model
 <../user-guide/evolve-your-model.rst>`__).
 
 The one that runs on a laptop is ``harness_evolve``, and it takes a second file:
@@ -216,5 +217,5 @@ and whether a candidate is good enough to publish. `Write a recipe
    Candidate :: a new unpublished artifact
    Version :: the published artifact now serving
 
-Pick a bundled recipe from `Choosing a recipe <../user-guide/recipes.rst>`__, or write one in
+Pick a cookbook recipe from `Choosing a recipe <../user-guide/recipes.rst>`__, or write one in
 `Write a recipe <../developer-guide/write-a-recipe.rst>`__.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -26,12 +26,12 @@ a bare ``--model_path /models/demo`` targets the ``reef`` section, and a dotted
 ``--training.checkpoint_dir /tmp/ckpt`` targets any other. Each process writes a
 log under ``/tmp/reef-stack/``; set ``run_dir`` to move it.
 
-Start from a bundled stack
---------------------------
+Start from a cookbook stack
+---------------------------
 
-Every runnable stack lives under ``recipes/``: the learn-nothing ones on the
-base ``recipe`` kind in ``recipes/basic/``, and each method's with its
-examples.
+The source checkout's runnable stacks live under the ``recipes/`` cookbook:
+the learn-nothing ones use the core ``recipe`` implementation in
+``recipes/basic/``, and each method owns its examples.
 
 +-------------------------------------------------------------+----------------------------------------------------------+
 | File                                                        | What it starts                                           |
@@ -70,7 +70,7 @@ The ``reef`` section
    reef.allow_implicit_scenario_creation | true | when false, an unknown scenario is HTTP 404
    reef.checkpoint_every_n_versions | 1 | how often a version becomes durable
 
-Storage paths default under ``.reef/``, but every bundled stack overrides them
+Storage paths default under ``.reef/``, but every cookbook stack overrides them
 to ``/var/lib/reef``. Point them somewhere persistent.
 
 .. config::
@@ -93,23 +93,26 @@ the service does not recognize are handed to the recipe.
 Recipe configuration
 --------------------
 
-A recipe is named three ways:
+A recipe is selected three ways:
 
-- **A bundled kind:** ``recipe: sao``
+- **The core record-only recipe:** ``recipe: recipe``
 - **A dotted class:** ``recipe: "my_pkg.my_method:MyMethodRecipe"``
 - **A named preset:** ``recipe: my-preset``, resolved to ``my-preset.yaml``
   under ``REEF_RECIPE_CONFIG_DIR``
+
+There is no recipe-implementation registry. A bare name other than ``recipe``
+is always a preset name; it never imports a learning method implicitly.
 
 ``REEF_RECIPE_CONFIG_DIR`` is the directory preset YAML is read from, and it has
 **no default**: a bare recipe name resolves to a preset only when it is set.
 
 A preset is read as-is. ``${VAR}`` interpolates in a deployment config, never
-in a preset. A preset carries its own ``kind``, ``model``, and ``data``
+in a preset. A preset carries its own ``implementation``, ``model``, and ``data``
 sections. Harness-evolution presets also carry an ``evolution`` section:
 
 .. code:: yaml
 
-   kind: harness_evolve
+   implementation: my_pkg.harness_evolve:HarnessEvolveRecipe
    model:
      path: qwen3-8b
    data:
@@ -121,9 +124,12 @@ sections. Harness-evolution presets also carry an ``evolution`` section:
      evaluate: methods.mine:evaluate
      tasks: ["..."]
 
-Weight recipes accept their fields as flat ``reef.<name>`` keys *or* as
-``data.<name>`` in a preset. Other kinds are configured only by a preset, where
-``data`` holds the batching fields and a kind-specific section holds the rest.
+The preset's ``implementation`` is ``recipe`` or a dotted recipe class. Weight-training
+recipes are selected directly by dotted class in the deployment config, so the
+service can assemble their Ray training runtime; their fields are flat
+``reef.<name>`` keys. Presets suit recipes whose runtime can be built from the
+preset or the deployment's upstream proxy. There, ``data`` holds batching
+fields and a recipe-specific section holds the rest.
 
 The ``services`` list
 ---------------------

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -46,16 +46,16 @@ Recipe
 ------
 
 The method a deployment runs. It binds a processor, a step preparer, a loss
-family, a runtime, and a surface. The base ``recipe`` kind records without
+family, a runtime, and a surface. The core ``recipe`` records without
 producing updates.
 
-Recipe kind
------------
+Recipe reference
+----------------
 
-The name Reef resolves from ``reef.recipe``. Bundled recipes register theirs
-with ``register_kind()``; a dotted ``package.module:ClassName`` selects a class
-Reef does not bundle, and a bare name may also resolve to a YAML preset under
-``REEF_RECIPE_CONFIG_DIR``.
+What ``reef.recipe`` selects. ``recipe`` is the core record-only implementation;
+a dotted ``package.module:ClassName`` selects an installed method class; any
+other bare name resolves only to a YAML preset under
+``REEF_RECIPE_CONFIG_DIR``. Reef has no global recipe-implementation registry.
 
 Artifact
 --------
@@ -145,7 +145,7 @@ SAO
 ---
 
 Single-Rollout Asynchronous Optimization (`arXiv:2607.07508
-<https://arxiv.org/abs/2607.07508>`__), the bundled `sao <../user-guide/recipes/sao.rst>`__
+<https://arxiv.org/abs/2607.07508>`__), the cookbook `sao <../user-guide/recipes/sao.rst>`__
 recipe. One graded rollout drives one training step, with no comparison group
 and no slowest-sample barrier.
 
@@ -153,14 +153,14 @@ TTT-Discover
 ------------
 
 Test-time-training discover (`arXiv:2601.16175
-<https://arxiv.org/abs/2601.16175>`__), the bundled `tttd <../user-guide/recipes/tttd.rst>`__
+<https://arxiv.org/abs/2601.16175>`__), the cookbook `tttd <../user-guide/recipes/tttd.rst>`__
 recipe. A model specializes to one hard problem during the search; the search
 loop stays in the harness.
 
 OpenClaw-RL
 -----------
 
-The bundled `openclawrl <../user-guide/recipes/openclawrl.rst>`__ recipe (`arXiv:2603.10165
+The cookbook `openclawrl <../user-guide/recipes/openclawrl.rst>`__ recipe (`arXiv:2603.10165
 <https://arxiv.org/abs/2603.10165>`__). It trains an unmodified agent from live
 conversation traffic using a next-state binary reward, with no external grader
 and no session headers.

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -164,8 +164,10 @@ Report
 
 .. code:: python
 
-   from reef.core.reports import ReportBase, ReportValidationError
-   from reef.core.reports import GroupedRolloutReport, ScoredRolloutReport   # bundled contracts
+   from reef.core.reports import ReportBase, ReportValidationError, ScoredRolloutReport
+
+Method-specific report contracts live in their method package; Reef does not
+import or re-export them.
 
 A report type declares the feedback a method accepts, so malformed input fails
 at ingress with HTTP 400.

--- a/docs/rfcs/method-integration.rst
+++ b/docs/rfcs/method-integration.rst
@@ -22,7 +22,7 @@ Method integration: one method, one trust domain
 
 ..
 
-   A bundled method's correctness-critical logic, including grading orchestration,
+   A cookbook method's correctness-critical logic, including grading orchestration,
    session correlation, and exclusion semantics, must live in **one** trust
    domain, versioned and tested with the processor that consumes its reports.
    Reef's core capabilities (records, inference, dispatch) are **served to**
@@ -115,7 +115,7 @@ defect above.
   (hints, teacher log-probs, rubric output) puts it in the report payload
   under a method-namespaced key, and its processor declares what it reads.
   No side channels.
-- **P7 · ``examples/`` teaches; it never load-bears.** Anything a bundled
+- **P7 · ``examples/`` teaches; it never load-bears.** Anything a cookbook
   method requires for correctness graduates out of ``examples/`` into the
   method's package. What remains in ``examples/`` is the harness a user would
   replace anyway (workload, agent plugin, launch config).
@@ -169,7 +169,7 @@ state, reconstructible by replay (P4).
 3.3 Method packages
 ~~~~~~~~~~~~~~~~~~~
 
-A bundled method is one package under ``reef/<name>/`` (landed 2026-08 as
+A cookbook method is one package under ``recipes/<name>/`` (landed 2026-08 as
 ``recipe``/``processor``/``preparer``/``slime``) containing
 every correctness-critical part: the recipe, the processor, and any grading
 service (judge orchestration, PRM client, correlation). Grading services run
@@ -245,12 +245,12 @@ Milestones, each independently shippable:
   `evolution boundary <evolution-boundary.rst>`__ is about harness-owned search
   state, and is untouched.
 - **Recipe authorship.** Third-party methods still need only a recipe class
-  and a config entry. Method packages are how *bundled* methods are held to
+  and a config entry. Method packages are how cookbook methods are held to
   a higher standard, not a new requirement on users.
 
-.. _6-compliance-checklist-for-a-new-bundled-method:
+.. _6-compliance-checklist-for-a-new-cookbook-method:
 
-6. Compliance checklist for a new bundled method
+6. Compliance checklist for a new cookbook method
 ------------------------------------------------
 
 Before a method merges, its review answers yes to all of:

--- a/docs/site/scripts/check-doc-contracts.mjs
+++ b/docs/site/scripts/check-doc-contracts.mjs
@@ -154,7 +154,7 @@ const glossaryTerms = [
   "Report",
   "Feedback",
   "Recipe",
-  "Recipe kind",
+  "Recipe reference",
   "Loss family",
   "Preparer",
   "Version chain",

--- a/docs/user-guide/evolve-your-model.rst
+++ b/docs/user-guide/evolve-your-model.rst
@@ -44,7 +44,7 @@ localhost; ``--ipc host --shm-size 32g`` is what the training stack needs for
 shared memory. ``recipes/openclawrl/examples/openclawrl/run.sh`` runs the same
 invocation non-interactively.
 
-The bundled ``recipes/sao/examples/sao/serve.yaml`` declares
+The cookbook ``recipes/sao/examples/sao/serve.yaml`` declares
 ``training.num_gpus: 2`` and ``cuda_visible_devices: "0,1"``.
 ``training.num_gpus`` must match the devices you actually expose, and the
 model at ``reef.model_path`` must be present or downloadable.

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -33,7 +33,7 @@ Pick by the signal your workload can produce.
 | Feedback on individual requests, and failures | `harness_evolve <recipes/harness-evolve.rst>`__ | harness tree  | no         |
 | worth learning from                           |                                                 |               |            |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
-| No feedback yet; record only                  | ``recipe``, the base kind                       | nothing       | no         |
+| No feedback yet; record only                  | ``recipe``, the core record-only recipe         | nothing       | no         |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 
 How a recipe is selected
@@ -46,12 +46,14 @@ a recipe. The scenario header is the only routing a caller provides.
 .. code:: yaml
 
    reef:
-     recipe: sao          # a bundled kind
+     recipe: recipes.sao.recipe:SAORecipe
      batch_size: 1
 
-``reef.recipe`` accepts a bundled kind, dotted class, or preset. `Configuration
-<../reference/configuration.rst#recipe-configuration>`__ describes the config
-for each kind.
+``reef.recipe`` accepts the core value ``recipe``, a dotted class, or a preset.
+Reef does not register or import learning methods. The ``recipes/`` tree in
+this repository is a cookbook; installed method packages work the same way.
+`Configuration <../reference/configuration.rst#recipe-configuration>`__
+describes each spelling.
 
 Every recipe has a checkpoint strategy, defaulting to ``EveryNVersions(1)``.
 ``checkpoint_every_n_versions`` is the shorter spelling in deployment YAML.
@@ -59,6 +61,6 @@ Every recipe has a checkpoint strategy, defaulting to ``EveryNVersions(1)``.
 See also
 --------
 
-- `tttd <recipes/tttd.rst>`__ includes the bundled TTT-Discover example,
+- `tttd <recipes/tttd.rst>`__ includes the cookbook TTT-Discover example,
   formal circle-packing results, and recovery details.
 - `Write a recipe <../developer-guide/write-a-recipe.rst>`__: when none of them fits.

--- a/docs/user-guide/recipes/harness-evolve.rst
+++ b/docs/user-guide/recipes/harness-evolve.rst
@@ -1,7 +1,7 @@
 harness_evolve
 ==============
 
-The only bundled recipe that updates text instead of weights. It proposes one
+The cookbook recipe that updates text instead of weights. It proposes one
 edit to the agent's harness tree, runs the agent both ways on your tasks, and
 publishes the edit only if it wins.
 
@@ -38,7 +38,7 @@ publishes as a new version, pulled through ``GET /reef/harness``.
 Configuration
 -------------
 
-This kind never reads the flat ``reef.*`` section. Its configuration lives in
+This recipe never reads the flat ``reef.*`` section. Its configuration lives in
 ``<name>.yaml`` under ``REEF_RECIPE_CONFIG_DIR``. The deployment config names
 that preset with ``reef.recipe`` (`Recipe configuration
 <../../reference/configuration.rst#recipe-configuration>`__). ``batch_size`` and

--- a/docs/user-guide/recipes/tttd.rst
+++ b/docs/user-guide/recipes/tttd.rst
@@ -31,7 +31,7 @@ Run one scenario per problem. The search archive retains the best candidate
 found so far. Mean rollout reward describes the programs sampled for a training
 step, so it can decrease even when the best archived solution does not change.
 
-The bundled example uses Qwen3-8B and includes the Erdős minimum-overlap problem
+The cookbook example uses Qwen3-8B and includes the Erdős minimum-overlap problem
 and the circle-packing problems for 26 and 32 circles.
 
 How one step runs
@@ -127,7 +127,7 @@ step grid. Reef validates these fields when it receives the report.
        },
    }, references=[receipt])
 
-The `bundled harness
+The `cookbook harness
 <../../../recipes/tttd/examples/tttd/README.md>`__ keeps the ordinary PUCT
 search separate from its Reef adapter. The adapter sends each inference through
 the scenario endpoint, retains the returned receipt, and reports the judge's

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -43,7 +43,7 @@ Reports and training
 
 **409 on a report.** The client-chosen ``agent_record_id`` was sent before with different content. Use a new id, or resend identical content.
 
-**The training step fails and /reef/status reports an error.** The service log has the traceback. A driver rejecting ``--wandb-key`` or ``--use-wandb`` means tracking must be configured under ``observability.wandb`` instead. A loss-family mismatch (``REEF_TRAINING_LOSS`` or the recipe's family against the Slime flags) is refused at startup by design.
+**The training step fails and /reef/status reports an error.** The service log has the traceback. A driver rejecting ``--wandb-key`` or ``--use-wandb`` means tracking must be configured under ``observability.wandb`` instead. A mismatch between the recipe's loss family and the Slime flags is refused at startup by design.
 
 **After a restart the previous live weights are gone.** Weights between checkpoints exist only in engine memory; a restart restores the last checkpoint and the step counter continues from there. Keep ``checkpoint_every_n_versions`` at 1 unless you can afford to lose live versions. A ``RUNNING`` job marker left by a crash mid-step needs an operator to decide whether the job completed before the stack is restarted.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,13 +85,10 @@ include-package-data = true
 
 # reef-client is now a separate repo (Human-Agent-Society/reef-client) and a
 # declared dependency; the reef wheel must not ship its source.
-# `reef` is the shared machinery; `recipes` holds the bundled methods that
-# `reef/__init__` imports to register their kinds. A method's `examples/`
-# (and the method-less `recipes/basic`) are runnable harnesses, not library
-# code, and never ship.
+# `reef` is the shared machinery. The sibling `recipes` tree is a cookbook,
+# not package code, so neither its methods nor its runnable examples ship.
 [tool.setuptools.packages.find]
-include = ["reef", "reef.*", "recipes", "recipes.*"]
-exclude = ["recipes.basic", "recipes.basic.*", "recipes.*.examples", "recipes.*.examples.*"]
+include = ["reef", "reef.*"]
 
 [tool.setuptools.package-data]
 reef = ["harness/adapters/*/descriptor.yaml", "harness/adapters/*/version_check.ts"]

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -10,7 +10,7 @@ pip install -e . "tide-eval[harbor]"
 Then `./run.sh` — it starts Reef (the example's stack YAML) and runs the loop
 (`run.py`).
 
-[Basic](basic/) is everything on the base, record-only `recipe` kind — the
+[Basic](basic/) is everything on the core, record-only `recipe` — the
 deployment that learns nothing, and the smallest complete loop around it.
 Its two stack files are where a deployment starts before it picks a method,
 and what the quickstart serves:
@@ -26,14 +26,14 @@ frozen `ServiceSettings` by
 a `services:` list the orchestrator starts in dependency order, with `${VAR}`
 environment and `${dotted.path}` config interpolation. Copy one and adapt it;
 `reef serve -c <stack> --<key> <value>` overrides any `reef.*` setting. The
-`recipe` kind they bind is the base contract in
+`recipe` they bind is the base contract in
 [`reef/recipe/base.py`](../reef/recipe/base.py); a stack that binds a method
 lives with that method (`recipes/<method>/examples/<example>/serve.yaml`; the
 smallest weight-training one is
 [`recipes/sao/examples/sao/serve.yaml`](sao/examples/sao/serve.yaml)).
 Two contracts hold the set honest:
 [`test_training_server.py`](../tests/reef_service/test_training_server.py)
-boots the internal service from every bundled stack, and
+boots the internal service from every cookbook stack, and
 [`docs/site/scripts/check-doc-contracts.mjs`](../docs/site/scripts/check-doc-contracts.mjs)
 derives the documented port and health route from `local-sglang.yaml`.
 
@@ -45,8 +45,8 @@ the verifier reward back at trial end (`harness/`), the loop written out
 `Lab.run`, one episode), and a launcher (`run.sh`) that starts Reef from
 `external-provider.yaml` with local overrides and runs it.
 
-[SAO](sao/examples/sao/README.md) is the functional smoke for the bundled
-`sao` recipe, the smallest weight-updating loop. Three IMOAnswerBench problems
+[SAO](sao/examples/sao/README.md) is the functional smoke for the cookbook
+SAO recipe, the smallest weight-updating loop. Three IMOAnswerBench problems
 run in order by `run.py`, each driving six scored rollouts through Reef with a
 verifiable binary reward, and every scored rollout is one training step. Its
 README keeps a comparison against GRPO(+DIS) at Qwen3-30B-A3B scale.
@@ -89,7 +89,7 @@ personal-agent experiment as a tide task stream: a simulated student brings
 72 GSM8K homework problems to a Hermes agent whose model calls go through
 reef, and the metric is the number of sessions before the agent's answers
 match the student's taste. The method (session correlation, PRM judging, the
-hint-conditioned teacher) is the `openclawrl` recipe package, so the example
+hint-conditioned teacher) is the `openclawrl` cookbook package, so the example
 contains only the harness side: the task stream, the Hermes agent wrapper,
 the student sidecar, and the analysis scripts. Its README keeps the learning
 curve and training curves of a complete run.

--- a/recipes/__init__.py
+++ b/recipes/__init__.py
@@ -1,9 +1,9 @@
-"""The bundled methods, one package each, laid out like stable-baselines3.
+"""Cookbook methods, one package each.
 
 ``recipes/<method>/`` holds a method's recipe, processor, preparer and (for
 weight methods) its ``slime/`` backend half, plus ``examples/`` — the
 runnable Harbor task + harness stacks that drive it. ``recipes/basic`` is the
-example for the record-only base ``recipe`` kind, which has no method
-package. ``reef/__init__`` imports the method packages, which registers
-their kinds; the examples never ship in the wheel.
+example for the core record-only ``recipe``, which has no method package.
+Reef does not import this tree, and none of it ships in the wheel. Example
+deployments select recipe and loss classes through explicit dotted references.
 """

--- a/recipes/basic/harness/agent.py
+++ b/recipes/basic/harness/agent.py
@@ -29,7 +29,7 @@ SERVICE_URL = "http://127.0.0.1:8900"
 TOKEN = "reef-local"
 #: This workload's isolated lane, and the recipe that serves it.
 SCENARIO = "basic-arithmetic"
-RECIPE = "recipe"  # the record-only base kind
+RECIPE = "recipe"  # the record-only core recipe
 #: Where the basic task's instruction says to put the answer
 #: (see ``harbor/instruction.md``).
 ANSWER_PATH = "/workspace/answer.txt"

--- a/recipes/harness_evolve/__init__.py
+++ b/recipes/harness_evolve/__init__.py
@@ -1,6 +1,6 @@
 """Harness composition evolution: one method, one package.
 
-- ``recipe`` — the ``harness_evolve`` recipe kind; ``propose`` and
+- ``recipe`` — the harness-evolution recipe class; ``propose`` and
   ``evaluate`` bind as dotted callable references.
 - ``processor`` — batches scored traces for the propose/evaluate/select
   loop.

--- a/recipes/harness_evolve/examples/harness_evolve/materialize_recipe.py
+++ b/recipes/harness_evolve/examples/harness_evolve/materialize_recipe.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import yaml
 
-RECIPE_SECTIONS = ("kind", "model", "evolution", "data")
+RECIPE_SECTIONS = ("implementation", "model", "evolution", "data")
 
 config = yaml.safe_load(Path("serve.yaml").read_text())
 recipe = {key: config[key] for key in RECIPE_SECTIONS}

--- a/recipes/harness_evolve/examples/harness_evolve/serve.yaml
+++ b/recipes/harness_evolve/examples/harness_evolve/serve.yaml
@@ -1,12 +1,12 @@
 # The stack `run.sh` starts: one Reef service on port 8900, state under
 # the example's ./work directory.
 #
-# This file also carries the harness_evolve recipe sections (kind, model,
+# This file also carries the harness_evolve recipe sections (implementation, model,
 # evolution, data). The recipe registry reads named recipe configs from
 # REEF_RECIPE_CONFIG_DIR, so run.sh copies those four sections into
 # work/recipes/harness_evolve.yaml.
 
-kind: harness_evolve
+implementation: recipes.harness_evolve.recipe:HarnessEvolveRecipe
 
 model:
   path: qwen3-8b

--- a/recipes/harness_evolve/examples/skillclaw/README.md
+++ b/recipes/harness_evolve/examples/skillclaw/README.md
@@ -6,7 +6,7 @@ This example rebuilds the SkillClaw method from [Evolving Skills for Autonomous 
 
 ```text
 skillclaw/
-  skillclaw.yaml      the recipe the driver boots: dotted kind, selection
+  skillclaw.yaml      the recipe the driver boots: explicit implementation, selection
                       always, batch_size 60, probe tasks, seed composition
   harbor/             one Harbor-format task (the standard layout the
                       sibling examples follow): the benchmark's

--- a/recipes/harness_evolve/examples/skillclaw/harness/skillclaw_recipe.py
+++ b/recipes/harness_evolve/examples/skillclaw/harness/skillclaw_recipe.py
@@ -1,8 +1,8 @@
 """SkillClaw's recipe: harness evolution plus the pool's own delivery surface.
 
-``skillclaw.yaml`` names this class as its dotted recipe kind
+``skillclaw.yaml`` names this class as its dotted recipe reference
 (``harness.skillclaw_recipe:SkillClawRecipe``). It changes exactly two things over
-the stock ``harness_evolve`` kind:
+the stock ``HarnessEvolveRecipe`` implementation:
 
 - ``build_surface`` returns ``create_skill_surface([SkillCatalogModule(...)])``, so
   every ``/v1`` request the service proxies carries the served pool's
@@ -23,7 +23,7 @@ from dataclasses import KW_ONLY, dataclass
 from pathlib import Path
 from typing import Any
 
-from reef import HarnessEvolveRecipe
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.recipe.errors import RecipeConfigError
 from reef.surface import Surface
 from reef.surface.skills import SkillValidator, create_skill_surface

--- a/recipes/harness_evolve/examples/skillclaw/run.py
+++ b/recipes/harness_evolve/examples/skillclaw/run.py
@@ -92,21 +92,21 @@ class Ledger:
 
 
 def load_recipe() -> tuple[str, Any]:
-    """The recipe skillclaw.yaml declares, built through its dotted kind.
+    """The recipe skillclaw.yaml declares, built through its explicit implementation.
 
     This driver is the deployment: it owns the upstream binding and hands it
     to the recipe as its runtime, the way ``reef.upstream_url`` does in a
     served deployment. The method (harness/) never sees the endpoint.
     """
     config = load_config(HERE / "skillclaw.yaml")
-    sections = {key: config[key] for key in ("kind", "model", "evolution", "data")}
+    sections = {key: config[key] for key in ("implementation", "model", "evolution", "data")}
     runtime = InferenceProxyRuntime(
         model_path=AGENT_MODEL,
         base_url=UPSTREAM_BASE,
         api_key=read_key(),
         inference_timeout_s=600.0,
     )
-    recipe = build_recipe(str(sections["kind"]), config=sections, runtime=runtime)
+    recipe = build_recipe(str(sections["implementation"]), config=sections, runtime=runtime)
     return recipe.name, recipe
 
 

--- a/recipes/harness_evolve/examples/skillclaw/skillclaw.yaml
+++ b/recipes/harness_evolve/examples/skillclaw/skillclaw.yaml
@@ -1,5 +1,5 @@
 # The recipe the campaign driver boots: run.py loads this file, builds
-# the dotted kind below, and serves it from its own embedded Reef service
+# the explicit implementation below, and serves it from its own embedded Reef service
 # (task containers reach that service through Docker's host gateway, and
 # every /v1 request they make carries the served pool's catalog).
 #
@@ -10,7 +10,7 @@
 # The method package's own recipe class: harness_evolve plus the
 # catalog-injecting delivery surface (harness/skillclaw_recipe.py, imported
 # from this directory - the driver runs with it as the working directory).
-kind: harness.skillclaw_recipe:SkillClawRecipe
+implementation: harness.skillclaw_recipe:SkillClawRecipe
 
 model:
   path: ${REEF_MODEL}

--- a/recipes/harness_evolve/recipe.py
+++ b/recipes/harness_evolve/recipe.py
@@ -26,7 +26,6 @@ from reef.observability import ExperimentLogger
 from reef.recipe.base import Recipe
 from reef.recipe.config_fields import config_field
 from reef.recipe.errors import RecipeConfigError
-from reef.recipe.registry import register_kind
 from reef.records import RecordStore
 from reef.surface.base import Surface
 from reef.surface.harnesses import create_harness_surface
@@ -74,10 +73,9 @@ def _resolve_candidate_selector(value: Any) -> CandidateSelector:
     )
 
 
-@register_kind("harness_evolve")
 @dataclass(frozen=True)
 class HarnessEvolveRecipe(Recipe):
-    """The harness evolution loop as a bootable recipe kind.
+    """The harness evolution loop as a bootable recipe class.
 
     Config shape (the ``evolution`` section): ``adapter`` (a name
     ``reef.harness.adapters.get_adapter`` resolves), ``propose`` and

--- a/recipes/openclawrl/__init__.py
+++ b/recipes/openclawrl/__init__.py
@@ -1,6 +1,6 @@
 """OpenClaw-RL (arXiv:2603.10165): one method, one package.
 
-- ``recipe`` — the ``openclawrl`` recipe kind and its ``WeightTrainingSpec``.
+- ``recipe`` — the OpenClaw-RL recipe class and its ``WeightTrainingSpec``.
 - ``processor`` — the computed-feedback processor: sessions trace-matched
   from records, turns judged on a processor-private PRM worker.
 - ``sessions`` / ``turns`` / ``prm`` — the derivation machinery the

--- a/recipes/openclawrl/examples/openclawrl/__init__.py
+++ b/recipes/openclawrl/examples/openclawrl/__init__.py
@@ -1,4 +1,4 @@
-"""OpenClaw-RL example: the harness side of the bundled recipe.
+"""OpenClaw-RL example: the harness side of the cookbook recipe.
 
 The method itself (next-state binary reward, arXiv:2603.10165) lives
 entirely in the reef package — the ``openclawrl`` recipe's processor

--- a/recipes/openclawrl/examples/openclawrl/serve.yaml
+++ b/recipes/openclawrl/examples/openclawrl/serve.yaml
@@ -1,6 +1,6 @@
 # OpenClaw-RL on reef — next-state binary reward, changes model weights.
 # Five processes: ray-head + prm-sglang + user-llm-sglang + slime-driver + reef.
-# The whole method is the bundled `openclawrl` recipe: its processor
+# The whole method is the cookbook `openclawrl` recipe: its processor
 # correlates sessions from recorded traffic by trace matching and judges
 # next states with the PRM on a private worker — agents talk to reef
 # directly, no grader proxy and no session headers.
@@ -30,7 +30,7 @@ reef:
   host: 0.0.0.0
   model_path: /root/models/Qwen3-4B-Thinking-2507
   port: 28900
-  recipe: openclawrl
+  recipe: recipes.openclawrl.recipe:OpenClawRLRecipe
   token: ${REEF_TOKEN}                 # run.sh mints one per run
   batch_size: 16                       # MUST equal training.global_batch_size
   checkpoint_every_n_versions: 1
@@ -215,6 +215,7 @@ services:
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
       REEF_TRAINING_RECIPE: ${reef.recipe}
+      REEF_TRAINING_LOSS: recipes.openclawrl.slime:OpenclawrlAlgorithm
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]

--- a/recipes/openclawrl/examples/openclawrl/serve.yaml
+++ b/recipes/openclawrl/examples/openclawrl/serve.yaml
@@ -214,8 +214,6 @@ services:
       RAY_ADDRESS: 127.0.0.1:${training.ray_port}
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
-      REEF_TRAINING_RECIPE: ${reef.recipe}
-      REEF_TRAINING_LOSS: recipes.openclawrl.slime:OpenclawrlAlgorithm
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]

--- a/recipes/openclawrl/recipe.py
+++ b/recipes/openclawrl/recipe.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from recipes.openclawrl.processor import OpenClawRLProcessor
 from reef.recipe.base import WeightTrainingRecipe, WeightTrainingSpec
 from reef.recipe.config_fields import config_field
-from reef.recipe.registry import register_kind
 
 _logger = logging.getLogger(__name__)
 
@@ -18,7 +17,6 @@ _logger = logging.getLogger(__name__)
 _RETIRED_FIELDS = {"prm_teacher_timeout_s": 900.0, "prm_logprob_temperature": 1.0}
 
 
-@register_kind("openclawrl")
 @dataclass(frozen=True, kw_only=True)
 class OpenClawRLRecipe(WeightTrainingRecipe):
     """Reproduces upstream OpenClaw-RL's binary-RL configuration on reef.

--- a/recipes/sao/__init__.py
+++ b/recipes/sao/__init__.py
@@ -1,6 +1,6 @@
 """Single-Rollout Asynchronous Optimization (arXiv:2607.07508): one method, one package.
 
-- ``recipe`` — the ``sao`` recipe kind and its ``WeightTrainingSpec``.
+- ``recipe`` — the SAO recipe class and its ``WeightTrainingSpec``.
 - ``processor`` — one scored rollout, one batch unit.
 - ``preparer`` — the backend-agnostic step preparer.
 - ``slime`` — the Slime loss family (DIS ratio, actor/critic cadence) and

--- a/recipes/sao/examples/sao/README.md
+++ b/recipes/sao/examples/sao/README.md
@@ -189,7 +189,7 @@ The integration reproduces:
 - sampling at `temperature=1.0, top_p=1.0`, a constant policy learning rate
   of `1e-6`, and no entropy bonus.
 
-The bundled configuration is a functional smoke rather than the paper's
+The cookbook configuration is a functional smoke rather than the paper's
 setup: it serves Qwen2.5-1.5B-Instruct with a 2048-token generation window,
 trains on the benchmark's own problems, and starts from the public
 instruction-tuned checkpoint. The paper-scale run below closes the model gap

--- a/recipes/sao/examples/sao/serve.yaml
+++ b/recipes/sao/examples/sao/serve.yaml
@@ -22,7 +22,7 @@ reef:
   host: 127.0.0.1
   model_path: ~/models/Qwen2.5-1.5B-Instruct
   port: 8900
-  recipe: sao
+  recipe: recipes.sao.recipe:SAORecipe
   token: reef-local
   batch_size: 1                        # MUST equal training.global_batch_size
   max_staleness: 18
@@ -119,6 +119,7 @@ services:
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
       REEF_TRAINING_RECIPE: ${reef.recipe}
+      REEF_TRAINING_LOSS: recipes.sao.slime:SaoAlgorithm
     depends_on: [ray-head]
 
   - name: reef

--- a/recipes/sao/examples/sao/serve.yaml
+++ b/recipes/sao/examples/sao/serve.yaml
@@ -118,8 +118,6 @@ services:
       RAY_ADDRESS: 127.0.0.1:${training.ray_port}
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
-      REEF_TRAINING_RECIPE: ${reef.recipe}
-      REEF_TRAINING_LOSS: recipes.sao.slime:SaoAlgorithm
     depends_on: [ray-head]
 
   - name: reef

--- a/recipes/sao/recipe.py
+++ b/recipes/sao/recipe.py
@@ -11,10 +11,8 @@ from reef.core.reports import ReportBase, ScoredRolloutReport
 from reef.recipe.base import WeightTrainingRecipe, WeightTrainingSpec
 from reef.recipe.config_fields import config_field
 from reef.recipe.errors import RecipeConfigError
-from reef.recipe.registry import register_kind
 
 
-@register_kind("sao")
 @dataclass(frozen=True, kw_only=True)
 class SAORecipe(WeightTrainingRecipe):
     """Single-Rollout Asynchronous Optimization (arXiv:2607.07508) on reef.

--- a/recipes/tttd/__init__.py
+++ b/recipes/tttd/__init__.py
@@ -2,9 +2,10 @@
 
 Everything Reef-side that decides what TTT-Discover trains lives here:
 
-- ``recipe`` — the ``tttd`` recipe kind, its config fields, and the
+- ``recipe`` — the TTT-Discover recipe class, its config fields, and the
   ``WeightTrainingSpec`` that binds the pieces below.
 - ``processor`` — the exact-step barrier and grouped policy-data processor.
+- ``report`` — the method-specific grouped rollout wire contract.
 - ``preparer`` — the backend-agnostic step preparer (adaptive-entropic
   grouped advantages).
 - ``slime`` — the Slime loss family and its torch objective hooks. It is
@@ -16,8 +17,9 @@ Everything Reef-side that decides what TTT-Discover trains lives here:
 from recipes.tttd.preparer import TttdPreparer
 from recipes.tttd.processor import TTTDProcessor
 from recipes.tttd.recipe import TTTDRecipe
+from recipes.tttd.report import TTTDGroupedRolloutReport
 from reef.train.algos.registry import register_loss_family_ref
 
 register_loss_family_ref("tttd", "recipes.tttd.slime:TttdAlgorithm")
 
-__all__ = ["TTTDProcessor", "TTTDRecipe", "TttdPreparer"]
+__all__ = ["TTTDGroupedRolloutReport", "TTTDProcessor", "TTTDRecipe", "TttdPreparer"]

--- a/recipes/tttd/examples/guidance_ttt/serve.yaml
+++ b/recipes/tttd/examples/guidance_ttt/serve.yaml
@@ -10,7 +10,7 @@ reef:
   host: 127.0.0.1
   model_path: work/model
   port: 8900
-  recipe: tttd
+  recipe: recipes.tttd.recipe:TTTDRecipe
   token: reef-local
   groups_per_step: 2
   rollouts_per_group: 4
@@ -142,7 +142,8 @@ services:
       RAY_ADDRESS: 127.0.0.1:6379
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
-      REEF_TRAINING_RECIPE: tttd
+      REEF_TRAINING_RECIPE: ${reef.recipe}
+      REEF_TRAINING_LOSS: recipes.tttd.slime:TttdAlgorithm
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]

--- a/recipes/tttd/examples/guidance_ttt/serve.yaml
+++ b/recipes/tttd/examples/guidance_ttt/serve.yaml
@@ -142,8 +142,6 @@ services:
       RAY_ADDRESS: 127.0.0.1:6379
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
-      REEF_TRAINING_RECIPE: ${reef.recipe}
-      REEF_TRAINING_LOSS: recipes.tttd.slime:TttdAlgorithm
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]

--- a/recipes/tttd/examples/tttd/serve.yaml
+++ b/recipes/tttd/examples/tttd/serve.yaml
@@ -138,8 +138,6 @@ services:
       RAY_ADDRESS: 127.0.0.1:6379
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
-      REEF_TRAINING_RECIPE: ${reef.recipe}
-      REEF_TRAINING_LOSS: recipes.tttd.slime:TttdAlgorithm
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]

--- a/recipes/tttd/examples/tttd/serve.yaml
+++ b/recipes/tttd/examples/tttd/serve.yaml
@@ -10,7 +10,7 @@ reef:
   host: 127.0.0.1
   model_path: work/model
   port: 8900
-  recipe: tttd
+  recipe: recipes.tttd.recipe:TTTDRecipe
   token: reef-local
   groups_per_step: 8
   rollouts_per_group: 64
@@ -138,7 +138,8 @@ services:
       RAY_ADDRESS: 127.0.0.1:6379
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
-      REEF_TRAINING_RECIPE: tttd
+      REEF_TRAINING_RECIPE: ${reef.recipe}
+      REEF_TRAINING_LOSS: recipes.tttd.slime:TttdAlgorithm
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]

--- a/recipes/tttd/recipe.py
+++ b/recipes/tttd/recipe.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from recipes.tttd.processor import TTTDProcessor
-from reef.core.reports import GroupedRolloutReport, ReportBase
+from recipes.tttd.report import TTTDGroupedRolloutReport
+from reef.core.reports import ReportBase
 from reef.recipe.base import WeightTrainingRecipe, WeightTrainingSpec
 from reef.recipe.config_fields import config_field
-from reef.recipe.registry import register_kind
 
 
-@register_kind("tttd")
 @dataclass(frozen=True, kw_only=True)
 class TTTDRecipe(WeightTrainingRecipe):
     name: str = "tttd"
@@ -22,7 +21,7 @@ class TTTDRecipe(WeightTrainingRecipe):
     def report_type(self) -> type[ReportBase]:
         # One rollout addressed into its exact step grid; the processor adds
         # the config-relative check against the served grid.
-        return GroupedRolloutReport
+        return TTTDGroupedRolloutReport
 
     @classmethod
     def training_spec(cls) -> WeightTrainingSpec:

--- a/recipes/tttd/report.py
+++ b/recipes/tttd/report.py
@@ -1,22 +1,15 @@
-"""Grouped rollout report contracts."""
+"""TTT-Discover's grouped rollout report contract."""
 
 from dataclasses import dataclass
 
-from reef.core.reports.base import ReportValidationError
-from reef.core.reports.scored_rollout import ScoredRolloutReport
+from reef.core.reports import ReportValidationError, ScoredRolloutReport
 
-__all__ = ["GroupedRolloutReport"]
+__all__ = ["TTTDGroupedRolloutReport"]
 
 
 @dataclass(frozen=True)
-class GroupedRolloutReport(ScoredRolloutReport):
-    """One rollout addressed into a step's exact comparison-group grid.
-
-    The metadata block is self-describing: coordinates plus the grid
-    cardinalities they index, the algorithm tag, and the ``comparison_set``
-    echo derived from the coordinates. Whether the announced grid matches the
-    serving recipe's configuration is the processor's decision.
-    """
+class TTTDGroupedRolloutReport(ScoredRolloutReport):
+    """One rollout addressed into a TTT-Discover comparison grid."""
 
     score: float
     step: int

--- a/reef/__init__.py
+++ b/reef/__init__.py
@@ -1,15 +1,12 @@
 """Reef: continual learning infra for self-improving agents.
 
-Laid out like stable-baselines3: ``reef`` holds every shared mechanism
+``reef`` holds every shared mechanism
 (records, service, runtime, scenario, artifacts, surfaces, the training
 loop with the candidate evaluation a recipe configures, and the recipe
-contract a method implements); each bundled
-method is one package under the sibling ``recipes`` tree —
-``recipes.sao``, ``recipes.tttd``, ``recipes.openclawrl``,
-``recipes.harness_evolve`` — holding its recipe, processor, preparer, (for
-weight methods) a ``slime/`` subpackage that only the training process
-imports, and its runnable ``examples/``. Importing ``reef`` imports the
-methods, which registers their kinds.
+contract a method implements). Learning methods are separate packages selected
+through dotted class references; importing ``reef`` never imports method code.
+The repository's sibling ``recipes`` tree is a cookbook and is not part of the
+installed Reef package.
 """
 
 # isort: skip_file
@@ -48,13 +45,6 @@ from reef.dispatcher import Dispatcher, build_default_dispatcher
 from reef.train import DataProcessor, Trainer
 from reef.runtime import ActivatedModel, InferenceRuntime, ModelCandidate, TrainingRuntime
 
-# The bundled methods, imported last: they depend on everything above and
-# register their recipe kinds and step preparers on import.
-from recipes.harness_evolve import HarnessEvolveRecipe
-from recipes.openclawrl import OpenClawRLRecipe
-from recipes.sao import SAORecipe
-from recipes.tttd import TTTDRecipe
-
 __all__ = [
     "SCENARIO_SNAPSHOT_METADATA_KEY",
     "ActivatedModel",
@@ -72,10 +62,8 @@ __all__ = [
     "Dispatcher",
     "EvaluationResult",
     "EveryNVersions",
-    "HarnessEvolveRecipe",
     "InferenceRuntime",
     "ModelCandidate",
-    "OpenClawRLRecipe",
     "Recipe",
     "RecipeConfigError",
     "RecipeRegistry",
@@ -86,12 +74,10 @@ __all__ = [
     "ReportValidationError",
     "RequestHeaders",
     "RequestType",
-    "SAORecipe",
     "Scenario",
     "ScenarioRecipeConflict",
     "ScenarioRecipeError",
     "SelectionDecision",
-    "TTTDRecipe",
     "Trainer",
     "TrainingRuntime",
     "UnknownScenarioRecipe",

--- a/reef/cli.py
+++ b/reef/cli.py
@@ -1,17 +1,15 @@
 """reef CLI: entry point for reef.
 
 Usage:
-  reef serve -c recipes/basic/<stack>.yaml     # start a configured stack
+  reef serve -c path/to/stack.yaml             # start a configured stack
 
 `reef serve` reads a config's `services` list and starts every declared
 process in dependency order, including the internal Reef HTTP service.
 Run `reef serve --help` for config options.
 
-``recipes/basic/`` holds the learn-nothing deployment stacks and
-``recipes/<method>/examples/`` each method's — the `services` layout a
-`reef serve -c` run starts. Named per-scenario recipe YAML is deployment
-data, not library data: point ``REEF_RECIPE_CONFIG_DIR`` at your own
-directory (see ``docs/reference/configuration.rst`` for the shape).
+Deployment stacks use the `services` layout documented in the configuration
+reference. Named per-scenario recipe YAML is deployment data, not library
+data: point ``REEF_RECIPE_CONFIG_DIR`` at your own directory.
 """
 
 from __future__ import annotations
@@ -30,8 +28,8 @@ usage: reef <command> [options]
   -c CONFIG   Config file (default: reef.yaml or $REEF_CONFIG)
 
 Examples:
-  reef serve -c recipes/basic/local-sglang.yaml
-  reef serve -c recipes/basic/external-provider.yaml
+  reef serve -c path/to/local-sglang.yaml
+  reef serve -c path/to/external-provider.yaml
 """
 
 

--- a/reef/core/reports/__init__.py
+++ b/reef/core/reports/__init__.py
@@ -4,16 +4,15 @@ A report is the second thing a harness sends Reef, after the inference it
 refers to (``AgentRecord``); both live in ``core`` because the service
 validates a report at ingress, the scenario binds its type, the recipe
 declares it, and the processors rehydrate it — packages that do not depend
-on each other. ``ReportBase`` is the contract; ``ScoredRolloutReport`` and
-``GroupedRolloutReport`` are the bundled vocabulary the methods share.
+on each other. ``ReportBase`` is the contract and ``ScoredRolloutReport`` is
+the shared score-only vocabulary; method-specific contracts live with their
+method packages.
 """
 
 from reef.core.reports.base import ReportBase, ReportValidationError
-from reef.core.reports.grouped_rollout import GroupedRolloutReport
 from reef.core.reports.scored_rollout import ScoredRolloutReport
 
 __all__ = [
-    "GroupedRolloutReport",
     "ReportBase",
     "ReportValidationError",
     "ScoredRolloutReport",

--- a/reef/core/reports/base.py
+++ b/reef/core/reports/base.py
@@ -14,8 +14,8 @@ The declaration is shared by every party that touches the wire:
 
 The report type is a floor, not a ceiling: parsing validates declared fields
 and ignores everything else, so producers may attach extra ``feedback`` and
-``metadata`` keys freely. Bundled concrete contracts live in this package;
-out-of-tree methods declare theirs in their own package.
+``metadata`` keys freely. Shared concrete contracts live in this package;
+methods declare specialized contracts in their own package.
 """
 
 from __future__ import annotations

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -707,7 +707,7 @@ def build_default_dispatcher(
     local_artifact_dir: Path | None = None,
     agent_record_dir: Path | None = None,
 ) -> Dispatcher:
-    """Build a Dispatcher serving the bundled ``recipe`` kind.
+    """Build a Dispatcher serving the core record-only ``recipe``.
 
     Convenience for tests and service entrypoints that want a working
     dispatcher without configuring a recipe registry by hand. The recipe is

--- a/reef/recipe/__init__.py
+++ b/reef/recipe/__init__.py
@@ -3,12 +3,12 @@
 A recipe is *how records and their feedback become a new version of the
 weights or the harness*. This package holds everything a method binds to:
 
-- ``base`` — ``Recipe`` (the default record-only kind and base contract:
+- ``base`` — ``Recipe`` (the default record-only recipe and base contract:
   ``build``, ``build_artifact_validator``, ``build_surface``, the
   ``CheckpointStrategy``) and ``WeightTrainingRecipe`` with its
   ``WeightTrainingSpec`` (step preparer, loss family, data processor).
-- ``registry`` — the kind table (``register_kind``, ``recipe_class_for``),
-  ``build_named_recipe`` for the recipe a deployment names, and
+- ``registry`` — dotted class resolution (``recipe_class_for``),
+  ``build_named_recipe`` for a deployment preset, and
   ``RecipeRegistry``, the closed instance table scenarios bind to.
 - ``config_fields`` — one dataclass field as the whole configuration surface
   for one setting (YAML key, env fallback, typed parser).
@@ -22,9 +22,10 @@ prepare and settle. Its types (``CandidateEvaluator``, ``CandidateSelector``,
 ``reef.train.evaluation`` because the trainer, backends, and runtime bind to
 them too — the recipe is what chooses and configures them.
 
-The bundled methods are packages under the sibling ``recipes`` tree
-(``recipes.sao``, ``recipes.tttd``, …); ``reef/__init__`` imports them last,
-which registers their kinds. Nothing else in ``reef`` imports a method package.
+Learning methods live outside the core package. The repository's sibling
+``recipes`` tree contains cookbook implementations, but Reef neither imports
+them at boot nor ships them in its wheel. Deployments select one explicitly by
+its dotted ``package.module:ClassName`` reference.
 
 The recipe decides; it does not execute or deliver. ``build`` returns a
 ``Trainer``, ``build_artifact_validator`` an admission policy,
@@ -38,7 +39,7 @@ from reef.recipe.base import Recipe, WeightTrainingRecipe, WeightTrainingSpec
 from reef.recipe.config import load_recipe_config
 from reef.recipe.config_fields import config_field
 from reef.recipe.errors import RecipeConfigError, ScenarioRecipeConflict, ScenarioRecipeError, UnknownScenarioRecipe
-from reef.recipe.registry import RecipeRegistry, build_named_recipe, build_recipe, recipe_class_for, register_kind
+from reef.recipe.registry import RecipeRegistry, build_named_recipe, build_recipe, recipe_class_for
 
 __all__ = [
     "Recipe",
@@ -54,5 +55,4 @@ __all__ = [
     "config_field",
     "load_recipe_config",
     "recipe_class_for",
-    "register_kind",
 ]

--- a/reef/recipe/base.py
+++ b/reef/recipe/base.py
@@ -156,11 +156,10 @@ class WeightTrainingRecipe(Recipe):
 
     :meth:`training_spec` binds the data processor, step preparer, and backend
     loss family. Keeping that static machinery in one structured return value
-    means the dataclass fields remain the recipe's instance configuration.
-    The training driver receives its loss implementation independently through
-    ``REEF_TRAINING_LOSS``. Cookbook deployments should give both the recipe
-    and loss family explicit dotted references; Reef never infers one from a
-    globally registered method name.
+    means the dataclass fields remain the recipe's instance configuration. The
+    training driver reads the selected class from the same deployment config
+    and obtains its loss family from this hook; deployments do not repeat that
+    binding in an environment variable.
 
     ``max_staleness`` is the shared stale-sample admission window. Zero keeps
     exact-version training; a positive value admits same-incarnation samples

--- a/reef/recipe/base.py
+++ b/reef/recipe/base.py
@@ -157,11 +157,10 @@ class WeightTrainingRecipe(Recipe):
     :meth:`training_spec` binds the data processor, step preparer, and backend
     loss family. Keeping that static machinery in one structured return value
     means the dataclass fields remain the recipe's instance configuration.
-    The driver resolves the loss family from ``REEF_TRAINING_RECIPE``, which
-    accepts a registered kind name (``sao``) or a dotted
-    ``package.module:ClassName`` reference to an unbundled recipe class — the
-    same spellings ``reef.recipe.registry.recipe_class_for`` resolves for
-    ``reef.recipe``.
+    The training driver receives its loss implementation independently through
+    ``REEF_TRAINING_LOSS``. Cookbook deployments should give both the recipe
+    and loss family explicit dotted references; Reef never infers one from a
+    globally registered method name.
 
     ``max_staleness`` is the shared stale-sample admission window. Zero keeps
     exact-version training; a positive value admits same-incarnation samples

--- a/reef/recipe/config.py
+++ b/reef/recipe/config.py
@@ -20,8 +20,8 @@ def load_recipe_config(path: str | Path) -> dict[str, Any]:
     if not isinstance(loaded, Mapping):
         raise RecipeConfigError("recipe config must be a YAML object")
     config = dict(loaded)
-    if not isinstance(config.get("kind"), str) or not config["kind"]:
-        raise RecipeConfigError("recipe config must contain a non-empty 'kind'")
+    if not isinstance(config.get("implementation"), str) or not config["implementation"]:
+        raise RecipeConfigError("recipe config must contain a non-empty 'implementation'")
     for section in ("data", "artifact", "runtime", "model", "rollout", "optimization"):
         value = config.get(section, {})
         if not isinstance(value, Mapping):

--- a/reef/recipe/registry.py
+++ b/reef/recipe/registry.py
@@ -1,13 +1,11 @@
-"""Recipe kind table and config-backed resolution of recipes by public name.
+"""Recipe references and config-backed resolution by public name.
 
 Two axes live here, deliberately separate:
 
-- The module-level *kind table* maps a config ``kind`` to a Recipe
-  implementation class (:func:`register_kind`, :func:`recipe_class_for`,
-  :func:`build_recipe`). Registration is process-wide and happens at import
-  time.
+- :func:`recipe_class_for` and :func:`build_recipe` resolve the core
+  record-only recipe or an explicit ``package.module:ClassName`` reference.
 - :func:`build_named_recipe` builds the recipe a deployment names: a YAML
-  preset from the recipe config directory, else a bundled kind.
+  preset from the recipe config directory, or the core record-only recipe.
 - :class:`RecipeRegistry` is the closed *instance* table mapping the public
   names scenarios bind to onto built ``Recipe`` objects.
 """
@@ -17,7 +15,7 @@ from __future__ import annotations
 import importlib
 import os
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -30,60 +28,41 @@ from reef.runtime.registry import RuntimeRegistry
 RECIPE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 RecipeType = type[Recipe]
 
-_RECIPE_KINDS: dict[str, RecipeType] = {}
 
+def recipe_class_for(reference: str) -> RecipeType | None:
+    """Return the Recipe implementation for ``reference``.
 
-def register_kind(kind: str) -> Callable[[RecipeType], RecipeType]:
-    """Register a Recipe implementation class under a config kind."""
-
-    def register(recipe_class: RecipeType) -> RecipeType:
-        if kind in _RECIPE_KINDS:
-            raise ValueError(f"recipe kind {kind!r} is already registered")
-        _RECIPE_KINDS[kind] = recipe_class
-        return recipe_class
-
-    return register
-
-
-register_kind("recipe")(Recipe)  # the base kind: records everything, trains nothing — the wiring check
-
-
-def recipe_kinds() -> tuple[str, ...]:
-    return tuple(_RECIPE_KINDS)
-
-
-def recipe_class_for(kind: str) -> RecipeType | None:
-    """Return the Recipe implementation for ``kind``.
-
-    A kind is either a registered name or a dotted reference
-    ``package.module:ClassName`` to a recipe class reef does not bundle — the
-    config path's way of serving cookbook and experiment recipes without a
-    hand-rolled service assembly per example.
+    ``recipe`` is the core record-only recipe. Every learning method is an
+    explicit ``package.module:ClassName`` reference, so importing Reef never
+    imports method code and operators can see exactly what a deployment loads.
+    A different bare name is a public preset name, not a class reference, and
+    returns ``None`` here.
     """
-    registered = _RECIPE_KINDS.get(kind)
-    if registered is not None or ":" not in kind:
-        return registered
-    module_name, _, attribute = kind.partition(":")
+    if reference == "recipe":
+        return Recipe
+    if ":" not in reference:
+        return None
+    module_name, _, attribute = reference.partition(":")
     if not module_name or not attribute:
-        raise RecipeConfigError(f"dotted recipe kind {kind!r} must be 'package.module:ClassName'")
+        raise RecipeConfigError(f"dotted recipe reference {reference!r} must be 'package.module:ClassName'")
     try:
         candidate = getattr(importlib.import_module(module_name), attribute)
     except (ImportError, AttributeError) as exc:
-        raise RecipeConfigError(f"cannot import recipe kind {kind!r}: {exc}") from exc
+        raise RecipeConfigError(f"cannot import recipe reference {reference!r}: {exc}") from exc
     if not (isinstance(candidate, type) and issubclass(candidate, Recipe)):
-        raise RecipeConfigError(f"recipe kind {kind!r} is not a Recipe class")
+        raise RecipeConfigError(f"recipe reference {reference!r} is not a Recipe class")
     return candidate
 
 
 def build_recipe(
-    kind: str,
+    implementation: str,
     environ: Mapping[str, str] | None = None,
     config: Mapping[str, Any] | None = None,
     runtime: InferenceRuntime | None = None,
 ) -> Recipe:
-    recipe_class = recipe_class_for(kind)
+    recipe_class = recipe_class_for(implementation)
     if recipe_class is None:
-        raise ValueError(f"unknown recipe kind {kind!r}")
+        raise ValueError(f"unknown recipe reference {implementation!r}")
     return recipe_class.from_environment(environ, config=config, runtime=runtime)
 
 
@@ -98,10 +77,10 @@ def build_named_recipe(
     """Build the recipe a deployment names by its public name.
 
     ``name`` is a YAML preset ``<name>.yaml`` under ``config_directory``
-    (defaulting to ``REEF_RECIPE_CONFIG_DIR``), else a bundled kind registered
-    under that name. reef bundles no presets — they are deployment data (see
+    (defaulting to ``REEF_RECIPE_CONFIG_DIR``), or the reserved core name
+    ``recipe``. Reef bundles no presets — they are deployment data (see
     ``docs/reference/configuration.rst``). A preset's ``runtime`` section builds the recipe's
-    runtime; without one the recipe gets ``default_runtime``. Dotted kinds are
+    runtime; without one the recipe gets ``default_runtime``. Dotted references are
     not names: they are operator configuration for :func:`build_recipe`, so a
     name never triggers an import.
     """
@@ -112,14 +91,14 @@ def build_named_recipe(
     directory = None if configured is None else Path(configured)
     path = None if directory is None else directory / f"{name}.yaml"
     if path is None or not path.exists():
-        if recipe_class_for(name) is None:
-            available = set(recipe_kinds())
-            if directory is not None:
-                available.update(preset.stem for preset in directory.glob("*.yaml"))
-            raise UnknownScenarioRecipe(
-                f"unknown scenario recipe {name!r}; available recipes: {', '.join(sorted(available))}"
-            )
-        return build_recipe(name, values, runtime=default_runtime)
+        if name == "recipe":
+            return build_recipe(name, values, runtime=default_runtime)
+        available = {"recipe"}
+        if directory is not None:
+            available.update(preset.stem for preset in directory.glob("*.yaml"))
+        raise UnknownScenarioRecipe(
+            f"unknown scenario recipe {name!r}; available recipes: {', '.join(sorted(available))}"
+        )
 
     settings = load_recipe_config(path)
     model_path = settings["model"].get("path")
@@ -134,14 +113,14 @@ def build_named_recipe(
         if runtime_config
         else default_runtime
     )
-    return build_recipe(settings["kind"], values, config=settings, runtime=runtime)
+    return build_recipe(settings["implementation"], values, config=settings, runtime=runtime)
 
 
 class RecipeRegistry:
     """The recipes a process serves, by the public name scenarios bind to.
 
     A closed set: request-time names resolve only to what the operator
-    injected, never materializing another kind or preset. A reef deployment
+    injected, never materializing another implementation or preset. A reef deployment
     serves exactly one recipe (see :attr:`served_recipe`); multi-recipe
     registries exist for tests that exercise scenario bindings across
     deployments.

--- a/reef/service/assembly.py
+++ b/reef/service/assembly.py
@@ -29,7 +29,7 @@ from reef.service.deploy.settings import ServiceSettings, service_owned_keys
 
 
 def _training_recipe_type(name: str) -> type[WeightTrainingRecipe] | None:
-    """The registered class for ``name`` when it is a weight-training recipe."""
+    """The explicit class for ``name`` when it is a weight-training recipe."""
     recipe_type = recipe_class_for(name)
     if recipe_type is not None and issubclass(recipe_type, WeightTrainingRecipe):
         return recipe_type
@@ -168,12 +168,12 @@ def _training_recipe(
 def _serving_recipe(selected: str, settings: ServiceSettings, env: Mapping[str, str], connector: Any) -> Recipe:
     """Build the one recipe ``reef.recipe`` names.
 
-    The three spellings differ only in where the recipe's config and runtime
-    come from: a weight-training kind reads the flat ``reef.*`` section and
-    connects the Ray training runtime; a dotted kind is operator configuration
-    built from the environment on the upstream proxy; any other name is a
-    bundled kind or a YAML preset under ``REEF_RECIPE_CONFIG_DIR``, whose own
-    ``runtime`` section wins over the upstream proxy.
+    The spellings differ only in where config and runtime come from: a dotted
+    weight-training class reads the flat ``reef.*`` section and connects the
+    Ray runtime; another dotted class is built from the environment on the
+    upstream proxy; a bare name is ``recipe`` or a YAML preset under
+    ``REEF_RECIPE_CONFIG_DIR``, whose own ``runtime`` section wins over the
+    upstream proxy.
     """
     training_recipe_type = _training_recipe_type(selected)
     if training_recipe_type is not None:
@@ -205,7 +205,7 @@ def build_dispatcher(
     )
     # A deployment serves one recipe, so its registry is closed over that
     # single entry and request-time names never materialize another. Scenarios
-    # bind to the operator's public name; a dotted kind is not a request name,
+    # bind to the operator's public name; an implementation reference is not a request name,
     # so it serves under the recipe's own.
     name = recipe.name if ":" in selected_recipe else selected_recipe
     return Dispatcher(

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -80,7 +80,7 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
     if not path.is_absolute():
         path = PROJECT_ROOT / path
     if not path.exists():
-        raise DeployConfigError(f"config not found: {path}\n  pick: reef serve -c recipes/basic/<stack>.yaml")
+        raise DeployConfigError(f"config not found: {path}\n  pass a deployment stack with: reef serve -c <path>")
     with open(path) as handle:
         config = yaml.safe_load(handle) or {}
     return _deep_interp_env(config, os.environ)

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -38,7 +38,7 @@ Config overrides:
 
   Examples:
     reef serve --model_path Qwen2.5-1.5B-Instruct
-    reef serve -c recipes/basic/local-sglang.yaml --port 9000
+    reef serve -c path/to/local-sglang.yaml --port 9000
     reef serve --training.checkpoint_dir /tmp/ckpt
 """
 

--- a/reef/surface/skills/__init__.py
+++ b/reef/surface/skills/__init__.py
@@ -2,9 +2,8 @@
 
 A *skill artifact* is the versioned tree of skill text that reef serves to
 its consumer — injected into requests or pulled from ``GET /reef/harness``.
-This surface delivers the artifact; evolution runs elsewhere
-(``harness_evolve``, where a skill is one node kind of the composition
-tree).
+This surface delivers the artifact; evolution runs in a method package, where
+a skill may be one node kind of its composition tree.
 """
 
 from reef.surface.skills.modules import RequestSkillLayer, SkillLayer

--- a/reef/train/__init__.py
+++ b/reef/train/__init__.py
@@ -16,8 +16,8 @@ the recipe's candidate gate; ``Trainer`` runs it between prepare and settle.
 Tests and deployment configuration stay at repository level, never inside an
 integration subtree: ``tests/slime_backend/`` for runtime internals,
 ``tests/plugin_contracts/`` for package boundaries, ``tests/reef_service/``
-for service-facing contracts, and a runnable example beside its method under
-``recipes/<method>/examples/``.
+for service-facing contracts, with runnable examples owned by their method
+packages.
 """
 
 from reef.train.backend import PreparedStep, StepExecution, TrainingBackend

--- a/reef/train/algos/base.py
+++ b/reef/train/algos/base.py
@@ -1,4 +1,4 @@
-"""Internal base and bundled registration for step preparers.
+"""Internal base and decorator registration for step preparers.
 
 Subclass :class:`StepPreparer`, set the class attribute ``name``, implement
 :meth:`StepPreparer.__call__`, and register with ``@register_step_preparer``::
@@ -40,8 +40,8 @@ class StepPreparer(ABC):
         ``__call__`` — turn a reserved batch and algorithm state into a
         :class:`StepSignal`.
 
-    Register a bundled preparer with the ``@register_step_preparer`` class
-    decorator; external preparers are either registered at runtime via
+    Register a preparer with the ``@register_step_preparer`` class decorator;
+    callers may alternatively register an instance at runtime via
     :func:`reef.train.algos.registry.register_preparer` or named as a dotted
     ``"module:callable"`` reference resolved by
     :func:`reef.train.algos.registry.resolve_preparer`.
@@ -72,27 +72,27 @@ class _CallableStepPreparer(StepPreparer):
 
 
 # ---------------------------------------------------------------------------
-# bundled-preparer registration (populated by the class decorator)
+# decorator registration
 # ---------------------------------------------------------------------------
 
-_builtin_preparers: dict[str, StepPreparer] = {}
-"""Bundled preparers registered at import time by :func:`register_step_preparer`.
+_decorated_preparers: dict[str, StepPreparer] = {}
+"""Preparers registered at import time by :func:`register_step_preparer`.
 
-Read by :class:`~reef.train.algos.registry.StepPreparerRegistry` for its
-bundled set; external preparers are registered at runtime through
+Read by :class:`~reef.train.algos.registry.StepPreparerRegistry`; instances
+may also be registered at runtime through
 :func:`~reef.train.algos.registry.register_preparer`.
 """
 
 
 def register_step_preparer(cls: type[StepPreparer]) -> type[StepPreparer]:
-    """Class decorator: instantiate and register a bundled step preparer.
+    """Class decorator: instantiate and register a step preparer.
 
     Each preparer module applies this to its ``StepPreparer`` subclass so
     the registry is populated at import time — no explicit dict entry.
     """
     instance = cls()
     name = instance.name
-    if name in _builtin_preparers:
+    if name in _decorated_preparers:
         raise ValueError(f"step preparer {name!r} is already registered")
-    _builtin_preparers[name] = instance
+    _decorated_preparers[name] = instance
     return cls

--- a/reef/train/algos/registry.py
+++ b/reef/train/algos/registry.py
@@ -1,11 +1,9 @@
-"""Registries a method fills at import time: step preparers and loss-family references.
+"""Registries a method may fill at import time.
 
-The bundled preparers register themselves at import time via the
-``@register_step_preparer`` class decorator in their module, each from its
-method package (``recipes.tttd.preparer`` and the like, imported by
-``reef``). This registry never imports a method package — a method
-depends on the machinery, not the other way round.  The table is open for external preparers the same way recipe
-kinds and loss families are: an external preparer registers its
+Step preparers register themselves via the ``@register_step_preparer`` class
+decorator in their method package. This registry never imports a method
+package: a method depends on the machinery, not the other way round. A
+preparer may instead register its
 :class:`StepPreparer` with :func:`register_preparer` from a module imported at
 boot, or is named as a dotted ``"package.module:callable"`` reference wherever
 a preparer is named (a recipe's ``training_spec().step_preparer``).
@@ -23,7 +21,7 @@ from __future__ import annotations
 
 import importlib
 
-from reef.train.algos.base import StepPreparer, _builtin_preparers, _CallableStepPreparer, register_step_preparer
+from reef.train.algos.base import StepPreparer, _CallableStepPreparer, _decorated_preparers, register_step_preparer
 
 __all__ = [
     "StepPreparer",
@@ -37,25 +35,19 @@ __all__ = [
 
 
 class StepPreparerRegistry:
-    """Reads bundled preparers from ``_builtin_preparers`` (populated by decorators).
+    """Resolves preparers registered by decorators or runtime callers.
 
-    External preparers are tracked separately so ``unregister`` can refuse
-    bundled ones while allowing plugin teardown. The bundled set is read live:
-    a method package (``recipes.tttd.preparer``) registers its preparer
-    when the recipe package imports it, which may happen after this registry
-    is constructed.
+    Decorated preparers are read live because a method package may be imported
+    after this registry is constructed. Runtime registrations are tracked
+    separately; unregistering removes whichever registration owns the name.
     """
 
     def __init__(self) -> None:
         self._external: dict[str, StepPreparer] = {}
 
     @property
-    def _bundled(self) -> frozenset[str]:
-        return frozenset(_builtin_preparers)
-
-    @property
     def names(self) -> tuple[str, ...]:
-        return tuple(sorted(set(_builtin_preparers) | set(self._external)))
+        return tuple(sorted(set(_decorated_preparers) | set(self._external)))
 
     def register(self, preparer: StepPreparer) -> StepPreparer:
         """Register an external preparer under its ``name``."""
@@ -65,27 +57,26 @@ class StepPreparerRegistry:
         existing = self._external.get(name)
         if existing is preparer:
             return preparer
-        bundled = _builtin_preparers.get(name)
-        if bundled is preparer:
+        decorated = _decorated_preparers.get(name)
+        if decorated is preparer:
             return preparer
-        if bundled is not None or existing is not None:
+        if decorated is not None or existing is not None:
             available = ", ".join(self.names)
             raise ValueError(f"step preparer {name!r} is already registered; registered preparers: {available}")
         self._external[name] = preparer
         return preparer
 
     def unregister(self, name: str) -> None:
-        """Remove a previously registered external preparer (test/plugin teardown)."""
-        if name in self._bundled:
-            raise ValueError(f"step preparer {name!r} is bundled and cannot be unregistered")
-        if name not in self._external:
-            registered = ", ".join(sorted(self._external)) or "none"
-            raise KeyError(f"step preparer {name!r} is not registered; registered external preparers: {registered}")
-        self._external.pop(name)
+        """Remove a preparer by name."""
+        runtime = self._external.pop(name, None)
+        decorated = _decorated_preparers.pop(name, None)
+        if runtime is None and decorated is None:
+            registered = ", ".join(self.names) or "none"
+            raise KeyError(f"step preparer {name!r} is not registered; registered preparers: {registered}")
 
     def resolve(self, preparer_id: str) -> StepPreparer:
         """Resolve a registered preparer name or a dotted ``"module:callable"`` reference."""
-        preparer = _builtin_preparers.get(preparer_id) or self._external.get(preparer_id)
+        preparer = _decorated_preparers.get(preparer_id) or self._external.get(preparer_id)
         if preparer is not None:
             return preparer
         if ":" in preparer_id:
@@ -141,3 +132,8 @@ def register_loss_family_ref(loss_family: str, reference: str) -> None:
 def loss_family_refs() -> dict[str, str]:
     """The registered ``{loss_family: reference}`` table (a copy)."""
     return dict(_loss_family_refs)
+
+
+def _unregister_loss_family_ref(loss_family: str) -> bool:
+    """Remove a registered family reference, returning whether it existed."""
+    return _loss_family_refs.pop(loss_family, None) is not None

--- a/reef/train/processors/base.py
+++ b/reef/train/processors/base.py
@@ -51,9 +51,8 @@ class DataProcessor:
       :class:`~reef.train.processors.computed.ComputedFeedbackProcessor` and write
       ``ingest`` (the method's own correlation, built from the engine's
       ``catch_up``/``dispatch``/``track``/``retire`` verbs), ``judge``,
-      ``make_sample``, and ``make_batch`` (``openclawrl.py`` is the worked
-      example; bulky machinery goes in the recipe's ``<kind>_internal/``
-      package). Here ``judge`` is an ``async def``: your ``ingest`` hands a
+      ``make_sample``, and ``make_batch``; bulky machinery stays in the
+      method package. Here ``judge`` is an ``async def``: your ``ingest`` hands a
       job to ``dispatch`` and a private worker thread awaits it, so it may
       call models and take minutes without blocking serving.
 

--- a/reef/train/processors/computed.py
+++ b/reef/train/processors/computed.py
@@ -54,9 +54,8 @@ class SupportsReceipt(Protocol):
     """What the engine needs of a recipe's job and of its judgment alike:
     the receipt of the tracked record they concern.
 
-    The recipe defines both types (``TurnJob``/``TurnJudgment`` for
-    openclawrl); the engine only ever reads ``receipt``, so this is the
-    whole seam between them. :class:`Failed` satisfies it too.
+    The recipe defines both types; the engine only ever reads ``receipt``, so
+    this is the whole seam between them. :class:`Failed` satisfies it too.
     """
 
     @property

--- a/reef/train/slime_backend/algorithm.py
+++ b/reef/train/slime_backend/algorithm.py
@@ -245,8 +245,8 @@ class SlimeAlgorithm(ABC):
     def validate_specific_args(self, args: Namespace, source: str) -> None:
         """Validate algorithm-specific backend args.
 
-        ``source`` is ``REEF_TRAINING_LOSS=<family>`` or
-        ``REEF_TRAINING_RECIPE=<recipe>`` — use it in error messages.
+        ``source`` identifies the configured ``reef.recipe`` — use it in error
+        messages.
         At minimum, ``pass`` if your algorithm has no specific requirements.
         """
 
@@ -368,7 +368,7 @@ class SlimeAlgorithm(ABC):
     # --- template methods (do not override) ---
 
     def validate_backend_args(self, args: Namespace, *, recipe: str | None = None) -> None:
-        source = f"REEF_TRAINING_RECIPE={recipe}" if recipe else f"REEF_TRAINING_LOSS={self.loss_family}"
+        source = f"reef.recipe={recipe}" if recipe else f"loss family {self.loss_family}"
         actual_loss = getattr(args, "loss_type", None)
         if actual_loss != self.loss_type:
             raise RuntimeError(f"{source} requires --loss-type {self.loss_type}, got {actual_loss!r}")

--- a/reef/train/slime_backend/algorithm.py
+++ b/reef/train/slime_backend/algorithm.py
@@ -47,10 +47,9 @@ override to carry per-run state such as a teacher client or a train schedule).
 Adding a family
 ---------------
 
-A family is a package ``recipes/<name>/slime/`` — the same place a method
-keeps its objective:
+A family lives in its method package beside its objective hooks:
 
-    recipes/<name>/slime/
+    my_method/slime/
       __init__.py     the spec: a SlimeAlgorithm subclass, no torch
       objective.py    the @objective hooks, torch (worker side)
       <concern>.py    further worker-side torch modules, imported only from
@@ -65,16 +64,14 @@ validates it at init time::
     def my_loss(args, batch, logits, sum_of_sample_mean): ...
 
 Register the spec by reference from the package ``__init__`` —
-``register_loss_family_ref("<name>", "recipes.<name>.slime:<Pkg>Algorithm")``
+``register_loss_family_ref("<name>", "my_method.slime:MyMethodAlgorithm")``
 (:mod:`reef.train.algos.registry`) — so the service never imports
 the Slime side and the driver imports it on first resolve. Naming conventions, enforced by
 ``tests/reef_service/test_slime_algorithm_contract.py``: the spec class is
 ``<Pkg>Algorithm`` and its driver options ``<Pkg>Settings``, both importable
 from the family package root; ``@objective`` entry points are ``<pkg>_loss``,
 ``<pkg>_advantages``, ``<pkg>_actor_init`` / ``<pkg>_actor_pre_train``; family
-CLI flags are ``--<pkg>-*``. Reference: ``tttd`` is the smallest family with
-an objective; ``sao`` overrides the most hooks; ``openclawrl`` uses the actor
-lifecycle hooks for a trainer-side teacher.
+CLI flags are ``--<pkg>-*``.
 """
 
 from __future__ import annotations
@@ -395,16 +392,16 @@ class SlimeAlgorithm(ABC):
 # --- loss family registration (driver-side) ---
 
 _loss_families: dict[str, SlimeAlgorithm] = {}
-"""Bundled loss families registered at import time by :func:`register_loss_family`.
+"""Loss families registered at import time by :func:`register_loss_family`.
 
 Read by :class:`~reef.train.slime_backend.loss_families.LossFamilyRegistry`
-for its bundled set; external families are registered at runtime through
+for decorated classes; instances may also be registered at runtime through
 ``register_loss_family(spec)``.
 """
 
 
 def register_loss_family(cls: Callable[..., Any]) -> Callable[..., Any]:
-    """Class decorator: instantiate and register a bundled loss family.
+    """Class decorator: instantiate and register a loss family.
 
     Each algorithm module applies this to its ``SlimeAlgorithm`` subclass so
     resolving the family's reference imports the module — no explicit dict entry.

--- a/reef/train/slime_backend/loss_families.py
+++ b/reef/train/slime_backend/loss_families.py
@@ -8,7 +8,7 @@ package. The same lazy path makes the reference available in the driver and in
 every worker. A family may instead register its
 :class:`SlimeAlgorithm` with :func:`register_loss_family` from a module imported
 at boot, or is named as a dotted ``"package.module:SPEC"`` reference wherever a
-loss family is named (``REEF_TRAINING_LOSS``, a recipe's ``loss_family``).
+loss family is named (a recipe's ``training_spec().loss_family``).
 ``SPEC`` is the ``@register_loss_family``-decorated class (an instance is
 accepted too). Resolving a dotted reference imports the module and registers
 the spec under its canonical ``loss_family`` name, so the wire payload's plain

--- a/reef/train/slime_backend/loss_families.py
+++ b/reef/train/slime_backend/loss_families.py
@@ -1,13 +1,11 @@
-"""Registry for Reef loss families supported by the Slime training backend.
+"""Registry for loss families supported by the Slime training backend.
 
-A bundled family registers a dotted reference to its spec in
-:mod:`reef.train.algos.registry` from its package ``__init__``
-(imported by ``reef``); this registry imports the reference the first time
-the name is resolved, and the ``@register_loss_family`` class decorator in
+A method package may register a dotted reference to its spec in
+:mod:`reef.train.algos.registry`; this registry imports the reference the first
+time the name is resolved, and the ``@register_loss_family`` class decorator in
 the spec module registers the instance. This module never imports a method
-package. The same lazy path keeps the table full
-in the driver and in every worker.  The table is open for external families the
-same way recipe kinds and step preparers are: an external family registers its
+package. The same lazy path makes the reference available in the driver and in
+every worker. A family may instead register its
 :class:`SlimeAlgorithm` with :func:`register_loss_family` from a module imported
 at boot, or is named as a dotted ``"package.module:SPEC"`` reference wherever a
 loss family is named (``REEF_TRAINING_LOSS``, a recipe's ``loss_family``).
@@ -19,16 +17,13 @@ starts with an empty registry, which is why the driver also stamps the
 reference itself on ``args.loss_family_ref`` (see
 :func:`~reef.train.slime_backend.algorithm.resolve_args_loss_family`).
 
-Renamed families keep their old name as an alias for one release
-(``_DEPRECATED_ALIASES``); resolving through the old name warns.
 """
 
 from __future__ import annotations
 
 import importlib
-import warnings
 
-from reef.train.algos.registry import loss_family_refs
+from reef.train.algos.registry import _unregister_loss_family_ref, loss_family_refs
 from reef.train.slime_backend.algorithm import SlimeAlgorithm, _loss_families
 
 
@@ -36,26 +31,20 @@ class UnknownLossFamilyError(RuntimeError):
     """Raised when the driver is asked to boot an unsupported loss family."""
 
 
-_DEPRECATED_ALIASES = {"openclawrl-topk": "openclawrl"}
-
-
 class LossFamilyRegistry:
-    """Bundled families come from the name → reference table and are imported
-    on first resolve; their specs land in ``_loss_families`` through the
-    decorator. External families are tracked separately so ``unregister`` can
-    refuse bundled ones while allowing plugin teardown.
+    """Referenced families are imported lazily from the name → reference table.
+
+    Their specs land in ``_loss_families`` through the decorator. Families
+    registered directly on this registry are tracked separately so test and
+    plugin teardown can unregister them without altering package registrations.
     """
 
     def __init__(self) -> None:
         self._external: dict[str, SlimeAlgorithm] = {}
 
     @property
-    def _bundled(self) -> frozenset[str]:
-        return frozenset(loss_family_refs())
-
-    @property
     def names(self) -> tuple[str, ...]:
-        return tuple(sorted(self._bundled | set(_loss_families) | set(self._external)))
+        return tuple(sorted(set(loss_family_refs()) | set(_loss_families) | set(self._external)))
 
     def register(self, spec: SlimeAlgorithm) -> SlimeAlgorithm:
         """Register an external loss-family spec under its ``loss_family`` name."""
@@ -64,10 +53,10 @@ class LossFamilyRegistry:
         existing = self._external.get(spec.loss_family)
         if existing is spec:
             return spec
-        bundled = _loss_families.get(spec.loss_family)
-        if bundled is spec:
+        decorated = _loss_families.get(spec.loss_family)
+        if decorated is spec:
             return spec
-        if bundled is not None or existing is not None:
+        if decorated is not None or existing is not None:
             raise ValueError(
                 f"loss family {spec.loss_family!r} is already registered; registered families: {', '.join(self.names)}"
             )
@@ -75,30 +64,16 @@ class LossFamilyRegistry:
         return spec
 
     def unregister(self, loss_family: str) -> None:
-        """Remove a previously registered external family (test/plugin teardown)."""
-        if loss_family in self._bundled:
-            raise ValueError(f"loss family {loss_family!r} is bundled and cannot be unregistered")
-        if loss_family in self._external:
-            self._external.pop(loss_family)
-            return
-        # A decorated class imported after boot lands in the decorator table
-        # without being bundled; it is external all the same.
-        if loss_family in _loss_families and loss_family not in self._bundled:
-            _loss_families.pop(loss_family)
-            return
-        registered = ", ".join(sorted(self._external)) or "none"
-        raise KeyError(f"loss family {loss_family!r} is not registered; registered external families: {registered}")
+        """Remove a loss family by name."""
+        runtime = self._external.pop(loss_family, None)
+        decorated = _loss_families.pop(loss_family, None)
+        referenced = _unregister_loss_family_ref(loss_family)
+        if runtime is None and decorated is None and not referenced:
+            registered = ", ".join(self.names) or "none"
+            raise KeyError(f"loss family {loss_family!r} is not registered; registered families: {registered}")
 
     def resolve(self, loss_family: str) -> SlimeAlgorithm:
         """Resolve a registered family name or a dotted ``"package.module:SPEC"`` reference."""
-        canonical = _DEPRECATED_ALIASES.get(loss_family)
-        if canonical is not None:
-            warnings.warn(
-                f"loss family {loss_family!r} is now {canonical!r}; the old name is accepted for one release",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            loss_family = canonical
         spec = _loss_families.get(loss_family) or self._external.get(loss_family)
         if spec is not None:
             return spec
@@ -110,7 +85,7 @@ class LossFamilyRegistry:
         available = ", ".join(self.names)
         raise UnknownLossFamilyError(
             f"unsupported Slime loss family: {loss_family!r}; available families: {available}. "
-            f"An unbundled family can be registered with register_loss_family() from a module "
+            f"A family can be registered with register_loss_family() from a module "
             f"imported at boot, or named as a dotted 'package.module:SPEC' reference."
         )
 
@@ -132,15 +107,15 @@ class LossFamilyRegistry:
             raise UnknownLossFamilyError(
                 f"loss family {reference!r} is not a SlimeAlgorithm (got {type(candidate).__name__})"
             )
-        bundled_ref = loss_family_refs().get(candidate.loss_family)
-        if bundled_ref is not None and bundled_ref != reference and candidate.loss_family not in _loss_families:
-            # A bundled family is imported on first resolve; load it before an
-            # external reference can claim its name.
-            self._resolve_dotted(bundled_ref)
-        bundled = _loss_families.get(candidate.loss_family)
-        if bundled is candidate:
+        registered_ref = loss_family_refs().get(candidate.loss_family)
+        if registered_ref is not None and registered_ref != reference and candidate.loss_family not in _loss_families:
+            # A referenced family is imported on first resolve; load it before
+            # another reference can claim its name.
+            self._resolve_dotted(registered_ref)
+        decorated = _loss_families.get(candidate.loss_family)
+        if decorated is candidate:
             return candidate
-        if bundled is not None:
+        if decorated is not None:
             raise UnknownLossFamilyError(
                 f"dotted loss family {reference!r} names family {candidate.loss_family!r}, which is "
                 f"already registered to a different spec; pick a family name not among: "

--- a/reef/train/slime_backend/reef_adapters/bridge.py
+++ b/reef/train/slime_backend/reef_adapters/bridge.py
@@ -1136,8 +1136,8 @@ def start_bridge(
         ray.init(namespace=namespace)
     pgs = create_placement_groups(args)
     rollout_manager = create_rollout_manager(args, pgs["rollout"])
-    # The sao loss family needs the critic actor group; the other loss
-    # families discard it. ``args.use_critic`` comes from the explicit
+    # Loss families that train a value model need the critic actor group;
+    # the others discard it. ``args.use_critic`` comes from the explicit
     # --use-critic driver flag (or implicitly from --advantage-estimator ppo),
     # so keeping the group here is what wires the value model into the bridge
     # schedule rather than leaving it uninitialized.

--- a/reef/train/slime_backend/reef_adapters/driver.py
+++ b/reef/train/slime_backend/reef_adapters/driver.py
@@ -19,10 +19,10 @@ Variable                         Meaning
                                  ``run_dir``); ``--ready-file`` overrides it.
 ``REEF_BRIDGE_HEALTH_TIMEOUT_S``  Healthcheck RPC timeout in seconds
                                  (default ``10``).
-``REEF_TRAINING_LOSS``           Loss family to run, named directly.
-``REEF_TRAINING_RECIPE``         Bundled recipe whose loss family to run;
-                                 informational when ``REEF_TRAINING_LOSS``
-                                 is set.
+``REEF_TRAINING_LOSS``           Required for training. A registered family
+                                 name or dotted ``package.module:SPEC``.
+``REEF_TRAINING_RECIPE``         Optional recipe label for logs and errors;
+                                 never used to infer the loss family.
 ===============================  =============================================
 """
 
@@ -102,47 +102,28 @@ def _parse_slime_args(arguments: Sequence[str]):
         sys.argv = original_argv
 
 
-def _recipe_loss_family(recipe: str) -> str:
-    """Resolve a recipe name to its configured backend loss family.
-
-    The registry is the single source of truth: the backend never keeps its
-    own list of method names, so a new method that reuses an existing loss
-    family needs no driver changes.
-    """
-    from reef.recipe import WeightTrainingRecipe
-    from reef.recipe.registry import recipe_class_for
-
-    recipe_type = recipe_class_for(recipe)
-    if recipe_type is None or not issubclass(recipe_type, WeightTrainingRecipe):
-        raise RuntimeError(f"unsupported REEF_TRAINING_RECIPE: {recipe!r}")
-    loss_family = recipe_type.training_spec().loss_family
-    if not loss_family:
-        raise RuntimeError(f"unsupported REEF_TRAINING_RECIPE: {recipe!r}")
-    return loss_family
-
-
 def _resolve_loss_family(environ) -> tuple[str | None, str | None, SlimeAlgorithm | None]:
     """Resolve the training loss family and its spec from the driver environment.
 
-    ``REEF_TRAINING_LOSS`` names a loss family directly, so self-registered
-    (cookbook) methods never have to borrow a bundled recipe's name. When it
-    is set, ``REEF_TRAINING_RECIPE`` is informational only. Without it, the
-    bundled recipe registry resolves ``REEF_TRAINING_RECIPE`` as before.
+    ``REEF_TRAINING_LOSS`` names the family directly. Cookbook methods should
+    use a dotted reference so the driver and fresh workers can import their
+    implementation without Reef importing any method at boot.
+    ``REEF_TRAINING_RECIPE`` is only an optional label; it cannot select a
+    loss family.
     Returns ``(loss_family, recipe, spec)``, resolved through the loss-family
     registry exactly once, or ``(None, None, None)`` when neither variable is
     set. The registry is the vocabulary authority: an unknown family fails in
     ``resolve_loss_family``.
     """
     loss = environ.get("REEF_TRAINING_LOSS", "").strip()
+    recipe = environ.get("REEF_TRAINING_RECIPE", "").strip() or None
     if loss:
         try:
-            return loss, None, resolve_loss_family(loss)
+            return loss, recipe, resolve_loss_family(loss)
         except UnknownLossFamilyError as exc:
             raise RuntimeError(f"unsupported REEF_TRAINING_LOSS: {loss!r} ({exc})") from exc
-    recipe = environ.get("REEF_TRAINING_RECIPE", "").strip()
     if recipe:
-        loss = _recipe_loss_family(recipe)
-        return loss, recipe, resolve_loss_family(loss)
+        raise RuntimeError("REEF_TRAINING_LOSS is required when REEF_TRAINING_RECIPE is set")
     return None, None, None
 
 

--- a/reef/train/slime_backend/reef_adapters/driver.py
+++ b/reef/train/slime_backend/reef_adapters/driver.py
@@ -9,6 +9,9 @@ Variable                         Meaning
 ``SLIME_ARGS_FILE``              Optional. Shell-like file of Slime flags,
                                  parsed without a shell; direct command-line
                                  flags are appended after it.
+``REEF_CONFIG``                  Required. Deployment config written or selected
+                                 by ``reef serve``; ``reef.recipe`` identifies
+                                 the weight-training recipe class.
 ``REEF_RAY_NAMESPACE``           Ray namespace of the bridge actor
                                  (default ``reef``).
 ``REEF_RAY_ACTOR_NAME``          Name the bridge actor is published under
@@ -19,10 +22,6 @@ Variable                         Meaning
                                  ``run_dir``); ``--ready-file`` overrides it.
 ``REEF_BRIDGE_HEALTH_TIMEOUT_S``  Healthcheck RPC timeout in seconds
                                  (default ``10``).
-``REEF_TRAINING_LOSS``           Required for training. A registered family
-                                 name or dotted ``package.module:SPEC``.
-``REEF_TRAINING_RECIPE``         Optional recipe label for logs and errors;
-                                 never used to infer the loss family.
 ===============================  =============================================
 """
 
@@ -36,13 +35,17 @@ import shlex
 import signal
 import sys
 import threading
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 import ray
 
+from reef.recipe import RecipeConfigError, WeightTrainingRecipe
+from reef.recipe.registry import recipe_class_for
 from reef.runtime.names import DEFAULT_ACTOR_NAME, DEFAULT_NAMESPACE
+from reef.service.deploy.config import config_value, load_config
+from reef.train.algos.registry import loss_family_refs
 from reef.train.slime_backend.algorithm import SlimeAlgorithm
 from reef.train.slime_backend.loss_families import UnknownLossFamilyError, resolve_loss_family
 from reef.train.slime_backend.reef_adapters.training_job.storage import RetentionConfig
@@ -102,29 +105,30 @@ def _parse_slime_args(arguments: Sequence[str]):
         sys.argv = original_argv
 
 
-def _resolve_loss_family(environ) -> tuple[str | None, str | None, SlimeAlgorithm | None]:
-    """Resolve the training loss family and its spec from the driver environment.
+def _resolve_training_recipe(config: Mapping[str, Any]) -> tuple[str, str, SlimeAlgorithm]:
+    """Resolve the recipe and its loss family from ``reef.recipe``.
 
-    ``REEF_TRAINING_LOSS`` names the family directly. Cookbook methods should
-    use a dotted reference so the driver and fresh workers can import their
-    implementation without Reef importing any method at boot.
-    ``REEF_TRAINING_RECIPE`` is only an optional label; it cannot select a
-    loss family.
-    Returns ``(loss_family, recipe, spec)``, resolved through the loss-family
-    registry exactly once, or ``(None, None, None)`` when neither variable is
-    set. The registry is the vocabulary authority: an unknown family fails in
-    ``resolve_loss_family``.
+    The deployment already has one authoritative recipe reference. Importing
+    that selected class is the extension boundary; its static
+    :meth:`WeightTrainingRecipe.training_spec` supplies the loss family without
+    a second environment setting.
     """
-    loss = environ.get("REEF_TRAINING_LOSS", "").strip()
-    recipe = environ.get("REEF_TRAINING_RECIPE", "").strip() or None
-    if loss:
-        try:
-            return loss, recipe, resolve_loss_family(loss)
-        except UnknownLossFamilyError as exc:
-            raise RuntimeError(f"unsupported REEF_TRAINING_LOSS: {loss!r} ({exc})") from exc
-    if recipe:
-        raise RuntimeError("REEF_TRAINING_LOSS is required when REEF_TRAINING_RECIPE is set")
-    return None, None, None
+    recipe = config_value(config, "reef", "recipe", expand=False)
+    if not isinstance(recipe, str) or not recipe:
+        raise RuntimeError("REEF_CONFIG must define reef.recipe")
+    try:
+        recipe_class = recipe_class_for(recipe)
+    except RecipeConfigError as exc:
+        raise RuntimeError(f"cannot load reef.recipe {recipe!r}: {exc}") from exc
+    if recipe_class is None or not issubclass(recipe_class, WeightTrainingRecipe):
+        raise RuntimeError(f"slime driver requires reef.recipe to name a WeightTrainingRecipe class, got {recipe!r}")
+    loss_family = recipe_class.training_spec().loss_family.strip()
+    if not loss_family:
+        raise RuntimeError(f"reef.recipe {recipe!r} declares no training loss family")
+    try:
+        return loss_family, recipe, resolve_loss_family(loss_family)
+    except UnknownLossFamilyError as exc:
+        raise RuntimeError(f"reef.recipe {recipe!r} declares unsupported loss family {loss_family!r}: {exc}") from exc
 
 
 def _stamp_loss_family_reference(args, reference: str | None) -> None:
@@ -134,8 +138,11 @@ def _stamp_loss_family_reference(args, reference: str | None) -> None:
     process cannot resolve for an external family: its registry starts empty.
     The reference is what it needs to import the module itself.
     """
-    if reference and ":" in reference:
-        args.loss_family_ref = reference
+    if not reference:
+        return
+    dotted = reference if ":" in reference else loss_family_refs().get(reference)
+    if dotted is not None:
+        args.loss_family_ref = dotted
 
 
 def _apply_bridge_resume_fallback(args) -> None:
@@ -255,24 +262,22 @@ def _serve(direct_args: Sequence[str], ready_file: Path) -> int:
     args_file = os.environ.get("SLIME_ARGS_FILE", "").strip() or None
     namespace = os.environ.get("REEF_RAY_NAMESPACE", DEFAULT_NAMESPACE)
     actor_name = os.environ.get("REEF_RAY_ACTOR_NAME", DEFAULT_ACTOR_NAME)
-    loss_family, recipe, spec = _resolve_loss_family(os.environ)
+    config = load_config(_required_environment("REEF_CONFIG"))
+    loss_family, recipe, spec = _resolve_training_recipe(config)
     combined_args = [*(load_args_file(args_file) if args_file else []), *direct_args]
     retention, remaining_args = _retention_options(combined_args)
-    loss_family_config, slime_args = (
-        spec.parse_driver_options(remaining_args) if spec is not None else (None, remaining_args)
-    )
+    loss_family_config, slime_args = spec.parse_driver_options(remaining_args)
     args = _parse_slime_args(slime_args)
     _validate_tracking_args(args)
     _apply_bridge_resume_fallback(args)
-    if spec is not None:
-        # Family-specific flags stripped by ``parse_specific_options`` are
-        # projected back onto args so Slime's workers can observe them.
-        spec.apply_driver_options(args, loss_family_config)
-        _stamp_loss_family_reference(args, loss_family)
-        from reef.train.slime_backend.reef_adapters.slime_arguments import configure_reef_loss_args
+    # Family-specific flags stripped by ``parse_specific_options`` are
+    # projected back onto args so Slime's workers can observe them.
+    spec.apply_driver_options(args, loss_family_config)
+    _stamp_loss_family_reference(args, loss_family)
+    from reef.train.slime_backend.reef_adapters.slime_arguments import configure_reef_loss_args
 
-        configure_reef_loss_args(args)
-        spec.validate_backend_args(args, recipe=recipe)
+    configure_reef_loss_args(args)
+    spec.validate_backend_args(args, recipe=recipe)
 
     stopping = threading.Event()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ a deployment that brought its own plain objective.
 
 from __future__ import annotations
 
+import importlib
 from argparse import Namespace
 from collections.abc import Mapping
 from typing import Any
@@ -24,7 +25,19 @@ from reef.train.slime_backend.algorithm import SlimeAlgorithm
 from reef.train.slime_backend.loss_families import register_loss_family
 from reef.train.types import PolicyBatch, TrainingBatch
 
-#: The plain families the suite registers on top of the bundled ones.
+# The source suite exercises the repository cookbook as well as Reef core.
+# Load those packages explicitly: production ``import reef`` deliberately does
+# not, while importing a selected cookbook package registers its preparer and
+# lazy loss-family reference in this test process.
+for _cookbook_package in (
+    "recipes.harness_evolve",
+    "recipes.openclawrl",
+    "recipes.sao",
+    "recipes.tttd",
+):
+    importlib.import_module(_cookbook_package)
+
+#: The plain families the suite registers alongside cookbook families.
 TEST_FAMILIES = ("pg", "sft")
 
 

--- a/tests/reef_service/test_contributor_docs.py
+++ b/tests/reef_service/test_contributor_docs.py
@@ -49,6 +49,7 @@ def test_component_playbooks_name_the_live_registration_points() -> None:
     runtime_registry = (REPO_ROOT / "reef" / "runtime" / "registry.py").read_text(encoding="utf-8")
     route_registry = (REPO_ROOT / "reef" / "service" / "routes" / "__init__.py").read_text(encoding="utf-8")
 
-    assert "@register_kind" in playbooks and "def register_kind" in recipe_registry
+    assert "register_kind" in playbooks and "def register_kind" not in recipe_registry
+    assert "package.module:ClassName" in playbooks
     assert "@register_runtime_kind" in playbooks and "def register_runtime_kind" in runtime_registry
     assert "register_routes" in playbooks and "def register_routes" in route_registry

--- a/tests/reef_service/test_dependency_boundaries.py
+++ b/tests/reef_service/test_dependency_boundaries.py
@@ -63,20 +63,14 @@ METHOD_PACKAGES = ("harness_evolve", "openclawrl", "sao", "tttd")
 
 def test_infra_never_imports_a_method_package() -> None:
     # The whole of reef is the machinery the method packages build on,
-    # never the reverse: a method registers its recipe kind, step preparer and
-    # loss-family reference at import time (reef/__init__ alone imports the
-    # methods, last), so no other reef module has any reason to name one — at
-    # module scope or inside a function.
+    # never the reverse. Dotted recipe references import cookbook code only
+    # when the operator selects it, so no reef module has any reason to name a
+    # method at module scope or inside a function.
     offenders: list[str] = []
     for path in sorted((REPO_ROOT / "reef").rglob("*.py")):
-        if path == REPO_ROOT / "reef" / "__init__.py":
-            continue
         package = ".".join(path.parent.relative_to(REPO_ROOT).parts)
         imported = _imported_modules(ast.parse(path.read_text(encoding="utf-8")), package=package)
-        for method in METHOD_PACKAGES:
-            offenders.extend(
-                f"{path.relative_to(REPO_ROOT)} -> {target}" for target in _imports_of(imported, f"recipes.{method}")
-            )
+        offenders.extend(f"{path.relative_to(REPO_ROOT)} -> {target}" for target in _imports_of(imported, "recipes"))
     assert offenders == []
 
 
@@ -155,12 +149,11 @@ def test_backend_agnostic_core_never_imports_slime_backend_at_module_scope() -> 
     assert offenders == []
 
 
-def test_recipe_package_does_not_load_slime_backend() -> None:
-    # Method packages keep their backend half in a ``slime`` subpackage that
-    # only the training process imports: importing every bundled recipe must
-    # leave the service process free of the Slime stack.
+def test_importing_reef_does_not_load_cookbook_or_slime_packages() -> None:
     _assert_isolated_import(
         "import sys; import reef; "
+        "assert not [m for m in sys.modules if m == 'recipes' or m.startswith('recipes.')], "
+        "[m for m in sys.modules if m == 'recipes' or m.startswith('recipes.')]; "
         "assert not [m for m in sys.modules if m.startswith('reef.train.slime_backend')], "
         "[m for m in sys.modules if m.startswith('reef.train.slime_backend')]"
     )

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -21,7 +21,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from reef_client.client import HARNESS_VERSION_SIDECAR, ReefClient
 
 import reef.harness.adapters
-from reef import HarnessEvolveRecipe
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.artifact import InMemoryRepositoryBackend
 from reef.dispatcher import Dispatcher
 from reef.harness.adapters import get_adapter

--- a/tests/reef_service/test_harness_example.py
+++ b/tests/reef_service/test_harness_example.py
@@ -1,4 +1,4 @@
-"""Guarantees of the bundled recipes/harness_evolve/examples/harness_evolve example, hermetic: the
+"""Guarantees of the recipes/harness_evolve/examples/harness_evolve cookbook example, hermetic: the
 model binding is stubbed, episodes never run, and the boot test drives the
 same serve.yaml materialization run.sh performs."""
 
@@ -13,7 +13,7 @@ from types import ModuleType
 import pytest
 import yaml
 
-from reef import HarnessEvolveRecipe
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.harness.episode import EpisodeResult
 from reef.harness.model_binding import ModelBindingError
 from reef.recipe import load_recipe_config
@@ -147,7 +147,7 @@ def test_example_yaml_boots_the_recipe_through_from_environment(evolution, tmp_p
     boot the recipe (seed validation included) with a fake binary."""
     monkeypatch.setenv("REEF_UPSTREAM_API_KEY", "dummy")
     config = load_config(EXAMPLE_DIR / "serve.yaml")
-    recipe_sections = {key: config[key] for key in ("kind", "model", "evolution", "data")}
+    recipe_sections = {key: config[key] for key in ("implementation", "model", "evolution", "data")}
     # serve.yaml names the real binary; this run has no pi on PATH.
     recipe_sections["evolution"] = {**recipe_sections["evolution"], "binary": str(tmp_path / "fake-pi")}
     materialized = tmp_path / "harness_evolve.yaml"

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -1,4 +1,4 @@
-"""Guarantees of the harness_evolve recipe kind and its evolution backend,
+"""Guarantees of the harness_evolve cookbook recipe and its evolution backend,
 hermetic: episodes run a fake pi binary through the real adapter path."""
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 import reef.train.harness_backend as reef_harness_backend
-from reef import HarnessEvolveRecipe
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.artifact import InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
 from reef.core.reports import ScoredRolloutReport
@@ -20,7 +20,7 @@ from reef.harness.adapters import get_adapter
 from reef.harness.episode import EpisodeResult
 from reef.harness.model_binding import ModelBinding, ModelBindingError, ModelBindings
 from reef.recipe import RecipeConfigError
-from reef.recipe.registry import RecipeRegistry, recipe_kinds
+from reef.recipe.registry import RecipeRegistry, recipe_class_for
 from reef.records import RecordStore
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.train.evaluation import DefaultCandidateEvaluationPlugin
@@ -144,11 +144,12 @@ def run_backend_step(
         raise
 
 
-# -- recipe registration --------------------------------------------------
+# -- recipe resolution ----------------------------------------------------
 
 
-def test_kind_is_registered() -> None:
-    assert "harness_evolve" in recipe_kinds()
+def test_recipe_resolves_by_dotted_reference() -> None:
+    assert recipe_class_for("recipes.harness_evolve.recipe:HarnessEvolveRecipe") is HarnessEvolveRecipe
+    assert recipe_class_for("harness_evolve") is None
 
 
 def test_yaml_config_boots_the_recipe_through_dotted_references(tmp_path: Path, monkeypatch) -> None:

--- a/tests/reef_service/test_model_binding.py
+++ b/tests/reef_service/test_model_binding.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 
-from reef import HarnessEvolveRecipe
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.harness.adapters import get_adapter
 from reef.harness.model_binding import ModelBinding, ModelBindings
 from reef.harness.render import render_composition

--- a/tests/reef_service/test_openclawrl.py
+++ b/tests/reef_service/test_openclawrl.py
@@ -534,7 +534,7 @@ def test_truncated_reasoning_never_comes_back_as_the_reply() -> None:
 def test_retired_openclawrl_fields_are_accepted_and_ignored(caplog) -> None:
     from reef_service.runtime_stubs import StubTrainingRuntime
 
-    from reef import OpenClawRLRecipe
+    from recipes.openclawrl import OpenClawRLRecipe
 
     with caplog.at_level("WARNING"):
         recipe = OpenClawRLRecipe(StubTrainingRuntime(), prm_teacher_timeout_s=5.0)

--- a/tests/reef_service/test_ray_runtime_multi_lora.py
+++ b/tests/reef_service/test_ray_runtime_multi_lora.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from reef import SAORecipe
+from recipes.sao import SAORecipe
 from reef.runtime.adapters.ray_runtime import RayRuntime, RayRuntimeError
 
 from .test_ray_runtime import DeferredWeightUpdateTrainGroupHandle

--- a/tests/reef_service/test_reef_contracts.py
+++ b/tests/reef_service/test_reef_contracts.py
@@ -45,7 +45,7 @@ def dispatcher_with_checkpoint_strategy(strategy, *, backend_factory, local_arti
 
 class WeightRecipe(Recipe):
     """A recipe whose scenarios commit live weights, so serving-version
-    verification applies (the bundled ``recipe`` kind serves a plain
+    verification applies (the core ``recipe`` implementation serves a plain
     evolution surface and never verifies a weight version)."""
 
     def build_surface(self, scenario: str) -> Surface:

--- a/tests/reef_service/test_reef_interface_inheritance.py
+++ b/tests/reef_service/test_reef_interface_inheritance.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from abc import ABC
 
-from reef import OpenClawRLRecipe
+from recipes.openclawrl import OpenClawRLRecipe
 from reef.artifact import GitLFSRepositoryBackend, InMemoryRepositoryBackend, RepositoryBackend
 from reef.recipe import Recipe
 from reef.scenario.checkpoint_strategy import CheckpointStrategy, EveryNVersions

--- a/tests/reef_service/test_reef_recipes.py
+++ b/tests/reef_service/test_reef_recipes.py
@@ -8,12 +8,11 @@ from pathlib import Path
 import pytest
 from reef_service.runtime_stubs import StubTrainingRuntime
 
-from recipes.openclawrl import OpenClawRLProcessor
+from recipes.openclawrl import OpenClawRLProcessor, OpenClawRLRecipe
 from recipes.sao import SAOProcessor, SAORecipe
-from recipes.tttd import TTTDProcessor
-from reef import OpenClawRLRecipe, TTTDRecipe
+from recipes.tttd import TTTDGroupedRolloutReport, TTTDProcessor, TTTDRecipe
 from reef.core import AgentRecord, RequestType
-from reef.core.reports import GroupedRolloutReport, ScoredRolloutReport
+from reef.core.reports import ScoredRolloutReport
 from reef.recipe import (
     Recipe,
     RecipeConfigError,
@@ -22,10 +21,8 @@ from reef.recipe import (
     WeightTrainingRecipe,
     WeightTrainingSpec,
     load_recipe_config,
-    register_kind,
 )
-from reef.recipe import registry as recipe_registry
-from reef.recipe.registry import build_named_recipe, build_recipe, recipe_class_for, recipe_kinds
+from reef.recipe.registry import build_named_recipe, build_recipe, recipe_class_for
 from reef.records import RecordStore
 from reef.runtime import InferenceProxyRuntime
 from reef.scenario.checkpoint_strategy import EveryNVersions
@@ -46,77 +43,44 @@ def test_training_recipes_share_max_staleness(recipe_type) -> None:
         recipe_type(StubTrainingRuntime(), max_staleness=2)
 
 
-def test_recipe_registry_registers_recipe_kind(monkeypatch) -> None:
-    monkeypatch.setattr(recipe_registry, "_RECIPE_KINDS", {})
-
-    @register_kind("custom")
-    class CustomRecipe(Recipe):
-        pass
-
-    assert recipe_kinds() == ("custom",)
-    assert recipe_class_for("custom") is CustomRecipe
-
-
-def test_recipe_registry_rejects_duplicate_kind(monkeypatch) -> None:
-    monkeypatch.setattr(recipe_registry, "_RECIPE_KINDS", {})
-
-    @register_kind("duplicate")
-    class FirstRecipe(Recipe):
-        pass
-
-    with pytest.raises(ValueError, match="recipe kind 'duplicate' is already registered"):
-
-        @register_kind("duplicate")
-        class SecondRecipe(Recipe):
-            pass
-
-
-def test_recipe_kinds_include_registered_builtins() -> None:
-    # The bundled vocabulary: the base wiring-check kind and the bundled
-    # methods. Registration order is an import detail, not a contract.
-    assert set(recipe_kinds()) == {
-        "recipe",
-        "openclawrl",
-        "sao",
-        "tttd",
-        "harness_evolve",
-    }
+def test_recipe_class_resolver_has_no_method_short_names() -> None:
     assert recipe_class_for("recipe") is Recipe
-    assert recipe_class_for("sft") is None
+    assert recipe_class_for("sao") is None
+    assert recipe_class_for("tttd") is None
+    assert recipe_class_for("openclawrl") is None
+    assert recipe_class_for("harness_evolve") is None
 
 
-def test_builtin_weight_training_recipe_loss_family_mappings() -> None:
+def test_cookbook_weight_training_recipe_loss_family_mappings() -> None:
     mappings = {
-        kind: recipe_type.training_spec().loss_family
-        for kind in recipe_kinds()
-        if (recipe_type := recipe_class_for(kind)) is not None and issubclass(recipe_type, WeightTrainingRecipe)
+        recipe_type.__name__: recipe_type.training_spec().loss_family
+        for recipe_type in (OpenClawRLRecipe, SAORecipe, TTTDRecipe)
     }
 
     assert mappings == {
-        "openclawrl": "openclawrl",
-        "sao": "sao",
-        "tttd": "tttd",
+        "OpenClawRLRecipe": "openclawrl",
+        "SAORecipe": "sao",
+        "TTTDRecipe": "tttd",
     }
 
 
-def test_dotted_kind_resolves_an_unbundled_recipe_class() -> None:
+def test_dotted_reference_resolves_an_external_recipe_class() -> None:
     assert recipe_class_for("reef.recipe.base:Recipe") is Recipe
-    # Dotted kinds never enter the bundled vocabulary.
-    assert "reef.recipe.base:Recipe" not in recipe_kinds()
+    assert recipe_class_for("recipes.sao.recipe:SAORecipe") is SAORecipe
 
 
 @pytest.mark.parametrize(
-    ("kind", "match"),
+    ("reference", "match"),
     [
-        ("nowhere.to.be:Found", "cannot import recipe kind"),
-        ("reef.recipe.base:missing", "cannot import recipe kind"),
+        ("nowhere.to.be:Found", "cannot import recipe reference"),
+        ("reef.recipe.base:missing", "cannot import recipe reference"),
         ("reef.recipe.base:config_positive_int", "is not a Recipe class"),
         (":Recipe", "must be 'package.module:ClassName'"),
     ],
 )
-def test_dotted_kind_rejects_bad_references(kind: str, match: str) -> None:
+def test_dotted_recipe_rejects_bad_references(reference: str, match: str) -> None:
     with pytest.raises(RecipeConfigError, match=match):
-        recipe_class_for(kind)
+        recipe_class_for(reference)
 
 
 def test_recipe_registry_resolves_registered_recipe() -> None:
@@ -151,7 +115,7 @@ def test_recipe_registry_resolves_registered_recipe() -> None:
             "tttd",
             TTTDProcessor,
             "tttd",
-            GroupedRolloutReport,
+            TTTDGroupedRolloutReport,
         ),
     ],
 )
@@ -194,8 +158,8 @@ def test_build_rejects_an_unknown_step_preparer_before_any_training_step() -> No
 
 
 def test_tttd_build_resolves_its_backend_registered_preparer_in_a_fresh_process() -> None:
-    # A service process never imports the Slime driver, so the bundled
-    # preparers must register from reef.train.algos alone for eager preparer
+    # A service process never imports the Slime driver, so the cookbook
+    # package must register its preparer when the dotted recipe is imported for eager preparer
     # resolution to accept "tttd" in the process the recipe is served from.
     # In-process tests cannot pin this (a sibling test may have imported the
     # driver for the whole session), hence the subprocess.
@@ -205,7 +169,7 @@ def test_tttd_build_resolves_its_backend_registered_preparer_in_a_fresh_process(
             "-c",
             (
                 f"import sys; sys.path.insert(0, {str(Path(__file__).resolve().parents[1])!r})\n"
-                "from reef import TTTDRecipe\n"
+                "from recipes.tttd import TTTDRecipe\n"
                 "from reef.records import RecordStore\n"
                 "from reef_service.runtime_stubs import StubTrainingRuntime\n"
                 "trainer = TTTDRecipe(StubTrainingRuntime(), groups_per_step=1, rollouts_per_group=2)"
@@ -255,9 +219,9 @@ def _turn_inference(agent_record_id: str, tokens: list[int], log_prob: float) ->
         ),
     ],
 )
-def test_bundled_recipes_reject_multi_turn_policy_samples(recipe, metadata) -> None:
+def test_cookbook_recipes_reject_multi_turn_policy_samples(recipe, metadata) -> None:
     # Observable pin: a valid, assemblable two-turn episode is refused by the
-    # bundled recipes' processors — the report is terminal and released, not
+    # cookbook recipes' processors — the report is terminal and released, not
     # accepted as a candidate. (openclawrl is absent: it consumes no reports
     # at all — see test_openclawrl_recipe_ignores_reports.)
     trainer = recipe.build("math", RecordStore())
@@ -302,7 +266,7 @@ def test_openclawrl_recipe_never_trains_on_reports() -> None:
 def test_recipe_factory_keeps_method_configuration_inside_recipe() -> None:
     runtime = StubTrainingRuntime()
     recipe = build_recipe(
-        "tttd",
+        "recipes.tttd.recipe:TTTDRecipe",
         {
             "REEF_TRAINER_URL": "http://trainer:8901",
             "REEF_TRAINER_TOKEN": "secret",
@@ -320,13 +284,13 @@ def test_recipe_factory_keeps_method_configuration_inside_recipe() -> None:
 
 def test_training_recipe_requires_its_runtime_environment() -> None:
     with pytest.raises(RecipeConfigError, match="requires a training runtime"):
-        build_recipe("tttd", {})
+        build_recipe("recipes.tttd.recipe:TTTDRecipe", {})
 
 
 def test_recipe_config_routes_sections_to_their_consumers(tmp_path) -> None:
     path = tmp_path / "openclawrl.yaml"
     path.write_text(
-        """kind: openclawrl
+        """implementation: recipes.openclawrl.recipe:OpenClawRLRecipe
 data:
   batch_size: 4
 artifact:
@@ -337,24 +301,24 @@ model:
     )
 
     settings = load_recipe_config(path)
-    recipe = build_recipe(settings["kind"], {}, config=settings, runtime=StubTrainingRuntime())
+    recipe = build_recipe(settings["implementation"], {}, config=settings, runtime=StubTrainingRuntime())
 
     assert recipe.batch_size == 4
     assert recipe.checkpoint_strategy == EveryNVersions(3)
 
 
-def test_recipe_config_requires_kind(tmp_path) -> None:
+def test_recipe_config_requires_implementation(tmp_path) -> None:
     path = tmp_path / "recipes.yaml"
     path.write_text("data:\n  batch_size: 1\n")
 
-    with pytest.raises(RecipeConfigError, match="non-empty 'kind'"):
+    with pytest.raises(RecipeConfigError, match="non-empty 'implementation'"):
         load_recipe_config(path)
 
 
 def test_named_recipe_resolves_preset_from_filename(tmp_path) -> None:
     path = tmp_path / "thorough.yaml"
     path.write_text(
-        """kind: recipe
+        """implementation: recipe
 runtime:
   type: inference_proxy
   base_url: http://provider
@@ -373,7 +337,7 @@ model:
 def test_config_backed_training_recipe_requires_an_injected_runtime(tmp_path) -> None:
     path = tmp_path / "sao-qwen.yaml"
     path.write_text(
-        """kind: sao
+        """implementation: recipes.sao.recipe:SAORecipe
 model:
   path: Qwen/Qwen3.5-27B
 """
@@ -382,14 +346,14 @@ model:
         build_named_recipe("sao-qwen", config_directory=tmp_path)
 
 
-def test_named_recipe_without_config_directory_resolves_kinds_only() -> None:
+def test_named_recipe_without_config_directory_resolves_core_recipe_only() -> None:
     assert isinstance(build_named_recipe("recipe", {}), Recipe)
     with pytest.raises(UnknownScenarioRecipe, match="unknown scenario recipe 'thorough'"):
         build_named_recipe("thorough", {})
 
 
 def test_named_recipe_reads_the_config_directory_from_the_environment(tmp_path) -> None:
-    (tmp_path / "thorough.yaml").write_text("kind: recipe\nmodel:\n  path: Qwen/Qwen3.5-27B\n")
+    (tmp_path / "thorough.yaml").write_text("implementation: recipe\nmodel:\n  path: Qwen/Qwen3.5-27B\n")
 
     recipe = build_named_recipe("thorough", {"REEF_RECIPE_CONFIG_DIR": str(tmp_path)})
 
@@ -403,17 +367,17 @@ def test_instance_registry_is_a_closed_set() -> None:
         registry.resolve("recipe")
 
 
-def test_named_recipes_never_import_dotted_kinds() -> None:
+def test_named_recipes_never_import_implementation_references() -> None:
     with pytest.raises(RecipeConfigError, match="invalid recipe name"):
         build_named_recipe("reef.recipe.base:Recipe", {})
 
 
 def test_named_recipe_configs_resolve_by_name(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "test-minimax-key")
-    # A local proxy preset: the bundled recipe kind pinned to a deployment's
+    # A local proxy preset: the core recipe pinned to a deployment's
     # own endpoint and model.
     (tmp_path / "local-proxy.yaml").write_text(
-        "kind: recipe\n"
+        "implementation: recipe\n"
         "runtime:\n"
         "  type: inference_proxy\n"
         "  base_url: http://127.0.0.1:30000\n"
@@ -428,10 +392,10 @@ def test_named_recipe_configs_resolve_by_name(monkeypatch, tmp_path) -> None:
     assert isinstance(local.runtime, InferenceProxyRuntime)
     assert local.runtime.model_path == "Qwen/Qwen3.6-27B"
 
-    # The hosted-provider shape (api_key_env) needs no bundled example: any
+    # The hosted-provider shape (api_key_env) needs no built-in example: any
     # directory of named YAMLs resolves the same way.
     (tmp_path / "hosted-proxy.yaml").write_text(
-        "kind: recipe\n"
+        "implementation: recipe\n"
         "runtime:\n"
         "  type: inference_proxy\n"
         "  base_url: https://api.minimax.io/anthropic\n"
@@ -447,7 +411,7 @@ def test_named_recipe_configs_resolve_by_name(monkeypatch, tmp_path) -> None:
     assert runtime.api_key == "test-minimax-key"
 
 
-def test_bundled_preparers_signal_their_recipes_loss_family() -> None:
+def test_cookbook_preparers_signal_their_recipes_loss_family() -> None:
     # The recipe's loss_family and the preparer's StepSignal.loss_family are
     # two strings; the bridge only compares them at the first training step.
     # Pin them here so a drift fails before any GPU spins up.
@@ -460,10 +424,7 @@ def test_bundled_preparers_signal_their_recipes_loss_family() -> None:
     first = PolicySample("i1", (5, 1), (1,), (-0.1,), 0.5)
     second = replace(first, source_agent_record_id="i2", reward=1.5)
     checked = set()
-    for kind in recipe_kinds():
-        recipe_type = recipe_class_for(kind)
-        if recipe_type is None or not issubclass(recipe_type, WeightTrainingRecipe):
-            continue
+    for recipe_type in (OpenClawRLRecipe, SAORecipe, TTTDRecipe):
         spec = recipe_type.training_spec()
         assert spec.processor is not None
         if spec.processor.output_schema is GroupedPolicyBatch:
@@ -471,7 +432,7 @@ def test_bundled_preparers_signal_their_recipes_loss_family() -> None:
         else:
             batch = PolicyBatch("b", (first, second))
         signal = resolve_preparer(spec.step_preparer)(batch, {})
-        assert signal.loss_family == spec.loss_family, kind
+        assert signal.loss_family == spec.loss_family, recipe_type.__name__
         assert resolve_loss_family(signal.loss_family).loss_family == spec.loss_family
-        checked.add(kind)
-    assert checked == {"openclawrl", "sao", "tttd"}
+        checked.add(recipe_type.__name__)
+    assert checked == {"OpenClawRLRecipe", "SAORecipe", "TTTDRecipe"}

--- a/tests/reef_service/test_reef_removed_lifecycle.py
+++ b/tests/reef_service/test_reef_removed_lifecycle.py
@@ -216,21 +216,21 @@ def test_recipe_config_field_declarations_replaced_the_config_spelling_quartet()
 
 
 @pytest.mark.unit
-def test_online_grpo_preparer_and_kind_are_removed() -> None:
-    """Neither the online_grpo step preparer nor its recipe kind may come back.
+def test_online_grpo_preparer_and_recipe_are_removed() -> None:
+    """Neither the online_grpo step preparer nor its recipe class may come back.
 
     Grouped preparers are cookbook-owned now; the grouped machinery (group
     keys, slots, the decide_group barrier in the reported-feedback processor) stays. The
     ``online_rft`` kind that replaced this arm is gone too — a filtered-SFT
     data recipe, with nothing in it addressing drift on a continually updated
     policy."""
-    from reef.recipe.registry import recipe_kinds
+    from reef.recipe.registry import recipe_class_for
     from reef.train.algos.registry import resolve_preparer
 
     with pytest.raises(ValueError, match="unknown step preparer"):
         resolve_preparer("online_grpo")
-    assert "online_grpo" not in recipe_kinds()
-    assert "online_rft" not in recipe_kinds()
+    assert recipe_class_for("online_grpo") is None
+    assert recipe_class_for("online_rft") is None
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_reports.py
+++ b/tests/reef_service/test_reports.py
@@ -10,10 +10,10 @@ from typing import Any
 
 import pytest
 
-from recipes.tttd import TTTDProcessor
+from recipes.tttd import TTTDGroupedRolloutReport, TTTDProcessor
 from reef.artifact.memory import InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
-from reef.core.reports import GroupedRolloutReport, ReportBase, ReportValidationError, ScoredRolloutReport
+from reef.core.reports import ReportBase, ReportValidationError, ScoredRolloutReport
 from reef.dispatcher import Dispatcher
 from reef.recipe.base import Recipe
 from reef.recipe.registry import RecipeRegistry
@@ -60,11 +60,11 @@ def test_scored_rollout_round_trip() -> None:
 
 
 def test_grouped_rollout_round_trip() -> None:
-    schema = GroupedRolloutReport(score=0.5, step=4, group=1, rollout=17, groups_per_step=8, rollouts_per_group=64)
+    schema = TTTDGroupedRolloutReport(score=0.5, step=4, group=1, rollout=17, groups_per_step=8, rollouts_per_group=64)
     body = schema.to_dict()
     assert isinstance(schema, ScoredRolloutReport)
     assert body["metadata"]["comparison_set"] == "tttd-step-4-group-1"
-    assert GroupedRolloutReport.from_dict(body) == schema
+    assert TTTDGroupedRolloutReport.from_dict(body) == schema
 
 
 def test_task_outcome_round_trip() -> None:
@@ -96,9 +96,9 @@ def test_minimal_score_only_report_is_a_valid_task_outcome() -> None:
         (ScoredRolloutReport, {}, "score is required"),
         (ScoredRolloutReport, {"score": True}, "score must be a number"),
         (ScoredRolloutReport, {"score": float("nan")}, "score must be finite"),
-        (GroupedRolloutReport, {"score": 1.0}, "metadata.step is required"),
+        (TTTDGroupedRolloutReport, {"score": 1.0}, "metadata.step is required"),
         (
-            GroupedRolloutReport,
+            TTTDGroupedRolloutReport,
             {
                 "score": 1.0,
                 "metadata": {
@@ -122,22 +122,22 @@ def test_violations_name_the_broken_field(report_type: type[ReportBase], payload
 
 
 def test_tttd_coordinates_must_sit_inside_their_announced_grid() -> None:
-    body = GroupedRolloutReport(
+    body = TTTDGroupedRolloutReport(
         score=1.0, step=0, group=0, rollout=0, groups_per_step=2, rollouts_per_group=3
     ).to_dict()
     body["metadata"]["group"] = 2  # == groups_per_step
     body["metadata"]["comparison_set"] = "tttd-step-0-group-2"
     with pytest.raises(ReportValidationError, match="group"):
-        GroupedRolloutReport.from_dict(body)
+        TTTDGroupedRolloutReport.from_dict(body)
 
 
 def test_tttd_comparison_set_must_echo_coordinates() -> None:
-    body = GroupedRolloutReport(
+    body = TTTDGroupedRolloutReport(
         score=1.0, step=0, group=0, rollout=0, groups_per_step=2, rollouts_per_group=3
     ).to_dict()
     body["metadata"]["comparison_set"] = "tttd-step-9-group-9"
     with pytest.raises(ReportValidationError, match="comparison_set"):
-        GroupedRolloutReport.from_dict(body)
+        TTTDGroupedRolloutReport.from_dict(body)
 
 
 # --------------------------------------------------------- floor, not a ceiling
@@ -234,12 +234,12 @@ def test_tttd_names_grid_mismatch_and_schema_violations() -> None:
         ProcessorContext(
             "discovery",
             {"groups_per_step": 2, "rollouts_per_group": 3},
-            report_type=GroupedRolloutReport,
+            report_type=TTTDGroupedRolloutReport,
         )
     )
     # Announces an 8x64 grid at a 2x3 scenario: a config-relative rejection
     # from the judge, named.
-    mismatched = GroupedRolloutReport(
+    mismatched = TTTDGroupedRolloutReport(
         score=1.0, step=0, group=0, rollout=0, groups_per_step=8, rollouts_per_group=64
     ).to_dict(references=["inference-a"])
     processor.ingest(

--- a/tests/reef_service/test_runtime_registry.py
+++ b/tests/reef_service/test_runtime_registry.py
@@ -55,7 +55,7 @@ def test_recipe_rejects_unknown_runtime_before_scenario_is_created(tmp_path) -> 
     recipes = tmp_path / "recipes"
     recipes.mkdir()
     (recipes / "qwen.yaml").write_text(
-        """kind: recipe
+        """implementation: recipe
 runtime:
   type: missing
   base_url: http://runtime
@@ -73,7 +73,7 @@ def test_recipe_resolution_does_not_probe_runtime(tmp_path, monkeypatch) -> None
     recipes = tmp_path / "recipes"
     recipes.mkdir()
     (recipes / "qwen.yaml").write_text(
-        """kind: recipe
+        """implementation: recipe
 runtime:
   type: inference_proxy
   base_url: http://provider

--- a/tests/reef_service/test_sao_configs.py
+++ b/tests/reef_service/test_sao_configs.py
@@ -3,7 +3,7 @@
 The SAO migration (commit 55e551d) removed ``--advantage-estimator=sao`` from
 Slime's argparse choices while the SAO config still passed it — the deployment
 could not boot, and nothing in CI noticed because no test ever
-re-parsed a bundled YAML's flags. These tests close that hole: for each
+re-parsed a cookbook YAML's flags. These tests close that hole: for each
 ``training-*.yaml`` they materialize the slime-driver command exactly as
 ``reef serve`` would, strip the driver/retention/loss-family options exactly as
 ``reef_adapters.driver`` does, and then feed the remaining flags to the actual
@@ -93,7 +93,7 @@ def _resolved_strings(config: dict, value):
         yield interpolate_config(config, value)
 
 
-# Megatron-native flags used by the bundled configs. Slime's parser only knows
+# Megatron-native flags used by the cookbook configs. Slime's parser only knows
 # them when Megatron is importable (its extra-args provider extends Megatron's
 # parser), so on CPU they surface as parse leftovers and are checked by name.
 _MEGATRON_ONLY_FLAGS = frozenset(
@@ -203,8 +203,8 @@ def _build_slime_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _driver_tokens(config: dict) -> tuple[list[str], str]:
-    """Materialize the slime-driver command tokens and the configured recipe."""
+def _driver_tokens(config: dict) -> tuple[list[str], str, str]:
+    """Materialize the driver command, recipe label, and explicit loss reference."""
     from reef.service.deploy.config import interpolate_config
 
     services = {service["name"]: service for service in config["services"]}
@@ -214,7 +214,9 @@ def _driver_tokens(config: dict) -> tuple[list[str], str]:
     assert module in tokens, f"slime-driver service must invoke {module}"
     recipe = services["slime-driver"]["env"]["REEF_TRAINING_RECIPE"]
     recipe = interpolate_config(config, recipe)
-    return tokens[tokens.index(module) + 1 :], recipe
+    loss = services["slime-driver"]["env"]["REEF_TRAINING_LOSS"]
+    loss = interpolate_config(config, loss)
+    return tokens[tokens.index(module) + 1 :], recipe, loss
 
 
 def _strip_sglang_flags(tokens: list[str]) -> list[str]:
@@ -233,23 +235,24 @@ def _strip_sglang_flags(tokens: list[str]) -> list[str]:
 
 
 def _parse_config(config_path: Path):
-    """Run one bundled config through the driver's own argument pipeline.
+    """Run one cookbook config through the driver's own argument pipeline.
 
     Returns ``(args, spec, options, recipe)`` with ``args`` parsed by the real
     Slime parser and Megatron-only leftovers verified against the allowlist.
     """
     from reef.service.deploy.config import load_config
     from reef.train.slime_backend.loss_families import resolve_loss_family
-    from reef.train.slime_backend.reef_adapters.driver import _driver_options, _recipe_loss_family, _retention_options
+    from reef.train.slime_backend.reef_adapters.driver import _driver_options, _retention_options
 
     with patch.dict(os.environ, _CONFIG_ENV, clear=False):
         config = load_config(config_path)
-    tokens, recipe = _driver_tokens(config)
+    tokens, recipe, loss = _driver_tokens(config)
     assert recipe == config["reef"]["recipe"], "slime-driver env must run the configured recipe"
+    assert ":" in loss, "cookbook loss families must be explicit dotted references"
 
     _, tokens = _driver_options(tokens)
     _, tokens = _retention_options(tokens)
-    spec = resolve_loss_family(_recipe_loss_family(recipe))
+    spec = resolve_loss_family(loss)
     options, tokens = spec.parse_driver_options(tokens)
     tokens = _strip_sglang_flags(tokens)
 
@@ -302,7 +305,7 @@ def _apply_validation_derivations(args) -> None:
 
 
 @pytest.mark.unit
-def test_bundled_training_configs_are_discovered() -> None:
+def test_cookbook_training_configs_are_discovered() -> None:
     paths = {_config_id(path) for path in TRAINING_CONFIGS}
     assert paths >= {
         "recipes/openclawrl/examples/openclawrl/serve.yaml",
@@ -358,9 +361,13 @@ def test_user_facing_example_deployment_resolves(config_path: Path) -> None:
 
     recipe_type = recipe_class_for(settings.recipe)
     if recipe_type is None:
-        named_recipe = config_path.with_name(f"{settings.recipe}.yaml")
-        assert named_recipe.is_file(), f"{config_path} selects unknown recipe {settings.recipe!r}"
-        recipe_type = recipe_class_for(load_recipe_config(named_recipe)["kind"])
+        inline_implementation = config.get("implementation")
+        if isinstance(inline_implementation, str):
+            recipe_type = recipe_class_for(inline_implementation)
+        else:
+            named_recipe = config_path.with_name(f"{settings.recipe}.yaml")
+            assert named_recipe.is_file(), f"{config_path} selects unknown recipe {settings.recipe!r}"
+            recipe_type = recipe_class_for(load_recipe_config(named_recipe)["implementation"])
     assert recipe_type is not None
     if settings.model_path is not None and hasattr(recipe_type, "service_config"):
         recipe_type.service_config(_recipe_owned_settings(settings), model_path=settings.model_path)
@@ -385,7 +392,7 @@ def test_tttd_deployment_anchors_git_and_checkpoint_state_to_absolute_root() -> 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("config_path", TRAINING_CONFIGS, ids=_config_id)
-def test_bundled_training_config_parses_and_validates(config_path: Path) -> None:
+def test_cookbook_training_config_parses_and_validates(config_path: Path) -> None:
     from reef.train.slime_backend.reef_adapters.preflight import validate_bridge_args
     from reef.train.slime_backend.reef_adapters.slime_arguments import configure_reef_loss_args
 
@@ -414,7 +421,7 @@ def test_sao_config_uses_the_hook_based_contract() -> None:
 
 
 # The parser marks a handful of flags required; standalone parses (outside a
-# full bundled command) must supply them.
+# full cookbook command) must supply them.
 _REQUIRED_BASELINE = ["--rollout-batch-size=1"]
 
 

--- a/tests/reef_service/test_sao_configs.py
+++ b/tests/reef_service/test_sao_configs.py
@@ -203,8 +203,8 @@ def _build_slime_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _driver_tokens(config: dict) -> tuple[list[str], str, str]:
-    """Materialize the driver command, recipe label, and explicit loss reference."""
+def _driver_tokens(config: dict) -> tuple[list[str], str]:
+    """Materialize the driver command and deployment recipe reference."""
     from reef.service.deploy.config import interpolate_config
 
     services = {service["name"]: service for service in config["services"]}
@@ -212,11 +212,11 @@ def _driver_tokens(config: dict) -> tuple[list[str], str, str]:
     tokens = shlex.split(command)
     module = SLIME_DRIVER_MODULE
     assert module in tokens, f"slime-driver service must invoke {module}"
-    recipe = services["slime-driver"]["env"]["REEF_TRAINING_RECIPE"]
-    recipe = interpolate_config(config, recipe)
-    loss = services["slime-driver"]["env"]["REEF_TRAINING_LOSS"]
-    loss = interpolate_config(config, loss)
-    return tokens[tokens.index(module) + 1 :], recipe, loss
+    driver_env = services["slime-driver"].get("env") or {}
+    assert "REEF_TRAINING_RECIPE" not in driver_env
+    assert "REEF_TRAINING_LOSS" not in driver_env
+    recipe = config["reef"]["recipe"]
+    return tokens[tokens.index(module) + 1 :], recipe
 
 
 def _strip_sglang_flags(tokens: list[str]) -> list[str]:
@@ -241,18 +241,20 @@ def _parse_config(config_path: Path):
     Slime parser and Megatron-only leftovers verified against the allowlist.
     """
     from reef.service.deploy.config import load_config
-    from reef.train.slime_backend.loss_families import resolve_loss_family
-    from reef.train.slime_backend.reef_adapters.driver import _driver_options, _retention_options
+    from reef.train.slime_backend.reef_adapters.driver import (
+        _driver_options,
+        _resolve_training_recipe,
+        _retention_options,
+    )
 
     with patch.dict(os.environ, _CONFIG_ENV, clear=False):
         config = load_config(config_path)
-    tokens, recipe, loss = _driver_tokens(config)
-    assert recipe == config["reef"]["recipe"], "slime-driver env must run the configured recipe"
-    assert ":" in loss, "cookbook loss families must be explicit dotted references"
+    tokens, recipe = _driver_tokens(config)
+    _loss_family, resolved_recipe, spec = _resolve_training_recipe(config)
+    assert resolved_recipe == recipe
 
     _, tokens = _driver_options(tokens)
     _, tokens = _retention_options(tokens)
-    spec = resolve_loss_family(loss)
     options, tokens = spec.parse_driver_options(tokens)
     tokens = _strip_sglang_flags(tokens)
 

--- a/tests/reef_service/test_sao_pipeline.py
+++ b/tests/reef_service/test_sao_pipeline.py
@@ -20,7 +20,7 @@ from reef.artifact.artifact import LiveWeightArtifactRef
 from reef.core import AgentRecord, RequestType
 from reef.dispatcher import Dispatcher
 from reef.recipe import RecipeRegistry
-from reef.recipe.registry import build_recipe, recipe_kinds
+from reef.recipe.registry import build_recipe, recipe_class_for
 from reef.records import RecordStore
 from reef.runtime import ActivatedModel, ModelCandidate, PreparedTrainingStep, TrainingRuntime
 from reef.runtime.candidates import StaleCandidate
@@ -103,10 +103,12 @@ def _sao_report(agent_record_id: str, reference: str, score: float) -> AgentReco
 
 
 @pytest.mark.unit
-def test_sao_recipe_is_registered_under_its_kind() -> None:
-    assert "sao" in recipe_kinds()
+def test_sao_recipe_resolves_by_dotted_reference() -> None:
+    reference = "recipes.sao.recipe:SAORecipe"
+    assert recipe_class_for(reference) is SAORecipe
+    assert recipe_class_for("sao") is None
 
-    recipe = build_recipe("sao", {}, runtime=_StubTrainingRuntime())
+    recipe = build_recipe(reference, {}, runtime=_StubTrainingRuntime())
 
     assert isinstance(recipe, SAORecipe)
     assert recipe.name == "sao"

--- a/tests/reef_service/test_skillclaw.py
+++ b/tests/reef_service/test_skillclaw.py
@@ -316,7 +316,7 @@ def test_the_day_ledger_feeds_the_digest_and_the_sentinel_means_unscored(skillcl
 
 def test_example_yaml_boots_the_recipe_with_the_paper_wiring(example, tmp_path, monkeypatch) -> None:
     """The driver's load_recipe contract, hermetic: interpolate skillclaw.yaml
-    through reef's config loader and build the dotted kind - selection
+    through reef's config loader and build the explicit implementation - selection
     always, batch_size 60, the seed composition plus the seed_skills pool."""
     from reef.records import RecordStore
     from reef.service.deploy.config import load_config
@@ -333,10 +333,10 @@ def test_example_yaml_boots_the_recipe_with_the_paper_wiring(example, tmp_path, 
     monkeypatch.setenv("REEF_UPSTREAM_API_KEY", "dummy")
     monkeypatch.setenv("REEF_SC_SKILLS", str(skills))
     config = load_config(EXAMPLE_DIR / "skillclaw.yaml")
-    sections = {key: config[key] for key in ("kind", "model", "evolution", "data")}
-    assert sections["kind"] == "harness.skillclaw_recipe:SkillClawRecipe"
+    sections = {key: config[key] for key in ("implementation", "model", "evolution", "data")}
+    assert sections["implementation"] == "harness.skillclaw_recipe:SkillClawRecipe"
 
-    built = build_recipe(str(sections["kind"]), {}, config=sections, runtime=runtime())
+    built = build_recipe(str(sections["implementation"]), {}, config=sections, runtime=runtime())
     assert type(built).__name__ == "SkillClawRecipe"
     assert built.name == "skillclaw"
     assert isinstance(built.candidate_selector, AlwaysSelect)

--- a/tests/reef_service/test_slime_algorithm_contract.py
+++ b/tests/reef_service/test_slime_algorithm_contract.py
@@ -15,6 +15,7 @@ import pytest
 
 from recipes.sao.slime import CRITIC_ATTENTION_PARAM_PATTERN
 from recipes.sao.slime.utils import schedule as sao_runtime
+from reef.train.algos.registry import register_loss_family_ref
 from reef.train.slime_backend.algorithm import SlimeAlgorithm, resolve_objective_paths
 from reef.train.slime_backend.loss_families import (
     LOSS_FAMILIES,
@@ -54,7 +55,7 @@ class _TestAlgorithm(SlimeAlgorithm):
         pass
 
 
-#: The bundled families plus the two plain ones tests/conftest.py registers.
+#: The cookbook families plus the two plain ones tests/conftest.py registers.
 _ALL_FAMILIES = ("openclawrl", "pg", "sao", "sft", "tttd")
 
 
@@ -75,7 +76,7 @@ def test_registry_is_the_complete_slime_loss_family_surface() -> None:
 
 
 @pytest.mark.unit
-def test_register_loss_family_opens_the_bundled_table() -> None:
+def test_register_loss_family_opens_the_registry() -> None:
     toy = _TestAlgorithm(loss_family="toy")
     try:
         assert register_loss_family(toy) is toy
@@ -94,10 +95,12 @@ def test_register_loss_family_opens_the_bundled_table() -> None:
 
 
 @pytest.mark.unit
-def test_bundled_families_cannot_be_unregistered() -> None:
-    with pytest.raises(ValueError, match="bundled"):
-        unregister_loss_family("tttd")
-    with pytest.raises(KeyError, match="registered external families"):
+def test_registered_family_references_can_be_unregistered() -> None:
+    register_loss_family_ref("temporary", "some_package.loss:TemporaryAlgorithm")
+    assert "temporary" in LOSS_FAMILIES.names
+    unregister_loss_family("temporary")
+    assert "temporary" not in LOSS_FAMILIES.names
+    with pytest.raises(KeyError, match="registered families"):
         unregister_loss_family("never_registered")
 
 
@@ -390,8 +393,8 @@ _EXPECTED_OBJECTIVE_CHANNELS = {
 def _family_package_name(loss_family: str) -> str:
     """The name a family's classes, flags and settings are spelled after.
 
-    Every bundled family is spelled after its canonical loss-family name,
-    and lives in its package, ``reef/<name>/slime/``.
+    Every cookbook family is spelled after its canonical loss-family name and
+    lives in its own method package.
     """
     return resolve_loss_family(loss_family).loss_family
 
@@ -407,7 +410,7 @@ def _family_package_dir(loss_family: str) -> Path:
 
 
 def _family_source_files() -> list[Path]:
-    """Every bundled family's source files, ``reef/<name>/slime/``."""
+    """Every cookbook family's source files."""
     files: set[Path] = set()
     for family in _BUNDLED_FAMILIES:
         files.update(_family_package_dir(family).rglob("*.py"))
@@ -687,14 +690,6 @@ def test_dotted_reference_accepts_the_decorated_class(monkeypatch) -> None:
     finally:
         unregister_loss_family("toy_decorated")
     assert "toy_decorated" not in LOSS_FAMILIES.names
-
-
-@pytest.mark.unit
-def test_renamed_family_keeps_its_old_name_as_an_alias() -> None:
-    with pytest.warns(DeprecationWarning, match="'openclawrl-topk' is now 'openclawrl'"):
-        spec = resolve_loss_family("openclawrl-topk")
-    assert spec is resolve_loss_family("openclawrl")
-    assert "openclawrl-topk" not in LOSS_FAMILIES.names
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_slime_bridge.py
+++ b/tests/reef_service/test_slime_bridge.py
@@ -833,7 +833,7 @@ def test_bridge_enforces_the_inclusive_max_staleness_boundary(
 
 @pytest.mark.unit
 @pytest.mark.parametrize("loss_family", ["openclawrl", "sao", "tttd"])
-def test_bridge_admits_bounded_lag_for_every_bundled_loss_family(tmp_path, loss_family) -> None:
+def test_bridge_admits_bounded_lag_for_every_cookbook_loss_family(tmp_path, loss_family) -> None:
     actor, group, manager, payload = _loss_family_durable_actor(tmp_path, loss_family)
 
     result = _execute_and_update_weights(actor, payload)
@@ -1345,22 +1345,19 @@ def test_driver_accepts_matching_reef_and_slime_objectives(loss_family, loss_typ
 
 
 @pytest.mark.unit
-def test_driver_resolves_loss_env_before_recipe_registry() -> None:
+def test_driver_requires_an_explicit_loss_environment() -> None:
     from reef.train.slime_backend.loss_families import resolve_loss_family
     from reef.train.slime_backend.reef_adapters.driver import _resolve_loss_family
 
     assert _resolve_loss_family({"REEF_TRAINING_LOSS": "pg"}) == ("pg", None, resolve_loss_family("pg"))
-    # REEF_TRAINING_RECIPE is informational when REEF_TRAINING_LOSS is set.
+    # REEF_TRAINING_RECIPE is an informational label when the explicit loss is set.
     assert _resolve_loss_family({"REEF_TRAINING_LOSS": "sft", "REEF_TRAINING_RECIPE": "custom_method"}) == (
         "sft",
-        None,
+        "custom_method",
         resolve_loss_family("sft"),
     )
-    assert _resolve_loss_family({"REEF_TRAINING_RECIPE": "openclawrl"}) == (
-        "openclawrl",
-        "openclawrl",
-        resolve_loss_family("openclawrl"),
-    )
+    with pytest.raises(RuntimeError, match="REEF_TRAINING_LOSS is required"):
+        _resolve_loss_family({"REEF_TRAINING_RECIPE": "openclawrl"})
     assert _resolve_loss_family({}) == (None, None, None)
 
 

--- a/tests/reef_service/test_slime_bridge.py
+++ b/tests/reef_service/test_slime_bridge.py
@@ -1345,20 +1345,20 @@ def test_driver_accepts_matching_reef_and_slime_objectives(loss_family, loss_typ
 
 
 @pytest.mark.unit
-def test_driver_requires_an_explicit_loss_environment() -> None:
+def test_driver_derives_the_loss_family_from_the_configured_recipe() -> None:
     from reef.train.slime_backend.loss_families import resolve_loss_family
-    from reef.train.slime_backend.reef_adapters.driver import _resolve_loss_family
+    from reef.train.slime_backend.reef_adapters.driver import _resolve_training_recipe
 
-    assert _resolve_loss_family({"REEF_TRAINING_LOSS": "pg"}) == ("pg", None, resolve_loss_family("pg"))
-    # REEF_TRAINING_RECIPE is an informational label when the explicit loss is set.
-    assert _resolve_loss_family({"REEF_TRAINING_LOSS": "sft", "REEF_TRAINING_RECIPE": "custom_method"}) == (
-        "sft",
-        "custom_method",
-        resolve_loss_family("sft"),
+    recipe = "recipes.sao.recipe:SAORecipe"
+    assert _resolve_training_recipe({"reef": {"recipe": recipe}}) == (
+        "sao",
+        recipe,
+        resolve_loss_family("sao"),
     )
-    with pytest.raises(RuntimeError, match="REEF_TRAINING_LOSS is required"):
-        _resolve_loss_family({"REEF_TRAINING_RECIPE": "openclawrl"})
-    assert _resolve_loss_family({}) == (None, None, None)
+    with pytest.raises(RuntimeError, match=r"must define reef\.recipe"):
+        _resolve_training_recipe({})
+    with pytest.raises(RuntimeError, match="WeightTrainingRecipe"):
+        _resolve_training_recipe({"reef": {"recipe": "reef.recipe.base:Recipe"}})
 
 
 @pytest.mark.unit
@@ -1371,17 +1371,33 @@ def test_driver_stamps_a_dotted_family_reference_for_the_workers() -> None:
     _stamp_loss_family_reference(dotted, "toy_pkg.family:ToyAlgorithm")
     assert dotted.loss_family_ref == "toy_pkg.family:ToyAlgorithm"
 
-    bundled = SimpleNamespace(loss_family="pg")
-    _stamp_loss_family_reference(bundled, "pg")
-    assert not hasattr(bundled, "loss_family_ref")
+    cookbook = SimpleNamespace(loss_family="sao")
+    _stamp_loss_family_reference(cookbook, "sao")
+    assert cookbook.loss_family_ref == "recipes.sao.slime:SaoAlgorithm"
+
+    unreferenced = SimpleNamespace(loss_family="pg")
+    _stamp_loss_family_reference(unreferenced, "pg")
+    assert not hasattr(unreferenced, "loss_family_ref")
 
 
 @pytest.mark.unit
-def test_driver_rejects_unknown_loss_env() -> None:
-    from reef.train.slime_backend.reef_adapters.driver import _resolve_loss_family
+def test_driver_rejects_a_recipe_with_an_unknown_loss_family(monkeypatch) -> None:
+    import sys
+    from types import ModuleType
 
-    with pytest.raises(RuntimeError, match="unsupported REEF_TRAINING_LOSS"):
-        _resolve_loss_family({"REEF_TRAINING_LOSS": "grpo"})
+    from reef.recipe import WeightTrainingRecipe, WeightTrainingSpec
+    from reef.train.slime_backend.reef_adapters.driver import _resolve_training_recipe
+
+    class UnknownLossRecipe(WeightTrainingRecipe):
+        @classmethod
+        def training_spec(cls):
+            return WeightTrainingSpec(step_preparer="unused", loss_family="grpo")
+
+    module = ModuleType("unknown_loss_recipe")
+    module.UnknownLossRecipe = UnknownLossRecipe
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    with pytest.raises(RuntimeError, match="declares unsupported loss family 'grpo'"):
+        _resolve_training_recipe({"reef": {"recipe": "unknown_loss_recipe:UnknownLossRecipe"}})
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_trainer.py
+++ b/tests/reef_service/test_trainer.py
@@ -6,10 +6,9 @@ import pytest
 
 import reef.train.processors.reported as reported_module
 from recipes.sao import SAOProcessor
-from recipes.tttd import TTTDProcessor
+from recipes.tttd import TTTDGroupedRolloutReport, TTTDProcessor
 from reef.artifact import InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
-from reef.core.reports import GroupedRolloutReport
 from reef.dispatcher import Dispatcher
 from reef.recipe import RecipeRegistry, WeightTrainingRecipe
 from reef.records import RecordStore
@@ -260,7 +259,7 @@ def test_pairing_processor_assembles_ordered_multi_reference_report() -> None:
         pytest.param(TTTDProcessor, id="tttd"),
     ],
 )
-def test_bundled_processors_assemble_before_rejecting_multi_turn_reports(
+def test_cookbook_processors_assemble_before_rejecting_multi_turn_reports(
     processor_type,
     monkeypatch,
 ) -> None:
@@ -289,7 +288,7 @@ def test_bundled_processors_assemble_before_rejecting_multi_turn_reports(
             "comparison_set": "tttd-step-0-group-0",
         }
 
-    report_type = GroupedRolloutReport if processor_type is TTTDProcessor else None
+    report_type = TTTDGroupedRolloutReport if processor_type is TTTDProcessor else None
     processor = processor_type(ProcessorContext("math", config, report_type=report_type))
     processor.ingest(training_inference("i1", [10, 20], [1], [-0.1]))
     multi_turn_report = report("r1", ("i1", "i2"), 1.0, **metadata)

--- a/tests/reef_service/test_training_server.py
+++ b/tests/reef_service/test_training_server.py
@@ -12,14 +12,16 @@ from reef.service.assembly import _repository_location
 from reef.service.deploy.config import interpolate_config
 from reef.service.deploy.settings import ServiceSettings
 
+OPENCLAWRL_RECIPE = "recipes.openclawrl.recipe:OpenClawRLRecipe"
+SAO_RECIPE = "recipes.sao.recipe:SAORecipe"
+
 
 def _example_owned(relative_path: str):
     """An example-owned stack, skipped where the examples do not ship.
 
     The package job runs this suite against the installed distribution, so
-    PROJECT_ROOT is site-packages: nothing under ``recipes/`` but the method
-    packages ships with the wheel. Absent there is correct, not
-    broken.
+    PROJECT_ROOT is site-packages and nothing under ``recipes/`` ships with
+    the wheel. Absent there is correct, not broken.
     """
     return pytest.param(
         relative_path,
@@ -40,7 +42,7 @@ def _settings(**overrides) -> ServiceSettings:
         "host": "0.0.0.0",
         "port": 8900,
         "tokens": ("token",),
-        "recipe": "openclawrl",
+        "recipe": OPENCLAWRL_RECIPE,
         "ray_address": "ray-head:6379",
         "ray_namespace": "reef",
         "ray_actor_name": "reef-train-bridge",
@@ -64,9 +66,9 @@ def _settings(**overrides) -> ServiceSettings:
 
 @pytest.mark.unit
 def test_service_config_exposes_shared_batch_controls() -> None:
-    args = deploy.service_settings_from_config({"reef": {"recipe": "openclawrl", "batch_size": 4}})
+    args = deploy.service_settings_from_config({"reef": {"recipe": OPENCLAWRL_RECIPE, "batch_size": 4}})
 
-    assert args.recipe == "openclawrl"
+    assert args.recipe == OPENCLAWRL_RECIPE
     assert not hasattr(args, "default_recipe")
     # Recipe config fields are not service settings fields: they pass through raw so each
     # default lives with its recipe.
@@ -88,7 +90,7 @@ def test_service_config_preserves_inference_backend_config() -> None:
     args = deploy.service_settings_from_config(
         {
             "reef": {
-                "recipe": "openclawrl",
+                "recipe": OPENCLAWRL_RECIPE,
                 "inference_backend_factory": "example.factory",
                 "inference_backend_config": {"tool_call_parser": "qwen25"},
             }
@@ -105,7 +107,7 @@ def test_service_config_preserves_candidate_evaluation_section() -> None:
         "config": {"threshold": 0.8},
     }
 
-    args = deploy.service_settings_from_config({"reef": {"recipe": "sao"}, "evaluation": evaluation})
+    args = deploy.service_settings_from_config({"reef": {"recipe": SAO_RECIPE}, "evaluation": evaluation})
 
     assert args.evaluation_settings == evaluation
 
@@ -113,7 +115,7 @@ def test_service_config_preserves_candidate_evaluation_section() -> None:
 @pytest.mark.unit
 def test_service_config_rejects_non_object_evaluation_section() -> None:
     with pytest.raises(ValueError, match="evaluation must be an object"):
-        deploy.service_settings_from_config({"reef": {"recipe": "sao"}, "evaluation": "disabled"})
+        deploy.service_settings_from_config({"reef": {"recipe": SAO_RECIPE}, "evaluation": "disabled"})
 
 
 @pytest.mark.unit
@@ -147,10 +149,10 @@ def test_service_config_requires_recipe() -> None:
     [
         ("recipes/basic/local-sglang.yaml", "recipe"),
         ("recipes/basic/external-provider.yaml", "recipe"),
-        ("recipes/openclawrl/examples/openclawrl/serve.yaml", "openclawrl"),
+        ("recipes/openclawrl/examples/openclawrl/serve.yaml", OPENCLAWRL_RECIPE),
     ],
 )
-def test_bundled_configs_launch_internal_service_from_reef_settings(
+def test_cookbook_configs_launch_internal_service_from_reef_settings(
     config_name: str,
     recipe: str,
     monkeypatch: pytest.MonkeyPatch,
@@ -178,7 +180,7 @@ def test_bundled_configs_launch_internal_service_from_reef_settings(
         _example_owned("recipes/openclawrl/examples/openclawrl/serve.yaml"),
     ],
 )
-def test_bundled_training_configs_leave_max_staleness_unset(relative_path) -> None:
+def test_cookbook_training_configs_leave_max_staleness_unset(relative_path) -> None:
     config = deploy.load_config(deploy.PROJECT_ROOT / relative_path)
 
     assert "max_staleness" not in config["reef"]
@@ -259,7 +261,7 @@ def test_build_dispatcher_loads_recipe_for_inference_service(monkeypatch, tmp_pa
     assert registry.names == ("recipe",)
     assert registry.served_recipe == "recipe"
     # The deployment serves one recipe: a request-time name never materializes
-    # another bundled kind, even though the open resolver could have built it.
+    # another method, even though a dotted resolver could have built it.
     with pytest.raises(UnknownScenarioRecipe):
         registry.resolve("harness_evolve")
 
@@ -295,7 +297,7 @@ def test_build_dispatcher_applies_common_recipe_controls(monkeypatch, tmp_path) 
     monkeypatch.setattr(deploy.GitLFSRepositoryBackend, "factory", factory)
     dispatcher = deploy.build_dispatcher(
         _settings(
-            recipe="openclawrl",
+            recipe=OPENCLAWRL_RECIPE,
             recipe_settings={"batch_size": 4, "checkpoint_every_n_versions": 5},
             agent_record_dir=str(tmp_path / "agent-record"),
         ),
@@ -323,7 +325,7 @@ def test_build_dispatcher_injects_candidate_evaluation_into_weight_recipe(monkey
 
     dispatcher = deploy.build_dispatcher(
         _settings(
-            recipe="openclawrl",
+            recipe=OPENCLAWRL_RECIPE,
             evaluation_settings=evaluation,
             agent_record_dir=str(tmp_path / "agent-record"),
         ),
@@ -369,7 +371,7 @@ def test_build_dispatcher_rejects_recipe_settings_nothing_consumes(monkeypatch, 
     with pytest.raises(RecipeConfigError, match=r"OpenClawRLRecipe does not consume reef\.groups_per_step") as excinfo:
         deploy.build_dispatcher(
             _settings(
-                recipe="openclawrl",
+                recipe=OPENCLAWRL_RECIPE,
                 recipe_settings={"groups_per_step": 4},
                 agent_record_dir=str(tmp_path / "agent-record"),
             ),
@@ -429,7 +431,7 @@ def test_build_dispatcher_treats_sao_as_training_recipe(monkeypatch, tmp_path) -
 
     dispatcher = deploy.build_dispatcher(
         _settings(
-            recipe="sao",
+            recipe=SAO_RECIPE,
             recipe_settings={"max_staleness": 2},
             agent_record_dir=str(tmp_path / "agent-record"),
         ),
@@ -463,7 +465,7 @@ def test_build_dispatcher_resolves_max_staleness_environment_for_runtime(
         return StubRuntime(max_staleness=kwargs.get("max_staleness", 0))
 
     dispatcher = deploy.build_dispatcher(
-        _settings(recipe="openclawrl", agent_record_dir=str(tmp_path / "agent-record")),
+        _settings(recipe=OPENCLAWRL_RECIPE, agent_record_dir=str(tmp_path / "agent-record")),
         environ={"REEF_MAX_STALENESS": str(max_staleness)},
         connector=connector,
     )
@@ -515,7 +517,7 @@ def test_service_tokens_rejects_non_list() -> None:
 def test_reef_token_is_service_owned_and_never_reaches_the_recipe() -> None:
     """``reef.token`` feeds ``ServiceSettings.tokens`` under another name; the
     recipe-owned remainder of the section must still exclude it, or every
-    training recipe would reject the bundled configs as unconsumed settings."""
+    training recipe would reject the cookbook configs as unconsumed settings."""
     from reef.service.assembly import _recipe_owned_settings
 
     config = {"reef": {"recipe": "openclawrl", "token": "secret", "tokens": ["next"], "batch_size": 2}}

--- a/tests/reef_service/test_tttd.py
+++ b/tests/reef_service/test_tttd.py
@@ -124,7 +124,7 @@ def test_tttd_backend_contract_rejects_objective_drift(overrides, message) -> No
     values.update(overrides)
 
     with pytest.raises(RuntimeError, match=message):
-        tttd.validate_specific_args(SimpleNamespace(**values), "REEF_TRAINING_LOSS=tttd")
+        tttd.validate_specific_args(SimpleNamespace(**values), "reef.recipe=tttd")
 
 
 @pytest.mark.unit
@@ -134,7 +134,7 @@ def test_tttd_accepts_any_positive_kl_coef() -> None:
     tttd = resolve_loss_family("tttd")
     tttd.validate_specific_args(
         SimpleNamespace(compute_advantages_and_returns=True, kl_coef=0.2),
-        "REEF_TRAINING_LOSS=tttd",
+        "reef.recipe=tttd",
     )
 
 

--- a/tests/reef_service/test_tttd.py
+++ b/tests/reef_service/test_tttd.py
@@ -6,11 +6,10 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
-from recipes.tttd import TTTDProcessor
+from recipes.tttd import TTTDGroupedRolloutReport, TTTDProcessor
 from recipes.tttd.preparer import TttdPreparer
 from reef.artifact import ArtifactRef
 from reef.core import AgentRecord, RequestType
-from reef.core.reports import GroupedRolloutReport
 from reef.train import ProcessorContext
 from reef.train.slime_backend.loss_families import resolve_loss_family
 from reef.train.slime_backend.reef_adapters.preparation import prepare_slime_step
@@ -79,7 +78,7 @@ def _processor(experiment_logger=None) -> TTTDProcessor:
                 "groups_per_step": 2,
                 "rollouts_per_group": 3,
             },
-            report_type=GroupedRolloutReport,
+            report_type=TTTDGroupedRolloutReport,
             experiment_logger=experiment_logger or _ExperimentLogger(),
         )
     )

--- a/tests/reef_service/test_version_check.py
+++ b/tests/reef_service/test_version_check.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from reef import HarnessEvolveRecipe
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.harness.adapters import get_adapter
 from reef.harness.model_binding import ModelBinding
 from reef.harness.render import render_composition


### PR DESCRIPTION
## Motivation

Recipe implementations now live in the repository cookbook rather than the Reef distribution, but the global recipe-kind registry and several method-specific contracts still made Reef behave as if those methods were built in. This change makes the dependency direction explicit: cookbook methods depend on Reef contracts, while Reef never imports cookbook code.

## Changes

- Remove `register_kind`, `recipe_kinds`, the global recipe-kind table, and cookbook recipe re-exports from `reef`.
- Resolve recipe implementations through explicit `package.module:ClassName` references while retaining the core `recipe` and named deployment presets.
- Rename the preset selector from `kind` to `implementation`.
- Make `reef.recipe` the single training-method setting: the launcher already passes `REEF_CONFIG`, and the Slime driver imports that recipe class and reads its loss family from `training_spec()`.
- Remove `REEF_TRAINING_RECIPE` and `REEF_TRAINING_LOSS` from cookbook deployment configuration.
- Move the TTTD grouped report contract into `recipes.tttd` and remove method-specific names and paths from `reef/`.
- Exclude `recipes/` from the Reef wheel and add package/import boundary tests.
- Let preparer and loss-family unregister operations remove any registration by name without protecting decorator registrations.
- Update cookbook configs, CI, tests, and user/developer documentation for the new extension model.

## Compatibility and operational impact

This intentionally changes public configuration and imports:

- Preset YAML must use `implementation:` instead of `kind:`.
- Bare method names such as `sao`, `tttd`, and `openclawrl` no longer resolve as implementations; deployments use dotted class references or named presets.
- Cookbook recipe classes and the TTTD-specific report are no longer re-exported from Reef.
- The Reef wheel no longer includes the `recipes` package.
- Weight-training recipe classes must declare their loss family through `training_spec()`; deployment YAML no longer repeats recipe or loss settings in the Slime driver environment.

The reserved core `recipe`, named preset resolution, and runtime `RecipeRegistry` instance binding remain available.

## Verification

- `.venv/bin/pre-commit run --all-files --show-diff-on-failure` — passed.
- `npm run check:docs` — passed.
- `npm run build` — passed.
- Updated driver/config/boundary suite — 189 passed.
- Full test suite — 1605 passed, 2 skipped; one integration test could not run because `git-lfs` is not installed on this machine.
- Built a wheel from a clean repository copy and verified it contains no `recipes/`, imports `reef` without loading cookbook modules, and resolves only the core bare recipe.

## AI assistance

Codex assisted with the implementation, documentation migration, contract tests, verification, and rebase conflict resolution. The author reviewed the resulting changes and test output.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [ ] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.