### PR TITLE
docs(site): put mermaid diagrams on the site's type and color system

### DIFF
--- a/docs/contributing/codebase-structure.rst
+++ b/docs/contributing/codebase-structure.rst
@@ -19,32 +19,31 @@ composition and use paths; they are not an exhaustive Python import graph:
 
 .. code:: mermaid
 
-   %%{init: {"flowchart": {"curve": "linear", "wrappingWidth": 220, "nodeSpacing": 28, "rankSpacing": 42}}}%%
    flowchart TD
        accTitle: Reef application kernel, capability domains, and adapters
 
-       Methods("<b>METHOD PLUG-INS</b><br/><code>recipes/*</code>")
-       Entry("<b>ENTRYPOINTS</b><br/>HTTP · CLI")
-       Policy("<b>POLICY</b><br/><code>reef/recipe</code>")
-       Service("<b>DELIVERY &amp; COMPOSITION</b><br/><code>reef/service</code>")
-       Kernel(["<b>APPLICATION KERNEL</b><br/><code>reef/dispatcher</code> · <code>reef/scenario</code>"])
+       Methods("<b>Method plug-ins</b><br/><code>recipes/*</code>")
+       Entry("<b>Entrypoints</b><br/>HTTP · CLI")
+       Policy("<b>Policy</b><br/><code>reef/recipe</code>")
+       Service("<b>Delivery &amp; composition</b><br/><code>reef/service</code>")
+       Kernel(["<b>Application kernel</b><br/><code>reef/dispatcher</code> · <code>reef/scenario</code>"])
 
-       subgraph Domains["CAPABILITY DOMAINS"]
+       subgraph Domains["Capability domains"]
            direction LR
-           Serving("<b>SERVING</b><br/><code>runtime</code> · <code>surface</code>")
-           Evolution("<b>EVOLUTION</b><br/><code>train</code> · <code>harness</code>")
-           State("<b>STATE</b><br/><code>artifact</code> · <code>records</code>")
+           Serving("<b>Serving</b><br/><code>runtime</code> · <code>surface</code>")
+           Evolution("<b>Evolution</b><br/><code>train</code> · <code>harness</code>")
+           State("<b>State</b><br/><code>artifact</code> · <code>records</code>")
        end
 
-       subgraph Adapters["CONCRETE ADAPTERS"]
+       subgraph Adapters["Concrete adapters"]
            direction LR
-           ServingAdapters[["runtime adapters<br/>surface implementations"]]
-           EvolutionAdapters[["training backends<br/>harness adapters"]]
-           StateAdapters[["Git/LFS repositories<br/>SQLite"]]
+           ServingAdapters("runtime adapters<br/>surface implementations")
+           EvolutionAdapters("training backends<br/>harness adapters")
+           StateAdapters("Git/LFS repositories<br/>SQLite")
        end
 
-       Observability(["<b>CROSS-CUTTING</b><br/><code>reef/observability</code>"])
-       Core(["<b>SHARED KERNEL</b><br/><code>reef/core</code>"])
+       Observability(["<b>Cross-cutting</b><br/><code>reef/observability</code>"])
+       Core(["<b>Shared kernel</b><br/><code>reef/core</code>"])
 
        Methods --> Policy --> Kernel
        Entry --> Service --> Kernel

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -24,6 +24,7 @@
   --brand-strong: #7a1f1a;
   --brand-soft: #fbf2f0;
   --coral: #a03729;
+  --diagram-line: #cec7bb;
   --diagram-emphasis: #dceeea;
   --diagram-emphasis-border: #3f8077;
   --diagram-emphasis-text: #21433f;
@@ -65,6 +66,7 @@ html[data-theme="dark"] {
   --brand-strong: #eeb2a5;
   --brand-soft: #241a18;
   --coral: #d99183;
+  --diagram-line: #443d34;
   --diagram-emphasis: #21423c;
   --diagram-emphasis-border: #68a79d;
   --diagram-emphasis-text: #d9eee9;
@@ -277,6 +279,34 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .markdown-body .mermaid-error figcaption { color: var(--muted); }
 .markdown-body .mermaid-error pre { margin-bottom: 0; }
 .markdown-body .mermaid-loading { min-height: 240px; display: grid; place-items: center; color: var(--muted); font-size: 13px; }
+/* Diagram typography. Mermaid ships its own type system: its default face, one
+   uniform weight for every label, and inline code wearing the brand red it
+   earns in prose, where it is rare and not repeated eleven times inside one
+   frame. These rules put diagram text back on the page's scale, and set group
+   titles in the same micro-label idiom as .page-brief dt so the group headings
+   are the only uppercase in the frame. Mermaid draws a subgraph title inside
+   the band without reserving a row for it, so the row comes from
+   `subGraphTitleMargin` in the diagram config; it also sizes the label box from
+   its own defaults before these rules apply, so the box is too narrow once the
+   title is uppercased and tracked and is allowed to overflow rather than wrap.
+   The title chip is the band's own fill, so a connector entering the group is
+   masked instead of striking through it. */
+.markdown-body .mermaid-diagram .nodeLabel, .markdown-body .mermaid-diagram .edgeLabel, .markdown-body .mermaid-diagram .cluster-label { font-family: var(--font-sans); }
+.markdown-body .mermaid-diagram .nodeLabel { color: var(--foreground); font-size: 12.5px; font-weight: 500; line-height: 1.45; }
+.markdown-body .mermaid-diagram .nodeLabel b, .markdown-body .mermaid-diagram .nodeLabel strong { font-weight: 600; letter-spacing: .005em; }
+.markdown-body .mermaid-diagram .nodeLabel code, .markdown-body .mermaid-diagram .nodeLabel .literal, .markdown-body .mermaid-diagram .edgeLabel code { padding: 0; color: var(--muted); border-radius: 0; background: none; font-size: 11px; font-weight: 400; overflow-wrap: normal; }
+.markdown-body .mermaid-diagram .edgeLabel, .markdown-body .mermaid-diagram .edgeLabel p { color: var(--muted); font-size: 11px; line-height: 1.3; }
+.markdown-body .mermaid-diagram .cluster-label foreignObject { overflow: visible; }
+/* Mermaid colors this span from an id-scoped rule, so the title needs the
+   override to stay a label rather than a second heading. */
+.markdown-body .mermaid-diagram .cluster-label .nodeLabel { display: inline-block; padding: 0 9px; color: var(--muted) !important; background: var(--accent); font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; white-space: nowrap; }
+/* The title is a <p> inside an inline <span>; without this the span fragments
+   around the block child and paints a stray chip beside the title. */
+.markdown-body .mermaid-diagram .cluster-label p { padding: 0; background: none; }
+.markdown-body .mermaid-diagram .flowchart-link { stroke-width: 1.1px; }
+.markdown-body .mermaid-diagram marker path { fill: var(--muted); stroke: none; }
+.markdown-body .mermaid-diagram .cluster rect { stroke-width: 1px; }
+.markdown-body .mermaid-diagram .node rect, .markdown-body .mermaid-diagram .node polygon, .markdown-body .mermaid-diagram .node path { stroke-width: 1px; }
 
 /* Documentation components */
 .markdown-body .fig { margin: 28px 0 36px; padding: 24px 18px; border: 1px solid var(--border); border-radius: 4px; background: var(--card); }

--- a/docs/site/components/mermaid-diagram.tsx
+++ b/docs/site/components/mermaid-diagram.tsx
@@ -73,21 +73,54 @@ const darkTheme = {
 // from the CSS variables at draw time so diagrams follow globals.css instead
 // of drifting when the palette changes.
 const paletteRoles: Record<string, string> = {
-  primaryColor: "--card",
-  mainBkg: "--card",
-  actorBkg: "--card",
-  edgeLabelBackground: "--background",
+  actorBkg: "--surface-raised",
+  edgeLabelBackground: "--card",
   tertiaryColor: "--accent",
   lineColor: "--muted",
   textColor: "--text",
   primaryTextColor: "--foreground",
   actorTextColor: "--foreground",
+  // Nodes sit on the figure's card, so they need their own raised surface and
+  // the page's hairline border; the fallback themes' green borders belong to a
+  // palette the site no longer uses.
+  primaryColor: "--surface-raised",
+  mainBkg: "--surface-raised",
+  nodeBorder: "--diagram-line",
+  primaryBorderColor: "--diagram-line",
+  // The group bands carry their title and their contents; an outline around
+  // them adds a third frame inside the figure's own card, and puts a rule
+  // exactly where the title sits.
+  clusterBkg: "--accent",
+  clusterBorder: "--accent",
+  // Sequence diagrams carried their own teal from the fallback theme, which
+  // reads as a second design next to a flowchart on the same page.
+  actorBorder: "--diagram-line",
+  actorLineColor: "--diagram-line",
+  signalColor: "--muted",
+  signalTextColor: "--text",
+  labelBoxBkgColor: "--accent",
+  labelBoxBorderColor: "--diagram-line",
+  labelTextColor: "--muted",
+  loopTextColor: "--text",
+  noteBkgColor: "--accent",
+  noteBorderColor: "--diagram-line",
+  noteTextColor: "--text",
+  activationBkgColor: "--accent",
+  activationBorderColor: "--diagram-line",
+  sequenceNumberColor: "--card",
 };
 
-function paletteOverrides(): Record<string, string> {
+// Mermaid ships Trebuchet MS as its default face. Left alone, every diagram
+// renders in a typeface the site uses nowhere else, which reads as a pasted-in
+// artifact rather than part of the page.
+const typographyRoles: Record<string, string> = {
+  fontFamily: "--font-sans",
+};
+
+function cssOverrides(roles: Record<string, string>): Record<string, string> {
   const style = getComputedStyle(document.documentElement);
   const overrides: Record<string, string> = {};
-  for (const [variable, cssVar] of Object.entries(paletteRoles)) {
+  for (const [variable, cssVar] of Object.entries(roles)) {
     const value = style.getPropertyValue(cssVar).trim();
     if (value) overrides[variable] = value;
   }
@@ -100,14 +133,20 @@ function renderDiagram(id: string, chart: string, dark: boolean) {
       startOnLoad: false,
       securityLevel: "strict",
       theme: "base",
-      themeVariables: { ...(dark ? darkTheme : lightTheme), ...paletteOverrides() },
+      themeVariables: {
+        ...(dark ? darkTheme : lightTheme),
+        fontSize: "13px",
+        ...cssOverrides({ ...paletteRoles, ...typographyRoles }),
+      },
       flowchart: {
         htmlLabels: true,
         useMaxWidth: true,
         curve: "basis",
-        nodeSpacing: 30,
-        rankSpacing: 42,
+        nodeSpacing: 24,
+        rankSpacing: 34,
         padding: 12,
+        diagramPadding: 4,
+        subGraphTitleMargin: { top: 0, bottom: 26 },
       },
       sequence: {
         useMaxWidth: true,


### PR DESCRIPTION
The Codebase structure diagram read as pasted in rather than part of the page. The cause was not that diagram: mermaid was rendering with its own defaults on every docs page.

**What was off**

- **Typeface.** No `fontFamily` was set, so every diagram rendered in mermaid's default Trebuchet MS — a face the site uses nowhere else.
- **Node code.** `<code>` inside labels inherited the prose brand red, which works when inline code is rare in a paragraph and turns into noise repeated eleven times inside one frame.
- **Palette.** Node borders and cluster fills came from the fallback teal theme, two palettes ago; sequence diagrams were entirely teal next to a flowchart on the same page.
- **Group titles.** Mermaid draws a subgraph title inside the band without reserving a row for it, so at any padding it landed on the first row of nodes.
- **Case.** Every node title was bold all-caps without tracking: eleven labels shouting at one level, no hierarchy.

**What changed**

`components/mermaid-diagram.tsx` — font family read from `--font-sans` at draw time alongside the palette; nodes on `--surface-raised` with a new `--diagram-line` hairline; borderless group bands; the sequence-diagram variables mapped to the same tokens; `subGraphTitleMargin` gives the group title its own row; spacing tightened.

`app/globals.css` — node titles at 12.5px/500, paths in muted 11px mono, group titles in the same micro-label idiom as the sidebar and `.page-brief dt`, on a chip in the band's own fill so a connector entering the group is masked rather than striking through the title.

`docs/contributing/codebase-structure.rst` — typography only, no wording changed: node titles lose the all-caps, the three adapter nodes take the same rounded shape as every other node, and the per-diagram `%%{init}%%` override goes so this figure follows the same configuration as the other ten.

The diagram is 45px shorter and narrower than before.

**Checked**

Codebase structure, Architecture (both diagrams), Write a recipe, and Python API, in light and dark. `npm run lint`, `npm run check:docs`, and `npm run build` pass.

**Left alone**

`--diagram-emphasis` is still defined only in the palette before last, so emphasized nodes (the checkpoint cylinders on Architecture, the method's own steps on Write a recipe) stay teal on a warm-paper page. Retuning it also touches `.fig-emphasis` and `.fig-group` on the home page, so it is worth deciding separately.