### PR TITLE
docs: align page labels with navigation tabs

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -57,9 +57,3 @@ registers on the ``reef.harness_adapters`` entry-point group. ``version_check:
 true`` writes an update notice into the tree and ships for ``pi`` only, so an
 ``opencode`` recipe that sets it refuses to boot. An evolved tree is
 adapter-specific: ``config`` node contents follow each adapter's schema.
-
-See also
---------
-
-- `Evolve your harness <../user-guide/evolve-your-harness.rst>`__: the loop that produces the tree.
-- `harness_evolve <../user-guide/recipes/harness-evolve.rst>`__: the recipe's configuration.

--- a/docs/developer-guide/loss-families.rst
+++ b/docs/developer-guide/loss-families.rst
@@ -144,9 +144,3 @@ Bundled families worth reading: ``recipes/tttd/slime/`` (two hooks, the default
 row), ``recipes/sao/slime/`` (critic schedule, the pg-primitive lane),
 ``recipes/openclawrl/slime/`` (a custom row, both actor lifecycle hooks, a
 frozen Megatron teacher).
-
-See also
---------
-
-- `Python API <../reference/python-api.rst#step-preparer>`__: the signal side of the pair.
-- `Write a recipe <write-a-recipe.rst>`__: binding a family to a method.

--- a/docs/developer-guide/processors.rst
+++ b/docs/developer-guide/processors.rst
@@ -151,9 +151,3 @@ Cookbook processors
 | ``recipes/openclawrl/processor.py``   | computed | a main turn whose next state the PRM scores ±1, or for which the | ``PolicyBatch``        |
 |                                       |          | teacher scored an accepted hindsight hint                        |                        |
 +---------------------------------------+----------+------------------------------------------------------------------+------------------------+
-
-See also
---------
-
-- `Write a recipe <write-a-recipe.rst>`__: a processor in a complete recipe.
-- `Loss families <loss-families.rst>`__: the numeric side, which lives in the preparer.

--- a/docs/developer-guide/surface.rst
+++ b/docs/developer-guide/surface.rst
@@ -150,9 +150,3 @@ capability protocol only when no existing call site can express the consumer
 interaction. The package depends only on ``artifact/`` and ``core/``; it sees
 runtimes structurally, through the ``ServingRuntime`` and ``WeightRuntime``
 protocols, and never imports a concrete one.
-
-See also
---------
-
-- `Write a recipe <write-a-recipe.rst>`__: where ``build_surface`` fits.
-- `Harness adapters <harness-adapters.rst>`__: the client side of a file tree.

--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -186,8 +186,3 @@ regressed and at least one improved.
 
 Name it ``selection: my_pkg.policies:pareto_selection``. Publishing outside
 candidate selection breaks revert.
-
-See also
---------
-
-- `Python API <../reference/python-api.rst#harness-method>`__: the contract as a table.

--- a/docs/developer-guide/write-a-recipe.rst
+++ b/docs/developer-guide/write-a-recipe.rst
@@ -148,8 +148,3 @@ Reef never invents feedback. Use whatever already judges your agent; for the
 numeric ``score`` field, a consistent scale where higher is better. If you have
 no number, `Choosing a recipe <../user-guide/recipes.rst>`__ lists the methods that need
 none.
-
-See also
---------
-
-- `Adding components <../contributing/adding-components.rst>`__: bundling a recipe into Reef itself.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -47,8 +47,3 @@ Where it writes
 Each service gets a log and a PID file under ``run_dir``, which defaults to
 ``/tmp/reef-stack``. Reef writes its own state, including records, commit logs,
 and the Git-backed version chain, to the ``reef.*_dir`` paths in the config.
-
-See also
---------
-
-- `Configuration <configuration.rst>`__: what goes in the file this reads.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -247,8 +247,3 @@ Checkpoint paths are metadata only unless ``upload_checkpoints: true``.
 
 Import, initialization, logging, summary, and upload failures are reported in
 the service log and never fail a training step or its commit.
-
-See also
---------
-
-- `Choosing a recipe <../user-guide/recipes.rst>`__: what to put in ``reef.recipe``.

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -701,8 +701,7 @@ body {
   font-size: 11px;
 }
 .doc-context a:hover { color: var(--brand-strong); }
-.doc-type {
-  margin-right: 5px;
+.doc-section {
   padding: 4px 8px;
   color: var(--brand-strong);
   border: 1px solid color-mix(in srgb, var(--brand) 25%, var(--border));
@@ -872,12 +871,10 @@ html[data-theme="dark"] {
   .home-table { font-size: 14px; }
 }
 
-/* Page brief and document-kind chip. The brief sits under the lede and answers
+/* Page brief. It sits under the lede and answers
    three questions before the first section: who the page is for, what to have
    ready, and what the reader has at the end. It reuses the callout geometry
-   so it reads as the page's own note, not a second heading. The chip tints
-   follow the kind so a tutorial and a reference page are told apart at the
-   breadcrumb, before the first paragraph. */
+   so it reads as the page's own note, not a second heading. */
 .markdown-body .page-brief {
   margin: -14px 0 40px;
   padding: 14px 18px;
@@ -904,10 +901,6 @@ html[data-theme="dark"] {
 .markdown-body .page-brief dd { margin: 0; color: var(--text); }
 .markdown-body .page-brief dd a { font-weight: 500; }
 .markdown-body .page-brief code, .markdown-body .page-brief .literal { background: color-mix(in srgb, var(--accent) 70%, transparent); }
-.doc-type[data-kind="Concept"] { color: var(--callout-note-ink); border-color: color-mix(in srgb, var(--callout-note-ink) 32%, var(--border)); background: var(--callout-note); }
-.doc-type[data-kind="Reference"], .doc-type[data-kind="Contributor guide"] { color: var(--muted); border-color: var(--border); background: color-mix(in srgb, var(--card) 70%, transparent); }
-.doc-type[data-kind="Tutorial"] { color: var(--callout-tip-ink); border-color: color-mix(in srgb, var(--callout-tip-ink) 32%, var(--border)); background: var(--callout-tip); }
-
 /* Expected-output blocks inside tutorials: the same code chrome, labeled so
    a reader can tell a command to type from the text they should see. */
 .markdown-body pre.language-console, .markdown-body pre.language-shellsession { position: relative; }

--- a/docs/site/components/docs-page.tsx
+++ b/docs/site/components/docs-page.tsx
@@ -24,10 +24,9 @@ export function DocsPage({ doc, navigation, previous, next }: { doc: Doc; naviga
       <Sidebar navigation={navigation} />
       <main className="docs-main">
         <div className="doc-context" aria-label="Breadcrumb">
-          <span className="doc-type" data-kind={doc.kind}>{doc.kind}</span>
           <Link href="/docs">Docs</Link>
           <ChevronRight size={13} aria-hidden="true" />
-          <span>{section}</span>
+          <span className="doc-section">{section}</span>
         </div>
         <article className="markdown-body">
           <ReStructuredText content={doc.content} sourcePath={doc.sourcePath} />

--- a/docs/site/lib/docs.ts
+++ b/docs/site/lib/docs.ts
@@ -16,19 +16,10 @@ export type TocItem = {
   level: 2 | 3;
 };
 
-// Every page is exactly one kind of document, and the kind is part of the
-// navigation contract rather than something inferred from the section: a
-// tutorial teaches one path with no options, a how-to answers "how do I",
-// a concept explains, a reference describes. The chip above each page title
-// shows the kind, so a reader knows before the first paragraph whether to
-// expect steps, tables, or prose.
-export type PageKind = "Tutorial" | "How-to" | "Concept" | "Reference" | "Contributor guide";
-
 export type Doc = {
   slug: string;
   title: string;
   description: string;
-  kind: PageKind;
   content: string;
   sourcePath: string;
   toc: TocItem[];
@@ -37,7 +28,6 @@ export type Doc = {
 export type NavItem = {
   title: string;
   description: string;
-  kind: PageKind;
   href: string;
   slug: string;
 };
@@ -49,19 +39,17 @@ export type NavGroup = {
 
 const docsRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
-type NavSource = { file: string; kind: PageKind };
-
-const navigationSources: ReadonlyArray<{ title: string; files: ReadonlyArray<NavSource> }> = [
+const navigationSources: ReadonlyArray<{ title: string; files: ReadonlyArray<string> }> = [
   {
     // What Reef is, what to install, the loop every later page assumes, and
     // what is underneath it. Architecture sits last because it spends the
     // vocabulary quickstart.rst teaches. The first entry is where /docs lands.
     title: "Getting Started",
     files: [
-      { file: "getting-started/intro.rst", kind: "Concept" },
-      { file: "getting-started/installation.rst", kind: "How-to" },
-      { file: "getting-started/quickstart.rst", kind: "Tutorial" },
-      { file: "getting-started/architecture.rst", kind: "Concept" },
+      "getting-started/intro.rst",
+      "getting-started/installation.rst",
+      "getting-started/quickstart.rst",
+      "getting-started/architecture.rst",
     ],
   },
   {
@@ -69,51 +57,51 @@ const navigationSources: ReadonlyArray<{ title: string; files: ReadonlyArray<Nav
     // deployment running, and find out why it did not.
     title: "User Guide",
     files: [
-      { file: "user-guide/recipes.rst", kind: "Reference" },
-      { file: "user-guide/evolve-your-harness.rst", kind: "Tutorial" },
-      { file: "user-guide/evolve-your-model.rst", kind: "Tutorial" },
-      { file: "user-guide/recipes/sao.rst", kind: "Reference" },
-      { file: "user-guide/recipes/tttd.rst", kind: "Reference" },
-      { file: "user-guide/recipes/openclawrl.rst", kind: "Reference" },
-      { file: "user-guide/recipes/harness-evolve.rst", kind: "Reference" },
-      { file: "user-guide/operate.rst", kind: "How-to" },
-      { file: "user-guide/troubleshooting.rst", kind: "How-to" },
+      "user-guide/recipes.rst",
+      "user-guide/evolve-your-harness.rst",
+      "user-guide/evolve-your-model.rst",
+      "user-guide/recipes/sao.rst",
+      "user-guide/recipes/tttd.rst",
+      "user-guide/recipes/openclawrl.rst",
+      "user-guide/recipes/harness-evolve.rst",
+      "user-guide/operate.rst",
+      "user-guide/troubleshooting.rst",
     ],
   },
   {
     // Writing your own method against Reef's contracts.
     title: "Developer Guide",
     files: [
-      { file: "developer-guide/write-a-recipe.rst", kind: "Tutorial" },
-      { file: "developer-guide/write-a-harness-method.rst", kind: "Tutorial" },
-      { file: "developer-guide/harness-adapters.rst", kind: "Reference" },
-      { file: "developer-guide/loss-families.rst", kind: "Reference" },
-      { file: "developer-guide/surface.rst", kind: "Concept" },
-      { file: "developer-guide/processors.rst", kind: "Concept" },
+      "developer-guide/write-a-recipe.rst",
+      "developer-guide/write-a-harness-method.rst",
+      "developer-guide/harness-adapters.rst",
+      "developer-guide/loss-families.rst",
+      "developer-guide/surface.rst",
+      "developer-guide/processors.rst",
     ],
   },
   {
     title: "CLI Reference",
     files: [
-      { file: "reference/cli.rst", kind: "Reference" },
-      { file: "reference/configuration.rst", kind: "Reference" },
+      "reference/cli.rst",
+      "reference/configuration.rst",
     ],
   },
   {
     title: "API Reference",
     files: [
-      { file: "reference/http-api.rst", kind: "Reference" },
-      { file: "reference/python-api.rst", kind: "Reference" },
-      { file: "reference/glossary.rst", kind: "Reference" },
+      "reference/http-api.rst",
+      "reference/python-api.rst",
+      "reference/glossary.rst",
     ],
   },
   {
     title: "Contributing",
     files: [
-      { file: "contributing/codebase-structure.rst", kind: "Contributor guide" },
-      { file: "contributing/adding-components.rst", kind: "Contributor guide" },
-      { file: "contributing/development.rst", kind: "Contributor guide" },
-      { file: "contributing/testing.rst", kind: "Contributor guide" },
+      "contributing/codebase-structure.rst",
+      "contributing/adding-components.rst",
+      "contributing/development.rst",
+      "contributing/testing.rst",
     ],
   },
 ];
@@ -122,7 +110,7 @@ const navigationSources: ReadonlyArray<{ title: string; files: ReadonlyArray<Nav
 // does not merely go unlinked — it 404s. Adding a page under a section
 // directory now fails the build until it is placed in the reading order. Not
 // scanned: rfcs/ (design records, read in the repo).
-const navigated = new Set<string>(navigationSources.flatMap((group) => group.files.map((source) => source.file)));
+const navigated = new Set<string>(navigationSources.flatMap((group) => group.files));
 // Pages live in one directory per navigation section, so a page's path names
 // its section and the URL follows the path.
 const sectionDirectories = ["getting-started", "user-guide", "user-guide/recipes", "developer-guide", "reference", "contributing"];
@@ -428,7 +416,7 @@ function tableOfContents(html: string) {
   return items;
 }
 
-function loadDoc({ file: sourcePath, kind }: NavSource): Doc {
+function loadDoc(sourcePath: string): Doc {
   const source = readFileSync(join(docsRoot, sourcePath), "utf8");
   const content = compileRst(source, sourcePath);
   const title = heading(content, 1)?.title;
@@ -438,7 +426,6 @@ function loadDoc({ file: sourcePath, kind }: NavSource): Doc {
     slug: slugFromSourcePath(sourcePath),
     title,
     description,
-    kind,
     content,
     sourcePath,
     toc: tableOfContents(content),
@@ -450,13 +437,12 @@ const docsBySlug = new Map(docs.map((doc) => [doc.slug, doc]));
 
 export const navigation: NavGroup[] = navigationSources.map((group) => ({
   title: group.title,
-  items: group.files.map((source) => {
-    const doc = docsBySlug.get(slugFromSourcePath(source.file));
-    if (!doc) throw new Error(`Documentation page not found: ${source.file}`);
+  items: group.files.map((sourcePath) => {
+    const doc = docsBySlug.get(slugFromSourcePath(sourcePath));
+    if (!doc) throw new Error(`Documentation page not found: ${sourcePath}`);
     return {
       title: doc.title,
       description: doc.description,
-      kind: doc.kind,
       href: `/docs/${doc.slug}`,
       slug: doc.slug,
     };

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -208,8 +208,3 @@ Connect a different agent
 
 `Harness adapters <../developer-guide/harness-adapters.rst>`__ is the descriptor reference and
 how to connect an agent that has no adapter yet.
-
-See also
---------
-
-- `harness_evolve <recipes/harness-evolve.rst>`__: the recipe's full configuration.

--- a/docs/user-guide/evolve-your-model.rst
+++ b/docs/user-guide/evolve-your-model.rst
@@ -176,8 +176,3 @@ is admitted the same way. It enters the version chain only if
 ``adapter_config.json`` declares a
 ``peft_type``, the weights are present, and its base model matches the one the
 engine holds.
-
-See also
---------
-
-- `Architecture <../getting-started/architecture.rst#the-version-chain>`__: the update transaction and durability model.

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -57,10 +57,3 @@ describes each spelling.
 
 Every recipe has a checkpoint strategy, defaulting to ``EveryNVersions(1)``.
 ``checkpoint_every_n_versions`` is the shorter spelling in deployment YAML.
-
-See also
---------
-
-- `tttd <recipes/tttd.rst>`__ includes the cookbook TTT-Discover example,
-  formal circle-packing results, and recovery details.
-- `Write a recipe <../developer-guide/write-a-recipe.rst>`__: when none of them fits.

--- a/docs/user-guide/recipes/harness-evolve.rst
+++ b/docs/user-guide/recipes/harness-evolve.rst
@@ -100,8 +100,3 @@ must reach the model on every live request, so its recipe overrides
 ``build_surface``, the hook controlling how a published artifact reaches the
 request path (`skillclaw_recipe.py
 <../../../recipes/harness_evolve/examples/skillclaw/harness/skillclaw_recipe.py>`__).
-
-See also
---------
-
-- `HTTP API <../../reference/http-api.rst#harness-artifacts>`__: pulling, pinning, and installing a published tree.

--- a/docs/user-guide/recipes/openclawrl.rst
+++ b/docs/user-guide/recipes/openclawrl.rst
@@ -120,9 +120,3 @@ student's preferences, with the work shown and the correct answer. The bold
 and list rates track the style the student rejects. From the curves we see both fall as training goes on, and
 the run reaches the paper's adaptation criterion (three passed sessions in
 a row) at session 14.
-
-See also
---------
-
-- `recipes/openclawrl/examples/openclawrl/README.md <../../../recipes/openclawrl/examples/openclawrl/README.md>`__ describes the homework sessions and the simulated student.
-- `Python API <../../reference/python-api.rst#computed-feedback>`__ documents the computed-feedback processor engine this recipe uses.

--- a/docs/user-guide/recipes/sao.rst
+++ b/docs/user-guide/recipes/sao.rst
@@ -100,8 +100,3 @@ training steps with no stale drops, which is the acceptance criterion for the
 smoke. Every score is 0.0 because Qwen2.5-1.5B-Instruct does not solve these
 problems. The useful output is the per-step training metrics, exported from an
 offline W&B run.
-
-See also
---------
-
-- `Evolve your model <../evolve-your-model.rst>`__: running the deployment.

--- a/docs/user-guide/recipes/tttd.rst
+++ b/docs/user-guide/recipes/tttd.rst
@@ -415,12 +415,3 @@ Add tests for the program contract, invalid outputs, reward calculation, and
 task registration. ``tests/test_tttd_harness.py`` and
 ``tests/test_tttd_packing_tasks.py`` show how the shared harness hands programs
 to a task-specific judge.
-
-See also
---------
-
-- `The example README <../../../recipes/tttd/examples/tttd/README.md>`__ records
-  implementation details and paper fidelity.
-- `sao <sao.rst>`__ handles ungrouped feedback when each attempt trains alone.
-- `Architecture <../../getting-started/architecture.rst#evaluation>`__ describes
-  how Reef evaluates a candidate before accepting an update.


### PR DESCRIPTION
## Motivation

Documentation pages used a second content-kind taxonomy in their breadcrumb, so a page under Developer Guide could still display a Reference label. The repeated See also footers also duplicated navigation already provided by the site.

## Changes

- Use the owning top-navigation tab as each page breadcrumb label.
- Remove the parallel Tutorial, How-to, Concept, Reference, and Contributor guide metadata.
- Remove all 15 See also footer sections from the RST documentation.

## Compatibility and operational impact

None. This changes documentation presentation and content only.

## Verification

- `npm run lint` — passed.
- `npm run check:docs` — validated 109 Markdown files, 34 RST files, internal routes, and Reef contracts.
- `npm run build` — production build and all 35 static pages completed successfully.
- `git diff --check` — passed.
- Full docs scan confirmed no remaining See also variants.

## AI assistance

OpenAI Codex inspected the documentation navigation implementation, applied the scoped edits, and ran the verification commands. The author reviewed the resulting diff and test output.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.