### PR TITLE
fix: make the docs site work on phone and pad

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -73,6 +73,13 @@ button { cursor: pointer; }
 .search-trigger span { flex: 1; text-align: left; font-size: 14px; }
 kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); border-radius: 4px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
 .header-actions { display: flex; align-items: center; gap: 2px; }
+.icon-button.menu-toggle { display: none; } /* two classes: outranks .icon-button's own display, declared below */
+.mobile-nav-overlay { position: fixed; z-index: 100; inset: 0; background: color-mix(in srgb, var(--foreground) 18%, transparent); }
+.mobile-nav-panel { position: absolute; top: 0; right: 0; bottom: 0; width: min(320px, 86vw); padding: 6px 20px 28px; overflow-y: auto; overscroll-behavior: contain; border-left: 1px solid var(--border); background: var(--background); }
+.mobile-nav-head { height: 48px; display: flex; align-items: center; justify-content: space-between; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
+.mobile-nav-panel h3 { margin: 18px 0 2px; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
+.mobile-nav-panel nav a { min-height: 44px; padding: 0 10px; margin: 0 -10px; display: flex; align-items: center; color: var(--text); border-radius: 8px; font-size: 15px; }
+.mobile-nav-panel nav a[aria-current="page"] { color: var(--foreground); background: var(--accent); font-weight: 600; }
 .icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 8px; background: transparent; }
 .icon-button:hover { color: var(--foreground); background: var(--accent); }
 .theme-toggle .sun-icon, .theme-toggle .moon-icon { display: none; }
@@ -84,9 +91,9 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
 .search-overlay { position: fixed; z-index: 100; inset: 0; padding: 11vh 20px 20px; display: flex; justify-content: center; align-items: flex-start; background: transparent; }
 .search-dialog { width: min(640px, 100%); overflow: hidden; border: 1px solid var(--border); border-radius: 14px; background: var(--background); box-shadow: 0 20px 55px rgba(15, 25, 35, .16); }
 .search-input-row { height: 60px; padding: 0 16px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid var(--border); }
-.search-input-row input { min-width: 0; height: 100%; flex: 1; color: var(--foreground); border: 0; outline: 0; background: transparent; }
+.search-input-row input { min-width: 0; height: 100%; flex: 1; color: var(--foreground); border: 0; outline: 0; background: transparent; font-size: 16px; } /* 16px floor: iOS Safari zooms the page when focusing a smaller input */
 .search-input-row button { width: 32px; height: 32px; padding: 0; display: grid; place-items: center; color: var(--muted); border: 0; border-radius: 7px; background: transparent; }
-.search-results { min-height: 250px; max-height: 55vh; padding: 10px; overflow: auto; }
+.search-results { min-height: 250px; max-height: 55vh; padding: 10px; overflow: auto; overscroll-behavior: contain; }
 .search-label { margin: 4px 8px 8px; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
 .search-results > a { padding: 10px; display: flex; align-items: center; gap: 11px; border-radius: 8px; }
 .search-results > a:hover { background: var(--accent); }
@@ -172,6 +179,10 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
 .markdown-body blockquote { margin: 24px 0; padding: 14px 18px; border-left: 3px solid var(--border); background: var(--card); }
 .markdown-body blockquote p:last-child { margin-bottom: 0; }
 .markdown-body code, .markdown-body .literal { padding: .15em .35em; color: var(--foreground); border-radius: 4px; background: var(--card); font-family: var(--font-mono); font-size: 14px; overflow-wrap: anywhere; }
+/* In tables the wrapper scrolls, so identifiers never split mid-token. */
+.markdown-body .table-scroll code, .markdown-body .table-scroll .literal { overflow-wrap: normal; }
+/* Code lines are newline-free block spans (see highlightedHtml); 1lh keeps blank lines open. */
+.markdown-body pre .line, pre.code .line { display: block; min-height: 1lh; }
 .markdown-body pre { margin: 24px 0 32px; padding: 20px; overflow-x: auto; color: var(--code-text); border: 1px solid var(--border); border-radius: 12px; box-shadow: inset 0 1px color-mix(in srgb, var(--foreground) 4%, transparent); font: 13px/1.65 var(--font-mono); }
 .markdown-body pre, .markdown-body .table-scroll {
   /* Scroll cue: local-attached covers slide over the pinned edge shadows,
@@ -184,7 +195,8 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
     var(--scroller-bg);
 }
 .markdown-body pre { --scroller-bg: var(--code); border-color: color-mix(in srgb, var(--border) 88%, transparent); }
-.markdown-body .table-scroll { --scroller-bg: var(--background); margin: 24px 0 32px; overflow-x: auto; border-radius: 12px; box-shadow: var(--shadow-sm); }
+.table-scroll { overflow-x: auto; } /* every table wrapper scrolls, on and off .markdown-body pages */
+.markdown-body .table-scroll { --scroller-bg: var(--background); margin: 24px 0 32px; border-radius: 12px; box-shadow: var(--shadow-sm); }
 .markdown-body .table-scroll table { margin: 0; }
 .markdown-body pre code { display: block; width: max-content; min-width: 100%; padding: 0; color: inherit; background: transparent; font-size: 13px; }
 .markdown-body .mermaid-diagram { margin: 24px 0 32px; padding: 20px 16px; overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; background: var(--card); }
@@ -263,8 +275,14 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
   .toc { display: none; }
 }
 
-@media (max-width: 800px) {
+@media (max-width: 1000px) {
+  /* Six tabs need ~990px of header; below that they clip the right-side
+     controls off screen, so the drawer takes over well before it hurts. */
   .header-links { display: none; }
+  .icon-button.menu-toggle { display: inline-grid; }
+}
+
+@media (max-width: 800px) {
   .header-search { margin-left: auto; }
   .home-hero { padding-top: 80px; grid-template-columns: 1fr; align-items: start; }
   .loop-card { max-width: 420px; }
@@ -287,7 +305,10 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
   .home h2 { font-size: 31px; }
   .resource-grid { grid-template-columns: 1fr; }
   .docs-main { padding: 40px 20px 70px; }
-  .markdown-body th, .markdown-body td { overflow-wrap: anywhere; }
+  /* Long words in cells break; header words never split mid-word - a header
+     that no longer fits widens its column and the wrapper scrolls instead. */
+  .markdown-body td { overflow-wrap: anywhere; }
+  .markdown-body th { overflow-wrap: normal; }
   .pager { grid-template-columns: 1fr; }
   .site-footer { align-items: flex-start; flex-direction: column; }
   .site-footer nav { flex-wrap: wrap; }
@@ -295,6 +316,7 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
 @media (pointer: coarse) {
   .icon-button { width: 44px; height: 44px; }
   .search-trigger { min-height: 44px; min-width: 44px; }
+  .logo { min-height: 44px; }
   .markdown-body a.heading-anchor { padding: 10px 15px; margin-left: 0; }
 }
 
@@ -639,6 +661,12 @@ body {
 }
 
 @media (max-width: 600px) {
+  /* Reassert the compact search: the skin rules above this block win the
+     cascade over the earlier compact media query, reintroducing the left
+     padding and raised background (off-center icon) and the desktop
+     .header-search width (a dead gap in the middle of the header). */
+  .search-trigger { padding: 0; background: transparent; box-shadow: none; }
+  .header-search { width: 44px; }
   .home-hero, .home-section { width: calc(100% - 28px); padding-right: 8px; padding-left: 8px; }
   .home-hero { padding-top: 66px; }
   .home h1 { font-size: 46px; }

--- a/docs/site/components/header.tsx
+++ b/docs/site/components/header.tsx
@@ -3,6 +3,7 @@ import { siteConfig } from "@/lib/site";
 import { GitHubIcon } from "./github-icon";
 import { HeaderNav } from "./header-nav";
 import { Logo } from "./logo";
+import { MobileNav } from "./mobile-nav";
 import { Search } from "./search";
 import { ThemeToggle } from "./theme-toggle";
 
@@ -18,6 +19,7 @@ export function Header({ documents, navigation }: { documents: SearchDocument[];
         <nav className="header-actions" aria-label="Global navigation">
           <a className="icon-button" href={siteConfig.repository} target="_blank" rel="noreferrer" aria-label="Reef on GitHub"><GitHubIcon size={19} /></a>
           <ThemeToggle />
+          <MobileNav navigation={navigation} />
         </nav>
       </div>
     </header>

--- a/docs/site/components/mobile-nav.tsx
+++ b/docs/site/components/mobile-nav.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { Menu, X } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import type { NavGroup } from "@/lib/docs";
+
+function isCurrent(pathname: string, href: string) {
+  return pathname === href || pathname === `${href}/`;
+}
+
+// The phone-width stand-in for the header tabs and the docs sidebar, which
+// are both hidden below 800px: one button, one slide-over with the full tree.
+export function MobileNav({ navigation }: { navigation: NavGroup[] }) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Adjust-during-render: a route change (back gesture included) closes the
+  // drawer without an effect pass.
+  const [lastPathname, setLastPathname] = useState(pathname);
+  if (pathname !== lastPathname) {
+    setLastPathname(pathname);
+    setOpen(false);
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    // Scroll lock: without it, scrolling past the end of the nav list chains
+    // into the page, and closing the drawer strands the reader mid-document.
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button className="icon-button menu-toggle" type="button" aria-label="Open navigation" aria-expanded={open} onClick={() => setOpen(true)}>
+        <Menu size={19} />
+      </button>
+
+      {/* Portal: the fixed overlay must escape the header, whose
+          backdrop-filter makes it the containing block for fixed children. */}
+      {open && createPortal(
+        <div className="mobile-nav-overlay" role="presentation" onMouseDown={() => setOpen(false)}>
+          <div className="mobile-nav-panel" role="dialog" aria-modal="true" aria-label="Site navigation" onMouseDown={(event) => event.stopPropagation()}>
+            <div className="mobile-nav-head">
+              <span>Documentation</span>
+              <button className="icon-button" type="button" aria-label="Close navigation" onClick={() => setOpen(false)}><X size={18} /></button>
+            </div>
+            <nav aria-label="Primary navigation">
+              {navigation.map((group) => (
+                <section key={group.title}>
+                  <h3>{group.title}</h3>
+                  {group.items.map((item) => (
+                    <Link key={item.href} href={item.href} aria-current={isCurrent(pathname, item.href) ? "page" : undefined} onClick={() => setOpen(false)}>
+                      {item.title}
+                    </Link>
+                  ))}
+                </section>
+              ))}
+            </nav>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/docs/site/components/search.tsx
+++ b/docs/site/components/search.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { ArrowRight, FileText, Search as SearchIcon, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 type SearchDocument = {
   slug: string;
@@ -37,6 +38,17 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
     if (open) requestAnimationFrame(() => inputRef.current?.focus());
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    // Same scroll lock as the nav drawer: result-list scrolling must not
+    // chain into the page behind the dialog.
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
   const results = useMemo(() => {
     const terms = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
     if (!terms.length) return documents.slice(0, 6);
@@ -68,7 +80,10 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
         <kbd>⌘ K</kbd>
       </button>
 
-      {open && (
+      {/* Portal: the fixed overlay must escape the header, whose
+          backdrop-filter makes it the containing block for fixed children;
+          inside it, the backdrop is header-sized and outside clicks miss it. */}
+      {open && createPortal(
         <div className="search-overlay" role="presentation" onMouseDown={closeSearch}>
           <div className="search-dialog" role="dialog" aria-modal="true" aria-label="Search documentation" onMouseDown={(event) => event.stopPropagation()}>
             <div className="search-input-row">
@@ -103,7 +118,8 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
             </div>
             <div className="search-footer"><span><kbd>↵</kbd> Open result</span><span><kbd>esc</kbd> Close</span></div>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   );

--- a/docs/site/lib/docs.ts
+++ b/docs/site/lib/docs.ts
@@ -211,7 +211,7 @@ const highlighter = createHighlighterCoreSync({
 
 function highlightedHtml(code: string, language: string) {
   if (!highlighter.getLoadedLanguages().includes(language)) return undefined;
-  return highlighter.codeToHtml(code, {
+  const html = highlighter.codeToHtml(code, {
     lang: language,
     theme: "reef",
     transformers: [
@@ -224,6 +224,10 @@ function highlightedHtml(code: string, language: string) {
       },
     ],
   });
+  // One line of HTML: the RST generator re-indents every line it writes, and
+  // inside <pre> that indent becomes phantom leading spaces on nested code
+  // blocks. Line breaks come back through display:block on .line in CSS.
+  return html.replace(/\n/g, "");
 }
 
 // Inline markup inside figure labels and reference rows: the directive bodies
@@ -348,9 +352,13 @@ function compileRst(content: string, sourcePath: string) {
       const language = /^[a-z0-9_+#.-]+$/i.test(node.initContentText)
         ? node.initContentText.toLowerCase()
         : "text";
+      const fallback = escapeHtml(node.rawBodyText)
+        .split("\n")
+        .map((line) => `<span class="line">${line}</span>`)
+        .join("");
       generatorState.writeLine(
         highlightedHtml(node.rawBodyText, language) ??
-          `<pre class="code language-${escapeHtml(language)}">${escapeHtml(node.rawBodyText)}</pre>`,
+          `<pre class="code language-${escapeHtml(language)}">${fallback}</pre>`,
       );
     },
   });


### PR DESCRIPTION
## Motivation

On a phone the docs site had an off center search magnifier, a page that zoomed whenever the search input got focus, a home table whose last column could never be scrolled into view, and no way to reach another section at all: the header tabs, the sidebar, and the contents were all hidden below 800px with no menu button. A scripted audit at 390, 768, and 1280 in both themes confirmed those and found more, including a band from 801 to 989px where the six header tabs pushed the theme toggle and GitHub link fully off screen. Closes #77.

## Changes

- Mobile navigation drawer: a hamburger below 1000px opens a full height slide-over with the whole section tree, 44px rows, current page highlight, scrim tap / Escape / route change close, body scroll lock, contained overscroll
- Portal both overlays (drawer, search dialog) to body: the header's backdrop-filter makes it the containing block for fixed children, which also had the search backdrop covering only the header strip
- Reassert the compact search under 600px against the late skin cascade (centers the magnifier, closes the dead header gap) and give the logo a 44px tap target
- 16px search input font so iOS stops zooming on focus
- Every .table-scroll wrapper scrolls (the home page's was overflow visible); table headers and code chips in tables never split mid-token, the wrapper scrolls instead
- Emit newline-free shiki HTML with block .line spans: the RST generator re-indents every written line, which was injecting eight phantom leading spaces into code blocks nested in lists

## Compatibility and operational impact

None. Static site only; desktop layout above 1000px is unchanged except the two cascade corrections.

## Verification

All checks are scripted with puppeteer against the static export and re-run after every change. Round one, 9/9: magnifier dx 6.5px to 0.0, home table scrolls (scrollLeft moves), th "Reef" on one line, logo 44px, drawer opens with 6 groups and 28 links all 44px, link tap navigates and closes, hamburger visible at 390/768 and absent at 1280. Round two, 9/9: quickstart code blocks free of phantom indent across all 7 blocks, 45 table chips with zero mid-token splits, drawer close 44x44 with body locked while open and unlocked on close, header controls on screen at 810/900/990 with the drawer active and tabs restored at 1010/1100. Theme persistence re-verified on Playwright WebKit with an iPhone 13 profile (choose light, reload, fresh tab: stays light). A 6-agent viewport-by-theme sweep over 6 pages ran before and after; every confirmed finding above is fixed and the magnifier fix held under recheck.

## AI assistance

Claude Code ran the audits, wrote the fixes, and took the verification screenshots. I reviewed the diff and the screenshots.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
