### PR TITLE
fix: recover a failed weight publication in place instead of wedging terminally

### DIFF
--- a/reef/runtime/adapter_residency.py
+++ b/reef/runtime/adapter_residency.py
@@ -194,10 +194,11 @@ class AdapterResidencyManager:
                 return name
             # A leaked slot still holds the engine's copy of exactly this
             # revision; reloading it in place reclaims the slot.
-            if slot is not None and not self._unload(slot, engine):
+            if slot is not None and (unload_error := self._unload(slot, engine)) is not None:
                 raise AdapterResidencyError(
-                    f"adapter {name!r} leaked in the engine and cannot be reloaded until the unload succeeds"
-                )
+                    f"adapter {name!r} leaked in the engine and cannot be reloaded until the unload "
+                    f"succeeds: {unload_error}"
+                ) from unload_error
             self._make_room(scenario, engine, supersede=supersede)
             slot = _Slot(name, scenario, version, self._next_order)
             self._next_order += 1
@@ -380,14 +381,17 @@ class AdapterResidencyManager:
                     f"engine adapter capacity {self._capacity} is exhausted and every resident adapter is "
                     f"protected (current, pinned, or in flight): {protected}; scenario {scenario!r} cannot activate"
                 )
-            if not self._unload(victim, engine):
+            if (unload_error := self._unload(victim, engine)) is not None:
                 # The engine refused to let go; the slot stays occupied and
                 # the caller sees exhaustion rather than a silent overcommit.
+                # The unload failure rides along: "capacity exhausted" alone
+                # would hide that the real event may be a dead engine.
                 self._counters["capacity_rejections"] += 1
                 raise AdapterCapacityExhausted(
-                    f"engine adapter capacity {self._capacity} is exhausted and evicting {victim.name!r} failed; "
-                    f"scenario {scenario!r} cannot activate until the leaked slot is reclaimed"
-                )
+                    f"engine adapter capacity {self._capacity} is exhausted and evicting {victim.name!r} "
+                    f"failed ({unload_error}); scenario {scenario!r} cannot activate until the leaked slot "
+                    f"is reclaimed"
+                ) from unload_error
             self._counters["evictions"] += 1
             self._note("evicted", victim.name, victim.scenario, f"for scenario {scenario!r}")
 
@@ -401,8 +405,8 @@ class AdapterResidencyManager:
         candidates.sort(key=lambda slot: (slot.state != "leaked", slot.order))
         return candidates[0]
 
-    def _unload(self, slot: _Slot, engine: AdapterEngine | None) -> bool:
-        """Drop ``slot`` from the engine and the table; False leaves it ``leaked``."""
+    def _unload(self, slot: _Slot, engine: AdapterEngine | None) -> Exception | None:
+        """Drop ``slot`` from the engine and the table; a returned failure leaves it ``leaked``."""
         try:
             if engine is not None:
                 engine.unload_adapter(slot.name)
@@ -411,13 +415,13 @@ class AdapterResidencyManager:
             slot.state = "leaked"
             self._note("leaked", slot.name, slot.scenario, str(exc))
             logger.warning("could not unload adapter %r; its engine slot leaks", slot.name, exc_info=True)
-            return False
+            return exc
         self._counters["unloads"] += 1
         self._slots.pop(slot.name, None)
         for scenario, name in list(self._current.items()):
             if name == slot.name:
                 self._current.pop(scenario, None)
-        return True
+        return None
 
     # -- Reconciliation --------------------------------------------------
 
@@ -434,7 +438,7 @@ class AdapterResidencyManager:
             for name in sorted(held - set(self._slots)):
                 stray = _Slot(name, scenario="", version="", order=-1)
                 self._slots[name] = stray
-                if self._unload(stray, engine):
+                if self._unload(stray, engine) is None:
                     self._counters["strays_unloaded"] += 1
                     self._note("stray_unloaded", name, "")
             lost = tuple(sorted(name for name in self._slots if name not in held and self._slots[name].order >= 0))

--- a/reef/runtime/adapters/ray_runtime.py
+++ b/reef/runtime/adapters/ray_runtime.py
@@ -438,7 +438,9 @@ class RayRuntime(TrainingRuntime):
         healthy = health.get("ok")
         if healthy is not None and not isinstance(healthy, bool):
             raise RayRuntimeError("train group returned malformed health status")
-        if healthy is False:
+        # A group that reports its failure as recoverable is retried through
+        # the normal reconciliation path instead of being declared dead.
+        if healthy is False and health.get("recoverable") is not True:
             phase = health.get("phase")
             detail = f" in phase {phase!r}" if isinstance(phase, str) and phase else ""
             raise RayRuntimeError(f"train group is unhealthy{detail}")

--- a/reef/train/slime_backend/reef_adapters/bridge.py
+++ b/reef/train/slime_backend/reef_adapters/bridge.py
@@ -626,8 +626,17 @@ class TrainBridgeActorImpl:
             )
             if "scenario" in marker:
                 training_job["scenario"] = marker["scenario"]
+        ok = self._phase not in {"training_failed", "checkpoint_failed", "weight_sync_failed"}
         return {
-            "ok": self._phase not in {"training_failed", "checkpoint_failed", "weight_sync_failed"},
+            "ok": ok,
+            # A publication failure with a durable UPDATING_WEIGHTS marker is
+            # replayable in place: ``update_serving_weights`` recovers the
+            # engines and republishes from the checkpoint. The bridge decides
+            # which failures are retryable so callers never re-derive it from
+            # phase and marker.
+            "recoverable": not ok
+            and self._phase == "weight_sync_failed"
+            and training_job.get("status") == "UPDATING_WEIGHTS",
             "start_rollout_id": self._next_rollout_id,
             "phase": self._phase,
             "colocate": self._colocate,
@@ -733,6 +742,16 @@ class TrainBridgeActorImpl:
             try:
                 if recovering:
                     self._manager_call("recover_updatable_engines")
+                    if self._ledger is not None:
+                        # The failed publication terminated every updatable
+                        # engine, so recovery restarted them from the frozen
+                        # base with no adapters resident. Align residency with
+                        # that — a slot leaked against the dead engine must
+                        # not read as exhausted capacity forever — and reload
+                        # the other scenarios' committed adapters before this
+                        # scenario's forced full publication.
+                        self._require_residency().reconcile((), self._adapter_engine)
+                        self._recover_scenario_adapters(marker)
                 self._pause_generation()
                 if self._ledger is not None:
                     # A restart between checkpoint and publication may have

--- a/tests/reef_service/test_adapter_residency.py
+++ b/tests/reef_service/test_adapter_residency.py
@@ -233,6 +233,17 @@ def test_failed_unload_leaks_the_slot_visibly_and_is_retried_first(engine: FakeE
     assert manager.status()["leaked"] == 0
 
 
+def test_a_failed_eviction_carries_the_engine_failure_as_its_cause(engine: FakeEngine) -> None:
+    # "Capacity exhausted" alone would hide the root event (e.g. a dead
+    # engine); the unload failure must ride along in the raised error.
+    manager = AdapterResidencyManager(capacity=1)
+    manager.activate("a", "a1", engine)
+    engine.fail_unload.add(adapter_name("a", "a1"))
+    with pytest.raises(AdapterCapacityExhausted, match="engine keeps") as excinfo:
+        manager.activate("a", "a2", engine, supersede=True)
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+
 def test_alias_routes_a_republished_version_through_the_resident_adapter(engine: FakeEngine) -> None:
     manager = AdapterResidencyManager(capacity=1)
     name = manager.activate("a", "a1", engine)

--- a/tests/reef_service/test_multi_scenario_bridge.py
+++ b/tests/reef_service/test_multi_scenario_bridge.py
@@ -105,6 +105,14 @@ class _Manager(_FakeRolloutManager):
         self.continue_generation_after_update = _RemoteMethod(lambda: self.paused.append("continue"))
         self.engine = _Engine()
         self.get_updatable_engines_and_lock = _RemoteMethod(lambda: ([self.engine], None, 0, [], [], []))
+        self.recovered = 0
+        self.recover_updatable_engines = _RemoteMethod(self._recover)
+
+    def _recover(self) -> None:
+        # Termination killed every updatable engine; recovery restarts them
+        # from the frozen base, holding no adapters.
+        self.recovered += 1
+        self.engine = _Engine()
 
 
 def _actor(
@@ -303,6 +311,38 @@ def test_a_full_engine_refuses_to_evict_another_scenarios_current_revision(tmp_p
     assert manager.engine.unloaded == []
     assert actor.health()["phase"] == "weight_sync_failed"
     assert actor.health()["adapter_residency"]["counters"]["capacity_rejections"] == 1
+
+
+@pytest.mark.unit
+def test_a_dead_engine_publication_recovers_in_place_on_retry(tmp_path, _local_ray_get) -> None:
+    # Issue #61: a wedged rollout engine failed the eviction, the leaked slot
+    # surfaced as AdapterCapacityExhausted, and every retry kept failing
+    # against the recovered (adapter-less) engines — a full stack restart was
+    # the only way out. The retry must instead reset residency to the
+    # recovered engines and finish the publication in the same incarnation.
+    version = _EngineVersion(0)
+    actor, _, manager, _ = _actor(tmp_path, version, adapter_capacity=1)
+    _run(actor, _job("a", 0, "inc:0"))  # a serves inc:1
+
+    manager.engine.refuse.add(scenario_adapter_name("a", "inc:1"))  # the engine wedges
+    result = actor.execute_training_job(_job("a", 1, "inc:1"))
+    with pytest.raises(AdapterCapacityExhausted, match="engine keeps"):
+        actor.update_serving_weights(result.training_job_id)
+    health = actor.health()
+    assert health["phase"] == "weight_sync_failed"
+    assert health["ok"] is False and health["recoverable"] is True
+    assert health["adapter_residency"]["leaked"] == 1
+
+    recovered = actor.update_serving_weights(result.training_job_id)
+    assert manager.recovered == 1
+    assert recovered.outcome == "complete" and recovered.weight_version == "inc:2"
+    actor.acknowledge_training_commit(recovered.training_job_id)
+    assert actor.health()["phase"] == "serving"
+    residency = actor.health()["adapter_residency"]
+    assert residency["leaked"] == 0
+    assert residency["scenarios"]["a"]["current"]["version"] == "inc:2"
+    # The fresh engine held nothing, so nothing was (or had to be) unloaded.
+    assert manager.engine.unloaded == []
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_ray_runtime.py
+++ b/tests/reef_service/test_ray_runtime.py
@@ -1040,6 +1040,38 @@ def test_ray_runtime_rejects_an_unhealthy_training_group() -> None:
 
 
 @pytest.mark.unit
+def test_recovery_retries_a_failed_publication_instead_of_declaring_the_group_dead() -> None:
+    # A wedged rollout engine fails the publication fan-out: the bridge
+    # terminates its engines and reports itself unhealthy but recoverable —
+    # the durable UPDATING_WEIGHTS marker keeps the publication replayable.
+    class FailedPublicationHandle(DeferredWeightUpdateTrainGroupHandle):
+        def health(self) -> Mapping[str, Any]:
+            health = dict(super().health())
+            if self.status == "UPDATING_WEIGHTS":
+                health.update(ok=False, phase="weight_sync_failed", recoverable=True)
+            return health
+
+    handle = FailedPublicationHandle(status="UPDATING_WEIGHTS")
+    runtime = RayRuntime(train_group_handle=handle, inference_url="http://router")
+
+    runtime.reconcile_training_job(scenario_step=0)
+
+    assert handle.calls == ["update_weights"]
+    assert handle.status == "READY_TO_COMMIT"
+
+
+@pytest.mark.unit
+def test_a_failure_the_group_does_not_call_recoverable_is_still_unhealthy() -> None:
+    # An older bridge (no recoverable field) degrades to the strict behavior.
+    class DeadPublicationHandle(DeferredWeightUpdateTrainGroupHandle):
+        def health(self) -> Mapping[str, Any]:
+            return {**super().health(), "ok": False, "phase": "weight_sync_failed"}
+
+    with pytest.raises(RayRuntimeError, match=r"unhealthy.*weight_sync_failed"):
+        RayRuntime(train_group_handle=DeadPublicationHandle(status="COMPLETE"), inference_url="http://router")
+
+
+@pytest.mark.unit
 def test_colocated_completed_checkpoint_replay_reopens_admission() -> None:
     class CompletedReplay(DeferredWeightUpdateTrainGroupHandle):
         def execute_training_job(self, payload: Mapping[str, Any]) -> TrainingJobResult:


### PR DESCRIPTION
Fixes #61.

## The failure chain

On a wedged/dead rollout engine, one publication failure became a full-deployment outage through three compounding links:

1. `make_room`'s eviction unload failed against the wedged engine; the slot leaked and `AdapterCapacityExhausted` surfaced with only the *consequence* — the engine's underlying exception went to a warning log that was lost with the container.
2. Every publication failure calls `terminate_updatable_engines`, so the retry's `recover_updatable_engines` restarts **all** updatable engines from the frozen base, holding no adapters — but residency bookkeeping was never reconciled, so the retry unloaded the leaked adapter against an engine that never held it, failed again, and looped on the identical `AdapterCapacityExhausted` (the 10+ repeated tracebacks in the issue).
3. `weight_sync_failed` ⇒ `health.ok: False` ⇒ the runtime's `_training_job_status` raised before ever reaching its own `UPDATING_WEIGHTS` recovery branch in `reconcile_training_job`.

Only a full stack restart recovered, which also reset the weight-version incarnation.

## The fix

- **`adapter_residency`**: `_unload` returns the failure, and a failed eviction chains it into `AdapterCapacityExhausted` (and the leaked-reload `AdapterResidencyError`) via `raise … from`, so the operator-facing story names the root event (e.g. a dead engine's RPC failure), not just exhausted capacity.
- **`bridge`**: the `update_serving_weights` recovery branch now aligns residency with reality after `recover_updatable_engines` — the recovered engines are guaranteed adapter-less (termination preceded recovery), so it resets residency (`reconcile((), …)`, reclaiming leaked slots) and reloads the other scenarios' committed adapters via the same path the constructor's restart recovery uses, before the forced full publication. The retry completes **in the same incarnation**: Megatron state, the weight-version sequence, and sequence-based consumers all survive.
- **health contract**: the bridge reports `recoverable: true` when unhealthy with a durable `UPDATING_WEIGHTS` marker (the publication is replayable in place); the Ray runtime's health gate lets such a group proceed so `reconcile_training_job` / the dispatcher's retry drives the recovery, instead of declaring the group dead. The judgment lives with the bridge — the runtime checks one generic flag, and an older bridge without the field degrades to the previous strict behavior.

Fail-safe semantics are unchanged: a publication failure still terminates the engines and marks `weight_sync_failed`; the state is now recoverable rather than terminal.

## Tests

- residency: a failed eviction carries the engine failure as its `__cause__`.
- bridge: a replay of the incident (capacity 1, eviction refused, engines replaced on recovery) — the retry publishes successfully in the same incarnation with no leaked slots.
- runtime: a recoverable failure is retried through reconciliation; an unhealthy group that does not report `recoverable` still raises.

Full suite in the pinned docker image: 1609 passed (the pre-existing `test_timeout_kills_the_whole_process_group` failure reproduces on clean `main` in this environment and is unrelated).

Not addressed here: why the SGLang scheduler wedged in the first place (issue item 3) — this PR turns that event from a terminal outage into one retryable publication failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBsXR2F9K97YszswDjb34X