### PR TITLE
fix: encode code block newlines as entities so mermaid renders again

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -181,8 +181,6 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
 .markdown-body code, .markdown-body .literal { padding: .15em .35em; color: var(--foreground); border-radius: 4px; background: var(--card); font-family: var(--font-mono); font-size: 14px; overflow-wrap: anywhere; }
 /* In tables the wrapper scrolls, so identifiers never split mid-token. */
 .markdown-body .table-scroll code, .markdown-body .table-scroll .literal { overflow-wrap: normal; }
-/* Code lines are newline-free block spans (see highlightedHtml); 1lh keeps blank lines open. */
-.markdown-body pre .line, pre.code .line { display: block; min-height: 1lh; }
 .markdown-body pre { margin: 24px 0 32px; padding: 20px; overflow-x: auto; color: var(--code-text); border: 1px solid var(--border); border-radius: 12px; box-shadow: inset 0 1px color-mix(in srgb, var(--foreground) 4%, transparent); font: 13px/1.65 var(--font-mono); }
 .markdown-body pre, .markdown-body .table-scroll {
   /* Scroll cue: local-attached covers slide over the pinned edge shadows,

--- a/docs/site/lib/docs.ts
+++ b/docs/site/lib/docs.ts
@@ -224,10 +224,12 @@ function highlightedHtml(code: string, language: string) {
       },
     ],
   });
-  // One line of HTML: the RST generator re-indents every line it writes, and
-  // inside <pre> that indent becomes phantom leading spaces on nested code
-  // blocks. Line breaks come back through display:block on .line in CSS.
-  return html.replace(/\n/g, "");
+  // One line of HTML: the RST generator re-indents every literal newline it
+  // writes, and inside <pre> that indent becomes phantom leading spaces on
+  // nested code blocks. As the entity, the newline survives untouched and
+  // parses back into real text, so rendering, copying, and consumers that
+  // read textContent (the mermaid path) all see the original line breaks.
+  return html.replace(/\n/g, "&#10;");
 }
 
 // Inline markup inside figure labels and reference rows: the directive bodies
@@ -352,10 +354,7 @@ function compileRst(content: string, sourcePath: string) {
       const language = /^[a-z0-9_+#.-]+$/i.test(node.initContentText)
         ? node.initContentText.toLowerCase()
         : "text";
-      const fallback = escapeHtml(node.rawBodyText)
-        .split("\n")
-        .map((line) => `<span class="line">${line}</span>`)
-        .join("");
+      const fallback = escapeHtml(node.rawBodyText).replace(/\n/g, "&#10;");
       generatorState.writeLine(
         highlightedHtml(node.rawBodyText, language) ??
           `<pre class="code language-${escapeHtml(language)}">${fallback}</pre>`,


### PR DESCRIPTION
## Motivation

The core loop diagram on the architecture page stopped rendering after #78. That PR made highlightedHtml emit newline-free HTML so the RST generator could not re-indent nested code blocks, but the mermaid path reads its chart source from the pre element's textContent, which the block spans had stripped of line breaks, so the chart no longer parsed. Regression introduced by #78; caught by the founder on production.

## Changes

- Encode code block newlines as the &#10; entity instead of removing them: the generator only re-indents literal newlines, and the entity parses back into real text
- Apply the same encoding to the unhighlighted fallback path (which is the one mermaid blocks take) and drop its line-span wrapping
- Remove the block-span display CSS the previous approach needed

## Compatibility and operational impact

None. Rendering, copy, and every textContent consumer see the original line breaks again.

## Verification

Local static export, scripted with puppeteer: the architecture page renders the mermaid svg (height over 100px, no stuck loading placeholder, no raw pre left in the DOM), and the quickstart page still has zero phantom-indent lines across all 7 code blocks with textContent carrying real newlines. Lint and build clean; pre-commit run on the changed files passes.

## AI assistance

Claude Code diagnosed the textContent path and wrote the fix. I reviewed the diff and the local render.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
