### PR TITLE
docs: define agents as model plus harness

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -1,9 +1,10 @@
 Harness adapters
 ================
 
-An adapter is how a rendered harness tree becomes a running agent. The tree
-never names a file path; the adapter does. Reef bundles two, one per third-party
-coding-agent CLI.
+An adapter maps a harness tree into the files expected by a third-party
+coding-agent CLI and binds that harness to the served model. The harness and
+model together form the running agent. The tree never names a file path; the
+adapter does. Reef bundles two, one per third-party coding-agent CLI.
 
 +--------------+-------------------------------------------+-----------------------------------------+
 | Adapter      | Config targets                            | Install pin                             |
@@ -17,7 +18,8 @@ coding-agent CLI.
 The descriptor
 --------------
 
-One ``descriptor.yaml`` declares how a tree becomes a running agent.
+One ``descriptor.yaml`` declares how a tree configures and starts a running
+agent.
 
 .. config::
 

--- a/docs/getting-started/architecture.rst
+++ b/docs/getting-started/architecture.rst
@@ -1,10 +1,10 @@
 Architecture
 ============
 
-Reef sits between an agent and the runtime that answers it. It records the
-artifact version that served each response, accepts feedback that refers to
-those responses, and lets a scenario's recipe use eligible records to produce
-the next version. Your harness keeps prompts, tools, environments, and graders.
+An agent is a model plus its harness. Reef sits between the harness and the
+runtime that executes the model. It records the artifact version that served
+each response, accepts feedback that refers to those responses, and lets a
+scenario's recipe use eligible records to produce the next version.
 
 Which package holds which code is `Codebase structure
 <../contributing/codebase-structure.rst>`__.

--- a/docs/getting-started/intro.rst
+++ b/docs/getting-started/intro.rst
@@ -4,15 +4,16 @@ Introduction
 Reef is a continual learning infrastructure. It serves an inference endpoint in
 front of the model your agent already calls, records what it served, accepts
 feedback about it, and uses that feedback to publish a better version of the
-model weights or of the agent's harness.
+model weights or of the agent's harness. The model and harness together form
+the agent.
 
 Nothing about the agent has to change except the base URL it sends requests to.
 
 .. diagram::
-   :caption: Reef serves the model, loads new weights into the engine, and sends a new harness tree to the agent.
+   :caption: An agent combines a harness and a model. Reef serves their connection and can improve either component.
 
    <div class="fig-lane">
-     <div class="fig-node">Your agent<span class="fig-node-caption">runs the harness tree: prompts, skills, config</span></div>
+     <div class="fig-node">The harness<span class="fig-node-caption">runs the control loop, prompts, skills, tools, and config</span></div>
      <div class="fig-edge">
        <span>requests and feedback</span>
        <svg class="fig-arrow fig-arrow-next" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h13"/><path d="m13 7 5 5-5 5"/></svg>
@@ -66,15 +67,16 @@ the whole thing:
 What Reef can evolve
 --------------------
 
-Weights and the harness are the two *artifacts* Reef versions. The recipe you
-configure picks one (composite version is a feature in the roadmap).
+Model weights and the harness tree are the two *artifacts* Reef versions. Each
+updates one of the agent's two components. The recipe you configure picks one
+(composite version is a feature in the roadmap).
 
 **Model weights.** Reef runs the training step and hot-swaps the result into the
 serving engine. See `Evolve your model <../user-guide/evolve-your-model.rst>`__.
 
-**The harness tree** is the agent's rules, prompts, skills, and config, versioned
-as one object. Reef proposes an edit, runs the current and proposed versions on
-your tasks, and keeps the winner. See `Evolve your harness
+**The harness tree** is the versioned representation of the harness's mutable
+rules, prompts, skills, config, and extension code. Reef proposes an edit, runs
+the current and proposed versions on your tasks, and keeps the winner. See `Evolve your harness
 <../user-guide/evolve-your-harness.rst>`__.
 
 What a call looks like

--- a/docs/getting-started/intro.rst
+++ b/docs/getting-started/intro.rst
@@ -10,7 +10,7 @@ the agent.
 Nothing about the agent has to change except the base URL it sends requests to.
 
 .. diagram::
-   :caption: An agent combines a harness and a model. Reef serves their connection and can improve either component.
+   :caption: Reef serves the model, loads new weights into the engine, and sends a new harness tree to the agent.
 
    <div class="fig-lane">
      <div class="fig-node">The harness<span class="fig-node-caption">runs the control loop, prompts, skills, tools, and config</span></div>

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -12,6 +12,13 @@ every other scenario. The first request carrying a new ``x-reef-scenario``
 creates it and permanently binds its recipe. The request may also bind a
 starting artifact version.
 
+Agent
+-----
+
+The complete system that acts: **model + harness**. The model supplies the
+learned behavior; the harness supplies the control loop and context around it.
+Reef improves an agent by updating either model weights or the harness tree.
+
 Agent record
 ------------
 
@@ -60,8 +67,8 @@ other bare name resolves only to a YAML preset under
 Artifact
 --------
 
-The versioned thing: a model checkpoint, or a tree of text files such as a
-harness or skill set. An ``ArtifactRef`` identifies one version. Between
+The versioned thing: a model checkpoint or a harness tree. An ``ArtifactRef``
+identifies one version. Between
 checkpoints a live weight artifact exists only in engine memory; a durable one
 stores its bytes in Git.
 
@@ -115,13 +122,17 @@ The tensor objective the training backend runs, declared by
 Harness
 -------
 
-Two meanings, both in use here.
+The part of an agent around the model. It owns the control loop, prompts,
+conversations, tools, environment integration, and grading, and calls the model
+through an inference runtime.
 
-1. **Your harness:** the agent program around the model, owning prompts,
-   conversations, tools, environments, and grading. It runs outside Reef.
-2. **The harness tree:** Reef's deliverable, a versioned artifact of config,
-   rules, prompt templates, skills, and extension code, served over
-   ``GET /reef/harness``.
+Harness tree
+------------
+
+Reef's versioned representation of the mutable files in a harness: config,
+rules, prompt templates, skills, and extension code. Reef serves it over
+``GET /reef/harness``. An adapter combines the rendered tree with a harness
+executable; that harness and its configured model form the running agent.
 
 Skill
 -----
@@ -199,8 +210,9 @@ scenario; ``harness_evolve`` is one mechanism running many possible methods.
 Adapter
 -------
 
-Two meanings. For harness evolution, the descriptor that turns a rendered tree
-into a running agent (`Harness adapters <../developer-guide/harness-adapters.rst>`__). For weight
+Two meanings. For harness evolution, the descriptor that combines a rendered
+tree with an executable to make a running harness (`Harness adapters
+<../developer-guide/harness-adapters.rst>`__). For weight
 serving, a LoRA/PEFT adapter layered on a frozen base model.
 
 Episode

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -1,10 +1,11 @@
 Evolve your harness
 ===================
 
-A harness is everything around the model: rules, prompt templates, skills,
-config, extension code. Harness evolution improves that text while the model
-weights stay fixed. Reef needs no GPU for this. The model stays a fixed
-endpoint, hosted or local, and the served agent stays online throughout.
+A harness is everything around the model: the control loop, rules, prompt
+templates, skills, tools, config, and extension code. Together, the model and
+harness form an agent. Harness evolution improves the harness tree while the
+model weights stay fixed. Reef needs no GPU for this. The model stays a fixed
+endpoint, hosted or local, and the agent stays online throughout.
 
 Reef supplies the mechanism: it snapshots the tree, applies a mutation, runs
 the paired episodes, and publishes or reverts. You supply two Python
@@ -15,7 +16,7 @@ contract.
 The harness tree
 ----------------
 
-Reef stores the whole text side of one agent in a single versioned object
+Reef stores the mutable, versioned files of one harness in a single object
 called the tree. A tree is a flat list of entries, and each entry has three
 fields: ``id`` is unique within the tree, ``name`` selects one of the node
 kinds below, and ``config`` holds that kind's own fields. For the named kinds


### PR DESCRIPTION
## Summary

- define an agent as the combination of a model and its harness
- distinguish the running harness from Reef’s versioned harness tree
- align the introduction, architecture, harness evolution, and adapter docs with that composition
- retain agent terminology for whole-system behavior and coding-agent CLIs

## Validation

- `npm run check:docs`
- `npm run build`