### PR TITLE
feat: prompt to update stale Reef harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ reef-pi report --score 0 --feedback "missed the empty-token case"
 
 Reef batches eligible reports according to the recipe configuration. When
 version checking is enabled, the adapter checks for a newer published version
-the next time it starts. The [harness evolution guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/)
+the next time it starts. Interactive sessions offer **Update with …** and
+**Skip** before accepting input; choosing update runs the installer directly.
+Headless sessions print the instruction instead.
+The [harness evolution guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/)
 describes the proposal, evaluation, and publication process.
 
 

--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -54,6 +54,8 @@ To connect an agent that has no adapter yet:
 descriptor at load, and the two bundled adapters under `reef/harness/adapters/
 <../../reef/harness/adapters>`__ are complete references. A third-party adapter
 registers on the ``reef.harness_adapters`` entry-point group. ``version_check:
-true`` writes an update notice into the tree and ships for ``pi`` only, so an
-``opencode`` recipe that sets it refuses to boot. An evolved tree is
-adapter-specific: ``config`` node contents follow each adapter's schema.
+true`` writes an update prompt into the tree and ships for ``pi`` only. The
+prompt offers to run the update or skip in interactive mode and prints the
+instructions in headless mode. An ``opencode`` recipe that sets it refuses to
+boot. An evolved tree is adapter-specific: ``config`` node contents follow each
+adapter's schema.

--- a/docs/user-guide/recipes/harness-evolve.rst
+++ b/docs/user-guide/recipes/harness-evolve.rst
@@ -62,7 +62,7 @@ zero.
    evolution.binary | overrides the adapter's binary name
    evolution.seed | entry options loaded into the tree on first boot; recovered state takes precedence
    evolution.models | auxiliary models for the method; each key read via its ``api_key_env``
-   evolution.version_check | appends the adapter's update notice, so a pulled tree reports when it is behind
+   evolution.version_check | appends the adapter's update notice; an interactive pulled tree offers to run the update or skip when behind
 
 The served model's binding is appended at render time; it never enters the
 published files. The seed defines the baseline the first mutation is measured

--- a/reef/harness/adapters/pi/version_check.ts
+++ b/reef/harness/adapters/pi/version_check.ts
@@ -1,45 +1,89 @@
-// Notify when the pulled tree is behind the channel head. Never auto-applies:
+// Prompt when the pulled tree is behind the channel head. An update runs only
+// after the user explicitly selects it:
 // Kept annotation-free on purpose: plain JavaScript in a .ts file, so plain
 // node can parse-check it in CI and pi's TS loader accepts it unchanged.
-// the notice names the head version and the one command install; the user
-// reviews the head's gate metrics first. Hermetic episodes set PI_OFFLINE and
-// this extension then makes no network calls at all.
+// Interactive sessions offer to run the update or skip before accepting input.
+// Headless sessions print the instructions instead. Hermetic episodes
+// set PI_OFFLINE and this extension then makes no network calls at all.
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-export default async function versionCheck() {
-  if (process.env.PI_OFFLINE) return; // hermetic episodes stay silent
-  const agentDir = process.env.PI_CODING_AGENT_DIR;
-  const serviceUrl = process.env.REEF_SERVICE_URL;
-  const scenario = process.env.REEF_SCENARIO;
-  if (!agentDir || !serviceUrl || !scenario) return;
-  let pinned;
-  try {
-    // harness_pull and the install script write the sidecar at the tree root.
-    pinned = JSON.parse(readFileSync(join(agentDir, "..", ".reef-harness-version"), "utf8")).artifact_version;
-  } catch {
-    return; // no sidecar: this tree did not come through the channel
-  }
-  let response;
-  try {
+export default function versionCheck(pi) {
+  let checked = false;
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (checked || process.env.PI_OFFLINE) return; // hermetic episodes stay silent
+    checked = true;
+    const agentDir = process.env.PI_CODING_AGENT_DIR;
+    const serviceUrl = process.env.REEF_SERVICE_URL;
+    const scenario = process.env.REEF_SCENARIO;
+    if (!agentDir || !serviceUrl || !scenario) return;
+    let pinned;
+    try {
+      // harness_pull and the install script write the sidecar at the tree root.
+      pinned = JSON.parse(readFileSync(join(agentDir, "..", ".reef-harness-version"), "utf8")).artifact_version;
+    } catch {
+      return; // no sidecar: this tree did not come through the channel
+    }
+    let response;
     const token = process.env.REEF_TOKEN;
-    response = await fetch(`${serviceUrl}/reef/harness/versions`, {
-      headers: {
-        "x-reef-scenario": scenario,
-        ...(token ? { authorization: `Bearer ${token}` } : {}),
-      },
-    });
-  } catch {
-    return; // the notice must never break the harness
-  }
-  if (!response.ok) return;
-  const { versions } = await response.json();
-  const head = versions[versions.length - 1];
-  if (head && head.artifact_version !== pinned) {
-    console.error(
-      `reef: harness version ${pinned} is behind head ${head.artifact_version}; ` +
-        "when you have reviewed its gate metrics, update with:\n" +
-        `  curl -H 'x-reef-scenario: ${scenario}' '${serviceUrl}/reef/harness/install?adapter=pi' | bash`,
-    );
-  }
+    try {
+      response = await fetch(`${serviceUrl}/reef/harness/versions`, {
+        headers: {
+          "x-reef-scenario": scenario,
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+      });
+    } catch {
+      return; // the notice must never break the harness
+    }
+    if (!response.ok) return;
+    const { versions } = await response.json();
+    const head = versions[versions.length - 1];
+    if (!head || head.artifact_version === pinned) return;
+
+    const instruction =
+      `curl -fsS -H 'x-reef-scenario: ${scenario}' ` +
+      (token ? '-H "Authorization: Bearer $REEF_TOKEN" ' : "") +
+      `'${serviceUrl}/reef/harness/install?adapter=pi' | bash`;
+    const updateOption = `Update with ${instruction}`;
+    const title =
+      "Reef harness update available\n\n" +
+      `Current: ${pinned}\n` +
+      `Latest:  ${head.artifact_version}`;
+
+    if (!ctx.hasUI) {
+      console.error(`${title}\n\nUpdate with:\n  ${instruction}`);
+      return;
+    }
+
+    const choice = await ctx.ui.select(title, [updateOption, "Skip"]);
+    if (choice !== updateOption) return;
+
+    ctx.ui.notify("Updating Reef harness...", "info");
+    let result;
+    try {
+      // Values travel as positional arguments rather than shell source. The
+      // downloaded installer is the only content deliberately executed.
+      result = await pi.exec("bash", [
+        "-c",
+        'set -o pipefail\nargs=(-fsS -H "x-reef-scenario: $1")\n' +
+          'if [[ -n "$3" ]]; then args+=(-H "Authorization: Bearer $3"); fi\n' +
+          'curl "${args[@]}" "$2/reef/harness/install?adapter=pi" | bash',
+        "reef-harness-update",
+        scenario,
+        serviceUrl,
+        token || "",
+      ]);
+    } catch (error) {
+      ctx.ui.notify(`Reef harness update failed: ${error instanceof Error ? error.message : String(error)}`, "error");
+      return;
+    }
+    if (result.code !== 0) {
+      const detail = result.stderr.trim();
+      ctx.ui.notify(`Reef harness update failed${detail ? `:\n${detail}` : "."}`, "error");
+      return;
+    }
+    ctx.ui.notify("Reef harness updated. Restart reef-pi to load it.", "info");
+  });
 }

--- a/reef/harness/version_check.py
+++ b/reef/harness/version_check.py
@@ -1,9 +1,10 @@
 """The shipped update notice: a seedable ``code_extension`` entry per adapter.
 
-The notice is composition, not runtime code: seeding the entry makes it part
+The prompt is composition, not runtime code: seeding the entry makes it part
 of the tree the gate measures, and every pulled or installed copy carries it.
-It notifies only (never auto-applies) and stays silent under ``PI_OFFLINE``,
-so hermetic benchmark episodes make no network calls.
+It offers to run the update or skip in interactive mode, prints the instructions
+in headless mode, and stays silent under ``PI_OFFLINE``, so hermetic benchmark
+episodes make no network calls.
 """
 
 from __future__ import annotations

--- a/tests/reef_service/test_version_check.py
+++ b/tests/reef_service/test_version_check.py
@@ -8,6 +8,8 @@ extension refuse boot with a config error naming them.
 
 from __future__ import annotations
 
+import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -71,10 +73,14 @@ def test_version_check_off_by_default_seeds_nothing() -> None:
     assert not any(options.get("id") == VERSION_CHECK_ENTRY_ID for options in recipe.seed)
 
 
-def test_the_notice_guards_come_first_and_the_install_command_matches_the_route() -> None:
+def test_the_notice_registers_a_startup_prompt_and_matches_the_install_route() -> None:
     text = ASSET.read_text(encoding="utf-8")
-    body = text.split("export default", 1)[1]
-    assert body.splitlines()[1].strip() == "if (process.env.PI_OFFLINE) return; // hermetic episodes stay silent"
+    assert 'pi.on("session_start"' in text
+    assert "checked || process.env.PI_OFFLINE" in text
+    assert "const updateOption = `Update with ${instruction}`" in text
+    assert '[updateOption, "Skip"]' in text
+    assert 'pi.exec("bash"' in text
+    assert "if (!ctx.hasUI)" in text
     assert "/reef/harness/install?adapter=pi" in text
     assert "| bash" in text
 
@@ -86,3 +92,79 @@ def test_the_notice_parses_as_plain_javascript(tmp_path: Path) -> None:
     module = tmp_path / "version_check.mjs"
     module.write_text(ASSET.read_text(encoding="utf-8"), encoding="utf-8")
     subprocess.run(["node", "--check", str(module)], check=True, capture_output=True)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+@pytest.mark.parametrize(
+    ("choose_update", "expected_kinds"),
+    [(True, ["select", "notify", "exec", "notify"]), (False, ["select"])],
+)
+def test_the_notice_prompts_before_start_and_honors_the_choice(
+    tmp_path: Path, choose_update: bool, expected_kinds: list[str]
+) -> None:
+    module = tmp_path / "version_check.mjs"
+    module.write_text(ASSET.read_text(encoding="utf-8"), encoding="utf-8")
+    agent_dir = tmp_path / "pi-agent"
+    agent_dir.mkdir()
+    (tmp_path / ".reef-harness-version").write_text(json.dumps({"artifact_version": "v1"}), encoding="utf-8")
+    runner = tmp_path / "runner.mjs"
+    runner.write_text(
+        """
+import versionCheck from "./version_check.mjs";
+
+let sessionStart;
+const events = [];
+versionCheck({
+  on(name, handler) {
+    if (name === "session_start") sessionStart = handler;
+  },
+  exec: async (command, args) => {
+    events.push({ kind: "exec", command, args });
+    return { stdout: "", stderr: "", code: 0, killed: false };
+  },
+});
+globalThis.fetch = async () => ({
+  ok: true,
+  json: async () => ({ versions: [{ artifact_version: "v1" }, { artifact_version: "v2" }] }),
+});
+await sessionStart(
+  { type: "session_start", reason: "startup" },
+  {
+    hasUI: true,
+    ui: {
+      select: async (title, options) => {
+        events.push({ kind: "select", title, options });
+        return process.env.TEST_CHOOSE_UPDATE === "1" ? options[0] : options[1];
+      },
+      notify: (message, type) => events.push({ kind: "notify", message, type }),
+    },
+  },
+);
+console.log(JSON.stringify(events));
+""".strip(),
+        encoding="utf-8",
+    )
+    env = {
+        **os.environ,
+        "PI_CODING_AGENT_DIR": str(agent_dir),
+        "REEF_SERVICE_URL": "http://reef:8900",
+        "REEF_SCENARIO": "code-repair",
+        "TEST_CHOOSE_UPDATE": "1" if choose_update else "0",
+    }
+    env.pop("PI_OFFLINE", None)
+
+    completed = subprocess.run(["node", str(runner)], check=True, capture_output=True, text=True, env=env)
+
+    events = json.loads(completed.stdout)
+    assert [event["kind"] for event in events] == expected_kinds
+    prompt = events[0]
+    assert prompt["options"][0].startswith("Update with curl -fsS ")
+    assert prompt["options"][1] == "Skip"
+    assert "Current: v1" in prompt["title"]
+    assert "Latest:  v2" in prompt["title"]
+    if choose_update:
+        execution = events[2]
+        assert execution["command"] == "bash"
+        assert "/reef/harness/install?adapter=pi" in execution["args"][1]
+        assert execution["args"][-3:] == ["code-repair", "http://reef:8900", ""]
+        assert events[3]["message"] == "Reef harness updated. Restart reef-pi to load it."


### PR DESCRIPTION
## Motivation

The shipped Pi version checker only printed an update instruction to stderr. Make an available harness update visible before Pi accepts input and let the user apply it directly.

## Changes

- register the check on Pi session startup and show the current and head artifact versions
- offer `Update with <install command>` and `Skip`; execute the installer only after the explicit update selection
- forward `REEF_TOKEN` when present, report update success or failure, and preserve the non-interactive stderr fallback
- document the new behavior and cover both interactive choices

## Compatibility and operational impact

This changes startup behavior only for interactive Pi harnesses with `evolution.version_check: true`; the option remains disabled by default. Headless sessions remain non-interactive. No wire, configuration, or persisted-data contract changes. A successfully updated running harness must be restarted to load the new tree.

## Verification

- `python -m pytest -q tests/reef_service/test_version_check.py tests/reef_service/test_harness_channel.py` — 35 passed
- `ruff check reef/harness/version_check.py tests/reef_service/test_version_check.py` — passed
- `ruff format --check reef/harness/version_check.py tests/reef_service/test_version_check.py` — passed
- `git diff origin/main...HEAD --check` — passed

## AI assistance

OpenAI Codex inspected the pinned Pi 0.84.2 extension API, implemented the startup selector and update execution, added tests, and updated documentation. The author remains responsible for the submitted changes.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.