### PR TITLE
fix: cycle the theme toggle through dark before light

### DIFF
--- a/docs/site/components/theme-toggle.tsx
+++ b/docs/site/components/theme-toggle.tsx
@@ -3,13 +3,16 @@
 import { Moon, Sun, SunMoon } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef } from "react";
 
-const MODES = ["auto", "light", "dark"] as const;
+// Click order matches the founder's personal-site toggle: an explicit dark,
+// then light, then back to following the OS. On a light-OS machine the first
+// click must visibly change the page; auto -> light would not.
+const MODES = ["auto", "dark", "light"] as const;
 type Mode = (typeof MODES)[number];
 
 const LABELS: Record<Mode, string> = {
-  auto: "Color theme: system. Switch to light.",
-  light: "Color theme: light. Switch to dark.",
-  dark: "Color theme: dark. Switch to system.",
+  auto: "Color theme: system. Switch to dark.",
+  dark: "Color theme: dark. Switch to light.",
+  light: "Color theme: light. Switch to system.",
 };
 
 function storedMode(): Mode {
@@ -56,7 +59,11 @@ export function ThemeToggle() {
   function cycleTheme() {
     const next = MODES[(MODES.indexOf(storedMode()) + 1) % MODES.length];
     try {
-      localStorage.setItem("reef-theme", next);
+      if (next === "auto") {
+        localStorage.removeItem("reef-theme");
+      } else {
+        localStorage.setItem("reef-theme", next);
+      }
     } catch {
       /* private browsing: the theme still applies for this page view */
     }


### PR DESCRIPTION
## Motivation

On a machine with a light OS appearance, the first click on the docs theme toggle moved system mode to an explicit light, which looks identical on screen and then pins the site to light on every later visit. A browser audit against production showed the storage chain works, so the defect is the click order. Closes #67.

## Changes

- Reorder the toggle cycle from system, light, dark to system, dark, light, matching the arena toggle, so the first click always makes a visible change
- Store system mode by removing the reef-theme key instead of writing auto
- Update the aria labels and titles to the new order
- State the click order rationale in a comment

## Compatibility and operational impact

None. The boot script already treats a missing key as system mode, and stored light or dark values keep their meaning.

## Verification

Built the site and audited every state transition with puppeteer against the static export, under both OS appearance emulations:

```
[os=light] PASS initial auto / click1 -> dark / dark persists / click2 -> light
           / light persists / click3 -> auto / auto persists
[os=dark]  PASS initial auto / click1 -> dark / dark persists / click2 -> light
           / light persists / click3 -> auto / auto persists
ALL TRANSITIONS PASS (14/14)
```

Each persistence step is a real reload; the click1 step also proves the first click now changes the rendered theme on a light OS.

## AI assistance

Claude Code investigated the report, wrote the fix, and ran the browser audit. I reviewed the diff and the audit output.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
