### PR TITLE
docs: add the harness evolution notebook tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,5 +210,6 @@ _examples_synced/
 .reef/
 
 # example run state
-recipes/*/examples/*/work/
+recipes/*/work/
+tutorials/*/work/
 recipes/basic/work/

--- a/tutorials/harness_evolve/1_evolve_your_harness.ipynb
+++ b/tutorials/harness_evolve/1_evolve_your_harness.ipynb
@@ -18,6 +18,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[<img align=\"left\" src=\"https://colab.research.google.com/assets/colab-badge.svg\">](https://colab.research.google.com/github/Human-Agent-Society/reef/blob/main/tutorials/harness_evolve/1_evolve_your_harness.ipynb)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "716a85d3",

--- a/tutorials/harness_evolve/1_evolve_your_harness.ipynb
+++ b/tutorials/harness_evolve/1_evolve_your_harness.ipynb
@@ -1,0 +1,392 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3d48dff9",
+   "metadata": {},
+   "source": [
+    "# Evolve your harness\n",
+    "\n",
+    "One full pass of the harness evolution loop, cell by cell: serve Reef,\n",
+    "send three coding tasks through it, report each score, and watch one\n",
+    "gated evolve step improve a skill and publish a new harness version.\n",
+    "\n",
+    "Needs: `pip install reef-client`, the `pi` binary on PATH\n",
+    "(`npm i -g @earendil-works/pi-coding-agent@0.84.2`), and an\n",
+    "OpenAI-compatible endpoint serving a model. Set the three values in the\n",
+    "next cell. No GPU is needed by Reef itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "716a85d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-31T11:15:22.161140Z",
+     "iopub.status.busy": "2026-08-31T11:15:22.161079Z",
+     "iopub.status.idle": "2026-08-31T11:15:22.163866Z",
+     "shell.execute_reply": "2026-08-31T11:15:22.163532Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The model under test: any OpenAI-compatible endpoint (no /v1 suffix).\n",
+    "UPSTREAM_URL = \"http://127.0.0.1:11434\"\n",
+    "UPSTREAM_MODEL = \"qwen2.5:7b\"\n",
+    "UPSTREAM_API_KEY = \"sk-local\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b31b6af3",
+   "metadata": {},
+   "source": [
+    "## Start Reef\n",
+    "\n",
+    "`serve.yaml` carries the whole stack: the service and the\n",
+    "`harness_evolve` recipe sections (seed skill composition, the three\n",
+    "evolve tasks, the gate). We patch the upstream binding AND the recipe's\n",
+    "model binding to the values above (the recipe's `model.path` names the\n",
+    "model under test: the proposer and the evaluation episodes call it, so a\n",
+    "mismatch leaves the evolve step without a working model), materialize\n",
+    "the recipe config from the patched text, and start the service as a\n",
+    "subprocess. Reef is a plain Python process; the model stays wherever\n",
+    "it is served."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2085a468",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-31T11:15:22.164828Z",
+     "iopub.status.busy": "2026-08-31T11:15:22.164766Z",
+     "iopub.status.idle": "2026-08-31T11:15:23.204270Z",
+     "shell.execute_reply": "2026-08-31T11:15:23.203266Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reef is up\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import pathlib\n",
+    "import re\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.request\n",
+    "\n",
+    "import yaml\n",
+    "\n",
+    "here = pathlib.Path.cwd()\n",
+    "work = here / \"work\"\n",
+    "(work / \"recipes\").mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "text = (here / \"serve.yaml\").read_text()\n",
+    "text = re.sub(r\"upstream_url: .*\", f\"upstream_url: {UPSTREAM_URL}\", text)\n",
+    "text = re.sub(r\"upstream_model: .*\", f\"upstream_model: {UPSTREAM_MODEL}\", text)\n",
+    "text = re.sub(r\"(?m)^  path: .*\", f\"  path: {UPSTREAM_MODEL}\", text)\n",
+    "(work / \"serve-notebook.yaml\").write_text(text)\n",
+    "\n",
+    "env = dict(os.environ)\n",
+    "env[\"REEF_RECIPE_CONFIG_DIR\"] = str(work / \"recipes\")\n",
+    "env[\"REEF_UPSTREAM_API_KEY\"] = UPSTREAM_API_KEY\n",
+    "env[\"PYTHONPATH\"] = str(here.parent.parent)\n",
+    "\n",
+    "# What materialize_recipe.py does, from the patched text instead of serve.yaml.\n",
+    "cfg = yaml.safe_load(text)\n",
+    "recipe = {key: cfg[key] for key in (\"implementation\", \"model\", \"evolution\", \"data\")}\n",
+    "(work / \"recipes\" / \"harness_evolve.yaml\").write_text(yaml.safe_dump(recipe, sort_keys=False))\n",
+    "(work / \"tasks.json\").write_text(json.dumps(recipe[\"evolution\"][\"tasks\"], indent=2) + \"\\n\")\n",
+    "\n",
+    "serve = subprocess.Popen(\n",
+    "    [\"python3\", \"-m\", \"reef\", \"serve\", \"-c\", str(work / \"serve-notebook.yaml\")],\n",
+    "    env=env, stdout=(work / \"reef.log\").open(\"w\"), stderr=subprocess.STDOUT,\n",
+    ")\n",
+    "for _ in range(60):\n",
+    "    try:\n",
+    "        urllib.request.urlopen(\"http://127.0.0.1:8900/healthz\", timeout=1)\n",
+    "        break\n",
+    "    except Exception:\n",
+    "        assert serve.poll() is None, (work / \"reef.log\").read_text()[-2000:]\n",
+    "        time.sleep(1)\n",
+    "print(\"reef is up\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5db779ff",
+   "metadata": {},
+   "source": [
+    "## Send the tasks and report the scores\n",
+    "\n",
+    "Each task goes through Reef's inference proxy, which injects the served\n",
+    "skill catalog and records the exchange. The report ties the score to\n",
+    "that recorded traffic. Only failing reports batch; the first failure\n",
+    "schedules one evolve step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ff54161f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-31T11:15:23.206942Z",
+     "iopub.status.busy": "2026-08-31T11:15:23.206749Z",
+     "iopub.status.idle": "2026-08-31T11:15:25.628872Z",
+     "shell.execute_reply": "2026-08-31T11:15:25.627944Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task 1 [sieve]: score 1.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task 2 [fib]: score 0.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task 3 [csv]: score 1.0\n",
+      "1 failing report(s); each schedules one gated evolve step\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from reef_client import ReefClient\n",
+    "from harness import evolution\n",
+    "\n",
+    "SCENARIO = \"harness-evolve-demo\"\n",
+    "client = ReefClient(\"http://127.0.0.1:8900\", token=\"reef-local\", timeout_s=300.0)\n",
+    "tasks = json.loads((work / \"tasks.json\").read_text())\n",
+    "\n",
+    "failures = 0\n",
+    "for index, task in enumerate(tasks, start=1):\n",
+    "    body, receipt = client.inference_with_record(\n",
+    "        SCENARIO, \"/v1/chat/completions\",\n",
+    "        {\"model\": UPSTREAM_MODEL, \"messages\": [{\"role\": \"user\", \"content\": task}]},\n",
+    "    )\n",
+    "    prefix = task.split(maxsplit=1)[0]\n",
+    "    score = evolution.grade_text(task, body[\"choices\"][0][\"message\"][\"content\"])\n",
+    "    client.report(\n",
+    "        SCENARIO,\n",
+    "        {\"agent_record_id\": f\"harness-evolve-{index}\", \"score\": score, \"feedback\": prefix},\n",
+    "        references=[receipt],\n",
+    "    )\n",
+    "    failures += score == 0.0\n",
+    "    print(f\"task {index} {prefix}: score {score}\")\n",
+    "print(f\"{failures} failing report(s); each schedules one gated evolve step\"\n",
+    "      if failures else \"every task passed: nothing batches, no evolve step runs\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5db5fee",
+   "metadata": {},
+   "source": [
+    "## Watch the evolve step publish\n",
+    "\n",
+    "The step proposes one skill mutation (the served model is its own\n",
+    "proposer), renders candidate and current compositions, runs the three\n",
+    "tasks twice each as headless `pi` episodes, and publishes only if the\n",
+    "candidate wins. `GET /reef/harness` answers 404 until then."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "14be7965",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-31T11:15:25.631414Z",
+     "iopub.status.busy": "2026-08-31T11:15:25.631202Z",
+     "iopub.status.idle": "2026-08-31T11:18:15.858481Z",
+     "shell.execute_reply": "2026-08-31T11:18:15.857774Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "published: artifact f98266d26785a02bb825b242b1911e3b168d0798 (parent bf022b0e8abc11ee71c58a693dbefe4f1ddcf7a0)\n",
+      "{\n",
+      "  \"candidate_score\": 1.0,\n",
+      "  \"current_score\": 0.0,\n",
+      "  \"episode_failures\": 0,\n",
+      "  \"failures\": {\n",
+      "    \"fixed\": 0,\n",
+      "    \"new\": 0,\n",
+      "    \"persisting\": 0\n",
+      "  },\n",
+      "  \"losses\": 0,\n",
+      "  \"mutation\": {\n",
+      "    \"id\": \"answer-style\",\n",
+      "    \"op\": \"update\"\n",
+      "  },\n",
+      "  \"published\": true,\n",
+      "  \"selected\": true,\n",
+      "  \"selection\": {\n",
+      "    \"candidate_id\": \"harness-evolve-demo:harness_evolve:1:candidate\",\n",
+      "    \"evaluation\": {\n",
+      "      \"evaluator\": \"harness_episode_pairs\",\n",
+      "      \"evaluator_version\": \"1\",\n",
+      "      \"metadata\": {},\n",
+      "      \"metrics\": {\n",
+      "        \"candidate_failures\": [],\n",
+      "        \"candidate_score\": 1.0,\n",
+      "        \"candidate_scores\": [\n",
+      "          1.0,\n",
+      "          0.0,\n",
+      "          0.0\n",
+      "        ],\n",
+      "        \"current_failures\": [],\n",
+      "        \"current_score\": 0.0,\n",
+      "        \"current_scores\": [\n",
+      "          0.0,\n",
+      "          0.0,\n",
+      "          0.0\n",
+      "        ],\n",
+      "        \"episode_failures\": 0\n",
+      "      }\n",
+      "    },\n",
+      "    \"metrics\": {\n",
+      "      \"losses\": 0,\n",
+      "      \"ties\": 2,\n",
+      "      \"wins\": 1\n",
+      "    },\n",
+      "    \"outcome\": \"select\",\n",
+      "    \"policy\": \"score_comparison\",\n",
+      "    \"policy_version\": \"1\",\n",
+      "    \"reason\": \"candidate won 1 task pairings and lost 0\"\n",
+      "  },\n",
+      "  \"steps\": 1,\n",
+      "  \"ties\": 2,\n",
+      "  \"traces\": 1,\n",
+      "  \"wins\": 1\n",
+      "}\n",
+      "--- pi-agent/skills/answer-style/SKILL.md ---\n",
+      "# answer-style\n",
+      "\n",
+      "Starter skill. The evolution loop replaces this placeholder with\n",
+      "concrete guidance learned from failing tasks.\n",
+      "\n",
+      "After reviewing the failing request, the issue lies in the incorrect formatting of the response. The assistant provided a string that is not an integer, and it includes unnecessary text. To address this, the next version of the 'answer-style' skill will ensure the response is a plain integer formatted correctly.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from reef_client import ReefClientError\n",
+    "\n",
+    "manifest = None\n",
+    "deadline = time.monotonic() + 900\n",
+    "while manifest is None and time.monotonic() < deadline and failures:\n",
+    "    try:\n",
+    "        manifest = client.get(\"/reef/harness\", extra_headers={\"x-reef-scenario\": SCENARIO})\n",
+    "    except ReefClientError as exc:  # noqa: PERF203 - publish poll\n",
+    "        if exc.status != 404:\n",
+    "            raise\n",
+    "        if error := client.get(\"/reef/status\").get(\"error\"):\n",
+    "            raise SystemExit(f\"evolve step failed: {error}\") from exc\n",
+    "        time.sleep(2)\n",
+    "if manifest:\n",
+    "    print(f\"published: artifact {manifest['artifact_version']}\"\n",
+    "          f\" (parent {manifest['parent_artifact_version']})\")\n",
+    "    print(json.dumps(manifest[\"gate\"], indent=2, sort_keys=True))\n",
+    "    for path, text in sorted(manifest[\"files\"].items()):\n",
+    "        if \"/skills/\" in path:\n",
+    "            print(f\"--- {path} ---\\n{text}\")\n",
+    "elif failures:\n",
+    "    # The commit log says why: a \"skipped\" metric means the proposer\n",
+    "    # returned no usable mutation; a selection reason means the candidate\n",
+    "    # ran its episodes and lost the gate.\n",
+    "    commits = [json.loads(line)\n",
+    "               for path in (work / \"agent-record\").glob(\"*.commits.jsonl\")\n",
+    "               for line in path.read_text().splitlines()]\n",
+    "    metrics = commits[-1][\"metrics\"] if commits else {}\n",
+    "    why = metrics.get(\"skipped\") or metrics.get(\"selection\", {}).get(\"reason\") or \"no evolve step committed\"\n",
+    "    print(f\"no publish this time ({why}); rerun the task cell for another attempt\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fa1c139",
+   "metadata": {},
+   "source": [
+    "## Stop the service\n",
+    "\n",
+    "The published tree stays under `work/`; any client can pull and install\n",
+    "it later through the HTTP API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8f2acc02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-31T11:18:15.860575Z",
+     "iopub.status.busy": "2026-08-31T11:18:15.860407Z",
+     "iopub.status.idle": "2026-08-31T11:18:15.941372Z",
+     "shell.execute_reply": "2026-08-31T11:18:15.940920Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reef stopped\n"
+     ]
+    }
+   ],
+   "source": [
+    "serve.terminate()\n",
+    "serve.wait(timeout=10)\n",
+    "print(\"reef stopped\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/harness_evolve/README.md
+++ b/tutorials/harness_evolve/README.md
@@ -3,9 +3,6 @@
 This example is the smallest full run of the harness evolution mechanism: the agent harness configuration is a composition tree of nodes, a proposal is one gated tree mutation, and a winning mutation publishes as a versioned artifact any client can pull. The proposer is the served model itself: it reads the current skill nodes and its own failing requests and proposes one skill mutation as a strict JSON object. `evaluate` grades real headless episodes on a small fixed task set by exact final answer, so a proposal only publishes when it makes previously failing tasks pass their episodes.
 
 The pinned paper reproduction built on this mechanism lives at `recipes/skillclaw/`.
-
-The proposer is the served model itself: it reads the current skill nodes and its own failing requests and proposes one skill mutation as a strict JSON object. `evaluate` grades real headless episodes on a small fixed task set by exact final answer, so a proposal only publishes when it makes previously failing tasks pass their episodes.
-
 ## Directory layout
 
 ```text
@@ -18,6 +15,9 @@ harness_evolve/
   run.py         the loop, written out: record -> report -> evolve -> pull
   run.sh         copies the recipe config out of serve.yaml, starts
                  reef serve, waits for /healthz, runs run.py
+  1_evolve_your_harness.ipynb
+                 the same pass cell by cell, with the service managed as a
+                 subprocess from the notebook
   pyproject.toml makes harness/ an installable package
   README.md      this file
 ```
@@ -39,6 +39,12 @@ You also need the pi coding agent binary on your PATH (serve.yaml's `evolution.b
 ```
 
 serve.yaml carries the endpoint (`upstream_url: http://127.0.0.1:8000`, no /v1 suffix) and the model (`qwen3-8b`) as literals; edit them there to point at your own. The one value it does not hold is the provider key: `export REEF_UPSTREAM_API_KEY=...` if your endpoint needs one.
+
+## Notebook
+
+`1_evolve_your_harness.ipynb` walks the same pass cell by cell and manages the service as a subprocess, so one kernel holds the whole loop. Set the endpoint, model, and key in its first code cell; the notebook patches both serve.yaml bindings (the `reef` section's upstream values and the recipe's `model.path`) into `work/serve-notebook.yaml` and materializes the recipe config from the patched text. `run.py` stays the reference implementation of the loop; the notebook mirrors it.
+
+Pick a model that fails at least one task and still writes the strict JSON mutation `propose` expects. A model that passes all three tasks reports no failures, so no evolve step ever runs (the DeepSeek result below); one that cannot author the JSON commits its step as `skipped: no proposal`, visible in `work/agent-record/*.commits.jsonl`. The committed outputs are a full local pass with no GPU: ollama `qwen2.5:7b` on a Mac mini scored 1.0 / 0.0 / 1.0 on the recorded pass, the self proposer updated `answer-style`, and the gate published on 1 win, 0 losses, 2 ties.
 
 ## What one run does
 


### PR DESCRIPTION
## Motivation

The harness evolution quickstart has one door: run.sh in a terminal. A notebook door lets someone read the loop cell by cell, run it against any OpenAI compatible endpoint with no GPU, and see the published skill in place. Building it also surfaced a real trap, now fixed and documented: patching only the upstream binding and not the recipe's model.path hands the proposer a model the endpoint does not serve, and every evolve step then commits as skipped with no proposal while the client polls 404 until timeout (the observability side of that is #69). References the layout RFC #56.

## Changes

- Add tutorials/harness_evolve/1_evolve_your_harness.ipynb with committed outputs from a full local pass
- Patch both serve.yaml bindings in the notebook (reef upstream values and the recipe model.path) and materialize the recipe from the patched text
- Read work/agent-record/*.commits.jsonl on a non publish so the notebook reports skipped versus gate lost instead of guessing
- Open in Colab badge at the top of the notebook, torchopt style (the repo is private, so Colab asks for GitHub authorization on first use)
- Add a Notebook section and layout entry to the README, with model guidance, and drop a duplicated paragraph
- Move the work/ ignore pattern to the post restructure paths (recipes/*/work/, tutorials/*/work/)

## Compatibility and operational impact

None. run.py stays the reference implementation of the loop; the notebook mirrors it and touches only its own work/ directory.

## Verification

Executed end to end on a Mac mini with ollama qwen2.5:7b and pi 0.84.2, via jupyter nbconvert --execute against this checkout. The committed outputs are that run: recorded pass 1.0 / 0.0 / 1.0, one failing report, self proposer update on answer-style, gate 1 win 0 losses 2 ties, published artifact f98266d2 with the evolved SKILL.md printed from GET /reef/harness. Model band checked empirically: qwen3:4b and qwen3:8b pass all three tasks and never open the evolve window; qwen2.5:7b fails fib and authors the JSON mutation. pre-commit run twice on the changed files, both clean.

## AI assistance

Claude Code built and executed the notebook, diagnosed the model binding trap, and wrote the README section. I reviewed the diff and the committed outputs.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.

