### PR TITLE
refactor: move harness evolution recipe out of Reef infra

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 /recipes/sao/ @Benjamin-eecs
 /recipes/tttd/ @Benjamin-eecs
 /recipes/openclawrl/ @Benjamin-eecs
+/recipes/harness_evolve/ @Benjamin-eecs
 /reef/train/cordis_backend/ @Benjamin-eecs
 /reef/surface/ @Benjamin-eecs
 /third_party/cordis/ @Benjamin-eecs

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,6 +30,7 @@
           - "recipes/sao/**"
           - "recipes/tttd/**"
           - "recipes/openclawrl/**"
+          - "recipes/harness_evolve/**"
           - "reef/train/cordis_backend/**"
           - "reef/surface/**"
           - "third_party/cordis/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,6 @@ jobs:
           from reef.recipe import Recipe
           from reef.recipe.registry import recipe_class_for
           assert importlib.util.find_spec('reef.train.slime_backend') is not None
-          assert importlib.util.find_spec('reef.train.cordis_backend') is not None
-          assert importlib.util.find_spec('reef.train.cordis_backend.recipe') is None
           assert importlib.util.find_spec('recipes') is None
           assert not hasattr(rp, 'register_kind')
           assert recipe_class_for('recipe') is Recipe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,8 @@ jobs:
           from reef.recipe import Recipe
           from reef.recipe.registry import recipe_class_for
           assert importlib.util.find_spec('reef.train.slime_backend') is not None
+          assert importlib.util.find_spec('reef.train.cordis_backend') is not None
+          assert importlib.util.find_spec('reef.train.cordis_backend.recipe') is None
           assert importlib.util.find_spec('recipes') is None
           assert not hasattr(rp, 'register_kind')
           assert recipe_class_for('recipe') is Recipe

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ and do not ship in the Reef wheel.
 | Agent traffic with useful next-state signals and no explicit reports | <code>recipes.openclawrl.recipe:OpenClawRLRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
 | Repeated, scored attempts at one problem | <code>recipes.tttd.recipe:TTTDRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
 | Scored code search with a trainable guidance model and a frozen executor | <code>recipes.tttd.recipe:TTTDRecipe</code> | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
-| Scored agent interactions used to improve prompts, rules, skills, or configuration | <code>reef.train.cordis_backend.recipe:CordisRecipe</code> | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
+| Scored agent interactions used to improve prompts, rules, skills, or configuration | <code>recipes.harness_evolve.recipe:HarnessEvolveRecipe</code> | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
 
 
 ## How is Reef different?

--- a/docs/contributing/codebase-structure.rst
+++ b/docs/contributing/codebase-structure.rst
@@ -8,8 +8,9 @@ Choose a destination
 --------------------
 
 ``reef/`` holds every shared mechanism, including the harness evolution engine
-at ``reef/train/cordis_backend/``. Paper-backed methods live in separate
-packages under ``recipes/`` (``sao``, ``tttd``, ``openclawrl``, ``skillclaw``)
+at ``reef/train/cordis_backend/``. Recipe implementations live in separate
+packages under ``recipes/`` (``harness_evolve``, ``sao``, ``tttd``,
+``openclawrl``, ``skillclaw``)
 with that method's recipe, processor, step preparer, and, for weight methods,
 the ``slime/`` subpackage only the training plane imports. Nothing under
 ``reef/`` imports a method package.

--- a/docs/developer-guide/processors.rst
+++ b/docs/developer-guide/processors.rst
@@ -122,10 +122,10 @@ Every file under ``reef/train/processors/`` is framework: ``base``,
 ``reported``, ``computed``, and ``common`` (shared report readers and sample
 builders). A method that owns its judgment writes
 ``recipes/<name>/processor.py``, and that file should show its data flow from
-top to bottom. A method that delegates to an engine backend writes none: the
-backend owns its concrete processor (``reef/train/cordis_backend/processor.py``)
-and wires it in its ``build``, which is why ``recipes/skillclaw/`` ships no
-processor file. Machinery beyond that file's job sits beside it as
+top to bottom. The reusable harness-evolution method owns
+``recipes/harness_evolve/processor.py`` and wires the Cordis backend in its
+recipe; ``recipes/skillclaw/`` inherits that processor rather than copying it.
+Machinery beyond a processor file's job sits beside it as
 modules named by concern (``recipes/openclawrl/``: ``sessions``, ``turns``,
 ``prm``), never in the processor file and never in a ``utils`` grab-bag.
 
@@ -151,7 +151,7 @@ Cookbook processors
 |                                             |          | scenario's grid; the step is the group, ready only when every    |                        |
 |                                             |          | ``groups_per_step`` x ``rollouts_per_group`` slot is filled      |                        |
 +---------------------------------------------+----------+------------------------------------------------------------------+------------------------+
-| ``reef/train/cordis_backend/processor.py``  | reported | a trainable, finitely scored report with exactly one reference   | ``TraceBatch``         |
+| ``recipes/harness_evolve/processor.py``     | reported | a trainable, finitely scored report with exactly one reference   | ``TraceBatch``         |
 |                                             |          | and a score inside ``[min_score, max_score]``; the recorded      |                        |
 |                                             |          | request is the sample, unmodified                                |                        |
 +---------------------------------------------+----------+------------------------------------------------------------------+------------------------+

--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -92,7 +92,7 @@ The recipe config names the callables, the tasks, and the first-boot tree:
 
 .. code:: yaml
 
-   implementation: reef.train.cordis_backend.recipe:CordisRecipe
+   implementation: recipes.harness_evolve.recipe:HarnessEvolveRecipe
 
    model:
      path: qwen3-8b

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -122,7 +122,7 @@ Harness-evolution presets also carry an ``evolution`` section:
 
 .. code:: yaml
 
-   implementation: reef.train.cordis_backend.recipe:CordisRecipe
+   implementation: recipes.harness_evolve.recipe:HarnessEvolveRecipe
    model:
      path: qwen3-8b
    data:

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -49,7 +49,7 @@ Recipe
 .. code:: python
 
    from reef.recipe import Recipe, WeightTrainingRecipe, config_field
-   from reef.train.cordis_backend import CordisRecipe
+   from recipes.harness_evolve import HarnessEvolveRecipe
 
 A recipe is one frozen dataclass binding a scenario to its serving and evolution
 behavior.
@@ -61,7 +61,7 @@ behavior.
    │   ├── SAORecipe                                        recipes.sao.recipe
    │   ├── TTTDRecipe                                       recipes.tttd.recipe
    │   └── OpenClawRLRecipe                                 recipes.openclawrl.recipe
-   └── CordisRecipe             harness tree + episodes  reef.train.cordis_backend
+   └── HarnessEvolveRecipe      harness tree + episodes  recipes.harness_evolve
        └── SkillClawRecipe                               recipes.skillclaw.harness
 
 Choose the narrowest class whose assumptions all hold. Inheriting ``Recipe``
@@ -75,7 +75,7 @@ recipe to remain record-only.
 +---------------------------------+------------------------------------------------------+
 | train and publish weights       | subclass ``WeightTrainingRecipe``                    |
 +---------------------------------+------------------------------------------------------+
-| use Reef's harness loop         | configure ``CordisRecipe``; subclass it only  |
+| use Reef's harness loop         | configure ``HarnessEvolveRecipe``; subclass it only  |
 |                                 | for a named preset or extra validation               |
 +---------------------------------+------------------------------------------------------+
 | evolve a different artifact     | subclass ``Recipe``, override ``build()`` and        |
@@ -521,7 +521,7 @@ Surface
 
 A surface binds one frozen release to its consumers.
 ``WeightTrainingRecipe.build_surface()`` already calls
-``create_weight_surface()``, and ``CordisRecipe`` calls
+``create_weight_surface()``, and ``HarnessEvolveRecipe`` calls
 ``create_harness_surface()``, so most methods never touch this.
 
 ``Surface`` is a frozen dataclass whose capabilities are fields, not subclass

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -13,7 +13,7 @@ A recipe is picked along two axes: **what it evolves**, and **how it learns**.
 |                         | ``openclawrl``: multi-turn traffic,              |                                          |
 |                         | reward read from the next state                  |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+
-| **Harness:** prompts,   | ``skillclaw``: grows a skill pool                  | not available                            |
+| **Harness:** prompts,   | ``harness_evolve``: improves a composition from    | not available                            |
 | rules, skills, config   | the failures in its own served traffic           |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+
 
@@ -30,8 +30,8 @@ Pick by the signal your workload can produce.
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 | Agent conversations without reports           | `openclawrl <recipes/openclawrl.rst>`__         | model weights | yes        |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
-| Feedback on individual requests, and failures | `skillclaw <recipes/skillclaw.rst>`__           | harness tree  | no         |
-| worth learning from                           | (built into Reef)                               |               |            |
+| Feedback on individual requests, and failures | `harness_evolve <evolve-your-harness.rst>`__    | harness tree  | no         |
+| worth learning from                           | cookbook recipe; ``skillclaw`` extends it       |               |            |
 +-----------------------------------------------+-------------------------------------------------+---------------+------------+
 
 How a recipe is selected

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -15,7 +15,7 @@ Starting Reef
 
 **A service never reports ready.** Its ``ready`` probe keeps failing; the stack waits ``ready_timeout`` seconds (3600 by default) before giving up. Read that service's log under ``run_dir``. For a training stack, the usual causes are a model that is still downloading, a ``reef.inference_url`` override that does not match where Slime bound its router (leave it unset; Reef takes the address from the training actor), or GPUs already in use.
 
-**Boot fails naming a config key.** A ``reef.*`` key that the selected recipe has no field for stops the start rather than being ignored. Recipe fields are listed in `Bundled recipes <recipes.rst>`__; ``harness_evolve`` takes none in the flat section and is configured through a preset.
+**Boot fails naming a config key.** A ``reef.*`` key that the selected recipe has no field for stops the start rather than being ignored. Recipe fields are listed in `Cookbook recipes <recipes.rst>`__; ``harness_evolve`` takes none in the flat section and is configured through a preset.
 
 **Boot fails naming a credential in the tree.** A harness-evolution seed, proposal, or recovered state holding a literal key (``apiKey``, ``token``, and their plural and list forms) is refused, because tree state is persisted and published. Rotate the key, remove it from the entry, and keep credentials in ``reef.upstream_api_key`` or an ``api_key_env``.
 
@@ -39,7 +39,7 @@ Reports and training
 
 **A report was accepted but nothing trains.** In order of likelihood: the recipe's step trigger is not reached yet (``batch_size`` reports, or a full ``groups_per_step × rollouts_per_group`` grid for ``tttd``); the report carries no finite ``score`` and the recipe requires one; ``metadata.training.eligible`` is ``false``; or the referenced receipts were already consumed by an earlier step, in which case the report is accepted and ignored. ``GET /reef/scenarios/{scenario}/contract`` shows what the recipe consumes; ``/reef/status`` shows whether a batch is ready.
 
-**400 on a report.** The recipe declares a report schema and the body violates it: a missing ``score``, a boolean where a number is expected, a missing ``metadata`` field. `Bundled recipes <recipes.rst>`__ lists each schema.
+**400 on a report.** The recipe declares a report schema and the body violates it: a missing ``score``, a boolean where a number is expected, a missing ``metadata`` field. `Cookbook recipes <recipes.rst>`__ lists each schema.
 
 **409 on a report.** The client-chosen ``agent_record_id`` was sent before with different content. Use a new id, or resend identical content.
 

--- a/recipes/harness_evolve/__init__.py
+++ b/recipes/harness_evolve/__init__.py
@@ -1,0 +1,6 @@
+"""Generic harness-evolution cookbook recipe built on the Cordis backend."""
+
+from recipes.harness_evolve.processor import HarnessEvolveProcessor
+from recipes.harness_evolve.recipe import HarnessEvolveRecipe
+
+__all__ = ["HarnessEvolveProcessor", "HarnessEvolveRecipe"]

--- a/recipes/harness_evolve/processor.py
+++ b/recipes/harness_evolve/processor.py
@@ -13,7 +13,7 @@ from reef.train.processors.reported import (
 from reef.train.types import ProcessorContext, TraceBatch, TraceSample
 
 
-class CordisProcessor(ReportedFeedbackProcessor):
+class HarnessEvolveProcessor(ReportedFeedbackProcessor):
     """Pair recorded requests with reported scores and batch them unmodified.
 
     Requests are recorded post-transform, so a trace shows exactly what the

--- a/recipes/harness_evolve/recipe.py
+++ b/recipes/harness_evolve/recipe.py
@@ -1,6 +1,6 @@
 """Harness evolution recipe: boots the composition mutation loop from config.
 
-``CordisRecipe`` boots the loop from a config yaml. ``propose`` and
+``HarnessEvolveRecipe`` boots the loop from a config yaml. ``propose`` and
 ``evaluate`` are Python callables, named as dotted ``module:attribute``
 references in YAML or passed directly when registering from code; ``propose``
 returns one ``Mutation``, a sequence of them (one composite proposal under
@@ -16,6 +16,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from recipes.harness_evolve.processor import HarnessEvolveProcessor
 from reef.core.reports import ScoredRolloutReport
 from reef.harness.adapters import get_adapter
 from reef.harness.descriptor import DescriptorError
@@ -29,7 +30,6 @@ from reef.records import RecordStore
 from reef.surface.base import Surface
 from reef.surface.harnesses import create_harness_surface
 from reef.train.cordis_backend import CordisBackend, EpisodeScorer, Proposer, ScoreComparisonSelector
-from reef.train.cordis_backend.processor import CordisProcessor
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
 from reef.train.evaluation.contracts import CandidateSelector
 from reef.train.evaluation.evaluators import AlwaysSelect, DefaultCandidateEvaluationPlugin
@@ -74,7 +74,7 @@ def _resolve_candidate_selector(value: Any) -> CandidateSelector:
 
 
 @dataclass(frozen=True)
-class CordisRecipe(Recipe):
+class HarnessEvolveRecipe(Recipe):
     """The harness evolution loop as a bootable recipe class.
 
     Config shape (the ``evolution`` section): ``adapter`` (a name
@@ -250,7 +250,7 @@ class CordisRecipe(Recipe):
         return Trainer.build(
             scenario,
             records,
-            processor_factory=lambda context: CordisProcessor(
+            processor_factory=lambda context: HarnessEvolveProcessor(
                 context.with_config({"batch_size": self.batch_size, "max_score": self.max_score})
             ),
             training_backend=training_backend,

--- a/recipes/skillclaw/harness/skillclaw_recipe.py
+++ b/recipes/skillclaw/harness/skillclaw_recipe.py
@@ -2,7 +2,7 @@
 
 ``skillclaw.yaml`` names this class as its dotted recipe reference
 (``harness.skillclaw_recipe:SkillClawRecipe``). It changes exactly two things over
-the stock ``CordisRecipe`` implementation:
+the stock ``HarnessEvolveRecipe`` implementation:
 
 - ``build_surface`` returns ``create_skill_surface([SkillCatalogModule(...)])``, so
   every ``/v1`` request the service proxies carries the served pool's
@@ -23,10 +23,10 @@ from dataclasses import KW_ONLY, dataclass
 from pathlib import Path
 from typing import Any
 
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.recipe.errors import RecipeConfigError
 from reef.surface import Surface
 from reef.surface.skills import SkillValidator, create_skill_surface
-from reef.train.cordis_backend import CordisRecipe
 
 from .catalog import SkillCatalogModule
 from .config import PUBLIC_SKILL_ROOT
@@ -53,7 +53,7 @@ def seed_skill_entries(skills_dir: Path) -> tuple[dict[str, Any], ...]:
 
 
 @dataclass(frozen=True)
-class SkillClawRecipe(CordisRecipe):
+class SkillClawRecipe(HarnessEvolveRecipe):
     """Harness evolution with catalog-injecting delivery of the skill pool."""
 
     _: KW_ONLY

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -487,14 +487,3 @@ def _write_rendered_files(files: Mapping[str, str]) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(text, encoding="utf-8")
     return directory
-
-
-# Re-exports of the engine's method shell; the ``as`` form marks them as
-# public per PEP 484, which keeps the unused-import hooks off them. Imported
-# last: recipe.py imports CordisBackend from this module.
-
-
-# Re-exports of the engine's method shell, imported last because recipe.py
-# imports CordisBackend from this module.
-from reef.train.cordis_backend.processor import CordisProcessor  # noqa: F401
-from reef.train.cordis_backend.recipe import CordisRecipe  # noqa: F401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ from reef.train.types import PolicyBatch, TrainingBatch
 # not, while importing a selected cookbook package registers its preparer and
 # lazy loss-family reference in this test process.
 for _cookbook_package in (
-    "reef.train.cordis_backend",
+    "recipes.harness_evolve",
     "recipes.openclawrl",
     "recipes.sao",
     "recipes.tttd",

--- a/tests/reef_service/test_commit_log.py
+++ b/tests/reef_service/test_commit_log.py
@@ -744,8 +744,8 @@ class _HarnessEvolveTestRecipe(Recipe):
     These tests exercise commit-log/version-chain mechanics, not
     harness-evolution semantics specifically; they just need a concrete,
     artifact-producing Recipe. Constructs CordisBackend and
-    CordisProcessor directly, the same shape
-    CordisRecipe.build() has, minus the config-boot layer these
+    HarnessEvolveProcessor directly, the same shape
+    HarnessEvolveRecipe.build() has, minus the config-boot layer these
     tests never touch (see tests/reef_service/test_harness_recipe.py for
     the backend's own guarantees).
     """
@@ -762,7 +762,7 @@ class _HarnessEvolveTestRecipe(Recipe):
         return create_harness_surface()
 
     def build(self, scenario, records, *, algorithm_state=None, experiment_logger=None) -> Trainer:
-        from reef.train.cordis_backend.processor import CordisProcessor
+        from recipes.harness_evolve import HarnessEvolveProcessor
 
         training_backend = CordisBackend(
             descriptor=get_adapter("pi"),
@@ -774,7 +774,7 @@ class _HarnessEvolveTestRecipe(Recipe):
         return Trainer.build(
             scenario,
             records,
-            processor_factory=lambda context: CordisProcessor(
+            processor_factory=lambda context: HarnessEvolveProcessor(
                 context.with_config({"batch_size": self.batch_size, "max_score": self.max_score})
             ),
             training_backend=training_backend,

--- a/tests/reef_service/test_dependency_boundaries.py
+++ b/tests/reef_service/test_dependency_boundaries.py
@@ -210,8 +210,6 @@ def test_harness_training_backend_does_not_require_gpu_dependencies() -> None:
         "import sys; sys.modules['ray'] = None; sys.modules['torch'] = None; "
         "import reef.train.cordis_backend as cordis; "
         "assert cordis.CordisBackend; "
-        "assert not hasattr(cordis, 'CordisRecipe'); "
-        "assert not hasattr(cordis, 'CordisProcessor'); "
         "assert not [m for m in sys.modules if m == 'recipes' or m.startswith('recipes.')], "
         "[m for m in sys.modules if m == 'recipes' or m.startswith('recipes.')]"
     )

--- a/tests/reef_service/test_dependency_boundaries.py
+++ b/tests/reef_service/test_dependency_boundaries.py
@@ -74,6 +74,19 @@ def test_infra_never_imports_a_method_package() -> None:
     assert offenders == []
 
 
+def test_training_integrations_do_not_define_recipe_implementations() -> None:
+    """Backends expose machinery; concrete recipe policy lives in recipes/."""
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "reef" / "train").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        offenders.extend(
+            f"{path.relative_to(REPO_ROOT)} -> {node.name}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef) and node.name.endswith("Recipe")
+        )
+    assert offenders == []
+
+
 def test_scenario_domain_does_not_depend_on_recipes() -> None:
     module = importlib.import_module("reef.scenario.scenario")
     tree = ast.parse(inspect.getsource(module))
@@ -195,8 +208,12 @@ def test_slime_step_preparation_resolves_tttd_torch_lazily() -> None:
 def test_harness_training_backend_does_not_require_gpu_dependencies() -> None:
     _assert_isolated_import(
         "import sys; sys.modules['ray'] = None; sys.modules['torch'] = None; "
-        "from reef.train.cordis_backend import CordisBackend; "
-        "assert CordisBackend"
+        "import reef.train.cordis_backend as cordis; "
+        "assert cordis.CordisBackend; "
+        "assert not hasattr(cordis, 'CordisRecipe'); "
+        "assert not hasattr(cordis, 'CordisProcessor'); "
+        "assert not [m for m in sys.modules if m == 'recipes' or m.startswith('recipes.')], "
+        "[m for m in sys.modules if m == 'recipes' or m.startswith('recipes.')]"
     )
 
 

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -22,6 +22,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from reef_client.client import ReefClient
 
 import reef.harness.adapters
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.artifact import InMemoryRepositoryBackend
 from reef.dispatcher import Dispatcher
 from reef.harness.adapters import get_adapter
@@ -33,7 +34,7 @@ from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.runtime.inference import InferenceBackend
 from reef.service.app import create_app
 from reef.service.install_script import HARNESS_RELEASE_SIDECAR, composition_checksum, render_install_script
-from reef.train.cordis_backend import CordisRecipe, Mutation
+from reef.train.cordis_backend import Mutation
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
 
 # The fake harness scores itself, as in test_harness_recipe.py: its
@@ -142,7 +143,7 @@ def _dispatcher(
     binary = tmp_path / "fake-pi"
     binary.write_text(PI_FAKE)
     binary.chmod(0o755)
-    recipe = CordisRecipe(
+    recipe = HarnessEvolveRecipe(
         resolve_proposer(lambda nodes, samples, model: next(proposals, None)),
         resolve_episode_scorer(evaluate),
         ("task one",),

--- a/tests/reef_service/test_harness_evolve_processor.py
+++ b/tests/reef_service/test_harness_evolve_processor.py
@@ -1,4 +1,4 @@
-"""CordisProcessor: the failed-trace batching half of harness evolution.
+"""HarnessEvolveProcessor: the failed-trace batching half of harness evolution.
 
 The processor pairs reports with their inference records and batches the
 traces whose scores fall inside the configured window; the evolution backend
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import pytest
 
+from recipes.harness_evolve import HarnessEvolveProcessor
 from reef.core import AgentRecord, RequestType
-from reef.train.cordis_backend.processor import CordisProcessor
 from reef.train.types import ProcessorContext, TraceBatch
 
 
@@ -33,8 +33,8 @@ def _report(agent_record_id: str, score: object, references: list[str]) -> Agent
     )
 
 
-def _processor(config: dict | None = None) -> CordisProcessor:
-    return CordisProcessor(ProcessorContext("s", config or {}))
+def _processor(config: dict | None = None) -> HarnessEvolveProcessor:
+    return HarnessEvolveProcessor(ProcessorContext("s", config or {}))
 
 
 def test_trace_processor_batches_a_failed_trace() -> None:
@@ -92,8 +92,8 @@ def test_trace_processor_validates_assembly_config_fields_at_construction() -> N
 
 
 def test_trace_processor_has_no_training_preparation_hook() -> None:
-    assert not hasattr(CordisProcessor, "prepare_training_step")
-    assert not hasattr(CordisProcessor, "prepare")
+    assert not hasattr(HarnessEvolveProcessor, "prepare_training_step")
+    assert not hasattr(HarnessEvolveProcessor, "prepare")
 
 
 def test_trace_processor_refuses_a_non_finite_score() -> None:

--- a/tests/reef_service/test_harness_example.py
+++ b/tests/reef_service/test_harness_example.py
@@ -13,13 +13,14 @@ from types import ModuleType
 import pytest
 import yaml
 
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.harness.episode import EpisodeResult
 from reef.harness.model_binding import ModelBindingError
 from reef.recipe import load_recipe_config
 from reef.records import RecordStore
 from reef.service.deploy.config import load_config
 from reef.service.deploy.settings import service_settings_from_config
-from reef.train.cordis_backend import CordisRecipe, Mutation
+from reef.train.cordis_backend import Mutation
 from reef.train.trainer import Trainer
 from reef.train.types import TraceSample
 
@@ -163,7 +164,7 @@ def test_example_yaml_boots_the_recipe_through_from_environment(evolution, tmp_p
     from reef.service.assembly import _upstream_runtime
 
     settings = load_recipe_config(materialized)
-    built = CordisRecipe.from_environment({}, config=settings, runtime=_upstream_runtime(service))
+    built = HarnessEvolveRecipe.from_environment({}, config=settings, runtime=_upstream_runtime(service))
     assert built.adapter == "pi"
     assert built.binary == str(tmp_path / "fake-pi")
     assert len(built.tasks) == 3

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 import reef.train.cordis_backend as reef_cordis_backend
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.artifact import InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
 from reef.core.reports import ScoredRolloutReport
@@ -22,7 +23,7 @@ from reef.recipe import RecipeConfigError
 from reef.recipe.registry import RecipeRegistry, recipe_class_for
 from reef.records import RecordStore
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
-from reef.train.cordis_backend import CordisBackend, CordisRecipe, Mutation, MutationError, ScoreComparisonSelector
+from reef.train.cordis_backend import CordisBackend, Mutation, MutationError, ScoreComparisonSelector
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
 from reef.train.evaluation import DefaultCandidateEvaluationPlugin
 from reef.train.trainer import Trainer
@@ -92,8 +93,8 @@ def runtime() -> InferenceProxyRuntime:
     return InferenceProxyRuntime(model_path=MODEL.model, base_url=MODEL.base_url, api_key=MODEL.api_key)
 
 
-def recipe(tmp_path: Path, propose, seed: tuple = ()) -> CordisRecipe:
-    return CordisRecipe(
+def recipe(tmp_path: Path, propose, seed: tuple = ()) -> HarnessEvolveRecipe:
+    return HarnessEvolveRecipe(
         resolve_proposer(propose),
         resolve_episode_scorer(evaluate),
         ("task one",),
@@ -147,7 +148,7 @@ def run_backend_step(
 
 
 def test_recipe_resolves_by_dotted_reference() -> None:
-    assert recipe_class_for("reef.train.cordis_backend.recipe:CordisRecipe") is CordisRecipe
+    assert recipe_class_for("recipes.harness_evolve.recipe:HarnessEvolveRecipe") is HarnessEvolveRecipe
     assert recipe_class_for("harness_evolve") is None
 
 
@@ -157,7 +158,7 @@ def test_yaml_config_boots_the_recipe_through_dotted_references(tmp_path: Path, 
         "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
     )
     monkeypatch.syspath_prepend(str(tmp_path))
-    built = CordisRecipe.from_environment(
+    built = HarnessEvolveRecipe.from_environment(
         {},
         config={
             "evolution": {
@@ -176,7 +177,7 @@ def test_yaml_config_boots_the_recipe_through_dotted_references(tmp_path: Path, 
 
 def test_config_without_evolution_section_is_rejected() -> None:
     with pytest.raises(RecipeConfigError, match="'evolution' config section"):
-        CordisRecipe.from_environment({}, config={})
+        HarnessEvolveRecipe.from_environment({}, config={})
 
 
 def test_build_returns_a_trainer_over_the_evolution_backend(tmp_path: Path) -> None:
@@ -737,12 +738,12 @@ def test_yaml_seed_must_be_a_list_of_mappings(tmp_path: Path, monkeypatch) -> No
             }
         }
 
-    built = CordisRecipe.from_environment({}, config=config([SEED_MODELS]))
+    built = HarnessEvolveRecipe.from_environment({}, config=config([SEED_MODELS]))
     assert built.seed == (SEED_MODELS,)
     with pytest.raises(RecipeConfigError, match=r"evolution\.seed must be a list"):
-        CordisRecipe.from_environment({}, config=config("models"))
+        HarnessEvolveRecipe.from_environment({}, config=config("models"))
     with pytest.raises(RecipeConfigError, match=r"evolution\.seed entries must be"):
-        CordisRecipe.from_environment({}, config=config(["models"]))
+        HarnessEvolveRecipe.from_environment({}, config=config(["models"]))
 
 
 def test_recipe_rejects_removed_acceptance_and_raw_selection_callable(tmp_path, monkeypatch) -> None:
@@ -765,9 +766,9 @@ def test_recipe_rejects_removed_acceptance_and_raw_selection_callable(tmp_path, 
         }
 
     with pytest.raises(RecipeConfigError, match=r"evolution\.acceptance was removed"):
-        CordisRecipe.from_environment({}, config=config(acceptance="always"))
+        HarnessEvolveRecipe.from_environment({}, config=config(acceptance="always"))
     with pytest.raises(RecipeConfigError, match=r"must provide decide"):
-        CordisRecipe.from_environment({}, config=config(selection="demo_method:accept"))
+        HarnessEvolveRecipe.from_environment({}, config=config(selection="demo_method:accept"))
 
 
 def test_recipe_resolves_candidate_selector(tmp_path, monkeypatch) -> None:
@@ -793,20 +794,20 @@ def test_recipe_resolves_candidate_selector(tmp_path, monkeypatch) -> None:
             }
         }
 
-    compared = CordisRecipe.from_environment({}, config=config())
+    compared = HarnessEvolveRecipe.from_environment({}, config=config())
     assert compared.candidate_selector is not None
     assert type(compared.candidate_selector).__name__ == "ScoreComparisonSelector"
 
-    named = CordisRecipe.from_environment({}, config=config(selection="always"))
+    named = HarnessEvolveRecipe.from_environment({}, config=config(selection="always"))
     assert named.candidate_selector is not None
     assert type(named.candidate_selector).__name__ == "AlwaysSelect"
 
-    dotted = CordisRecipe.from_environment({}, config=config(selection="demo_selection:policy"))
+    dotted = HarnessEvolveRecipe.from_environment({}, config=config(selection="demo_selection:policy"))
     assert dotted.candidate_selector is not None
     assert type(dotted.candidate_selector).__name__ == "Policy"
 
     with pytest.raises(RecipeConfigError, match="acceptance was removed"):
-        CordisRecipe.from_environment(
+        HarnessEvolveRecipe.from_environment(
             {},
             config=config(selection="always", acceptance="pairwise"),
         )
@@ -852,7 +853,7 @@ def test_propose_receives_the_model_binding(tmp_path: Path) -> None:
 
 
 def test_recipe_without_a_runtime_refuses_to_build(tmp_path: Path) -> None:
-    built = CordisRecipe(
+    built = HarnessEvolveRecipe(
         resolve_proposer(lambda n, s, m: None),
         resolve_episode_scorer(evaluate),
         ("task one",),

--- a/tests/reef_service/test_model_binding.py
+++ b/tests/reef_service/test_model_binding.py
@@ -9,12 +9,12 @@ from typing import Any
 
 import pytest
 
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.harness.adapters import get_adapter
 from reef.harness.model_binding import ModelBinding, ModelBindings
 from reef.harness.render import render_composition
 from reef.recipe import RecipeConfigError
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
-from reef.train.cordis_backend import CordisRecipe
 
 
 class _Response(io.BytesIO):
@@ -173,16 +173,16 @@ def test_recipe_declares_named_models_under_evolution_models(tmp_path) -> None:
             },
         }
         runtime = InferenceProxyRuntime(model_path="small", base_url="http://up")
-        built = CordisRecipe.from_environment({"TEACHER_KEY": "sk-t"}, config=config, runtime=runtime)
+        built = HarnessEvolveRecipe.from_environment({"TEACHER_KEY": "sk-t"}, config=config, runtime=runtime)
         models = built.model_bindings()
         assert models.served.model == "small" and models["teacher"].api_key == "sk-t"
 
         bad = {**config, "evolution": {**config["evolution"], "models": {"served": {"url": "http://x", "model": "m"}}}}
         with pytest.raises(RecipeConfigError, match="may not name a model 'served'"):
-            CordisRecipe.from_environment({}, config=bad, runtime=runtime)
+            HarnessEvolveRecipe.from_environment({}, config=bad, runtime=runtime)
         bad = {**config, "evolution": {**config["evolution"], "models": {"t": {"model": "m"}}}}
         with pytest.raises(RecipeConfigError, match=r"evolution\.models\.t\.url"):
-            CordisRecipe.from_environment({}, config=bad, runtime=runtime)
+            HarnessEvolveRecipe.from_environment({}, config=bad, runtime=runtime)
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("demo_models", None)

--- a/tests/reef_service/test_skillclaw.py
+++ b/tests/reef_service/test_skillclaw.py
@@ -16,13 +16,13 @@ from typing import Any
 import pytest
 import yaml
 
+from recipes.harness_evolve import HarnessEvolveProcessor
 from reef.core import AgentRecord, RequestType
 from reef.harness.model_binding import ModelBinding, ModelBindings
 from reef.recipe import RecipeConfigError
 from reef.recipe.registry import build_recipe
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.train.cordis_backend import Mutation
-from reef.train.cordis_backend.processor import CordisProcessor
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
 from reef.train.evaluation import AlwaysSelect
 from reef.train.types import ProcessorContext, TraceSample
@@ -404,7 +404,7 @@ def test_the_days_last_report_completes_the_batch_passes_included() -> None:
             agent_record_id=agent_record_id,
         )
 
-    processor = CordisProcessor(ProcessorContext("s", {"batch_size": 3}))
+    processor = HarnessEvolveProcessor(ProcessorContext("s", {"batch_size": 3}))
     for index, score in enumerate((1.0, 0.0), start=1):
         processor.ingest(_inference(f"inf-{index}"))
         processor.ingest(_report(f"rep-{index}", score, f"inf-{index}"))

--- a/tests/reef_service/test_version_check.py
+++ b/tests/reef_service/test_version_check.py
@@ -16,12 +16,13 @@ from pathlib import Path
 
 import pytest
 
+from recipes.harness_evolve import HarnessEvolveRecipe
 from reef.harness.adapters import get_adapter
 from reef.harness.model_binding import ModelBinding
 from reef.harness.render import render_composition
 from reef.harness.version_check import VERSION_CHECK_ENTRY_ID, version_check_entry
 from reef.recipe import RecipeConfigError
-from reef.train.cordis_backend import CordisBackend, CordisRecipe
+from reef.train.cordis_backend import CordisBackend
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
 
 ASSET = Path(__file__).parents[2] / "reef" / "harness" / "adapters" / "pi" / "version_check.ts"
@@ -39,7 +40,7 @@ def _config(**evolution: object) -> dict[str, object]:
 
 
 def test_version_check_seeds_the_shipped_extension_and_renders_it_byte_exact() -> None:
-    recipe = CordisRecipe.from_environment({}, config=_config(version_check=True))
+    recipe = HarnessEvolveRecipe.from_environment({}, config=_config(version_check=True))
     entry = next(options for options in recipe.seed if options["id"] == VERSION_CHECK_ENTRY_ID)
     nodes = tuple((str(options["name"]), options["config"]) for options in recipe.seed)
     files = render_composition(nodes, get_adapter("pi"))
@@ -60,16 +61,16 @@ def test_version_check_entry_passes_the_backends_seed_validation() -> None:
 
 def test_version_check_refuses_an_adapter_without_a_shipped_extension() -> None:
     with pytest.raises(RecipeConfigError, match="'opencode' ships no version check extension"):
-        CordisRecipe.from_environment({}, config=_config(adapter="opencode", version_check=True))
+        HarnessEvolveRecipe.from_environment({}, config=_config(adapter="opencode", version_check=True))
 
 
 def test_version_check_must_be_a_boolean() -> None:
     with pytest.raises(RecipeConfigError, match="version_check must be a boolean"):
-        CordisRecipe.from_environment({}, config=_config(version_check="yes"))
+        HarnessEvolveRecipe.from_environment({}, config=_config(version_check="yes"))
 
 
 def test_version_check_off_by_default_seeds_nothing() -> None:
-    recipe = CordisRecipe.from_environment({}, config=_config())
+    recipe = HarnessEvolveRecipe.from_environment({}, config=_config())
     assert not any(options.get("id") == VERSION_CHECK_ENTRY_ID for options in recipe.seed)
 
 

--- a/tutorials/harness_evolve/serve.yaml
+++ b/tutorials/harness_evolve/serve.yaml
@@ -6,7 +6,7 @@
 # REEF_RECIPE_CONFIG_DIR, so run.sh copies those four sections into
 # work/recipes/harness_evolve.yaml.
 
-implementation: reef.train.cordis_backend.recipe:CordisRecipe
+implementation: recipes.harness_evolve.recipe:HarnessEvolveRecipe
 
 model:
   path: qwen3-8b


### PR DESCRIPTION
## Summary

- move the concrete harness evolution recipe and processor from reef.train.cordis_backend to recipes.harness_evolve
- rename them to HarnessEvolveRecipe and HarnessEvolveProcessor and update SkillClaw, tutorial configs, tests, docs, ownership, and labels
- keep CordisBackend as infrastructure-only machinery and add regression checks that reef.train integrations do not define recipe implementations
- verify the Reef wheel contains the Cordis backend but no cookbook recipe or processor

## Validation

- pre-commit run --all-files
- 242 focused recipe, config, boundary, and service tests passed
- full suite: 1614 passed, 2 skipped; one unrelated Git LFS integration test could not run because git-lfs is not installed locally
- built and inspected the wheel with pip wheel; no recipes package or Cordis recipe/processor modules are included