### PR TITLE
docs: clarify package ownership guidance

### DIFF
--- a/docs/contributing/adding-components.rst
+++ b/docs/contributing/adding-components.rst
@@ -53,7 +53,7 @@ Surrounding changes
   ``tests/reef_service/test_reef_recipes.py`` and
   ``tests/reef_service/test_recipe_config_fields.py``.
 - Add method behavior tests under ``tests/reef_service/``. Add an integration
-  contract when the method crosses a backend boundary.
+  contract when the method calls into a concrete backend.
 - Put every runnable configuration beside its method under
   ``recipes/<name>/examples/``; only a stack that binds no method belongs in
   ``recipes/basic/``.
@@ -95,7 +95,7 @@ Tests and documentation
 - Put service-facing lifecycle and wire contracts in ``tests/reef_service/``.
 - Prove that importing backend-neutral Reef modules does not import the
   framework. Extend ``tests/reef_service/test_dependency_boundaries.py`` when
-  a new boundary is introduced.
+  a new package dependency rule is added.
 - Update the ``reef/train`` package docstring, the Integration API,
   deployment guidance, and the configuration reference.
 
@@ -149,7 +149,7 @@ Add a service route
 
 Routes adapt HTTP to transport-independent behavior. The ``reef/service``
 package docstring and `HTTP API <../reference/http-api.rst>`__ define the
-current request boundary.
+current request contract.
 
 - Add or extend a module in ``reef/service/routes/`` with a
   ``register_*_routes`` function.
@@ -164,8 +164,8 @@ current request boundary.
 - Add route and service tests under ``tests/reef_service/``. Update the wire
   guide for a public endpoint; the docs contract check requires the guide to
   name every registered route.
-- Treat removal, incompatible payload changes, and authentication-boundary
-  changes as public API changes requiring an RFC and contract tests.
+- Treat removal, incompatible payload changes, and changes to authentication
+  rules as public API changes requiring an RFC and contract tests.
 
 Add a harness adapter
 ---------------------
@@ -197,9 +197,9 @@ Definition of done
 For every playbook:
 
 - the implementation is in the owning package and does not reverse an
-  existing dependency boundary;
+  existing package dependency;
 - registration happens through the documented registry or entry point;
-- focused unit and contract tests cover the new boundary;
+- focused unit and contract tests cover the new interface;
 - configuration, package data, and dependencies are declared at their
   repository-level homes;
 - user, operator, and contributor documentation describe the public change;

--- a/docs/contributing/codebase-structure.rst
+++ b/docs/contributing/codebase-structure.rst
@@ -7,52 +7,60 @@ This page says which package should own a change.
 Choose a destination
 --------------------
 
-``reef/`` holds every shared mechanism. Cookbook methods live in separate
-packages under ``recipes/`` (``sao``, ``tttd``, ``openclawrl``, or
-``harness_evolve``) with that method's recipe, processor, step
-preparer, and, for weight methods, the ``slime/`` subpackage only the training
-plane imports. Nothing under ``reef/`` imports a method package.
+Start with the change's scope. Reef infrastructure belongs under ``reef/``;
+Cookbook methods belong in that method's package under
+``recipes/``:
 
-The packages form layers. A layer imports only the layers beneath it, so
-a change that needs to reach upward is in the wrong package:
+.. diagram::
 
-.. code:: mermaid
+   <div class="ownership-map">
+     <div class="ownership-step-label">1. Who should reuse the change?</div>
+     <div class="ownership-scope">
+       <div class="fig-node">One cookbook method<span class="fig-node-caption"><code>recipes/&lt;name&gt;</code><br/>policy, processor, preparer, examples</span></div>
+       <div class="fig-node fig-emphasis">Reef or multiple methods<span class="fig-node-caption">shared behavior; choose a responsibility below</span></div>
+       <div class="fig-node">Repository support<span class="fig-node-caption"><code>tests/</code>, <code>docker/</code>, or <code>pyproject.toml</code></span></div>
+     </div>
+     <div class="fig-edge ownership-continue">
+       <span>if shared</span>
+       <svg class="fig-arrow fig-arrow-next" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v13"/><path d="m7 13 5 5 5-5"/></svg>
+     </div>
+     <div class="ownership-step-label">2. What responsibility changes?</div>
+     <div class="ownership-groups">
+       <div class="ownership-group">
+         <div class="ownership-group-title">Request and scenario control</div>
+         <div class="ownership-packages">
+           <div class="fig-node"><code>reef/service</code><span class="fig-node-caption">HTTP and process lifecycle</span></div>
+           <div class="fig-node"><code>reef/scenario</code><span class="fig-node-caption">state, commit, recovery</span></div>
+           <div class="fig-node"><code>reef/recipe</code><span class="fig-node-caption">method contract and binding</span></div>
+         </div>
+       </div>
+       <div class="ownership-group">
+         <div class="ownership-group-title">Execution and integrations</div>
+         <div class="ownership-packages">
+           <div class="fig-node"><code>reef/runtime</code><span class="fig-node-caption">backend-neutral model contracts</span></div>
+           <div class="fig-node"><code>reef/train</code><span class="fig-node-caption">training loop, processors, backends</span></div>
+           <div class="fig-node"><code>reef/harness</code><span class="fig-node-caption">descriptors, episodes, trajectories</span></div>
+         </div>
+       </div>
+       <div class="ownership-group">
+         <div class="ownership-group-title">Artifact lifecycle</div>
+         <div class="ownership-packages">
+           <div class="fig-node"><code>reef/artifact</code><span class="fig-node-caption">store and version bytes</span></div>
+           <div class="fig-node"><code>reef/surface</code><span class="fig-node-caption">deliver or activate artifacts</span></div>
+         </div>
+       </div>
+       <div class="ownership-group">
+         <div class="ownership-group-title">Shared vocabulary</div>
+         <div class="ownership-packages">
+           <div class="fig-node"><code>reef/core</code><span class="fig-node-caption">shared values, wire shapes, errors</span></div>
+         </div>
+       </div>
+     </div>
+   </div>
 
-   flowchart TD
-       accTitle: Dependency direction between package layers
-       subgraph Methods["Methods in recipes/"]
-           direction LR
-           M["sao, tttd, openclawrl, harness_evolve<br/>recipe, processor, preparer"]
-       end
-       subgraph Orchestration["Orchestration"]
-           direction LR
-           Service["reef/service<br/>HTTP, assembly, lifecycle"]
-           Scenario["reef/scenario<br/>commit order, recovery"]
-       end
-       subgraph Contracts["Contracts"]
-           direction LR
-           Recipe["reef/recipe<br/>what a method implements"]
-           Runtime["reef/runtime<br/>inference and training"]
-           Harness["reef/harness<br/>descriptors, episodes"]
-       end
-       subgraph Engines["Engines and storage"]
-           direction LR
-           Train["reef/train<br/>trainer, processors, backends"]
-           Surfaces["reef/surface<br/>delivery of an artifact"]
-           Artifacts["reef/artifact<br/>bytes, repositories, versions"]
-       end
-       Core["reef/core: value types, wire shapes, errors"]
-       Methods --> Orchestration
-       Orchestration --> Contracts
-       Contracts --> Engines
-       Engines --> Core
-
-Two edges skip a layer and are allowed: a method package binds ``reef/train``
-machinery directly, and ``reef/service`` imports ``reef/artifact`` to stream
-artifact bytes. Everything else follows the arrows.
-
-Concrete integrations may depend on shared contracts; shared contracts never
-import a concrete integration.
+``reef/`` should be self-contained, whereas ``recipes`` depends on ``reef/``
+for building customized methods for deployment. For developing the reef infrastructure,
+refer to the following table for which package owns which responsibility:
 
 +----------------------+----------------------------------------------------------+--------------------------------------------+
 | Package              | Owns                                                     | Does not own                               |
@@ -84,69 +92,10 @@ import a concrete integration.
 | ``reef/harness/``    | harness descriptors, tree rendering,                     | recipe policy, the version chain           |
 |                      | episodes, trajectories                                   |                                            |
 +----------------------+----------------------------------------------------------+--------------------------------------------+
-| ``recipes/``         | one method per package: recipe, processor, preparer,     | shared machinery, or another method        |
-|                      | and its runnable examples                                |                                            |
-+----------------------+----------------------------------------------------------+--------------------------------------------+
-| ``tests/``           | repository-level tests grouped by responsibility         | tests hidden inside an integration subtree |
-+----------------------+----------------------------------------------------------+--------------------------------------------+
-| ``docker/``          | container and GPU environment setup                      | Python dependency declarations             |
-+----------------------+----------------------------------------------------------+--------------------------------------------+
 
 The extension points those packages expose are in `Python API
 <../reference/python-api.rst>`__.
 
-
-- Is it a value or error needed by unrelated layers without behavior attached?
-  Put it in ``reef/core/``.
-- Does it own scenario state, commit ordering, recovery, or rollback? Put it in
-  ``reef/scenario/``.
-- Does it persist or materialize versioned bytes? Put it in
-  ``reef/artifact/``. If it decides how consumers activate those bytes, put
-  that behavior in ``reef/surface/`` instead.
-- Does it define a backend-neutral model-service contract? Put it in
-  ``reef/runtime/``. Put implementation tied to a concrete training stack in
-  its own ``reef/train/<integration>/`` subtree.
-- Does it turn records and feedback into a batch or step signal? Put it in
-  ``reef/train/processors/`` or ``reef/train/algos/``. A recipe selects and
-  binds that machinery; it should not reimplement it.
-- Is it HTTP-specific? Keep the aiohttp adapter in ``reef/service/routes/``
-  and put transport-independent behavior in a service or domain object.
-- Does it orchestrate a benchmark, task, grader, or external environment?
-  Keep it under ``recipes/<name>/examples/`` or in the external harness.
-
-Repository-level homes
-----------------------
-
-Code for a concrete training integration lives together under
-``reef/train/<integration>/``, but its surrounding files remain at repository
-level:
-
-- internal integration tests in ``tests/<integration>/``;
-- import and packaging contracts in ``tests/plugin_contracts/``;
-- service-facing contracts in ``tests/reef_service/``;
-- the learn-nothing deployment stacks, and the smallest example around them, in
-  ``recipes/basic/``;
-- configuration for one runnable deployment under ``recipes/<name>/examples/``;
-- container and environment setup under ``docker/``; and
-- Python dependencies, package data, and plugin entry points in
-  ``pyproject.toml``.
-
-Do not copy third-party source into an integration subtree. Pin or declare the
-dependency in ``pyproject.toml`` and keep Reef-owned adapters local to the
-integration.
-
-Where the detailed rules live
------------------------------
-
-Each package's ``__init__`` docstring states the boundaries it holds and
-how to extend it; there are no READMEs under ``reef/``. Design pages for the
-two packages that need more than a docstring are `Surfaces
-<../developer-guide/surface.rst>`__ and `Processors
-<../developer-guide/processors.rst>`__; the extension points every package
-exposes are in `Python API <../reference/python-api.rst>`__, and the public
-harness wire contract is `HTTP API <../reference/http-api.rst>`__. The
-`top-level README <../../README.md>`__ shows how the cookbook methods sit
-beside ``reef/``.
 
 Adding a new subpackage under ``reef/`` or a new method under ``recipes/``
 requires an RFC that states which layer owns the behavior.

--- a/docs/contributing/development.rst
+++ b/docs/contributing/development.rst
@@ -22,8 +22,8 @@ The ``runtime`` dependency group installs the reviewed training-runtime commit.
 Keep ``--no-deps`` in this command because GPU development uses the
 CUDA-compatible dependencies already installed in the container.
 
-Package boundaries
-------------------
+Package responsibilities
+------------------------
 
 - The ``slime`` extra installs the Python-side dependencies used by
   ``reef/train/slime_backend/``; the ``runtime`` dependency group pins the

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -102,7 +102,7 @@ Common members
 +---------------------------------------------------+-----------------------------+--------------------------------+
 | ``build(scenario, records, algorithm_state=...)`` | ``Trainer``                 | construct the scenario trainer |
 +---------------------------------------------------+-----------------------------+--------------------------------+
-| ``build_surface(scenario)``                       | ``Surface``                 | the delivery boundary for one  |
+| ``build_surface(scenario)``                       | ``Surface``                 | the delivery contract for one  |
 |                                                   |                             | named scenario                 |
 +---------------------------------------------------+-----------------------------+--------------------------------+
 | ``build_artifact_validator()``                    | ``ArtifactValidator``       | artifact admission, enforced   |

--- a/docs/rfcs/continual-opd.rst
+++ b/docs/rfcs/continual-opd.rst
@@ -97,13 +97,12 @@ Continual OPD on Reef: framework
 |                 |                |                       | in git history)   |
 +-----------------+----------------+-----------------------+-------------------+
 | L2              | GLM/Kimi →     | Project both          | L1 + an alignment |
-| cross-tokenizer | Qwen           | tokenizers'           | library           |
-| OPD             |                | boundaries onto the   |                   |
-|                 |                | byte stream, cut      |                   |
-|                 |                | chunks at common      |                   |
-|                 |                | boundaries, compare   |                   |
-|                 |                | summed log-probs per  |                   |
-|                 |                | chunk                 |                   |
+| cross-tokenizer | Qwen           | tokenizers' token     | library           |
+| OPD             |                | spans onto the byte   |                   |
+|                 |                | stream, cut chunks at |                   |
+|                 |                | shared byte offsets,  |                   |
+|                 |                | compare summed        |                   |
+|                 |                | log-probs per chunk   |                   |
 |                 |                | (tokenizer-invariant, |                   |
 |                 |                | no vocab mapping      |                   |
 |                 |                | needed)               |                   |

--- a/docs/rfcs/evolution-scope.rst
+++ b/docs/rfcs/evolution-scope.rst
@@ -1,7 +1,7 @@
-.. _the-evolution-boundary--what-reef-updates-and-what-it-doesnt:
+.. _the-evolution-scope--what-reef-updates-and-what-it-doesnt:
 
-The evolution boundary: what Reef updates, and what it doesn't
-===============================================================
+The evolution scope: what Reef updates, and what it doesn't
+============================================================
 
 :Status: Deprecated
 
@@ -15,7 +15,7 @@ The evolution boundary: what Reef updates, and what it doesn't
    harness produces while executing a fixed algorithm, and it stays on the
    harness side. Whether an
    update is gated before publishing is a separate, per-backend risk policy, not
-   what decides the boundary.
+   what decides where the state belongs.
 
 .. _1-the-question:
 
@@ -31,13 +31,13 @@ Several methods raise the same design question:
 - GEPA evolves prompts by keeping a candidate frontier. Should that live in
   Reef or outside it?
 
-The presence of a gate cannot determine this boundary because **no update is
+The presence of a gate cannot answer this question because **no update is
 guaranteed to be an improvement**. A PPO step can regress. The
 ``openclawrl`` and ``sao`` algorithms
 publish every batch with no gate at all, and their safety net is not a gate but
 the version chain: every publish is a commit, receipts tie each outcome to the
 exact version that produced it, and rollback restores any earlier one. Gating
-therefore cannot be the boundary criterion. The boundary depends on two
+therefore cannot be the placement rule. Placement depends on two
 orthogonal axes.
 
 .. _2-axis-1--what-changes-this-decides-where-the-code-lives:
@@ -163,10 +163,10 @@ Reef because that loop reads records and publishes artifacts. One method can
 have both: TTTD's search harness runs outside while its grouped training step
 runs inside. They exchange receipts and reports.
 
-.. _5-what-the-boundary-unlocks:
+.. _5-what-this-split-unlocks:
 
-5. What the boundary unlocks
-----------------------------
+5. What this split unlocks
+--------------------------
 
 1. **Ungated continual publishing for harness artifacts** (unlocks ACE,
    `arXiv:2510.04618 <https://arxiv.org/abs/2510.04618>`__). Structurally

--- a/docs/rfcs/method-integration.rst
+++ b/docs/rfcs/method-integration.rst
@@ -239,10 +239,10 @@ Milestones, each independently shippable:
 
 - **The client contract.** Two headers, one report route, receipts. Agents
   integrated today keep working unmodified; tags are optional.
-- **The evolution boundary.** This RFC moves *method* code, not *run state*.
+- **The evolution scope.** This RFC moves *method* code, not *run state*.
   A grader's session table is derived bookkeeping over Reef-served traffic,
   which is why it belongs on Reef's store. The
-  `evolution boundary <evolution-boundary.rst>`__ is about harness-owned search
+  `evolution scope <evolution-scope.rst>`__ is about harness-owned search
   state, and is untouched.
 - **Recipe authorship.** Third-party methods still need only a recipe class
   and a config entry. Method packages are how cookbook methods are held to

--- a/docs/rfcs/reef-router.rst
+++ b/docs/rfcs/reef-router.rst
@@ -32,7 +32,7 @@ Routing cannot change the bound scenario.
 
    Reef scenario B ──▶ SR entrypoint B ──▶ SR recipe B ──▶ roles {stable, candidate}
            ▲
-           └──────── route, fallback, and replay must stay inside this boundary
+           └──────── route, fallback, and replay must stay in this scenario
 
 The gateway binds each authenticated tenant to one Reef scenario. The scenario
 remains Reef's isolated workload: its records, training state, and version
@@ -46,7 +46,7 @@ Motivation
 A scenario already isolates records, trainer state, and artifact versions.
 Routing one scenario into another would break that ownership model and could
 mix tenant traffic or training data. Semantic Router owns model-choice policy;
-Reef enforces the scenario boundary and records the resulting execution.
+Reef enforces scenario isolation and records the resulting execution.
 Canary, shadow, and student/teacher policies should be reusable rather than
 copied into every client or harness.
 
@@ -79,7 +79,7 @@ Non-goals
 Proposal
 --------
 
-Isolation boundary
+Scenario isolation
 ~~~~~~~~~~~~~~~~~~
 
 Each routed ingress is bound to one scenario. The reference deployment runs
@@ -118,7 +118,7 @@ One Semantic Router process per scenario is not required. Routing recipes
 scope model eligibility and policy, while the process, canonical
 configuration, providers, management API, replay backend, and metrics endpoint
 remain shared and operator-only. This is logical isolation, not a process
-security boundary. Deployments requiring hard tenant isolation use separate
+security guarantee. Deployments requiring hard tenant isolation use separate
 Envoy, Semantic Router, Reef, and runtime stacks. Semantic Router aliases are
 process-wide, so the bridge names each one ``<scenario>/<role>``, for example
 ``tenant-a/student``. Reef validates the scenario prefix, role, and resolved
@@ -165,7 +165,7 @@ Architecture
      - Select a healthy replica for the resolved provider model.
 
 Reef adds no competing policy engine. Semantic Router owns policy; Reef owns
-the scenario boundary and the auditable execution contract.
+scenario isolation and the auditable execution contract.
 
 Routing decision
 ~~~~~~~~~~~~~~~~
@@ -322,8 +322,8 @@ state, but it may not re-route. A normal Reef pause/update does not abort or
 re-route the request; token-level serving version spans remain authoritative
 when generation crosses a weight update.
 
-Trust boundary
-~~~~~~~~~~~~~~
+Trust model
+~~~~~~~~~~~
 
 .. code:: python
 
@@ -427,7 +427,7 @@ artifacts, requires a separate RFC.
 This remains compatible with recipe-declared report contracts: those schemas
 validate their declared fields while preserving additional report metadata.
 
-Failure boundary
+Failure handling
 ~~~~~~~~~~~~~~~~
 
 .. code:: mermaid
@@ -719,10 +719,10 @@ Alternatives considered
    * - Alternative
      - Why not
    * - Router selects a Reef scenario
-     - Crosses the tenant boundary and can mix records, policy, or training
+     - Breaks tenant isolation and can mix records, policy, or training
        data.
    * - One Semantic Router recipe for all scenarios
-     - Allows policy, state, and fallback behavior to cross scenario boundaries.
+     - Allows policy, state, and fallback behavior to escape their scenarios.
    * - Build another Reef policy engine
      - Duplicates Semantic Router and still needs an Envoy bridge.
    * - Route directly to workers

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -787,9 +787,21 @@ html[data-theme="dark"] {
 .fig-node .fig-node-caption { display: block; margin-top: 2px; color: var(--muted); font-size: 13px; font-weight: 400; }
 .fig-node.fig-emphasis { border-color: var(--diagram-emphasis-border); background: var(--diagram-emphasis); color: var(--diagram-emphasis-text); }
 .fig-node.fig-emphasis .fig-node-caption { color: color-mix(in srgb, var(--diagram-emphasis-text) 78%, transparent); }
-.fig-boundary { position: relative; display: flex; align-items: center; gap: 12px; padding: 34px 16px 16px; border: 1px dashed color-mix(in srgb, var(--diagram-emphasis-border) 65%, var(--border)); border-radius: 12px; background: color-mix(in srgb, var(--accent) 55%, transparent); }
-.fig-boundary-label { position: absolute; top: 10px; left: 16px; right: 16px; color: var(--muted); font-size: 13px; line-height: 1.4; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fig-group { position: relative; display: flex; align-items: center; gap: 12px; padding: 34px 16px 16px; border: 1px dashed color-mix(in srgb, var(--diagram-emphasis-border) 65%, var(--border)); border-radius: 12px; background: color-mix(in srgb, var(--accent) 55%, transparent); }
+.fig-group-label { position: absolute; top: 10px; left: 16px; right: 16px; color: var(--muted); font-size: 13px; line-height: 1.4; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .fig-edge { display: flex; flex-direction: column; align-items: center; gap: 2px; color: var(--muted); font-size: 13px; line-height: 1.4; text-align: center; }
+
+/* Package ownership map: scope first, then the responsibility of shared code. */
+.ownership-map { display: grid; gap: 14px; }
+.ownership-step-label { color: var(--foreground); font-size: 14px; font-weight: 600; line-height: 1.4; }
+.ownership-scope { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.ownership-continue { gap: 3px; }
+.ownership-groups { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.ownership-group { min-width: 0; padding: 12px; border: 1px dashed color-mix(in srgb, var(--diagram-emphasis-border) 65%, var(--border)); border-radius: 12px; background: color-mix(in srgb, var(--accent) 55%, transparent); }
+.ownership-group-title { margin-bottom: 10px; color: var(--muted); font-size: 13px; font-weight: 600; line-height: 1.4; }
+.ownership-packages { display: grid; gap: 8px; }
+.ownership-map .fig-node { padding: 10px 12px; }
+.ownership-map .fig-node code { padding: 0; border: 0; background: transparent; color: inherit; font-size: 13px; }
 
 /* Reference rows: keys are deep-linkable scan lines, not headings or tables. */
 .markdown-body .config-card { margin: 24px 0 32px; overflow: hidden; border: 1px solid var(--border); border-radius: 12px; background: var(--card); box-shadow: var(--shadow-sm); font-size: 14px; line-height: 1.6; }
@@ -822,13 +834,14 @@ html[data-theme="dark"] {
 .steps > ol > li:last-child::after { display: none; }
 
 @media (max-width: 720px) {
-  .fig-flow-track, .fig-lane, .fig-boundary { flex-direction: column; align-items: stretch; }
-  .fig-boundary { padding-top: 16px; }
-  .fig-boundary-label { position: static; white-space: normal; text-align: center; }
-  .fig-flow-track .fig-arrow-next, .fig-lane .fig-arrow-next, .fig-boundary .fig-arrow-next,
-  .fig-lane .fig-arrow-back, .fig-boundary .fig-arrow-back { transform: rotate(90deg); }
+  .fig-flow-track, .fig-lane, .fig-group { flex-direction: column; align-items: stretch; }
+  .fig-group { padding-top: 16px; }
+  .fig-group-label { position: static; white-space: normal; text-align: center; }
+  .fig-flow-track .fig-arrow-next, .fig-lane .fig-arrow-next, .fig-group .fig-arrow-next,
+  .fig-lane .fig-arrow-back, .fig-group .fig-arrow-back { transform: rotate(90deg); }
   .fig-flow-loop { text-align: center; }
   .config-row { grid-template-columns: 1fr; }
+  .ownership-scope, .ownership-groups { grid-template-columns: 1fr; }
 }
 
 /* Home: information sections added alongside the path cards — a two-up grid,

--- a/docs/site/lib/docs.ts
+++ b/docs/site/lib/docs.ts
@@ -373,7 +373,7 @@ function compileRst(content: string, sourcePath: string) {
     },
   });
   // `.. diagram::` is the escape hatch for genuinely spatial figures: the body
-  // is hand-built HTML over the fig-node/fig-boundary/fig-edge primitives in
+  // is hand-built HTML over the fig-node/fig-group/fig-edge primitives in
   // globals.css, passed through inside the shared figure chrome.
   compiler.useDirectiveGenerator({
     directives: ["diagram"],

--- a/docs/user-guide/recipes/tttd.rst
+++ b/docs/user-guide/recipes/tttd.rst
@@ -200,9 +200,9 @@ because the packing tasks need a longer context on the same GPUs.
    TTTD_TASK=circle_packing_26 ./run.sh
 
 The judges run each submitted program in a subprocess and recompute the returned
-quantity. The circle-packing judges verify the circle count, square boundaries,
-pairwise non-overlap, and finite values before summing the radii. They do not use
-the sum reported by the generated program.
+quantity. The circle-packing judges verify the circle count, ensure every circle
+stays inside the square, check pairwise non-overlap and finite values, and then
+sum the radii. They do not use the sum reported by the generated program.
 
 Configure a trajectory
 ----------------------
@@ -259,9 +259,9 @@ about the global optima.
    :alt: Verified circle configurations for Packing 26 and Packing 32
 
 The saved programs were executed again before the configurations were plotted.
-The replay checked the circle count, finite values, square boundaries, and every
-pairwise distance with a tolerance of ``1e-12``. Floating point summation changed
-the recorded values by less than ``1.2e-12``.
+The replay checked the circle count, finite values, whether every circle stayed
+inside the square, and every pairwise distance with a tolerance of ``1e-12``.
+Floating point summation changed the recorded values by less than ``1.2e-12``.
 
 Best solution found so far
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -413,8 +413,8 @@ when that contract changes.
 
 Add tests for the program contract, invalid outputs, reward calculation, and
 task registration. ``tests/test_tttd_harness.py`` and
-``tests/test_tttd_packing_tasks.py`` show the boundary between the shared harness
-and a task-specific judge.
+``tests/test_tttd_packing_tasks.py`` show how the shared harness hands programs
+to a task-specific judge.
 
 See also
 --------


### PR DESCRIPTION
## Summary

- replace the dense package-layer diagram with a two-step ownership map
- make the map readable at desktop and mobile widths
- replace vague boundary terminology with concrete responsibility, contract, isolation, scope, and interface language

## Validation

- `npm --prefix docs/site run check:docs`
- `npm --prefix docs/site run build`