### PR TITLE
docs: sync the harness evolution pages with the restructure

### DIFF
--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -123,13 +123,18 @@ From a Reef checkout:
 .. code:: bash
 
    export REEF_UPSTREAM_API_KEY=sk-...    # only if your endpoint needs one
-   cd examples/harness_evolve
+   cd tutorials/harness_evolve
    ./run.sh
 
 ``serve.yaml`` holds the endpoint (``http://127.0.0.1:8000``, no ``/v1``
 suffix), the model (``qwen3-8b``), and the service token as literals; edit
 them there to point at your own. The provider key is the one value it does
 not hold.
+
+`1_evolve_your_harness.ipynb
+<../../tutorials/harness_evolve/1_evolve_your_harness.ipynb>`__ is the same
+pass as a notebook, cell by cell, with the service managed as a subprocess;
+its committed outputs are a full local run on ollama with no GPU.
 
 ``run.sh`` copies the recipe config out of ``serve.yaml``, starts the service, and runs
 ``run.py``: three exact-answer coding tasks go through Reef, each reply is

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -31,7 +31,7 @@ Pick by the signal your workload can produce.
 | Agent conversations without reports           | `openclawrl <recipes/openclawrl.rst>`__         | model weights | yes        |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 | Feedback on individual requests, and failures | `harness_evolve <recipes/harness-evolve.rst>`__ | harness tree  | no         |
-| worth learning from                           |                                                 |               |            |
+| worth learning from                           | (built into Reef)                               |               |            |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 | No feedback yet; record only                  | ``recipe``, the core record-only recipe         | nothing       | no         |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+

--- a/docs/user-guide/recipes/harness-evolve.rst
+++ b/docs/user-guide/recipes/harness-evolve.rst
@@ -1,9 +1,12 @@
 harness_evolve
 ==============
 
-The cookbook recipe that updates text instead of weights. It proposes one
-edit to the agent's harness tree, runs the agent both ways on your tasks, and
-publishes the edit only if it wins.
+The harness half of Reef, built in: the general engine that evolves any kind
+of harness, carried by ``reef/train/cordis_backend/`` the way
+``slime_backend`` carries weights. It proposes one edit to the agent's harness
+tree, runs the agent both ways on your tasks, and publishes the edit only if
+it wins. The demo lives in ``tutorials/harness_evolve/``; the paper-backed
+reproduction on the same engine is ``recipes/skillclaw/``.
 
 `Evolve your harness <../evolve-your-harness.rst>`__ is the guide and the
 runnable example.
@@ -15,7 +18,7 @@ runnable example.
 | Signal      | one report with a finite ``score`` and exactly one         |
 |             | reference                                                  |
 +-------------+------------------------------------------------------------+
-| Package     | ``reef/train/cordis_backend/``                                   |
+| Package     | ``reef/train/cordis_backend/``                             |
 +-------------+------------------------------------------------------------+
 | Loss family | none (no weight training)                                  |
 +-------------+------------------------------------------------------------+
@@ -79,18 +82,22 @@ wired.
 Results
 -------
 
-`examples/harness_evolve
+`tutorials/harness_evolve
 <../../../tutorials/harness_evolve/README.md>`__ measured one
 end-to-end run in 63 s on Qwen3-8B: one failing task entered the window, the
 served model proposed a new skill beside the starter, the gate scored the
 candidate 3.0 against 2.0 (1 win, 0 losses, 2 ties), and the tree published.
 
+The committed notebook run repeats the arc with no GPU at all: ollama
+``qwen2.5:7b`` on a Mac mini failed one task, the self proposer updated the
+seed skill, and the gate published on 1 win, 0 losses, 2 ties.
+
 SkillClaw
 ~~~~~~~~~
 
-`examples/skillclaw
+`recipes/skillclaw
 <../../../recipes/skillclaw/README.md>`__ is the
-larger worked instance: a full method package on the same mechanism. Each night,
+paper reproduction: a full method package on the same engine. Each night,
 ``propose`` makes one decision per skill group plus the no-skill bucket and maps
 them to a single composite mutation sequence. ``selection: always`` publishes
 every night that produces a proposal.


### PR DESCRIPTION
## Motivation

The user guide still described harness evolution as a cookbook recipe and pointed the walkthrough at the pre restructure path. After the restructure, the engine is built into Reef at reef/train/cordis_backend (the harness counterpart of slime_backend), the demo lives in tutorials/harness_evolve, and the paper reproduction on the same engine is recipes/skillclaw. The run command in the guide (cd examples/harness_evolve) pointed at a directory that no longer exists.

## Changes

- harness-evolve page: describe the built in engine and the tutorials versus recipes split, fix the two stale examples/ link texts, add the committed notebook run to Results
- evolve-your-harness guide: correct the run path to tutorials/harness_evolve and mention the notebook door
- Choosing a recipe: mark harness_evolve as built into Reef in the signal table

## Compatibility and operational impact

None. Documentation only.

## Verification

Docs build passes locally through the site build (the navigation completeness check and RST compile run at build time). Rebased on main after #79; the pages carry no renamed identity vocabulary.

## AI assistance

Claude Code wrote the updates. I reviewed the diff.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
