### PR TITLE
docs: clarify README learning loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,13 @@ artifact that should be updated. These implementations live in this
 repository's `recipes/` cookbook; they are selected by dotted class reference
 and do not ship in the Reef wheel.
 
-| Workload | Method and recipe | Updated artifact | Documentation |
+| Workload | Method / recipe module | Updated artifact | Documentation |
 |---|---|---|---|
-| A stream of tasks scored by tests or a verifier | SAO, `sao` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [Example](recipes/sao/examples/sao/README.md) |
-| Agent traffic with useful next-state signals and no explicit reports | OpenClaw-RL, `openclawrl` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
-| Repeated, scored attempts at one problem | TTT-Discover, `tttd` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
-| Scored code search with a trainable guidance model and a frozen executor | Guidance-TTT, `tttd` | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
-| Scored agent interactions used to improve prompts, rules, skills, or configuration | Harness evolution, `harness_evolve` | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
+| A stream of tasks scored by tests or a verifier | SAO<br>`recipes.sao.recipe:SAORecipe` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [Example](recipes/sao/examples/sao/README.md) |
+| Agent traffic with useful next-state signals and no explicit reports | OpenClaw-RL<br>`recipes.openclawrl.recipe:OpenClawRLRecipe` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
+| Repeated, scored attempts at one problem | TTT-Discover<br>`recipes.tttd.recipe:TTTDRecipe` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
+| Scored code search with a trainable guidance model and a frozen executor | Guidance-TTT<br>`recipes.tttd.recipe:TTTDRecipe` | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
+| Scored agent interactions used to improve prompts, rules, skills, or configuration | Harness evolution<br>`reef.train.cordis_backend.recipe:CordisRecipe` | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
 
 
 ## How is Reef different?

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ and do not ship in the Reef wheel.
 | A stream of tasks scored by tests or a verifier | SAO, `sao` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [Example](recipes/sao/examples/sao/README.md) |
 | Agent traffic with useful next-state signals and no explicit reports | OpenClaw-RL, `openclawrl` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
 | Repeated, scored attempts at one problem | TTT-Discover, `tttd` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
-| Scored code search with a trainable guidance model and a frozen executor | Guidance-TTT, `tttd` | Guidance-model weights | [Example and Reef results](recipes/tttd/examples/guidance_ttt/README.md) |
+| Scored code search with a trainable guidance model and a frozen executor | Guidance-TTT, `tttd` | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
 | Scored agent interactions used to improve prompts, rules, skills, or configuration | Harness evolution, `harness_evolve` | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
 
 

--- a/README.md
+++ b/README.md
@@ -197,13 +197,13 @@ artifact that should be updated. These implementations live in this
 repository's `recipes/` cookbook; they are selected by dotted class reference
 and do not ship in the Reef wheel.
 
-| Workload | Method / recipe module | Updated artifact | Documentation |
+| Workload | Recipe module | Updated artifact | Documentation |
 |---|---|---|---|
-| A stream of tasks scored by tests or a verifier | SAO<br><code>recipes.<wbr>sao.<wbr>recipe:<wbr>SAORecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [Example](recipes/sao/examples/sao/README.md) |
-| Agent traffic with useful next-state signals and no explicit reports | OpenClaw-RL<br><code>recipes.<wbr>openclawrl.<wbr>recipe:<wbr>OpenClawRLRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
-| Repeated, scored attempts at one problem | TTT-Discover<br><code>recipes.<wbr>tttd.<wbr>recipe:<wbr>TTTDRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
-| Scored code search with a trainable guidance model and a frozen executor | Guidance-TTT<br><code>recipes.<wbr>tttd.<wbr>recipe:<wbr>TTTDRecipe</code> | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
-| Scored agent interactions used to improve prompts, rules, skills, or configuration | Harness evolution<br><code>reef.<wbr>train.<wbr>cordis_backend.<wbr>recipe:<wbr>CordisRecipe</code> | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
+| A stream of tasks scored by tests or a verifier | <code>recipes.sao.recipe:SAORecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [Example](recipes/sao/examples/sao/README.md) |
+| Agent traffic with useful next-state signals and no explicit reports | <code>recipes.openclawrl.recipe:OpenClawRLRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
+| Repeated, scored attempts at one problem | <code>recipes.tttd.recipe:TTTDRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
+| Scored code search with a trainable guidance model and a frozen executor | <code>recipes.tttd.recipe:TTTDRecipe</code> | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
+| Scored agent interactions used to improve prompts, rules, skills, or configuration | <code>reef.train.cordis_backend.recipe:CordisRecipe</code> | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
 
 
 ## How is Reef different?

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ better and better results without having to do anything.
 Reef processes each learning cycle in four steps. The table also shows which
 modules implement each step.
 
-| Step | What happens | Core code |
-|---|---|---|
-| 1&nbsp;·&nbsp;Serve | Serve agent requests and record interactions. | [`service/`](reef/service) receives agent requests, returns model responses, and records each interaction. [`runtime/`](reef/runtime) runs inference and manages artifact updates. |
-| 2&nbsp;·&nbsp;Observe | Match feedback to recorded interactions. | [`records.py`](reef/records.py) stores agent interactions and feedback. [`train/processors/`](reef/train/processors) matches reports with the interactions they reference and decides what can be used for learning. |
-| 3&nbsp;·&nbsp;Grow | Produce an update from eligible records. | [`recipe/`](reef/recipe) defines how learning recipes plug into Reef. [`train/`](reef/train) builds batches and runs update jobs. |
-| 4&nbsp;·&nbsp;Commit | Evaluate and publish accepted updates. | [`train/evaluation/`](reef/train/evaluation) evaluates each candidate and decides whether to accept it. [`artifact/`](reef/artifact) stores the Git-backed version history. [`surface/`](reef/surface) delivers each artifact to the serving runtime. |
+| Step | What happens | Where it lives |
+|:---:|---|---|
+| **1&nbsp;·&nbsp;Serve** | Serve agent requests and record interactions. | [`service/`](reef/service) — agent requests and interaction records<br>[`runtime/`](reef/runtime) — inference and artifact updates |
+| **2&nbsp;·&nbsp;Observe** | Match feedback to recorded interactions. | [`records.py`](reef/records.py) — stored interactions and feedback<br>[`train/processors/`](reef/train/processors) — feedback matching and eligibility |
+| **3&nbsp;·&nbsp;Grow** | Produce an update from eligible records. | [`recipe/`](reef/recipe) — recipe integration<br>[`train/`](reef/train) — batches and update jobs |
+| **4&nbsp;·&nbsp;Commit** | Evaluate and publish accepted updates. | [`train/evaluation/`](reef/train/evaluation) — candidate evaluation<br>[`artifact/`](reef/artifact) — version history<br>[`surface/`](reef/surface) — artifact delivery |
 
 
 ## Using Reef

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Reef processes each learning cycle in four steps. The table also shows which
 modules implement each step.
 
 | Step | What happens | Where it lives |
-|:---:|---|---|
+|---|---|---|
 | **1&nbsp;·&nbsp;Serve** | Serve agent requests and record interactions. | [`service/`](reef/service) — agent requests and interaction records<br>[`runtime/`](reef/runtime) — inference and artifact updates |
 | **2&nbsp;·&nbsp;Observe** | Match feedback to recorded interactions. | [`records.py`](reef/records.py) — stored interactions and feedback<br>[`train/processors/`](reef/train/processors) — feedback matching and eligibility |
 | **3&nbsp;·&nbsp;Grow** | Produce an update from eligible records. | [`recipe/`](reef/recipe) — recipe integration<br>[`train/`](reef/train) — batches and update jobs |

--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ and do not ship in the Reef wheel.
 
 | Workload | Method / recipe module | Updated artifact | Documentation |
 |---|---|---|---|
-| A stream of tasks scored by tests or a verifier | SAO<br>`recipes.sao.recipe:SAORecipe` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [Example](recipes/sao/examples/sao/README.md) |
-| Agent traffic with useful next-state signals and no explicit reports | OpenClaw-RL<br>`recipes.openclawrl.recipe:OpenClawRLRecipe` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
-| Repeated, scored attempts at one problem | TTT-Discover<br>`recipes.tttd.recipe:TTTDRecipe` | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
-| Scored code search with a trainable guidance model and a frozen executor | Guidance-TTT<br>`recipes.tttd.recipe:TTTDRecipe` | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
-| Scored agent interactions used to improve prompts, rules, skills, or configuration | Harness evolution<br>`reef.train.cordis_backend.recipe:CordisRecipe` | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
+| A stream of tasks scored by tests or a verifier | SAO<br><code>recipes.<wbr>sao.<wbr>recipe:<wbr>SAORecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [Example](recipes/sao/examples/sao/README.md) |
+| Agent traffic with useful next-state signals and no explicit reports | OpenClaw-RL<br><code>recipes.<wbr>openclawrl.<wbr>recipe:<wbr>OpenClawRLRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
+| Repeated, scored attempts at one problem | TTT-Discover<br><code>recipes.<wbr>tttd.<wbr>recipe:<wbr>TTTDRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
+| Scored code search with a trainable guidance model and a frozen executor | Guidance-TTT<br><code>recipes.<wbr>tttd.<wbr>recipe:<wbr>TTTDRecipe</code> | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
+| Scored agent interactions used to improve prompts, rules, skills, or configuration | Harness evolution<br><code>reef.<wbr>train.<wbr>cordis_backend.<wbr>recipe:<wbr>CordisRecipe</code> | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
 
 
 ## How is Reef different?

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
+<div align="left">
+
 Reef is infrastructure that serves an entire continual learning backend. Reef
 exposes standardized http endpoints so that you can download agents just like
 how you download `codex` or `opencode` using `curl`, and so that your agent can
@@ -25,6 +27,8 @@ send its model requests to Reef's inference endpoint instead of the provider's.
 The only difference is that, Reef constantly evaluates your agent behavior
 and improves the served harness and model weights in the backend. You keep getting
 better and better results without having to do anything.
+
+</div>
 
 </div>
 
@@ -43,10 +47,10 @@ modules implement each step.
 
 | Step | What happens | Core code |
 |---|---|---|
-| 1&nbsp;·&nbsp;Serve | Forward a request to the model provider and store the interaction. | [`service/`](reef/service) implements HTTP routes, authentication, and streaming. [`runtime/`](reef/runtime) connects Reef to the model provider. |
-| 2&nbsp;·&nbsp;Observe | Associate each report with the stored interactions referenced by its receipts. | [`core/`](reef/core) defines the stored record types. [`dispatcher.py`](reef/dispatcher.py) sends each record to its scenario. |
-| 3&nbsp;·&nbsp;Grow | Build a batch from eligible records and use it to update model weights or harness files. | [`sao/`](recipes/sao), [`tttd/`](recipes/tttd), [`openclawrl/`](recipes/openclawrl), [`harness_evolve/`](reef/train/cordis_backend) are the learning methods, one package each; [`infra/recipe/`](reef/recipe) is the contract they implement and [`infra/train/`](reef/train) prepares batches and runs training jobs. |
-| 4&nbsp;·&nbsp;Commit | Gate the candidate against your tasks, then record an accepted update as a new version and make it available for serving. | [`train/evaluation/`](reef/train/evaluation) evaluates each candidate and decides whether to accept it. [`artifact/`](reef/artifact) stores the Git-backed version history. [`surface/`](reef/surface) delivers each artifact to the serving runtime or harness client. |
+| 1&nbsp;·&nbsp;Serve | Serve agent requests and record interactions. | [`service/`](reef/service) receives agent requests, returns model responses, and records each interaction. [`runtime/`](reef/runtime) runs inference and manages artifact updates. |
+| 2&nbsp;·&nbsp;Observe | Match feedback to recorded interactions. | [`records.py`](reef/records.py) stores agent interactions and feedback. [`train/processors/`](reef/train/processors) matches reports with the interactions they reference and decides what can be used for learning. |
+| 3&nbsp;·&nbsp;Grow | Produce an update from eligible records. | [`recipe/`](reef/recipe) defines how learning recipes plug into Reef. [`train/`](reef/train) builds batches and runs update jobs. |
+| 4&nbsp;·&nbsp;Commit | Evaluate and publish accepted updates. | [`train/evaluation/`](reef/train/evaluation) evaluates each candidate and decides whether to accept it. [`artifact/`](reef/artifact) stores the Git-backed version history. [`surface/`](reef/surface) delivers each artifact to the serving runtime. |
 
 
 ## Using Reef


### PR DESCRIPTION
## Motivation

The README learning-loop table used imprecise package descriptions and made Reef-owned infrastructure sound like built-in learning methods. The introductory prose was also centered with the surrounding header content.

## Changes

- Left-align the two introductory paragraphs while keeping the logo, heading, and badges centered.
- Shorten the Serve, Observe, Grow, and Commit summaries.
- Correct the package boundaries across service/runtime, records/processors, recipe/train, and evaluation/artifact/surface.
- Remove references that imply cookbook recipes are built-in Reef learning methods.

## Compatibility and operational impact

None. Documentation only.

## Verification

- git diff --check — passed
- npm ci — passed
- npm run check:docs — passed; validated 114 Markdown files, 34 RST files, and internal docs routes
- npm run lint — passed
- npm run build — passed

## AI assistance

OpenAI Codex inspected the package boundaries, edited README.md, and ran the documentation checks. The author reviewed the wording and final diff.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the maintenance model for review and merge requirements.