### PR TITLE
docs: rename the harness evolution page to cordis

### DIFF
--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -149,7 +149,7 @@ Keep the ``tasks`` list short because it sets each step's cost. Start Reef where
 package is importable, and give ``-c`` an absolute path: Reef resolves a
 relative ``-c`` against its own repo root, not your working directory. Recovered
 tree state always wins over ``seed``. The full field list is in `harness_evolve
-<../user-guide/recipes/harness-evolve.rst>`__.
+<../user-guide/recipes/cordis.rst>`__.
 
 Selection policies
 ~~~~~~~~~~~~~~~~~~

--- a/docs/site/lib/docs.ts
+++ b/docs/site/lib/docs.ts
@@ -63,7 +63,7 @@ const navigationSources: ReadonlyArray<{ title: string; files: ReadonlyArray<str
       "user-guide/recipes/sao.rst",
       "user-guide/recipes/tttd.rst",
       "user-guide/recipes/openclawrl.rst",
-      "user-guide/recipes/harness-evolve.rst",
+      "user-guide/recipes/cordis.rst",
       "user-guide/operate.rst",
       "user-guide/troubleshooting.rst",
     ],

--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -155,12 +155,22 @@
     },
     {
       "source": "/docs/recipes/harness-evolve",
-      "destination": "/docs/user-guide/recipes/harness-evolve",
+      "destination": "/docs/user-guide/recipes/cordis",
+      "permanent": true
+    },
+    {
+      "source": "/docs/user-guide/recipes/harness-evolve",
+      "destination": "/docs/user-guide/recipes/cordis",
+      "permanent": true
+    },
+    {
+      "source": "/docs/user-guide/recipes/harness-evolve/",
+      "destination": "/docs/user-guide/recipes/cordis/",
       "permanent": true
     },
     {
       "source": "/docs/recipes/harness-evolve/",
-      "destination": "/docs/user-guide/recipes/harness-evolve/",
+      "destination": "/docs/user-guide/recipes/cordis/",
       "permanent": true
     },
     {

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -13,7 +13,7 @@ A recipe is picked along two axes: **what it evolves**, and **how it learns**.
 |                         | ``openclawrl``: multi-turn traffic,              |                                          |
 |                         | reward read from the next state                  |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+
-| **Harness:** prompts,   | ``harness_evolve``: proposes edits from          | not available                            |
+| **Harness:** prompts,   | ``cordis``: proposes edits from                  | not available                            |
 | rules, skills, config   | the failures in its own served traffic           |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+
 
@@ -30,7 +30,7 @@ Pick by the signal your workload can produce.
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 | Agent conversations without reports           | `openclawrl <recipes/openclawrl.rst>`__         | model weights | yes        |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
-| Feedback on individual requests, and failures | `harness_evolve <recipes/harness-evolve.rst>`__ | harness tree  | no         |
+| Feedback on individual requests, and failures | `cordis <recipes/cordis.rst>`__                 | harness tree  | no         |
 | worth learning from                           | (built into Reef)                               |               |            |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 | No feedback yet; record only                  | ``recipe``, the core record-only recipe         | nothing       | no         |

--- a/docs/user-guide/recipes/cordis.rst
+++ b/docs/user-guide/recipes/cordis.rst
@@ -1,9 +1,10 @@
-harness_evolve
-==============
+cordis
+======
 
-The harness half of Reef, built in: the general engine that evolves any kind
-of harness, carried by ``reef/train/cordis_backend/`` the way
-``slime_backend`` carries weights. It proposes one edit to the agent's harness
+The harness half of Reef, built in: cordis is the general engine that evolves
+any kind of harness, carried by ``reef/train/cordis_backend/`` the way
+``slime_backend`` carries weights. The demo deployment selects it through a
+recipe config named ``harness_evolve``. It proposes one edit to the agent's harness
 tree, runs the agent both ways on your tasks, and publishes the edit only if
 it wins. The demo lives in ``tutorials/harness_evolve/``; the paper-backed
 reproduction on the same engine is ``recipes/skillclaw/``.


### PR DESCRIPTION
## Motivation

The engine page still carried the harness_evolve identity. Since the restructure, cordis is the name of the general harness evolution engine built into Reef; harness_evolve is only the demo deployment's recipe config name. The page, the navigation, and the recipe tables should all say cordis.

## Changes

- Rename user-guide/recipes/harness-evolve.rst to cordis.rst and retitle it, stating that the demo selects the engine through a recipe config named harness_evolve
- Point the Choosing a recipe tables and the developer guide link at cordis
- Update the site navigation list
- Redirect the old page URLs (user-guide and legacy recipes paths) to /docs/user-guide/recipes/cordis

## Compatibility and operational impact

The page URL changes; all old URLs 308 to the new one through vercel.json.

## Verification

Site build passes (35/35 pages, navigation completeness check included). Rendered locally: the page serves at /docs/user-guide/recipes/cordis/ with the cordis title, the sidebar shows cordis and no harness_evolve entry, and the remaining harness-evolve strings in the tree are the scenario id and the redirect sources only.

## AI assistance

Claude Code wrote the rename and the redirects. I reviewed the diff.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
