### PR TITLE
docs: map Reef architecture by responsibility

### DIFF
--- a/docs/contributing/codebase-structure.rst
+++ b/docs/contributing/codebase-structure.rst
@@ -13,31 +13,53 @@ packages under ``recipes/`` (``sao``, ``tttd``, ``openclawrl``, or
 preparer, and, for weight methods, the ``slime/`` subpackage only the training
 plane imports. Nothing under ``reef/`` imports a method package.
 
-The packages form layers. A layer imports only the layers beneath it, so
-a change that needs to reach upward is in the wrong package:
+Reef is organized around an application kernel and three capability domains,
+not a strict stack of top-level packages. The arrows below show the primary
+composition and use paths; they are not an exhaustive Python import graph:
 
 .. code:: mermaid
 
-   %%{init: {"flowchart": {"curve": "linear", "wrappingWidth": 480, "rankSpacing": 34}}}%%
+   %%{init: {"flowchart": {"curve": "linear", "wrappingWidth": 220, "nodeSpacing": 28, "rankSpacing": 42}}}%%
    flowchart TD
-       accTitle: Dependency direction between package layers
-       Methods("<b>METHOD PACKAGES</b> &nbsp; outside <code>reef/</code><br/><code>sao</code> · <code>tttd</code> · <code>openclawrl</code> · <code>harness_evolve</code>")
+       accTitle: Reef application kernel, capability domains, and adapters
 
-       subgraph Reef["reef/"]
-           direction TB
-           Orchestration("<b>ORCHESTRATION</b><br/><code>service</code> · <code>scenario</code>")
-           Contracts("<b>CONTRACTS</b><br/><code>recipe</code> · <code>runtime</code> · <code>harness</code>")
-           Engines("<b>ENGINES &amp; STORAGE</b><br/><code>train</code> · <code>surface</code> · <code>artifact</code>")
-           Core(["<b>CORE</b><br/><code>core</code>"])
+       Methods("<b>METHOD PLUG-INS</b><br/><code>recipes/*</code>")
+       Entry("<b>ENTRYPOINTS</b><br/>HTTP · CLI")
+       Policy("<b>POLICY</b><br/><code>reef/recipe</code>")
+       Service("<b>DELIVERY &amp; COMPOSITION</b><br/><code>reef/service</code>")
+       Kernel(["<b>APPLICATION KERNEL</b><br/><code>reef/dispatcher</code> · <code>reef/scenario</code>"])
 
-           Orchestration --> Contracts --> Engines --> Core
+       subgraph Domains["CAPABILITY DOMAINS"]
+           direction LR
+           Serving("<b>SERVING</b><br/><code>runtime</code> · <code>surface</code>")
+           Evolution("<b>EVOLUTION</b><br/><code>train</code> · <code>harness</code>")
+           State("<b>STATE</b><br/><code>artifact</code> · <code>records</code>")
        end
 
-       Methods --> Orchestration
+       subgraph Adapters["CONCRETE ADAPTERS"]
+           direction LR
+           ServingAdapters[["runtime adapters<br/>surface implementations"]]
+           EvolutionAdapters[["training backends<br/>harness adapters"]]
+           StateAdapters[["Git/LFS repositories<br/>SQLite"]]
+       end
 
-Two edges skip a layer and are allowed: a method package binds ``reef/train``
-machinery directly, and ``reef/service`` imports ``reef/artifact`` to stream
-artifact bytes. Everything else follows the arrows.
+       Observability(["<b>CROSS-CUTTING</b><br/><code>reef/observability</code>"])
+       Core(["<b>SHARED KERNEL</b><br/><code>reef/core</code>"])
+
+       Methods --> Policy --> Kernel
+       Entry --> Service --> Kernel
+       Kernel --> Serving & Evolution & State
+       Serving --> ServingAdapters
+       Evolution --> EvolutionAdapters
+       State --> StateAdapters
+       Kernel -. telemetry .-> Observability
+       ServingAdapters & EvolutionAdapters & StateAdapters --> Core
+
+Method packages provide policy through ``reef/recipe`` and may bind
+``reef/train`` machinery directly. HTTP and CLI entrypoints compose Reef
+through ``reef/service``; the transport-free dispatcher and scenario aggregate
+coordinate serving, evolution, and state. ``reef/service`` also imports
+``reef/artifact`` directly to stream artifact bytes.
 
 Concrete integrations may depend on shared contracts; shared contracts never
 import a concrete integration.


### PR DESCRIPTION
## Motivation

Follow-up to #84. The package layer cake still implied a strict top-level dependency stack that the codebase does not have. It also grouped components with different architectural roles and omitted the dispatcher, record store, and observability boundary.

## Changes

- Replace the package layer cake with a responsibility-oriented component map.
- Show method plug-ins and HTTP/CLI entrypoints converging on the application kernel.
- Group Reef capabilities into Serving, Evolution, and State domains.
- Separate concrete adapters, observability, and the shared core from the capability domains.
- Clarify that arrows show primary composition and use paths rather than an exhaustive Python import graph.
- Update the adjacent prose to explain the method, service, dispatcher, and scenario roles.

## Compatibility and operational impact

None. This is a documentation-only change.

## Verification

- `cd docs/site && npm run check:docs` — passed.
- `cd docs/site && npm run build` — passed; all 35 static pages generated.
- Previewed the complete rendered Mermaid diagram in the local documentation site and checked browser console output.

## AI assistance

OpenAI Codex reviewed the repository's package docstrings, composition root, scenario bindings, dependency-boundary tests, and high-level import graph; revised the Mermaid diagram from the agreed code-structure sketch; and ran visual and build verification. The author reviewed the result and remains responsible for the submitted change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.
