### PR TITLE
docs: limit Vercel deployments to main

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -2,6 +2,12 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "npm run build",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  },
   "redirects": [
     {
       "source": "/docs/concepts",


### PR DESCRIPTION
## Summary

- disable automatic Vercel deployments for non-main branches
- keep Vercel production builds enabled for main
- leave the existing GitHub Actions docs gate unchanged

## Validation

- parsed docs/site/vercel.json successfully
- ran git diff --check