### PR TITLE
docs: refine typography and consolidate styles

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -1,97 +1,128 @@
 @import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;600;800&family=Source+Serif+4:opsz,wght@8..60,500;8..60,600&display=swap");
 
+/* Site design tokens */
 :root {
-  --background: #f3f6fb;
-  --card: #e8edf6;
-  --accent: #e1e7f0;
-  --foreground: #18222e;
-  --text: #26323f;
-  --muted: #647585;
-  --border: #bec8d8;
-  --code: #eef2f8;
-  --code-text: #1f2d3a;
-  --syntax-comment: #596b7c;
-  --syntax-keyword: #6f42c1;
-  --syntax-string: #236a55;
-  --syntax-title: #205e9b;
-  --syntax-number: #8a4b22;
-  --syntax-built-in: #963a64;
-  --syntax-variable: #315d78;
-  --syntax-regexp: #a13d39;
+  --background: #ffffff;
+  --card: #fbfaf8;
+  --accent: #f4f2ee;
+  --surface-raised: #ffffff;
+  --foreground: #14110e;
+  --text: #302c28;
+  --muted: #716b65;
+  --border: #ddd8d0;
+  --code: #f7f5f1;
+  --code-text: #2c2824;
+  --syntax-comment: #797268;
+  --syntax-keyword: #7c4a94;
+  --syntax-string: #3f6b4c;
+  --syntax-title: #2f5c86;
+  --syntax-number: #96581f;
+  --syntax-built-in: #8a3f5e;
+  --syntax-variable: #4a5560;
+  --syntax-regexp: #a03729;
+  --brand: #a03729;
+  --brand-strong: #7a1f1a;
+  --brand-soft: #fbf2f0;
+  --coral: #a03729;
   --diagram-emphasis: #dceeea;
   --diagram-emphasis-border: #3f8077;
   --diagram-emphasis-text: #21433f;
-  --font-sans: "DM Sans", system-ui, sans-serif;
-  --font-serif: "Source Serif 4", Georgia, serif;
+  --callout-note: #f6f5f2;
+  --callout-note-ink: #625d57;
+  --callout-tip: #f4f3ef;
+  --callout-tip-ink: #53604c;
+  --callout-warn: #f8f1ef;
+  --callout-warn-ink: #7a1f1a;
+  --shadow-sm: 0 1px 1px rgba(20, 17, 14, .03);
+  --shadow-lg: 0 24px 64px rgba(20, 17, 14, .07);
+  --font-sans: "DM Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-serif: "Source Serif 4", Georgia, "Times New Roman", serif;
   --font-mono: "DM Mono", ui-monospace, monospace;
 }
 
-html { color-scheme: light; }
+html { color-scheme: light; scroll-behavior: smooth; scroll-padding-top: 92px; }
 html[data-theme="dark"] {
   color-scheme: dark;
-  --background: #111820;
-  --card: #1b2530;
-  --accent: #222e3a;
-  --foreground: #f0f3f7;
-  --text: #d3dae2;
-  --muted: #94a2b1;
-  --border: #3b4857;
-  --code: #18212b;
-  --code-text: #e6edf3;
-  --syntax-comment: #9aa9b8;
-  --syntax-keyword: #c8a5ff;
-  --syntax-string: #8fd5b8;
-  --syntax-title: #8fc3ff;
-  --syntax-number: #f2b585;
-  --syntax-built-in: #f0a6ca;
-  --syntax-variable: #a8d1e5;
-  --syntax-regexp: #ffaaa5;
+  --background: #100e0c;
+  --card: #171512;
+  --accent: #201d19;
+  --surface-raised: #171512;
+  --foreground: #f7f4f0;
+  --text: #d8d2ca;
+  --muted: #aaa198;
+  --border: #373129;
+  --code: #0a0908;
+  --code-text: #ece8e2;
+  --syntax-comment: #a79e94;
+  --syntax-keyword: #d6b6ea;
+  --syntax-string: #b6d1ae;
+  --syntax-title: #b5cbe4;
+  --syntax-number: #e6c9a3;
+  --syntax-built-in: #e3b8c6;
+  --syntax-variable: #d7d1c8;
+  --syntax-regexp: #e7b5aa;
+  --brand: #d99183;
+  --brand-strong: #eeb2a5;
+  --brand-soft: #241a18;
+  --coral: #d99183;
   --diagram-emphasis: #21423c;
   --diagram-emphasis-border: #68a79d;
   --diagram-emphasis-text: #d9eee9;
+  --callout-note: #1a1815;
+  --callout-note-ink: #bbb2a8;
+  --callout-tip: #191c17;
+  --callout-tip-ink: #bbc5b0;
+  --callout-warn: #241a18;
+  --callout-warn-ink: #d99183;
+  --shadow-sm: 0 1px 1px rgba(0, 0, 0, .3);
+  --shadow-lg: 0 24px 64px rgba(0, 0, 0, .5);
 }
 
+/* Base */
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; scroll-padding-top: 80px; }
-body { margin: 0; color: var(--text); background: var(--background); font-family: var(--font-sans); font-size: 16px; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+body { margin: 0; color: var(--text); background: var(--background); font-family: var(--font-sans); font-size: 15px; line-height: 1.7; -webkit-font-smoothing: antialiased; }
 a { color: inherit; text-decoration: none; }
 button, input { color: inherit; font: inherit; }
 button { cursor: pointer; }
-::selection { background: var(--accent); }
+::selection { color: var(--foreground); background: color-mix(in srgb, var(--brand) 28%, transparent); }
 
-.site-header { position: fixed; z-index: 50; top: 0; right: 0; left: 0; height: 56px; border-bottom: 1px solid color-mix(in srgb, var(--border) 65%, transparent); background: color-mix(in srgb, var(--background) 80%, transparent); backdrop-filter: blur(12px); }
-.header-inner { width: 100%; height: 56px; padding: 0 16px; display: flex; align-items: center; gap: 24px; }
-.logo { display: inline-flex; align-items: center; gap: 10px; color: var(--foreground); font-weight: 600; }
-.logo-mark { color: var(--foreground); }
-.logo-name { font-size: 16px; letter-spacing: .01em; }
-.header-links { display: flex; align-items: center; gap: 20px; white-space: nowrap; }
-.header-links a { color: var(--text); font-size: 14px; }
-.header-links a:hover, .header-links a.active { color: var(--foreground); }
+/* Header and navigation */
+.site-header { position: fixed; z-index: 50; top: 0; right: 0; left: 0; height: 68px; border-bottom: 1px solid color-mix(in srgb, var(--border) 76%, transparent); background: color-mix(in srgb, var(--background) 82%, transparent); backdrop-filter: blur(20px) saturate(140%); }
+.header-inner { width: min(1440px, 100%); height: 68px; margin: 0 auto; padding: 0 28px; display: flex; align-items: center; gap: 32px; }
+.logo { display: inline-flex; align-items: center; gap: 11px; color: var(--foreground); font-weight: 600; }
+.logo-mark { color: var(--brand); stroke-width: 2.4; }
+.logo-name { color: var(--foreground); font-size: 15px; font-weight: 700; letter-spacing: .15em; }
+.header-links { display: flex; align-items: center; gap: 22px; white-space: nowrap; }
+.header-links a { color: var(--muted); font-size: 13px; font-weight: 500; }
+.header-links a:hover, .header-links a.active { color: var(--brand-strong); }
 .header-links a.active { font-weight: 600; }
-.header-search { width: 240px; margin-left: auto; }
-.search-trigger { width: 100%; height: 36px; padding: 6px 6px 6px 10px; display: flex; align-items: center; gap: 8px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; background: color-mix(in srgb, var(--card) 50%, transparent); }
-.search-trigger span { flex: 1; text-align: left; font-size: 14px; }
-kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); border-radius: 4px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
+.header-search { width: 264px; margin-left: auto; }
 .header-actions { display: flex; align-items: center; gap: 2px; }
-.icon-button.menu-toggle { display: none; } /* two classes: outranks .icon-button's own display, declared below */
+.icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 10px; background: transparent; }
+.icon-button:hover { color: var(--brand-strong); background: var(--accent); }
+.icon-button.menu-toggle { display: none; }
+.theme-toggle .sun-icon, .theme-toggle .moon-icon { display: none; }
+html[data-theme-mode="light"] .theme-toggle .sun-icon { display: block; }
+html[data-theme-mode="dark"] .theme-toggle .moon-icon { display: block; }
+html[data-theme-mode="light"] .theme-toggle .system-icon,
+html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
+kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); border-radius: 4px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
+
 .mobile-nav-overlay { position: fixed; z-index: 100; inset: 0; background: color-mix(in srgb, var(--foreground) 18%, transparent); }
 .mobile-nav-panel { position: absolute; top: 0; right: 0; bottom: 0; width: min(320px, 86vw); padding: 6px 20px 28px; overflow-y: auto; overscroll-behavior: contain; border-left: 1px solid var(--border); background: var(--background); }
 .mobile-nav-head { height: 48px; display: flex; align-items: center; justify-content: space-between; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
 .mobile-nav-panel h3 { margin: 18px 0 2px; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
 .mobile-nav-panel nav a { min-height: 44px; padding: 0 10px; margin: 0 -10px; display: flex; align-items: center; color: var(--text); border-radius: 8px; font-size: 15px; }
 .mobile-nav-panel nav a[aria-current="page"] { color: var(--foreground); background: var(--accent); font-weight: 600; }
-.icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 8px; background: transparent; }
-.icon-button:hover { color: var(--foreground); background: var(--accent); }
-.theme-toggle .sun-icon, .theme-toggle .moon-icon { display: none; }
-html[data-theme-mode="light"] .theme-toggle .sun-icon { display: block; }
-html[data-theme-mode="dark"] .theme-toggle .moon-icon { display: block; }
-html[data-theme-mode="light"] .theme-toggle .system-icon,
-html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
 
+/* Search */
+.search-trigger { width: 100%; height: 38px; padding: 6px 6px 6px 13px; display: flex; align-items: center; gap: 8px; color: var(--muted); border: 1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius: 10px; background: var(--surface-raised); box-shadow: 0 1px 2px rgba(15, 58, 53, .03); }
+.search-trigger:hover { border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
+.search-trigger span { flex: 1; text-align: left; font-size: 14px; }
 .search-overlay { position: fixed; z-index: 100; inset: 0; padding: 11vh 20px 20px; display: flex; justify-content: center; align-items: flex-start; background: transparent; }
-.search-dialog { width: min(640px, 100%); overflow: hidden; border: 1px solid var(--border); border-radius: 14px; background: var(--background); box-shadow: 0 20px 55px rgba(15, 25, 35, .16); }
+.search-dialog { width: min(640px, 100%); overflow: hidden; border: 1px solid var(--border); border-radius: 14px; background: color-mix(in srgb, var(--card) 96%, transparent); box-shadow: var(--shadow-lg); backdrop-filter: blur(20px); }
 .search-input-row { height: 60px; padding: 0 16px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid var(--border); }
-.search-input-row input { min-width: 0; height: 100%; flex: 1; color: var(--foreground); border: 0; outline: 0; background: transparent; font-size: 16px; } /* 16px floor: iOS Safari zooms the page when focusing a smaller input */
+.search-input-row input { min-width: 0; height: 100%; flex: 1; color: var(--foreground); border: 0; outline: 0; background: transparent; font-size: 16px; }
 .search-input-row button { width: 32px; height: 32px; padding: 0; display: grid; place-items: center; color: var(--muted); border: 0; border-radius: 7px; background: transparent; }
 .search-results { min-height: 250px; max-height: 55vh; padding: 10px; overflow: auto; overscroll-behavior: contain; }
 .search-label { margin: 4px 8px 8px; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
@@ -106,698 +137,154 @@ html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
 .search-footer { padding: 10px 16px; display: flex; gap: 18px; color: var(--muted); border-top: 1px solid var(--border); background: var(--card); font-size: 11px; }
 .search-footer span { display: flex; align-items: center; gap: 6px; }
 
-.home { padding-top: 56px; }
-.home h1, .home h2, .home h3 { color: var(--foreground); font-family: var(--font-serif); }
-.home-hero { width: min(1152px, calc(100% - 48px)); margin: 0 auto; padding: 112px 24px; display: grid; grid-template-columns: 1.35fr .65fr; align-items: end; gap: 40px; }
-.pill { width: fit-content; margin: 0 0 20px; padding: 4px 12px; color: var(--text); border: 1px solid var(--border); border-radius: 999px; background: var(--card); font-size: 14px; font-weight: 500; }
-.home h1 { max-width: 820px; margin: 0; font-size: clamp(48px, 5.65vw, 72px); font-weight: 600; letter-spacing: -.015em; line-height: 1; }
-.lead { max-width: 680px; margin: 28px 0 0; color: var(--muted); font-size: 20px; line-height: 1.6; }
-.home-actions { margin-top: 36px; display: flex; flex-wrap: wrap; gap: 12px; }
-.primary-action, .secondary-action { padding: 12px 20px; display: inline-flex; align-items: center; justify-content: center; border-radius: 8px; font-weight: 500; }
-.primary-action { color: var(--background); background: var(--foreground); }
-.primary-action:hover { opacity: .85; }
-.secondary-action { color: var(--foreground); border: 1px solid var(--border); background: var(--card); }
-.secondary-action:hover { background: var(--accent); }
-.loop-card { padding: 24px; border: 1px solid var(--border); border-radius: 16px; background: var(--card); }
-.loop-card > p { margin: 0; color: var(--muted); font-size: 14px; font-weight: 500; letter-spacing: .18em; text-transform: uppercase; }
-.loop-card pre, .quick-start pre { margin: 20px 0 0; padding: 20px; overflow-x: auto; color: var(--foreground); border: 1px solid var(--border); border-radius: 12px; background: var(--background); font: 13px/2 var(--font-mono); }
-.band { background: color-mix(in srgb, var(--card) 50%, transparent); }
-.home-section { width: min(1152px, calc(100% - 48px)); margin: 0 auto; padding: 80px 24px; }
-.section-label { margin: 0 0 12px; color: var(--muted); font-size: 14px; font-weight: 500; }
-.home h2 { margin: 0; font-size: 36px; font-weight: 600; letter-spacing: -.015em; line-height: 1.12; }
-.feature-grid { margin-top: 40px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
-.feature-grid article { padding: 24px; border: 1px solid var(--border); border-radius: 16px; background: var(--background); }
-.home h3 { margin: 0 0 12px; font-size: 22px; font-weight: 600; }
-.feature-grid p, .process-section > div > p, .quick-start > div > p, .resource-grid p { margin: 0; color: var(--muted); line-height: 1.65; }
-.process-section { display: grid; grid-template-columns: 1fr 1fr; gap: 72px; }
-.process-section h2, .quick-start h2 { margin-bottom: 20px; }
-.text-link { margin-top: 24px; display: inline-flex; color: var(--foreground); font-weight: 500; text-decoration: underline; text-decoration-color: var(--border); text-underline-offset: 4px; }
-.step-list { margin: 0; padding: 0; list-style: none; }
-.step-list li { padding: 18px 0; display: flex; align-items: center; gap: 16px; border-bottom: 1px solid var(--border); }
-.step-list li:first-child { border-top: 1px solid var(--border); }
-.step-list span { width: 28px; height: 28px; display: grid; place-items: center; flex: none; border: 1px solid var(--border); border-radius: 50%; font: 12px var(--font-mono); }
-.quick-start { display: grid; grid-template-columns: 1fr 1fr; align-items: center; gap: 72px; }
-.quick-start .primary-action { margin-top: 24px; }
-.quick-start pre { margin: 0; }
-.resource-section { padding-top: 96px; padding-bottom: 96px; }
-.resource-grid { margin-top: 36px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; }
-.resource-grid > a { min-height: 235px; padding: 28px; display: flex; flex-direction: column; border: 1px solid var(--border); border-radius: 16px; }
-.resource-grid > a:hover { background: var(--card); }
-.resource-grid small { color: var(--muted); }
-.resource-grid h3 { margin-top: 14px; }
-.resource-grid span { margin-top: auto; color: var(--foreground); font-weight: 500; }
-
-.docs-layout { width: 100%; min-height: 100vh; padding-top: 56px; display: grid; grid-template-columns: 286px minmax(0, 708px) minmax(220px, 1fr); }
-.docs-sidebar { position: fixed; z-index: 20; top: 56px; bottom: 0; left: 0; width: 286px; padding: 48px 19px; overflow-y: auto; border-right: 1px solid var(--border); background: var(--background); }
-.sidebar-group { margin-bottom: 28px; }
-.sidebar-group-items { display: grid; gap: 2px; }
-.sidebar-group a { padding: 8px; color: var(--muted); border-radius: 8px; font-size: 14px; line-height: 20px; }
-.sidebar-group > .sidebar-group-title { margin: 0 8px 8px; padding: 0; color: var(--foreground); border-radius: 0; font-family: var(--font-serif); font-size: 16px; font-weight: 600; letter-spacing: -.01em; line-height: 22px; }
-.sidebar-group a:hover { color: var(--foreground); background: color-mix(in srgb, var(--foreground) 5%, transparent); }
-.sidebar-group a.active { color: var(--foreground); background: color-mix(in srgb, var(--foreground) 10%, transparent); }
-.docs-main { grid-column: 2; width: 100%; padding: 48px 32px 80px; }
-.markdown-body { color: var(--text); font-size: 17px; line-height: 1.78; }
-.markdown-body h1, .markdown-body h2, .markdown-body h3 { color: var(--foreground); font-family: var(--font-serif); font-weight: 600; letter-spacing: -.015em; }
-.markdown-body > h1:first-child { margin-top: 0; }
-.markdown-body h1 { margin: 0 0 16px; font-size: 28px; line-height: 42px; }
-.markdown-body h1 + p { margin: 0 0 32px; color: var(--text); font-size: 18px; line-height: 28px; }
-.markdown-body h2 { margin: 48px 0 24px; font-size: 24px; line-height: 32px; }
-.markdown-body h3 { margin: 36px 0 16px; font-size: 20px; line-height: 28px; }
-.markdown-body a.heading-anchor { margin-left: 7px; color: var(--muted); font-family: var(--font-sans); font-size: 14px; text-decoration: none; }
-@media (hover: hover) and (pointer: fine) {
-  .markdown-body a.heading-anchor { color: transparent; }
-  .markdown-body h2:hover .heading-anchor, .markdown-body h3:hover .heading-anchor { color: var(--muted); }
-  .markdown-body .heading-anchor:focus-visible { color: var(--muted); }
-}
-.markdown-body p { margin: 0 0 26px; }
-.markdown-body a { color: var(--foreground); font-weight: 500; text-decoration: underline; text-decoration-color: var(--border); text-underline-offset: 4px; }
-.markdown-body a:hover { text-decoration-color: var(--foreground); }
-.external-link-icon { display: inline; margin-left: 3px; }
-.markdown-body ul, .markdown-body ol { margin: 16px 0 24px; padding-left: 24px; }
-.markdown-body li { margin: 7px 0; padding-left: 3px; }
-.markdown-body strong { color: var(--foreground); font-weight: 600; }
-.markdown-body blockquote { margin: 24px 0; padding: 14px 18px; border-left: 3px solid var(--border); background: var(--card); }
-.markdown-body blockquote p:last-child { margin-bottom: 0; }
-.markdown-body code, .markdown-body .literal { padding: .15em .35em; color: var(--foreground); border-radius: 4px; background: var(--card); font-family: var(--font-mono); font-size: 14px; overflow-wrap: anywhere; }
-/* In tables the wrapper scrolls, so identifiers never split mid-token. */
-.markdown-body .table-scroll code, .markdown-body .table-scroll .literal { overflow-wrap: normal; }
-.markdown-body pre { margin: 24px 0 32px; padding: 20px; overflow-x: auto; color: var(--code-text); border: 1px solid var(--border); border-radius: 12px; box-shadow: inset 0 1px color-mix(in srgb, var(--foreground) 4%, transparent); font: 13px/1.65 var(--font-mono); }
-.markdown-body pre, .markdown-body .table-scroll {
-  /* Scroll cue: local-attached covers slide over the pinned edge shadows,
-     so the cue vanishes exactly when that edge is fully scrolled. */
-  background:
-    linear-gradient(90deg, var(--scroller-bg) 45%, transparent) left center / 32px 100% no-repeat local,
-    linear-gradient(270deg, var(--scroller-bg) 45%, transparent) right center / 32px 100% no-repeat local,
-    radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) left center / 14px 100% no-repeat scroll,
-    radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) right center / 14px 100% no-repeat scroll,
-    var(--scroller-bg);
-}
-.markdown-body pre { --scroller-bg: var(--code); border-color: color-mix(in srgb, var(--border) 88%, transparent); }
-.table-scroll { overflow-x: auto; } /* every table wrapper scrolls, on and off .markdown-body pages */
-.markdown-body .table-scroll { --scroller-bg: var(--background); margin: 24px 0 32px; border-radius: 12px; box-shadow: var(--shadow-sm); }
-.markdown-body .table-scroll table { margin: 0; }
-.markdown-body pre code { display: block; width: max-content; min-width: 100%; padding: 0; color: inherit; background: transparent; font-size: 13px; }
-.markdown-body .mermaid-diagram { margin: 24px 0 32px; padding: 20px 16px; overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; background: var(--card); }
-.markdown-body .mermaid-diagram svg { display: block; width: 100%; max-width: 100%; height: auto; margin: 0 auto; background: transparent !important; }
-.markdown-body .mermaid-diagram svg rect.actor,
-.markdown-body .mermaid-diagram svg rect.note,
-.markdown-body .mermaid-diagram svg rect.labelBox { rx: 6px; ry: 6px; }
-.markdown-body .mermaid-diagram svg .cluster rect { rx: 10px; ry: 10px; }
-.markdown-body .mermaid-diagram svg .node rect { rx: 7px; ry: 7px; }
-.markdown-body .mermaid-diagram svg .node.user-owned rect,
-.markdown-body .mermaid-diagram svg .node.user-owned path,
-.markdown-body .mermaid-diagram svg .node.durable rect,
-.markdown-body .mermaid-diagram svg .node.durable path { fill: var(--diagram-emphasis) !important; stroke: var(--diagram-emphasis-border) !important; }
-.markdown-body .mermaid-diagram svg .node.user-owned text,
-.markdown-body .mermaid-diagram svg .node.durable text { fill: var(--diagram-emphasis-text) !important; }
-.markdown-body .mermaid-diagram svg .node.user-owned span,
-.markdown-body .mermaid-diagram svg .node.user-owned p,
-.markdown-body .mermaid-diagram svg .node.durable span,
-.markdown-body .mermaid-diagram svg .node.durable p { color: var(--diagram-emphasis-text) !important; }
-.markdown-body .mermaid-diagram svg .node.volatile rect { stroke-dasharray: 5 3; }
-.markdown-body .mermaid-diagram svg .messageLine0,
-.markdown-body .mermaid-diagram svg .messageLine1,
-.markdown-body .mermaid-diagram svg .actor-line { stroke-width: 1.25px; }
-.markdown-body .mermaid-error { color: var(--text); }
-.markdown-body .mermaid-error figcaption { color: var(--muted); }
-.markdown-body .mermaid-error pre { margin-bottom: 0; }
-.markdown-body .mermaid-loading { min-height: 240px; display: grid; place-items: center; color: var(--muted); font-size: 13px; }
-@media (max-width: 720px) {
-  .markdown-body .mermaid-diagram svg { min-width: 600px; }
-  /* Scroll shadows: the local-attached covers slide over the pinned shadows
-     at each scroll extreme, so the cue vanishes exactly when the edge is
-     reached; iOS overlay scrollbars give no affordance of their own. */
-  .markdown-body .mermaid-diagram {
-    background:
-      linear-gradient(90deg, var(--card) 45%, transparent) left center / 32px 100% no-repeat local,
-      linear-gradient(270deg, var(--card) 45%, transparent) right center / 32px 100% no-repeat local,
-      radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) left center / 14px 100% no-repeat scroll,
-      radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) right center / 14px 100% no-repeat scroll,
-      var(--card);
-  }
-}
-.markdown-body table { width: 100%; margin: 24px 0 32px; border-collapse: separate; border-spacing: 0; overflow: hidden; border: 1px solid var(--border); border-radius: 10px; font-size: 14px; line-height: 1.5; }
-.markdown-body th { color: var(--foreground); background: var(--card); font-weight: 500; text-align: left; }
-.markdown-body th, .markdown-body td { padding: 10px 12px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); vertical-align: top; }
-.markdown-body th > p:last-child, .markdown-body td > p:last-child { margin-bottom: 0; }
-.markdown-body th:last-child, .markdown-body td:last-child { border-right: 0; }
-.markdown-body tr:last-child td { border-bottom: 0; }
-.markdown-body hr { height: 1px; margin: 40px 0; border: 0; background: var(--border); }
-.edit-row { margin-top: 48px; padding-top: 18px; border-top: 1px solid var(--border); }
-.edit-row a { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 12px; }
-.pager { margin-top: 28px; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-.pager-link { min-height: 88px; padding: 16px; display: flex; flex-direction: column; justify-content: center; gap: 6px; border: 1px solid var(--border); border-radius: 10px; }
-.pager-link:hover { background: var(--card); }
-.pager-link small { color: var(--muted); font-size: 11px; }
-.pager-link span { display: flex; align-items: center; gap: 7px; color: var(--foreground); font-size: 13px; font-weight: 500; }
-.pager-link.next { text-align: right; }
-.pager-link.next span { justify-content: flex-end; }
-.toc { position: fixed; top: 56px; right: 0; bottom: 0; left: 994px; padding: 48px 16px; overflow-y: auto; }
-.toc > p { margin: 0 0 12px; color: var(--foreground); font-family: var(--font-serif); font-size: 14px; }
-.toc nav { display: grid; }
-.toc a { padding: 5px 0; color: var(--muted); font-size: 13px; line-height: 18px; }
-.toc a:hover, .toc a.active { color: var(--foreground); }
-.toc a.nested { padding-left: 12px; }
-
-.not-found { min-height: 80vh; padding: 120px 24px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; }
-.not-found h1 { color: var(--foreground); font-family: var(--font-serif); font-size: 40px; }
-.not-found p { color: var(--muted); }
-.site-footer { width: min(1104px, calc(100% - 48px)); margin: 0 auto; padding: 40px 0; display: flex; justify-content: space-between; gap: 24px; border-top: 1px solid var(--border); }
-.site-footer > div > p { margin: 10px 0 0; color: var(--muted); font-size: 12px; }
-.site-footer nav { display: flex; align-items: center; gap: 20px; color: var(--muted); font-size: 13px; }
-.site-footer nav a:hover { color: var(--foreground); }
-
-@media (max-width: 1050px) {
-  .docs-layout { grid-template-columns: 260px minmax(0, 708px); }
-  .docs-sidebar { width: 260px; }
-  .toc { display: none; }
-}
-
-@media (max-width: 1000px) {
-  /* Six tabs need ~990px of header; below that they clip the right-side
-     controls off screen, so the drawer takes over well before it hurts. */
-  .header-links { display: none; }
-  .icon-button.menu-toggle { display: inline-grid; }
-}
-
-@media (max-width: 800px) {
-  .header-search { margin-left: auto; }
-  .home-hero { padding-top: 80px; grid-template-columns: 1fr; align-items: start; }
-  .loop-card { max-width: 420px; }
-  .feature-grid { grid-template-columns: 1fr; }
-  .process-section, .quick-start { grid-template-columns: 1fr; gap: 48px; }
-  .docs-layout { display: block; }
-  .docs-sidebar { display: none; }
-  .docs-main { width: min(708px, 100%); margin: 0 auto; }
-}
-
-@media (max-width: 600px) {
-  .header-inner { gap: 8px; }
-  .header-search { width: 36px; }
-  .search-trigger { width: 36px; padding: 0; justify-content: center; border: 0; background: transparent; }
-  .search-trigger span, .search-trigger kbd { display: none; }
-  .home-hero, .home-section { width: calc(100% - 24px); padding-right: 12px; padding-left: 12px; }
-  .home-hero { padding-top: 64px; padding-bottom: 72px; }
-  .home h1 { font-size: 46px; }
-  .lead { font-size: 18px; }
-  .home h2 { font-size: 31px; }
-  .resource-grid { grid-template-columns: 1fr; }
-  .docs-main { padding: 40px 20px 70px; }
-  /* Long words in cells break; header words never split mid-word - a header
-     that no longer fits widens its column and the wrapper scrolls instead. */
-  .markdown-body td { overflow-wrap: anywhere; }
-  .markdown-body th { overflow-wrap: normal; }
-  .pager { grid-template-columns: 1fr; }
-  .site-footer { align-items: flex-start; flex-direction: column; }
-  .site-footer nav { flex-wrap: wrap; }
-}
-@media (pointer: coarse) {
-  .icon-button { width: 44px; height: 44px; }
-  .search-trigger { min-height: 44px; min-width: 44px; }
-  .logo { min-height: 44px; }
-  .markdown-body a.heading-anchor { padding: 10px 15px; margin-left: 0; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
-}
-
-/* Quiet-luxury editorial: paper white, ink, one restrained accent. */
-:root {
-  --background: #ffffff;
-  --card: #fbfaf8;
-  --accent: #f4f2ee;
-  --foreground: #14110e;
-  --text: #3b3733;
-  --muted: #85807a;
-  --border: #e3dfd8;
-  /* Listings are dark ink on paper, like the prose around them: a light chip
-     keeps the page from carrying a heavy dark mass, and reads better at length.
-     The syntax palette is muted inks, not saturated hues. */
-  --code: #f7f5f1;
-  --code-text: #2c2824;
-  --syntax-comment: #918a80;
-  --syntax-keyword: #7c4a94;
-  --syntax-string: #3f6b4c;
-  --syntax-title: #2f5c86;
-  --syntax-number: #96581f;
-  --syntax-built-in: #8a3f5e;
-  --syntax-variable: #4a5560;
-  --syntax-regexp: #a03729;
-  --brand: #a03729;
-  --brand-strong: #7a1f1a;
-  --brand-soft: #fbf2f0;
-  --coral: #a03729;
-  --surface-raised: #ffffff;
-  --shadow-sm: 0 1px 1px rgba(20, 17, 14, .03);
-  --shadow-lg: 0 24px 64px rgba(20, 17, 14, .07);
-  --font-sans: "DM Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-serif: "Source Serif 4", Georgia, "Times New Roman", serif;
-}
-
-html[data-theme="dark"] {
-  color-scheme: dark;
-  --background: #100e0c;
-  --card: #171512;
-  --accent: #201d19;
-  --foreground: #f7f4f0;
-  --text: #cec8c0;
-  --muted: #8d867d;
-  --border: #2b2721;
-  --code: #0a0908;
-  --code-text: #ece8e2;
-  --syntax-comment: #8b847b;
-  --syntax-keyword: #d6b6ea;
-  --syntax-string: #b6d1ae;
-  --syntax-title: #b5cbe4;
-  --syntax-number: #e6c9a3;
-  --syntax-built-in: #e3b8c6;
-  --syntax-variable: #d7d1c8;
-  --syntax-regexp: #e7b5aa;
-  --brand: #d99183;
-  --brand-strong: #eeb2a5;
-  --brand-soft: #241a18;
-  --coral: #d99183;
-  --surface-raised: #171512;
-  --shadow-sm: 0 1px 1px rgba(0, 0, 0, .3);
-  --shadow-lg: 0 24px 64px rgba(0, 0, 0, .5);
-}
-
-body {
-  background: var(--background);
-  font-size: 15px;
-  line-height: 1.7;
-}
-
-::selection { color: var(--foreground); background: color-mix(in srgb, var(--brand) 28%, transparent); }
-
-.site-header {
-  height: 68px;
-  border-bottom-color: color-mix(in srgb, var(--border) 76%, transparent);
-  background: color-mix(in srgb, var(--background) 82%, transparent);
-  backdrop-filter: blur(20px) saturate(140%);
-}
-
-.header-inner {
-  width: min(1440px, 100%);
-  height: 68px;
-  margin: 0 auto;
-  padding: 0 28px;
-  gap: 32px;
-}
-
-.logo { gap: 11px; }
-.logo-mark { color: var(--brand); stroke-width: 2.4; }
-.logo-name { color: var(--foreground); font-size: 15px; font-weight: 700; letter-spacing: .15em; }
-.header-links { gap: 22px; }
-.header-links a { color: var(--muted); font-size: 13px; font-weight: 500; }
-.header-links a:hover, .header-links a.active { color: var(--brand-strong); }
-.header-search { width: 264px; }
-.search-trigger {
-  height: 38px;
-  padding-left: 13px;
-  border-color: color-mix(in srgb, var(--border) 82%, transparent);
-  border-radius: 10px;
-  background: var(--surface-raised);
-  box-shadow: 0 1px 2px rgba(15, 58, 53, .03);
-}
-.search-trigger:hover { border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
-.icon-button { border-radius: 10px; }
-.icon-button:hover { color: var(--brand-strong); background: var(--accent); }
-.search-dialog {
-  border-color: var(--border);
-  background: color-mix(in srgb, var(--card) 96%, transparent);
-  box-shadow: var(--shadow-lg);
-  backdrop-filter: blur(20px);
-}
-
+/* Home */
 .home { padding-top: 68px; overflow: hidden; }
-.home h1, .home h2, .home h3 { font-family: var(--font-sans); }
-
-.home-hero {
-  position: relative;
-  width: min(1240px, calc(100% - 48px));
-  min-height: 680px;
-  padding: 112px 44px 104px;
-  grid-template-columns: minmax(0, 1.3fr) minmax(330px, .7fr);
-  align-items: center;
-  gap: 72px;
-}
-
-.home-hero::before {
-  position: absolute;
-  z-index: -2;
-  inset: 0 -30vw;
-  content: "";
-  background:
-    linear-gradient(color-mix(in srgb, var(--brand) 7%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in srgb, var(--brand) 7%, transparent) 1px, transparent 1px);
-  background-size: 44px 44px;
-  mask-image: linear-gradient(to bottom, rgba(0,0,0,.85), transparent 92%);
-}
-
-.pill {
-  position: relative;
-  margin-bottom: 26px;
-  padding: 7px 13px 7px 30px;
-  color: var(--brand-strong);
-  border-color: color-mix(in srgb, var(--brand) 35%, var(--border));
-  background: color-mix(in srgb, var(--brand-soft) 62%, var(--card));
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: .035em;
-  text-transform: uppercase;
-}
-
-.pill::before {
-  position: absolute;
-  top: 50%;
-  left: 12px;
-  width: 7px;
-  height: 7px;
-  content: "";
-  border-radius: 50%;
-  background: var(--brand);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 14%, transparent);
-  transform: translateY(-50%);
-}
-
-.home h1 {
-  max-width: 780px;
-  font-size: clamp(50px, 5.35vw, 76px);
-  font-weight: 700;
-  letter-spacing: -.052em;
-  line-height: .99;
-}
-
-.home h1::after {
-  display: inline-block;
-  width: .17em;
-  height: .17em;
-  margin-left: .09em;
-  content: "";
-  border-radius: 50%;
-  background: var(--coral);
-}
-
-.lead { max-width: 700px; margin-top: 30px; color: var(--text); font-family: var(--font-serif); font-size: 21px; line-height: 1.62; }
-.home-actions { margin-top: 38px; gap: 10px; }
-.primary-action, .secondary-action { min-height: 46px; padding: 11px 19px; border-radius: 10px; font-size: 14px; transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease; }
+.home h1, .home h2, .home h3 { color: var(--foreground); font-family: var(--font-sans); }
+.home-hero { position: relative; width: min(1240px, calc(100% - 48px)); min-height: 680px; margin: 0 auto; padding: 112px 44px 104px; display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(330px, .7fr); align-items: center; gap: 72px; }
+.home-hero::before { position: absolute; z-index: -2; inset: 0 -30vw; content: ""; background: linear-gradient(color-mix(in srgb, var(--brand) 7%, transparent) 1px, transparent 1px), linear-gradient(90deg, color-mix(in srgb, var(--brand) 7%, transparent) 1px, transparent 1px); background-size: 44px 44px; mask-image: linear-gradient(to bottom, rgba(0,0,0,.85), transparent 92%); }
+.pill { position: relative; width: fit-content; margin: 0 0 26px; padding: 7px 13px 7px 30px; color: var(--brand-strong); border: 1px solid color-mix(in srgb, var(--brand) 35%, var(--border)); border-radius: 999px; background: color-mix(in srgb, var(--brand-soft) 62%, var(--card)); font-size: 12px; font-weight: 600; letter-spacing: .035em; text-transform: uppercase; }
+.pill::before { position: absolute; top: 50%; left: 12px; width: 7px; height: 7px; content: ""; border-radius: 50%; background: var(--brand); box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 14%, transparent); transform: translateY(-50%); }
+.home h1 { max-width: 780px; margin: 0; font-size: clamp(50px, 5.35vw, 76px); font-weight: 700; letter-spacing: -.052em; line-height: .99; }
+.home h1::after { display: inline-block; width: .17em; height: .17em; margin-left: .09em; content: ""; border-radius: 50%; background: var(--coral); }
+.lead { max-width: 700px; margin: 30px 0 0; color: var(--text); font-size: 20px; line-height: 1.62; }
+.home-actions { margin-top: 38px; display: flex; flex-wrap: wrap; gap: 10px; }
+.primary-action, .secondary-action { min-height: 46px; padding: 11px 19px; display: inline-flex; align-items: center; justify-content: center; border-radius: 10px; font-size: 14px; font-weight: 500; transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease; }
 .primary-action { color: var(--background); background: var(--brand-strong); box-shadow: 0 8px 22px color-mix(in srgb, var(--brand) 24%, transparent); }
-.primary-action:hover { opacity: 1; box-shadow: 0 12px 30px color-mix(in srgb, var(--brand) 32%, transparent); transform: translateY(-1px); }
-.secondary-action { border-color: var(--border); background: var(--surface-raised); box-shadow: var(--shadow-sm); }
+.primary-action:hover { box-shadow: 0 12px 30px color-mix(in srgb, var(--brand) 32%, transparent); transform: translateY(-1px); }
+.secondary-action { color: var(--foreground); border: 1px solid var(--border); background: var(--surface-raised); box-shadow: var(--shadow-sm); }
 .secondary-action:hover { border-color: color-mix(in srgb, var(--brand) 35%, var(--border)); background: var(--card); transform: translateY(-1px); }
-
-.loop-card {
-  position: relative;
-  padding: 0;
-  overflow: hidden;
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  background: var(--card);
-  box-shadow: var(--shadow-lg);
-  transform: rotate(1.1deg);
-}
-
-.loop-card::before {
-  display: block;
-  height: 42px;
-  content: "";
-  border-bottom: 1px solid var(--border);
-  background:
-    radial-gradient(circle at 18px 21px, color-mix(in srgb, var(--muted) 42%, transparent) 0 4px, transparent 4.5px),
-    radial-gradient(circle at 34px 21px, color-mix(in srgb, var(--muted) 30%, transparent) 0 4px, transparent 4.5px),
-    radial-gradient(circle at 50px 21px, color-mix(in srgb, var(--muted) 20%, transparent) 0 4px, transparent 4.5px),
-    var(--accent);
-}
-
-.loop-card > p { padding: 24px 28px 0; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .2em; }
-.loop-card pre {
-  margin: 14px 16px 16px;
-  padding: 24px 28px 28px;
-  color: var(--code-text);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: var(--code);
-  font-size: 13px;
-  line-height: 2.05;
-}
-
-.band {
-  position: relative;
-  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: color-mix(in srgb, var(--accent) 40%, transparent);
-}
-.home-section { width: min(1160px, calc(100% - 48px)); padding: 96px 24px; }
-.section-label { margin-bottom: 14px; color: var(--brand-strong); font-size: 11px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
-.home h2 { max-width: 700px; font-size: clamp(32px, 4vw, 46px); font-weight: 650; letter-spacing: -.04em; line-height: 1.08; }
-.feature-grid { margin-top: 48px; gap: 16px; }
-.feature-grid article {
-  position: relative;
-  min-height: 230px;
-  padding: 68px 26px 26px;
-  overflow: hidden;
-  border-color: var(--border);
-  border-radius: 16px;
-  background: var(--surface-raised);
-  box-shadow: var(--shadow-sm);
-}
-.feature-grid article::before {
-  position: absolute;
-  top: 26px;
-  left: 26px;
-  width: 28px;
-  height: 28px;
-  content: "";
-  border: 7px solid color-mix(in srgb, var(--brand) 18%, transparent);
-  border-radius: 9px;
-  background: var(--brand);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand) 36%, transparent);
-}
+.loop-card { position: relative; padding: 0; overflow: hidden; color: var(--text); border: 1px solid var(--border); border-radius: 20px; background: var(--card); box-shadow: var(--shadow-lg); transform: rotate(1.1deg); }
+.loop-card::before { display: block; height: 42px; content: ""; border-bottom: 1px solid var(--border); background: radial-gradient(circle at 18px 21px, color-mix(in srgb, var(--muted) 42%, transparent) 0 4px, transparent 4.5px), radial-gradient(circle at 34px 21px, color-mix(in srgb, var(--muted) 30%, transparent) 0 4px, transparent 4.5px), radial-gradient(circle at 50px 21px, color-mix(in srgb, var(--muted) 20%, transparent) 0 4px, transparent 4.5px), var(--accent); }
+.loop-card > p { margin: 0; padding: 24px 28px 0; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .2em; text-transform: uppercase; }
+.loop-card pre, .quick-start pre { overflow-x: auto; font: 13px/2 var(--font-mono); }
+.loop-card pre { margin: 14px 16px 16px; padding: 24px 28px 28px; color: var(--code-text); border: 1px solid var(--border); border-radius: 12px; background: var(--code); line-height: 2.05; }
+.band { position: relative; border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent); border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent); background: color-mix(in srgb, var(--accent) 40%, transparent); }
+.home-section { width: min(1160px, calc(100% - 48px)); margin: 0 auto; padding: 96px 24px; }
+.section-label { margin: 0 0 14px; color: var(--brand-strong); font-size: 11px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+.home h2 { max-width: 700px; margin: 0; font-size: clamp(32px, 4vw, 46px); font-weight: 600; letter-spacing: -.04em; line-height: 1.08; }
+.home h3 { margin: 0 0 10px; font-size: 19px; font-weight: 600; letter-spacing: -.02em; }
+.feature-grid { margin-top: 48px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.feature-grid article { position: relative; min-height: 230px; padding: 68px 26px 26px; overflow: hidden; border: 1px solid var(--border); border-radius: 16px; background: var(--surface-raised); box-shadow: var(--shadow-sm); }
+.feature-grid article::before { position: absolute; top: 26px; left: 26px; width: 28px; height: 28px; content: ""; border: 7px solid color-mix(in srgb, var(--brand) 18%, transparent); border-radius: 9px; background: var(--brand); box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand) 36%, transparent); }
 .feature-grid article:nth-child(2)::before { border-radius: 50%; background: var(--coral); border-color: color-mix(in srgb, var(--coral) 18%, transparent); box-shadow: 0 0 0 1px color-mix(in srgb, var(--coral) 36%, transparent); }
 .feature-grid article:nth-child(3)::before { border-radius: 4px 12px 4px 12px; }
-.home h3 { margin-bottom: 10px; font-size: 19px; font-weight: 650; letter-spacing: -.02em; }
-.feature-grid p, .process-section > div > p, .quick-start > div > p, .resource-grid p { line-height: 1.75; }
-
-.process-section { padding-top: 112px; padding-bottom: 112px; gap: 110px; }
-.text-link { color: var(--brand-strong); text-decoration-color: color-mix(in srgb, var(--brand) 35%, transparent); }
-.step-list { counter-reset: reef-step; }
-.step-list li { min-height: 76px; padding: 18px 0; color: var(--foreground); border-color: var(--border); font-weight: 500; }
-.step-list span { color: var(--brand-strong); border: 0; background: var(--accent); font-weight: 600; }
-.quick-start { gap: 96px; }
-.quick-start pre { padding: 26px; color: #ddfaf5; border-color: #173832; background: #081714; box-shadow: 0 20px 60px rgba(5, 34, 30, .18); }
+.feature-grid p, .process-section > div > p, .quick-start > div > p, .resource-grid p { margin: 0; color: var(--muted); line-height: 1.75; }
+.process-section { padding-top: 112px; padding-bottom: 112px; display: grid; grid-template-columns: 1fr 1fr; gap: 110px; }
+.process-section h2, .quick-start h2 { margin-bottom: 20px; }
+.text-link { margin-top: 24px; display: inline-flex; align-items: center; gap: 6px; color: var(--brand-strong); font-weight: 500; text-decoration: underline; text-decoration-color: color-mix(in srgb, var(--brand) 35%, transparent); text-underline-offset: 4px; }
+.step-list { margin: 0; padding: 0; list-style: none; }
+.step-list li { min-height: 76px; padding: 18px 0; display: flex; align-items: center; gap: 16px; color: var(--foreground); border-bottom: 1px solid var(--border); font-weight: 500; }
+.step-list li:first-child { border-top: 1px solid var(--border); }
+.step-list span { width: 28px; height: 28px; display: grid; place-items: center; flex: none; color: var(--brand-strong); border-radius: 50%; background: var(--accent); font: 600 12px var(--font-mono); }
+.quick-start { display: grid; grid-template-columns: 1fr 1fr; align-items: center; gap: 96px; }
+.quick-start .primary-action { margin-top: 24px; }
+.quick-start pre { margin: 0; padding: 26px; color: #ddfaf5; border: 1px solid #173832; border-radius: 12px; background: #081714; box-shadow: 0 20px 60px rgba(5, 34, 30, .18); }
 .resource-section { padding-top: 112px; padding-bottom: 112px; }
-.resource-grid { gap: 16px; }
-.resource-grid > a { min-height: 245px; border-radius: 16px; background: var(--surface-raised); box-shadow: var(--shadow-sm); transition: border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease; }
+.resource-grid { margin-top: 36px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.resource-grid > a { min-height: 245px; padding: 28px; display: flex; flex-direction: column; border: 1px solid var(--border); border-radius: 16px; background: var(--surface-raised); box-shadow: var(--shadow-sm); transition: border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease; }
 .resource-grid > a:hover { border-color: color-mix(in srgb, var(--brand) 38%, var(--border)); background: var(--card); box-shadow: 0 16px 42px rgba(15, 70, 64, .09); transform: translateY(-3px); }
 .resource-grid small { color: var(--brand-strong); font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
-.resource-grid span { color: var(--brand-strong); font-size: 13px; }
-
-.docs-layout {
-  padding-top: 68px;
-  grid-template-columns: 270px minmax(0, 760px) minmax(220px, 1fr);
-}
-.docs-sidebar {
-  top: 68px;
-  width: 270px;
-  padding: 38px 22px 48px;
-  border-right-color: color-mix(in srgb, var(--border) 72%, transparent);
-  background: color-mix(in srgb, var(--background) 92%, var(--accent));
-}
-.sidebar-group { margin-bottom: 30px; }
-.sidebar-group-items { gap: 3px; }
-.sidebar-group a { padding: 7px 10px; border-radius: 7px; font-size: 13px; }
-.sidebar-group > .sidebar-group-title { margin: 0 10px 9px; color: var(--muted); font-family: var(--font-sans); font-size: 10px; font-weight: 800; letter-spacing: .13em; line-height: 18px; text-transform: uppercase; }
-.sidebar-group a:hover { color: var(--foreground); background: color-mix(in srgb, var(--accent) 65%, transparent); }
-.sidebar-group a.active { position: relative; color: var(--brand-strong); background: var(--accent); font-weight: 600; }
-.sidebar-group a.active::before { position: absolute; top: 7px; bottom: 7px; left: 0; width: 2px; content: ""; border-radius: 2px; background: var(--brand); }
-.docs-main { padding: 56px 44px 96px; }
-.markdown-body { color: var(--text); font-size: 15px; line-height: 1.8; }
-.markdown-body h1, .markdown-body h2, .markdown-body h3 { font-family: var(--font-serif); font-weight: 600; letter-spacing: -.01em; }
-.markdown-body h1 { font-size: 34px; line-height: 1.25; }
-.markdown-body h1 + p { color: var(--text); font-family: var(--font-serif); font-size: 19px; line-height: 1.62; }
-.markdown-body h2 { margin-top: 64px; font-size: 24px; }
-.markdown-body h1 { margin-bottom: 18px; color: var(--foreground); font-size: 36px; font-weight: 680; letter-spacing: -.04em; line-height: 1.18; }
-.markdown-body h1 + p { margin-bottom: 44px; color: var(--muted); font-size: 17px; line-height: 1.75; }
-.markdown-body h2 { margin: 58px 0 20px; padding-top: 4px; color: var(--foreground); font-size: 24px; font-weight: 650; letter-spacing: -.025em; }
-.markdown-body h3 { margin-top: 40px; font-size: 18px; font-weight: 650; }
-.markdown-body a { color: var(--brand-strong); text-decoration-color: color-mix(in srgb, var(--brand) 34%, transparent); }
-.markdown-body a:hover { text-decoration-color: var(--brand); }
-.markdown-body blockquote { padding: 16px 20px; border-left-color: var(--brand); border-radius: 0 10px 10px 0; background: var(--accent); }
-.markdown-body code, .markdown-body .literal { color: var(--brand-strong); background: var(--accent); }
-.markdown-body pre { padding: 22px 24px; color: var(--code-text); border-color: #173934; border-radius: 12px; box-shadow: inset 0 1px rgba(255,255,255,.03); }
-.markdown-body pre code { color: inherit; }
-.markdown-body table { border-radius: 12px; }
-.markdown-body th { background: var(--accent); }
-.pager-link { border-radius: 12px; background: var(--surface-raised); box-shadow: var(--shadow-sm); }
-.pager-link:hover { border-color: color-mix(in srgb, var(--brand) 34%, var(--border)); background: var(--card); }
-.pager-link small { color: var(--muted); text-transform: uppercase; letter-spacing: .08em; }
-.pager-link span { color: var(--brand-strong); }
-.toc { top: 68px; left: 1030px; padding: 56px 24px; }
-.toc > p { color: var(--muted); font-family: var(--font-sans); font-size: 10px; font-weight: 700; letter-spacing: .13em; text-transform: uppercase; }
-.toc a { position: relative; padding: 6px 0 6px 13px; border-left: 1px solid var(--border); font-size: 12px; }
-.toc a.active { color: var(--brand-strong); border-left-color: var(--brand); }
-.site-footer { border-top-color: var(--border); }
-
-@media (max-width: 1050px) {
-  .docs-layout { grid-template-columns: 250px minmax(0, 760px); }
-  .docs-sidebar { width: 250px; }
-  .header-links { gap: 16px; }
-  .header-search { width: 200px; }
-}
-
-@media (max-width: 800px) {
-  .header-inner { padding: 0 18px; }
-  .home-hero { min-height: auto; padding-top: 84px; grid-template-columns: 1fr; gap: 54px; }
-  .loop-card { max-width: 480px; transform: none; }
-  .feature-grid { grid-template-columns: 1fr; }
-  .feature-grid article { min-height: 190px; }
-  .process-section, .quick-start { grid-template-columns: 1fr; gap: 52px; }
-  .docs-main { padding-top: 48px; }
-}
-
-@media (max-width: 600px) {
-  /* Reassert the compact search: the skin rules above this block win the
-     cascade over the earlier compact media query, reintroducing the left
-     padding and raised background (off-center icon) and the desktop
-     .header-search width (a dead gap in the middle of the header). */
-  .search-trigger { padding: 0; background: transparent; box-shadow: none; }
-  .header-search { width: 44px; }
-  .home-hero, .home-section { width: calc(100% - 28px); padding-right: 8px; padding-left: 8px; }
-  .home-hero { padding-top: 66px; }
-  .home h1 { font-size: 46px; }
-  .lead { font-size: 17px; }
-  .home-section { padding-top: 76px; padding-bottom: 76px; }
-  .home h2 { font-size: 32px; }
-  .docs-main { padding: 40px 20px 72px; }
-  .markdown-body h1 { font-size: 31px; }
-}
-
-/* Navigation and journey layer */
+.resource-grid h3 { margin-top: 14px; }
+.resource-grid span { margin-top: auto; display: flex; align-items: center; gap: 6px; color: var(--brand-strong); font-size: 13px; font-weight: 500; }
 
 .section-heading-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 430px); align-items: end; gap: 72px; }
 .section-heading-row > p { margin: 0; color: var(--muted); line-height: 1.75; }
 .path-grid { margin-top: 48px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
-.path-card {
-  min-height: 330px;
-  padding: 26px;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--border);
-  border-radius: 18px;
-  background: var(--surface-raised);
-  box-shadow: var(--shadow-sm);
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
-}
-.path-card:hover {
-  border-color: color-mix(in srgb, var(--brand) 42%, var(--border));
-  box-shadow: 0 18px 48px rgba(15, 70, 64, .11);
-  transform: translateY(-4px);
-}
-.path-card-icon {
-  width: 42px;
-  height: 42px;
-  margin-bottom: 34px;
-  display: grid;
-  place-items: center;
-  color: var(--brand-strong);
-  border: 1px solid color-mix(in srgb, var(--brand) 23%, var(--border));
-  border-radius: 12px;
-  background: var(--accent);
-}
+.path-grid-2 { grid-template-columns: repeat(2, 1fr); }
+.path-card { min-height: 330px; padding: 26px; display: flex; flex-direction: column; border: 1px solid var(--border); border-radius: 18px; background: var(--surface-raised); box-shadow: var(--shadow-sm); transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease; }
+.path-card:hover { border-color: color-mix(in srgb, var(--brand) 42%, var(--border)); box-shadow: 0 18px 48px rgba(15, 70, 64, .11); transform: translateY(-4px); }
+.path-card-icon { width: 42px; height: 42px; margin-bottom: 34px; display: grid; place-items: center; color: var(--brand-strong); border: 1px solid color-mix(in srgb, var(--brand) 23%, var(--border)); border-radius: 12px; background: var(--accent); }
 .path-card:nth-child(2) .path-card-icon { color: var(--coral); border-color: color-mix(in srgb, var(--coral) 28%, var(--border)); background: color-mix(in srgb, var(--coral) 9%, var(--card)); }
 .path-card small { color: var(--brand-strong); font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
 .path-card h3 { margin: 12px 0 10px; }
 .path-card p { margin: 0 0 24px; color: var(--muted); line-height: 1.7; }
 .path-card-link { margin-top: auto; display: inline-flex; align-items: center; gap: 7px; color: var(--brand-strong); font-size: 13px; font-weight: 600; }
-.path-card:hover .path-card-link svg { transform: translateX(3px); }
 .path-card-link svg { transition: transform 160ms ease; }
-.text-link, .resource-grid span { align-items: center; gap: 6px; }
-.resource-grid span { display: flex; }
+.path-card:hover .path-card-link svg { transform: translateX(3px); }
+.home-table { width: 100%; margin-top: 32px; border-collapse: collapse; font-size: 15px; }
+.home-table th, .home-table td { padding: 14px 18px 14px 0; text-align: left; vertical-align: top; border-bottom: 1px solid var(--border); }
+.home-table thead th { color: var(--muted); border-bottom-color: color-mix(in srgb, var(--foreground) 34%, transparent); font-size: 13px; font-weight: 500; }
+.home-table tbody tr:last-child td { border-bottom: 0; }
+.home-table td code { padding: .12em .42em; color: var(--foreground); border: 1px solid var(--border); border-radius: 4px; background: var(--accent); font-size: 13px; }
+.home-table a:hover code { border-color: var(--brand); color: var(--brand); }
+.home-section > .text-link { margin-top: 28px; }
+.shelf-grid { margin-top: 40px; display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 40px 32px; }
+.shelf h3 { margin: 0 0 16px; padding-bottom: 12px; border-bottom: 1px solid var(--border); font-size: 14px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
+.shelf ul { margin: 0; padding: 0; display: grid; gap: 10px; list-style: none; }
+.shelf a { color: var(--text); font-size: 15px; }
+.shelf a:hover { color: var(--brand); }
 
-.doc-context {
-  min-height: 28px;
-  margin-bottom: 26px;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--muted);
-  font-size: 11px;
-}
+/* Documentation layout */
+.docs-layout { width: 100%; min-height: 100vh; padding-top: 68px; display: grid; grid-template-columns: 270px minmax(0, 760px) minmax(220px, 1fr); }
+.docs-sidebar { position: fixed; z-index: 20; top: 68px; bottom: 0; left: 0; width: 270px; padding: 38px 22px 48px; overflow-y: auto; border-right: 1px solid color-mix(in srgb, var(--border) 72%, transparent); background: color-mix(in srgb, var(--background) 92%, var(--accent)); }
+.sidebar-group { margin-bottom: 30px; }
+.sidebar-group-items { display: grid; gap: 3px; }
+.sidebar-group a { padding: 7px 10px; color: var(--muted); border-radius: 7px; font-size: 13px; line-height: 20px; }
+.sidebar-group > .sidebar-group-title { margin: 0 10px 9px; padding: 0; color: var(--muted); font-size: 10px; font-weight: 800; letter-spacing: .13em; line-height: 18px; text-transform: uppercase; }
+.sidebar-group a:hover { color: var(--foreground); background: color-mix(in srgb, var(--accent) 65%, transparent); }
+.sidebar-group a.active { position: relative; color: var(--brand-strong); background: var(--accent); font-weight: 600; }
+.sidebar-group a.active::before { position: absolute; top: 7px; bottom: 7px; left: 0; width: 2px; content: ""; border-radius: 2px; background: var(--brand); }
+.docs-main { grid-column: 2; width: 100%; padding: 56px 44px 96px; }
+.doc-context { min-height: 28px; margin-bottom: 26px; display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: 11px; }
 .doc-context a:hover { color: var(--brand-strong); }
-.doc-section {
-  padding: 4px 8px;
-  color: var(--brand-strong);
-  border: 1px solid color-mix(in srgb, var(--brand) 25%, var(--border));
-  border-radius: 999px;
-  background: var(--accent);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: .1em;
-  text-transform: uppercase;
-}
-.pager-link { min-height: 128px; align-items: flex-start; }
-.pager-link.next { align-items: flex-end; }
-.pager-link p {
-  max-width: 270px;
-  margin: 2px 0 0;
-  display: -webkit-box;
-  overflow: hidden;
-  color: var(--muted);
-  font-size: 11px;
-  line-height: 1.5;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
+.doc-section { padding: 4px 8px; color: var(--brand-strong); border: 1px solid color-mix(in srgb, var(--brand) 25%, var(--border)); border-radius: 999px; background: var(--accent); font-size: 9px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
 
-@media (max-width: 800px) {
-  .section-heading-row { grid-template-columns: 1fr; gap: 22px; }
-  .path-grid { grid-template-columns: 1fr; }
-  .path-card { min-height: 260px; }
-}
+/* Documentation typography: one serif display face, one sans reading face. */
+.markdown-body { color: var(--text); font-family: var(--font-sans); font-size: 16px; line-height: 1.72; }
+.markdown-body > h1:first-child { margin-top: 0; }
+.markdown-body h1 { margin: 0 0 18px; color: var(--foreground); font-family: var(--font-serif); font-size: 36px; font-weight: 600; letter-spacing: -.025em; line-height: 1.2; }
+.markdown-body h1 + p { margin: 0 0 40px; color: var(--text); font-family: var(--font-sans); font-size: 17px; line-height: 1.7; }
+.markdown-body h2, .markdown-body h3 { color: var(--foreground); font-family: var(--font-sans); font-weight: 600; }
+.markdown-body h2 { margin: 56px 0 18px; padding-top: 4px; font-size: 23px; letter-spacing: -.02em; line-height: 1.35; }
+.markdown-body h3 { margin: 38px 0 14px; font-size: 18px; letter-spacing: -.01em; line-height: 1.45; }
+.markdown-body p { margin: 0 0 24px; }
+.markdown-body a { color: var(--brand-strong); font-weight: 500; text-decoration: underline; text-decoration-color: color-mix(in srgb, var(--brand) 34%, transparent); text-underline-offset: 4px; }
+.markdown-body a:hover { text-decoration-color: var(--brand); }
+.markdown-body a.heading-anchor { margin-left: 7px; color: var(--muted); font-size: 14px; text-decoration: none; }
+.external-link-icon { display: inline; margin-left: 3px; }
+.markdown-body ul, .markdown-body ol { margin: 16px 0 24px; padding-left: 24px; }
+.markdown-body li { margin: 7px 0; padding-left: 3px; }
+.markdown-body strong { color: var(--foreground); font-weight: 600; }
+.markdown-body blockquote { margin: 24px 0; padding: 16px 20px; border-left: 3px solid var(--brand); border-radius: 0 10px 10px 0; background: var(--accent); }
+.markdown-body blockquote p:last-child { margin-bottom: 0; }
+.markdown-body code, .markdown-body .literal { padding: .15em .35em; color: var(--brand-strong); border-radius: 4px; background: var(--accent); font-family: var(--font-mono); font-size: 14px; overflow-wrap: anywhere; }
+.markdown-body .table-scroll code, .markdown-body .table-scroll .literal { overflow-wrap: normal; }
+.markdown-body pre { --scroller-bg: var(--code); margin: 24px 0 32px; padding: 22px 24px; overflow-x: auto; color: var(--code-text); border: 1px solid color-mix(in srgb, var(--border) 88%, transparent); border-radius: 10px; box-shadow: inset 0 1px color-mix(in srgb, var(--foreground) 4%, transparent); font: 13px/1.65 var(--font-mono); }
+.markdown-body pre, .markdown-body .table-scroll { background: linear-gradient(90deg, var(--scroller-bg) 45%, transparent) left center / 32px 100% no-repeat local, linear-gradient(270deg, var(--scroller-bg) 45%, transparent) right center / 32px 100% no-repeat local, radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) left center / 14px 100% no-repeat scroll, radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) right center / 14px 100% no-repeat scroll, var(--scroller-bg); }
+.markdown-body pre code { display: block; width: max-content; min-width: 100%; padding: 0; color: inherit; background: transparent; font-size: 13px; }
+.table-scroll { overflow-x: auto; }
+.markdown-body .table-scroll { --scroller-bg: var(--background); margin: 24px 0 32px; border-radius: 10px; box-shadow: var(--shadow-sm); }
+.markdown-body .table-scroll table { margin: 0; }
+.markdown-body table { width: 100%; margin: 24px 0 32px; border-collapse: separate; border-spacing: 0; overflow: hidden; border: 1px solid var(--border); border-radius: 10px; font-size: 14px; line-height: 1.5; }
+.markdown-body th { color: var(--foreground); background: var(--accent); font-weight: 600; text-align: left; }
+.markdown-body th, .markdown-body td { padding: 10px 12px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); vertical-align: top; }
+.markdown-body th > p:last-child, .markdown-body td > p:last-child { margin-bottom: 0; }
+.markdown-body th:last-child, .markdown-body td:last-child { border-right: 0; }
+.markdown-body tr:last-child td { border-bottom: 0; }
+.markdown-body hr { height: 1px; margin: 40px 0; border: 0; background: var(--border); }
 
-@media (max-width: 600px) {
-  .doc-context { margin-bottom: 22px; }
-  .path-grid { margin-top: 34px; }
-  .path-card { min-height: 250px; padding: 22px; }
-  .path-card-icon { margin-bottom: 28px; }
-  .pager-link { min-height: 112px; }
-}
+.markdown-body .mermaid-diagram { margin: 24px 0 32px; padding: 20px 16px; overflow-x: auto; border: 1px solid var(--border); border-radius: 10px; background: var(--card); }
+.markdown-body .mermaid-diagram svg { display: block; width: 100%; max-width: 100%; height: auto; margin: 0 auto; background: transparent !important; }
+.markdown-body .mermaid-diagram svg rect.actor, .markdown-body .mermaid-diagram svg rect.note, .markdown-body .mermaid-diagram svg rect.labelBox { rx: 6px; ry: 6px; }
+.markdown-body .mermaid-diagram svg .cluster rect { rx: 10px; ry: 10px; }
+.markdown-body .mermaid-diagram svg .node rect { rx: 7px; ry: 7px; }
+.markdown-body .mermaid-diagram svg .node.user-owned rect, .markdown-body .mermaid-diagram svg .node.user-owned path, .markdown-body .mermaid-diagram svg .node.durable rect, .markdown-body .mermaid-diagram svg .node.durable path { fill: var(--diagram-emphasis) !important; stroke: var(--diagram-emphasis-border) !important; }
+.markdown-body .mermaid-diagram svg .node.user-owned text, .markdown-body .mermaid-diagram svg .node.durable text { fill: var(--diagram-emphasis-text) !important; }
+.markdown-body .mermaid-diagram svg .node.user-owned span, .markdown-body .mermaid-diagram svg .node.user-owned p, .markdown-body .mermaid-diagram svg .node.durable span, .markdown-body .mermaid-diagram svg .node.durable p { color: var(--diagram-emphasis-text) !important; }
+.markdown-body .mermaid-diagram svg .node.volatile rect { stroke-dasharray: 5 3; }
+.markdown-body .mermaid-diagram svg .messageLine0, .markdown-body .mermaid-diagram svg .messageLine1, .markdown-body .mermaid-diagram svg .actor-line { stroke-width: 1.25px; }
+.markdown-body .mermaid-error { color: var(--text); }
+.markdown-body .mermaid-error figcaption { color: var(--muted); }
+.markdown-body .mermaid-error pre { margin-bottom: 0; }
+.markdown-body .mermaid-loading { min-height: 240px; display: grid; place-items: center; color: var(--muted); font-size: 13px; }
 
-/* Docs visual language: figures, callouts, reference rows, step lists.
-   Every component reuses the existing geometry family (hairline border,
-   10-16px radius, card tint) and emits one theme-neutral render; light and
-   dark flip entirely through the variables above. Figure labels are DOM text
-   at body size, and figures reflow to a vertical stack on narrow screens
-   instead of scaling text down. */
-:root {
-  --callout-note: #f6f5f2;
-  --callout-note-ink: #6d6862;
-  --callout-tip: #f4f3ef;
-  --callout-tip-ink: #5f6b57;
-  --callout-warn: #f8f1ef;
-  --callout-warn-ink: #7a1f1a;
-}
-
-html[data-theme="dark"] {
-  color-scheme: dark;
-  --callout-note: #1a1815;
-  --callout-note-ink: #a29b92;
-  --callout-tip: #191c17;
-  --callout-tip-ink: #a8b39c;
-  --callout-warn: #241a18;
-  --callout-warn-ink: #d99183;
-}
-
+/* Documentation components */
 .markdown-body .fig { margin: 28px 0 36px; padding: 24px 18px; border: 1px solid var(--border); border-radius: 4px; background: var(--card); }
-.markdown-body .fig figcaption { margin: 16px auto 0; max-width: 560px; color: var(--muted); font-size: 13px; line-height: 1.5; text-align: center; }
+.markdown-body .fig figcaption { max-width: 560px; margin: 16px auto 0; color: var(--muted); font-size: 13px; line-height: 1.5; text-align: center; }
 .fig .fig-arrow { flex: none; align-self: center; color: var(--muted); }
-
 .fig-flow-track { display: flex; align-items: stretch; gap: 6px; }
 .fig-flow-track > .fig-arrow-next { width: 14px; height: 14px; }
-.fig-flow-stage { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; justify-content: center; gap: 3px; padding: 12px 8px; border: 1px solid var(--border); border-radius: 10px; background: var(--background); text-align: center; overflow-wrap: break-word; }
+.fig-flow-stage { min-width: 0; padding: 12px 8px; display: flex; flex: 1 1 0; flex-direction: column; justify-content: center; gap: 3px; border: 1px solid var(--border); border-radius: 8px; background: var(--background); text-align: center; overflow-wrap: break-word; }
 .fig-flow-stage code, .fig-flow-stage .literal { padding: .1em .3em; font-size: 12px; }
 .fig-flow-title { color: var(--foreground); font-size: 14px; font-weight: 600; line-height: 1.35; }
 .fig-flow-caption { color: var(--muted); font-size: 13px; line-height: 1.45; }
@@ -805,39 +292,31 @@ html[data-theme="dark"] {
 .fig-flow-stage.fig-emphasis .fig-flow-title { color: var(--diagram-emphasis-text); }
 .fig-flow-stage.fig-emphasis .fig-flow-caption { color: color-mix(in srgb, var(--diagram-emphasis-text) 78%, transparent); }
 .fig-flow-loop { margin-top: 14px; display: flex; align-items: center; justify-content: center; gap: 8px; color: var(--muted); font-size: 14px; }
-
-/* Primitives for hand-built spatial figures inside `.. diagram::`. */
 .fig-lane { display: flex; align-items: center; justify-content: center; gap: 12px; }
-.fig-node { padding: 12px 16px; border: 1px solid var(--border); border-radius: 10px; background: var(--background); color: var(--foreground); font-size: 14px; font-weight: 600; line-height: 1.35; text-align: center; }
-.fig-node .fig-node-caption { display: block; margin-top: 2px; color: var(--muted); font-size: 13px; font-weight: 400; }
-.fig-node.fig-emphasis { border-color: var(--diagram-emphasis-border); background: var(--diagram-emphasis); color: var(--diagram-emphasis-text); }
+.fig-node { padding: 12px 16px; color: var(--foreground); border: 1px solid var(--border); border-radius: 8px; background: var(--background); font-size: 14px; font-weight: 600; line-height: 1.35; text-align: center; }
+.fig-node .fig-node-caption { margin-top: 2px; display: block; color: var(--muted); font-size: 13px; font-weight: 400; }
+.fig-node.fig-emphasis { color: var(--diagram-emphasis-text); border-color: var(--diagram-emphasis-border); background: var(--diagram-emphasis); }
 .fig-node.fig-emphasis .fig-node-caption { color: color-mix(in srgb, var(--diagram-emphasis-text) 78%, transparent); }
-.fig-group { position: relative; display: flex; align-items: center; gap: 12px; padding: 34px 16px 16px; border: 1px dashed color-mix(in srgb, var(--diagram-emphasis-border) 65%, var(--border)); border-radius: 12px; background: color-mix(in srgb, var(--accent) 55%, transparent); }
-.fig-group-label { position: absolute; top: 10px; left: 16px; right: 16px; color: var(--muted); font-size: 13px; line-height: 1.4; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fig-group { position: relative; padding: 34px 16px 16px; display: flex; align-items: center; gap: 12px; border: 1px dashed color-mix(in srgb, var(--diagram-emphasis-border) 65%, var(--border)); border-radius: 10px; background: color-mix(in srgb, var(--accent) 55%, transparent); }
+.fig-group-label { position: absolute; top: 10px; right: 16px; left: 16px; overflow: hidden; color: var(--muted); font-size: 13px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
 .fig-edge { display: flex; flex-direction: column; align-items: center; gap: 2px; color: var(--muted); font-size: 13px; line-height: 1.4; text-align: center; }
-
-/* Package ownership map: scope first, then the responsibility of shared code. */
 .ownership-map { display: grid; gap: 14px; }
 .ownership-step-label { color: var(--foreground); font-size: 14px; font-weight: 600; line-height: 1.4; }
 .ownership-scope { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
 .ownership-continue { gap: 3px; }
 .ownership-groups { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-.ownership-group { min-width: 0; padding: 12px; border: 1px dashed color-mix(in srgb, var(--diagram-emphasis-border) 65%, var(--border)); border-radius: 12px; background: color-mix(in srgb, var(--accent) 55%, transparent); }
+.ownership-group { min-width: 0; padding: 12px; border: 1px dashed color-mix(in srgb, var(--diagram-emphasis-border) 65%, var(--border)); border-radius: 10px; background: color-mix(in srgb, var(--accent) 55%, transparent); }
 .ownership-group-title { margin-bottom: 10px; color: var(--muted); font-size: 13px; font-weight: 600; line-height: 1.4; }
 .ownership-packages { display: grid; gap: 8px; }
 .ownership-map .fig-node { padding: 10px 12px; }
-.ownership-map .fig-node code { padding: 0; border: 0; background: transparent; color: inherit; font-size: 13px; }
-
-/* Reference rows: keys are deep-linkable scan lines, not headings or tables. */
-.markdown-body .config-card { margin: 24px 0 32px; overflow: hidden; border: 1px solid var(--border); border-radius: 12px; background: var(--card); box-shadow: var(--shadow-sm); font-size: 14px; line-height: 1.6; }
-.config-row { display: grid; grid-template-columns: minmax(130px, max-content) 1fr; gap: 4px 20px; padding: 12px 16px; border-bottom: 1px solid color-mix(in srgb, var(--border) 62%, transparent); scroll-margin-top: 92px; }
+.ownership-map .fig-node code { padding: 0; color: inherit; border: 0; background: transparent; font-size: 13px; }
+.markdown-body .config-card { margin: 24px 0 32px; overflow: hidden; border: 1px solid var(--border); border-radius: 10px; background: var(--card); box-shadow: var(--shadow-sm); font-size: 14px; line-height: 1.6; }
+.config-row { padding: 12px 16px; display: grid; grid-template-columns: minmax(130px, max-content) 1fr; gap: 4px 20px; border-bottom: 1px solid color-mix(in srgb, var(--border) 62%, transparent); scroll-margin-top: 92px; }
 .config-row:last-child { border-bottom: 0; }
 .config-key { color: var(--foreground); font-family: var(--font-mono); font-size: 13px; overflow-wrap: anywhere; }
 .config-default { margin-right: 10px; padding: 1px 8px; display: inline-block; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; font-family: var(--font-mono); font-size: 12px; }
 .config-desc { color: var(--text); }
-
-/* Callouts: one shape, color the only severity signal. */
-.markdown-body .admonition { margin: 24px 0 32px; padding: 14px 18px; border: 1px solid; border-radius: 12px; }
+.markdown-body .admonition { margin: 24px 0 32px; padding: 14px 18px; border: 1px solid; border-radius: 10px; }
 .markdown-body .admonition p { margin: 0 0 10px; }
 .markdown-body .admonition p:last-child { margin-bottom: 0; }
 .markdown-body .admonition-title { display: flex; align-items: center; gap: 7px; font-size: 14px; font-weight: 600; }
@@ -847,92 +326,128 @@ html[data-theme="dark"] {
 .markdown-body .admonition.tip .admonition-title { color: var(--callout-tip-ink); }
 .markdown-body .admonition.warning, .markdown-body .admonition.caution, .markdown-body .admonition.important { border-color: color-mix(in srgb, var(--callout-warn-ink) 32%, var(--border)); background: var(--callout-warn); }
 .markdown-body .admonition.warning .admonition-title, .markdown-body .admonition.caution .admonition-title, .markdown-body .admonition.important .admonition-title { color: var(--callout-warn-ink); }
-.markdown-body .admonition code, .markdown-body .admonition .literal { background: color-mix(in srgb, var(--background) 62%, transparent); color: var(--foreground); }
-
-/* Step lists: CSS counters draw the circle and connector around an ordinary
-   enumerated list, so everything inside keeps its normal rendering. */
+.markdown-body .admonition code, .markdown-body .admonition .literal { color: var(--foreground); background: color-mix(in srgb, var(--background) 62%, transparent); }
 .steps > ol { margin: 16px 0 24px; padding-left: 0; list-style: none; counter-reset: steps; }
 .steps > ol > li { position: relative; margin: 0; padding: 0 0 24px 44px; counter-increment: steps; }
-.steps > ol > li::before { content: counter(steps); position: absolute; top: 0; left: 0; width: 28px; height: 28px; display: grid; place-items: center; color: var(--foreground); border: 1px solid var(--border); border-radius: 50%; background: var(--card); font-size: 14px; font-weight: 600; }
-.steps > ol > li::after { content: ""; position: absolute; top: 34px; bottom: 6px; left: 14px; width: 1px; background: var(--border); }
+.steps > ol > li::before { position: absolute; top: 0; left: 0; width: 28px; height: 28px; display: grid; place-items: center; content: counter(steps); color: var(--foreground); border: 1px solid var(--border); border-radius: 50%; background: var(--card); font-size: 14px; font-weight: 600; }
+.steps > ol > li::after { position: absolute; top: 34px; bottom: 6px; left: 14px; width: 1px; content: ""; background: var(--border); }
 .steps > ol > li:last-child { padding-bottom: 0; }
 .steps > ol > li:last-child::after { display: none; }
-
-@media (max-width: 720px) {
-  .fig-flow-track, .fig-lane, .fig-group { flex-direction: column; align-items: stretch; }
-  .fig-group { padding-top: 16px; }
-  .fig-group-label { position: static; white-space: normal; text-align: center; }
-  .fig-flow-track .fig-arrow-next, .fig-lane .fig-arrow-next, .fig-group .fig-arrow-next,
-  .fig-lane .fig-arrow-back, .fig-group .fig-arrow-back { transform: rotate(90deg); }
-  .fig-flow-loop { text-align: center; }
-  .config-row { grid-template-columns: 1fr; }
-  .ownership-scope, .ownership-groups { grid-template-columns: 1fr; }
-}
-
-/* Home: information sections added alongside the path cards — a two-up grid,
-   the two data tables, and the shelf index that reaches every page. */
-.path-grid-2 { grid-template-columns: repeat(2, 1fr); }
-
-.home-table { width: 100%; margin-top: 32px; border-collapse: collapse; font-size: 15px; }
-.home-table th, .home-table td { padding: 14px 18px 14px 0; text-align: left; vertical-align: top; border-bottom: 1px solid var(--border); }
-.home-table thead th { color: var(--muted); border-bottom-color: color-mix(in srgb, var(--foreground) 34%, transparent); font-size: 13px; font-weight: 500; }
-.home-table thead th small { display: block; margin-top: 2px; font-size: 12px; font-weight: 400; }
-.home-table tbody tr:last-child td { border-bottom: 0; }
-.home-table td code { padding: .12em .42em; color: var(--foreground); border: 1px solid var(--border); border-radius: 4px; background: var(--accent); font-size: 13px; }
-.home-table a { color: inherit; text-decoration: none; }
-.home-table a:hover code { border-color: var(--brand); color: var(--brand); }
-.home-table td.yes, .home-table td.no { width: 1%; padding-right: 32px; font-size: 16px; }
-.home-table td.yes { color: var(--brand); }
-.home-table td.no { color: color-mix(in srgb, var(--muted) 55%, transparent); }
-.home-section > .text-link { margin-top: 28px; }
-
-.shelf-grid { margin-top: 40px; display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 40px 32px; }
-.shelf h3 { margin: 0 0 16px; padding-bottom: 12px; border-bottom: 1px solid var(--border); font-size: 14px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
-.shelf ul { margin: 0; padding: 0; list-style: none; display: grid; gap: 10px; }
-.shelf a { color: var(--text); font-size: 15px; text-decoration: none; }
-.shelf a:hover { color: var(--brand); }
-
-@media (max-width: 800px) {
-  .path-grid-2 { grid-template-columns: 1fr; }
-  .home-table { font-size: 14px; }
-}
-
-/* Page brief. It sits under the lede and answers
-   three questions before the first section: who the page is for, what to have
-   ready, and what the reader has at the end. It reuses the callout geometry
-   so it reads as the page's own note, not a second heading. */
-.markdown-body .page-brief {
-  margin: -14px 0 40px;
-  padding: 14px 18px;
-  display: grid;
-  grid-template-columns: max-content minmax(0, 1fr);
-  gap: 8px 22px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: var(--card);
-  box-shadow: var(--shadow-sm);
-  font-size: 14px;
-  line-height: 1.6;
-}
-.markdown-body .page-brief dt {
-  padding-top: 2px;
-  color: var(--muted);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: .12em;
-  line-height: 18px;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
+.markdown-body .page-brief { margin: -12px 0 40px; padding: 14px 18px; display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 8px 22px; border: 1px solid var(--border); border-radius: 10px; background: var(--card); box-shadow: var(--shadow-sm); font-size: 14px; line-height: 1.6; }
+.markdown-body .page-brief dt { padding-top: 2px; color: var(--muted); font-size: 10px; font-weight: 700; letter-spacing: .12em; line-height: 18px; text-transform: uppercase; white-space: nowrap; }
 .markdown-body .page-brief dd { margin: 0; color: var(--text); }
 .markdown-body .page-brief dd a { font-weight: 500; }
 .markdown-body .page-brief code, .markdown-body .page-brief .literal { background: color-mix(in srgb, var(--accent) 70%, transparent); }
-/* Expected-output blocks inside tutorials: the same code chrome, labeled so
-   a reader can tell a command to type from the text they should see. */
 .markdown-body pre.language-console, .markdown-body pre.language-shellsession { position: relative; }
 
+/* Page navigation and footer */
+.edit-row { margin-top: 48px; padding-top: 18px; border-top: 1px solid var(--border); }
+.edit-row a { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 12px; }
+.pager { margin-top: 28px; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.pager-link { min-height: 128px; padding: 16px; display: flex; flex-direction: column; align-items: flex-start; justify-content: center; gap: 6px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-raised); box-shadow: var(--shadow-sm); }
+.pager-link:hover { border-color: color-mix(in srgb, var(--brand) 34%, var(--border)); background: var(--card); }
+.pager-link small { color: var(--muted); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+.pager-link span { display: flex; align-items: center; gap: 7px; color: var(--brand-strong); font-size: 13px; font-weight: 500; }
+.pager-link.next { align-items: flex-end; text-align: right; }
+.pager-link.next span { justify-content: flex-end; }
+.pager-link p { max-width: 270px; margin: 2px 0 0; display: -webkit-box; overflow: hidden; color: var(--muted); font-size: 11px; line-height: 1.5; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+.toc { position: fixed; top: 68px; right: 0; bottom: 0; left: 1030px; padding: 56px 24px; overflow-y: auto; }
+.toc > p { margin: 0 0 12px; color: var(--muted); font-size: 10px; font-weight: 700; letter-spacing: .13em; text-transform: uppercase; }
+.toc nav { display: grid; }
+.toc a { position: relative; padding: 6px 0 6px 13px; color: var(--muted); border-left: 1px solid var(--border); font-size: 12px; line-height: 18px; }
+.toc a:hover, .toc a.active { color: var(--foreground); }
+.toc a.active { color: var(--brand-strong); border-left-color: var(--brand); }
+.toc a.nested { padding-left: 24px; }
+.not-found { min-height: 80vh; padding: 120px 24px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; }
+.not-found h1 { color: var(--foreground); font-family: var(--font-serif); font-size: 40px; }
+.not-found p { color: var(--muted); }
+.site-footer { width: min(1104px, calc(100% - 48px)); margin: 0 auto; padding: 40px 0; display: flex; justify-content: space-between; gap: 24px; border-top: 1px solid var(--border); }
+.site-footer > div > p { margin: 10px 0 0; color: var(--muted); font-size: 12px; }
+.site-footer nav { display: flex; align-items: center; gap: 20px; color: var(--muted); font-size: 13px; }
+.site-footer nav a:hover { color: var(--foreground); }
+
+@media (hover: hover) and (pointer: fine) {
+  .markdown-body a.heading-anchor { color: transparent; }
+  .markdown-body h2:hover .heading-anchor, .markdown-body h3:hover .heading-anchor { color: var(--muted); }
+  .markdown-body .heading-anchor:focus-visible { color: var(--muted); }
+}
+
+@media (max-width: 1050px) {
+  .docs-layout { grid-template-columns: 250px minmax(0, 760px); }
+  .docs-sidebar { width: 250px; }
+  .toc { display: none; }
+  .header-links { gap: 16px; }
+  .header-search { width: 200px; }
+}
+
+@media (max-width: 1000px) {
+  .header-links { display: none; }
+  .icon-button.menu-toggle { display: inline-grid; }
+}
+
+@media (max-width: 800px) {
+  .header-inner { padding: 0 18px; }
+  .header-search { margin-left: auto; }
+  .home-hero { min-height: auto; padding-top: 84px; grid-template-columns: 1fr; align-items: start; gap: 54px; }
+  .loop-card { max-width: 480px; transform: none; }
+  .feature-grid, .path-grid, .path-grid-2, .resource-grid { grid-template-columns: 1fr; }
+  .feature-grid article { min-height: 190px; }
+  .process-section, .quick-start { grid-template-columns: 1fr; gap: 52px; }
+  .section-heading-row { grid-template-columns: 1fr; gap: 22px; }
+  .path-card { min-height: 260px; }
+  .home-table { font-size: 14px; }
+  .docs-layout { display: block; }
+  .docs-sidebar { display: none; }
+  .docs-main { width: min(760px, 100%); margin: 0 auto; padding-top: 48px; }
+}
+
+@media (max-width: 720px) {
+  .markdown-body .mermaid-diagram svg { min-width: 600px; }
+  .markdown-body .mermaid-diagram { background: linear-gradient(90deg, var(--card) 45%, transparent) left center / 32px 100% no-repeat local, linear-gradient(270deg, var(--card) 45%, transparent) right center / 32px 100% no-repeat local, radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) left center / 14px 100% no-repeat scroll, radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) right center / 14px 100% no-repeat scroll, var(--card); }
+  .fig-flow-track, .fig-lane, .fig-group { flex-direction: column; align-items: stretch; }
+  .fig-group { padding-top: 16px; }
+  .fig-group-label { position: static; white-space: normal; text-align: center; }
+  .fig-flow-track .fig-arrow-next, .fig-lane .fig-arrow-next, .fig-group .fig-arrow-next, .fig-lane .fig-arrow-back, .fig-group .fig-arrow-back { transform: rotate(90deg); }
+  .fig-flow-loop { text-align: center; }
+  .config-row, .ownership-scope, .ownership-groups { grid-template-columns: 1fr; }
+}
+
 @media (max-width: 600px) {
-  .markdown-body .page-brief { grid-template-columns: 1fr; gap: 2px 0; margin-top: -8px; }
+  .header-inner { gap: 8px; }
+  .header-search { width: 44px; }
+  .search-trigger { width: 44px; padding: 0; justify-content: center; border: 0; background: transparent; box-shadow: none; }
+  .search-trigger span, .search-trigger kbd { display: none; }
+  .home-hero, .home-section { width: calc(100% - 28px); padding-right: 8px; padding-left: 8px; }
+  .home-hero { padding-top: 66px; padding-bottom: 72px; }
+  .home h1 { font-size: 46px; }
+  .lead { font-size: 17px; }
+  .home-section { padding-top: 76px; padding-bottom: 76px; }
+  .home h2 { font-size: 32px; }
+  .path-grid { margin-top: 34px; }
+  .path-card { min-height: 250px; padding: 22px; }
+  .path-card-icon { margin-bottom: 28px; }
+  .docs-main { padding: 40px 20px 72px; }
+  .doc-context { margin-bottom: 22px; }
+  .markdown-body { font-size: 16px; line-height: 1.68; }
+  .markdown-body h1 { font-size: 31px; }
+  .markdown-body td { overflow-wrap: anywhere; }
+  .markdown-body th { overflow-wrap: normal; }
+  .markdown-body .page-brief { margin-top: -8px; grid-template-columns: 1fr; gap: 2px 0; }
   .markdown-body .page-brief dd { margin-bottom: 8px; }
   .markdown-body .page-brief dd:last-child { margin-bottom: 0; }
+  .pager { grid-template-columns: 1fr; }
+  .pager-link { min-height: 112px; }
+  .site-footer { align-items: flex-start; flex-direction: column; }
+  .site-footer nav { flex-wrap: wrap; }
+}
+
+@media (pointer: coarse) {
+  .icon-button { width: 44px; height: 44px; }
+  .search-trigger { min-width: 44px; min-height: 44px; }
+  .logo { min-height: 44px; }
+  .markdown-body a.heading-anchor { padding: 10px 15px; margin-left: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
 }


### PR DESCRIPTION
## Summary

- consolidate the docs site’s base rules and late visual overrides into one design system stylesheet
- use 16px DM Sans for documentation prose and reserve Source Serif 4 for page-level headings
- increase prose and muted-text contrast while preserving the existing homepage composition and docs column widths
- update stylesheet references used by the layout and rendering comments

## Validation

- `npm run lint`
- `npm run check:docs`
- `npm run build`
- visually checked the Configuration page and homepage at the desktop breakpoint