### PR TITLE
docs: match the harness evolution pages to the code behavior

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -28,10 +28,10 @@ agent.
    argv | the argument list for one headless prompt; ``{prompt}`` is substituted
    files | where each node kind renders, like ``skills/{name}/SKILL.md``
    trajectory | the format and path of the session log Reef reads back
-   env | variables pointing the agent's state under the episode root
-   install | the npm package and version the one-command install pins
-   model_binding | per provider dialect, the config that points the agent at the served model
-   cleanup_whitelist | files the agent's own boot creates, tolerated instead of read as drift
+   env | variables pointing the agent's state under the episode root; ``{root}`` is substituted
+   install | the one-command install pin: ``kind`` (``npm`` only), ``package``, ``version``, and ``binary_path`` under the install prefix
+   model_binding | per API dialect (``openai``, ``anthropic``), the config nodes Reef appends at evaluation time; ``{base_url}``, ``{api_key}``, and ``{model}`` substitute into string values
+   cleanup_whitelist | files the agent itself writes at boot or during the run, tolerated instead of read as drift
    quirks | an optional module for adapter-specific render checks and boot mutations
 
 Connect a new agent
@@ -48,13 +48,17 @@ To connect an agent that has no adapter yet:
       (`reef/harness/trajectory.py <../../reef/harness/trajectory.py>`__) and
       registers with ``@register_trajectory_reader``.
    #. The files its first boot creates go in ``cleanup_whitelist``, so a fresh
-      episode root is treated as clean.
+      episode root is treated as clean. ``dir/**`` tolerates a whole subtree
+      (session storage, ``node_modules``); any other entry is a glob against
+      the root-relative path, so anchor a single file with its full path, like
+      ``pi-agent/auth.json``. A bare directory name matches nothing under it.
 
 `reef/harness/descriptor.py <../../reef/harness/descriptor.py>`__ validates every
 descriptor at load, and the two bundled adapters under `reef/harness/adapters/
 <../../reef/harness/adapters>`__ are complete references. A third-party adapter
-registers on the ``reef.harness_adapters`` entry-point group. ``version_check:
-true`` writes an update prompt into the tree and ships for ``pi`` only. The
+registers on the ``reef.harness_adapters`` entry-point group.
+``evolution.version_check: true`` in the recipe config writes an update
+prompt into the tree and ships for ``pi`` only. The
 prompt offers to run the update or skip in interactive mode and prints the
 instructions in headless mode. An ``opencode`` recipe that sets it refuses to
 boot. An evolved tree is adapter-specific: ``config`` node contents follow each

--- a/docs/developer-guide/processors.rst
+++ b/docs/developer-guide/processors.rst
@@ -120,34 +120,41 @@ Where a processor lives
 
 Every file under ``reef/train/processors/`` is framework: ``base``,
 ``reported``, ``computed``, and ``common`` (shared report readers and sample
-builders). A method's processor is ``recipes/<name>/processor.py`` and should
-show its data flow from top to bottom. Machinery beyond that file's job sits beside it as
+builders). A method that owns its judgment writes
+``recipes/<name>/processor.py``, and that file should show its data flow from
+top to bottom. A method that delegates to an engine backend writes none: the
+backend owns its concrete processor (``reef/train/cordis_backend/processor.py``)
+and wires it in its ``build``, which is why ``recipes/skillclaw/`` ships no
+processor file. Machinery beyond that file's job sits beside it as
 modules named by concern (``recipes/openclawrl/``: ``sessions``, ``turns``,
 ``prm``), never in the processor file and never in a ``utils`` grab-bag.
 
 Each structure the engines keep answers one requirement of continual
-serving; delete one and a documented failure returns. The list, naming the
-attribute each requirement forces, is in the module docstrings of
-``reported.py`` and ``computed.py``.
+serving; delete one and a documented failure returns. The list for the
+reported engine, naming the attribute each requirement forces, is in the
+module docstring of ``reported.py``; the computed engine names its per-state
+structures on ``ComputedFeedbackProcessor`` itself.
 
 Cookbook processors
 -------------------
 
-+---------------------------------------+----------+------------------------------------------------------------------+------------------------+
-| File                                  | Tier     | What its ``judge`` accepts                                       | Batch                  |
-+=======================================+==========+==================================================================+========================+
-| ``recipes/sao/processor.py``          | reported | a trainable, finitely scored report with exactly one referenced  | ``PolicyBatch``        |
-|                                       |          | inference whose assembled sample passes the action-mask check;   |                        |
-|                                       |          | one rollout, one unit                                            |                        |
-+---------------------------------------+----------+------------------------------------------------------------------+------------------------+
-| ``recipes/tttd/processor.py``         | reported | a report parsing as ``TTTDGroupedRolloutReport`` on this         | ``GroupedPolicyBatch`` |
-|                                       |          | scenario's grid; the step is the group, ready only when every    |                        |
-|                                       |          | ``groups_per_step`` × ``rollouts_per_group`` slot is filled      |                        |
-+---------------------------------------+----------+------------------------------------------------------------------+------------------------+
-| ``reef/train/cordis_backend/processor.py``| reported | a trainable, finitely scored report with exactly one reference   | ``TraceBatch``         |
-|                                       |          | and a score inside ``[min_score, max_score]``; the recorded      |                        |
-|                                       |          | request is the sample, unmodified                                |                        |
-+---------------------------------------+----------+------------------------------------------------------------------+------------------------+
-| ``recipes/openclawrl/processor.py``   | computed | a main turn whose next state the PRM scores ±1, or for which the | ``PolicyBatch``        |
-|                                       |          | teacher scored an accepted hindsight hint                        |                        |
-+---------------------------------------+----------+------------------------------------------------------------------+------------------------+
++---------------------------------------------+----------+------------------------------------------------------------------+------------------------+
+| File                                        | Tier     | What its ``judge`` accepts                                       | Batch                  |
++=============================================+==========+==================================================================+========================+
+| ``recipes/sao/processor.py``                | reported | a trainable, finitely scored report whose assembled sample       | ``PolicyBatch``        |
+|                                             |          | passes the action-mask check; one referenced inference, or       |                        |
+|                                             |          | several assembled into one multi-turn sample when                |                        |
+|                                             |          | ``accept_multi_turn_policy_samples`` is set; one rollout,        |                        |
+|                                             |          | one unit                                                         |                        |
++---------------------------------------------+----------+------------------------------------------------------------------+------------------------+
+| ``recipes/tttd/processor.py``               | reported | a report parsing as ``TTTDGroupedRolloutReport`` on this         | ``GroupedPolicyBatch`` |
+|                                             |          | scenario's grid; the step is the group, ready only when every    |                        |
+|                                             |          | ``groups_per_step`` x ``rollouts_per_group`` slot is filled      |                        |
++---------------------------------------------+----------+------------------------------------------------------------------+------------------------+
+| ``reef/train/cordis_backend/processor.py``  | reported | a trainable, finitely scored report with exactly one reference   | ``TraceBatch``         |
+|                                             |          | and a score inside ``[min_score, max_score]``; the recorded      |                        |
+|                                             |          | request is the sample, unmodified                                |                        |
++---------------------------------------------+----------+------------------------------------------------------------------+------------------------+
+| ``recipes/openclawrl/processor.py``         | computed | a main turn whose next state the PRM scores +/-1, or for which   | ``PolicyBatch``        |
+|                                             |          | the teacher scored an accepted hindsight hint                    |                        |
++---------------------------------------------+----------+------------------------------------------------------------------+------------------------+

--- a/docs/developer-guide/surface.rst
+++ b/docs/developer-guide/surface.rst
@@ -38,8 +38,9 @@ Capabilities and call sites
 
 ``Surface`` is a frozen composition of optional capabilities; ``None`` means
 the scenario does not support one. Callers inspect fields, never types, and a
-recipe never subclasses ``Surface``. Each capability has exactly one place it
-is called from:
+recipe never subclasses ``Surface``. Every call site for each capability is
+listed here; ``loader.activate`` alone is invoked from more than one module,
+once per lifecycle event that makes a version servable:
 
 +---------------------------------------------------+-------------------------------------+----------------------------------------------------------------------+
 | Capability                                        | Called from                         | Meaning                                                              |

--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -133,6 +133,7 @@ the one to copy:
    reef:
      recipe: <name>                      # resolves to recipes/<name>.yaml
      token: reef-local
+     port: 8900                          # the ready probe's ${reef.port} resolves against this
      upstream_url: ${REEF_UPSTREAM_URL}  # interpolated here, unlike the preset
      upstream_api_key: ${REEF_UPSTREAM_API_KEY}
      upstream_model: ${REEF_MODEL}
@@ -148,8 +149,8 @@ See `Recipe configuration <../reference/configuration.rst#recipe-configuration>`
 Keep the ``tasks`` list short because it sets each step's cost. Start Reef where the method
 package is importable, and give ``-c`` an absolute path: Reef resolves a
 relative ``-c`` against its own repo root, not your working directory. Recovered
-tree state always wins over ``seed``. The full field list is in `harness_evolve
-<../user-guide/recipes/skillclaw.rst>`__.
+tree state always wins over ``seed``. The full field list is in `Harness
+evolution keys <../reference/configuration.rst#harness-evolution-keys>`__.
 
 Selection policies
 ~~~~~~~~~~~~~~~~~~

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -29,9 +29,10 @@ log under ``/tmp/reef-stack/``; set ``run_dir`` to move it.
 Start from a cookbook stack
 ---------------------------
 
-The source checkout's runnable stacks live under the ``recipes/`` cookbook:
-the learn-nothing ones use the core ``recipe`` implementation in
-``recipes/basic/``, and each method owns its examples.
+The source checkout's runnable stacks live under the ``recipes/`` cookbook
+and ``tutorials/``: the learn-nothing ones use the core ``recipe``
+implementation in ``recipes/basic/``, each weight-training method owns its
+examples, and harness evolution ships as a tutorial.
 
 +-------------------------------------------------------------+----------------------------------------------------------+
 | File                                                        | What it starts                                           |
@@ -43,6 +44,9 @@ the learn-nothing ones use the core ``recipe`` implementation in
 +-------------------------------------------------------------+----------------------------------------------------------+
 | ``recipes/<method>/examples/<example>/serve.yaml``          | weight training: Ray head, Slime driver, Reef, and the   |
 |                                                             | method's own services                                    |
++-------------------------------------------------------------+----------------------------------------------------------+
+| ``tutorials/harness_evolve/serve.yaml``                     | harness evolution: one Reef process, no GPU; ``run.sh``  |
+|                                                             | materializes its recipe preset and starts the stack      |
 +-------------------------------------------------------------+----------------------------------------------------------+
 
 Each weight-training example ships its stack as ``serve.yaml``.
@@ -86,10 +90,13 @@ persistent.
    On ephemeral storage, a restart loses the record store, the commit logs, and
    every version.
 
-Recipe settings such as ``batch_size`` and ``min_score`` sit beside these in
-the same section, along with any others the recipe declares with
-``config_field``. Keys
-the service does not recognize are handed to the recipe.
+Recipe settings such as ``batch_size`` sit beside these in the same section,
+along with any others the recipe declares with ``config_field``. When
+``reef.recipe`` is a dotted weight-training class, keys the service does not
+recognize are handed to the recipe, and the recipe rejects any key it does
+not declare. With the core ``recipe`` or a named preset, the recipe reads its
+configuration from the preset, and unrecognized keys here are silently
+ignored.
 
 Recipe configuration
 --------------------
@@ -108,8 +115,10 @@ is always a preset name; it never imports a learning method implicitly.
 **no default**: a bare recipe name resolves to a preset only when it is set.
 
 A preset is read as-is. ``${VAR}`` interpolates in a deployment config, never
-in a preset. A preset carries its own ``implementation``, ``model``, and ``data``
-sections. Harness-evolution presets also carry an ``evolution`` section:
+in a preset. A preset carries its own ``implementation``, ``model``, and
+``data`` sections, plus an optional ``runtime`` section when the recipe
+builds its own runtime instead of using the deployment's upstream proxy.
+Harness-evolution presets also carry an ``evolution`` section:
 
 .. code:: yaml
 
@@ -156,7 +165,7 @@ zero.
    evolution.adapter | pi | ``opencode``, or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
    evolution.seed | entry options loaded into the tree on first boot; recovered state takes precedence
-   evolution.models | auxiliary models for the method; each key read via its ``api_key_env``
+   evolution.models | auxiliary models for the method: ``url``, ``model``, optional ``api`` (default ``openai``) and ``timeout_s``, with the credential as a literal ``api_key`` or an ``api_key_env`` variable name
    evolution.version_check | appends the adapter's update notice; an interactive pulled tree offers to run the update or skip when behind
 
 The served model's binding is appended at render time; it never enters the
@@ -173,6 +182,7 @@ Each entry is one process.
    services[].name | the service's id, used by ``depends_on``
    services[].command | the command line to run
    services[].ready | a shell command that succeeds once the service is up
+   services[].ready_timeout | seconds to wait for ``ready`` before giving up; the top-level ``ready_timeout`` sets the default
    services[].depends_on | services that must be ready first
    services[].cuda | the value of ``CUDA_VISIBLE_DEVICES`` for this process
    services[].env | extra environment variables
@@ -199,9 +209,12 @@ Slime fills architecture flags such as layer counts and hidden sizes from
 The ``evaluation`` section
 --------------------------
 
-Absent by default, in which case a successful training step publishes without a
-gate. When present, Reef calls the named factory once per scenario and hands the
-plugin the exported but unpublished checkpoint.
+Only weight-training recipes read this section; a deployment that pairs it
+with any other recipe fails at startup, because a harness recipe builds its
+evaluator in code. Absent by default, in which case a successful
+weight-training step publishes without a gate. When present, Reef calls the
+named factory once per scenario and hands the plugin the exported but
+unpublished checkpoint.
 
 .. config::
 

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -59,9 +59,12 @@ Headers
 | ``Authorization: Bearer <token>`` | every route except ``GET /healthz``, when auth is       |
 |                                   | configured.                                             |
 +-----------------------------------+---------------------------------------------------------+
-| ``x-reef-release-id``             | optional: pin inference to this release, or bind a new  |
-|                                   | scenario to this starting release. A later request      |
-|                                   | naming a different one is HTTP 409.                     |
+| ``x-reef-release-id``             | optional: bind a new scenario to this starting release; |
+|                                   | on an existing scenario it must name the bound starting |
+|                                   | release, or the request is HTTP 409. Inference always   |
+|                                   | answers from the scenario's current release; to pull a  |
+|                                   | specific release, use ``?release_id=`` on the harness   |
+|                                   | manifest or install route.                              |
 +-----------------------------------+---------------------------------------------------------+
 | ``x-reef-tag-<name>``             | optional on inference: opaque key/value context stored  |
 |                                   | on the record under ``metadata.tags``, for a processor  |
@@ -102,9 +105,12 @@ unknown scenario returns HTTP 404 and you create it first:
 Inference
 ---------
 
-Send the same body you would send to the provider. Reef adds and changes
-nothing, sampling parameters included. Set ``"stream": true`` and read the SSE
-response for streaming.
+Send the same body you would send to the provider. Reef never touches your
+sampling parameters. On a weight-serving deployment it adds engine
+bookkeeping keys: ``lora_path`` to address the served adapter and
+``return_meta_info`` so the record proves which weights answered; a body
+naming a different ``lora_path`` is refused. Set ``"stream": true`` and read
+the SSE response for streaming.
 
 The receipt identifies the stored record:
 
@@ -135,7 +141,8 @@ data inside ``metadata`` or ``feedback``.
 | ``feedback``   | string or object | no       | opaque to Reef's core: a rubric, judge    |
 |                |                  |          | output, plain text                        |
 +----------------+------------------+----------+-------------------------------------------+
-| ``references`` | list of strings  | yes      | the receipts this report grades           |
+| ``references`` | list of strings  | no       | the receipts this report grades; a report |
+|                |                  |          | without them is accepted but never trains |
 +----------------+------------------+----------+-------------------------------------------+
 | ``metadata``   | object           | no       | opaque, except                            |
 |                |                  |          | ``training.eligible`` (default ``true``)  |
@@ -236,8 +243,9 @@ an update is being trained or published.
 
 ``error`` and ``preload_errors`` report asynchronous training and preload
 failures. ``batch_ready`` says whether the processor has a batch waiting.
-``serving`` is runtime-wide but recipe-shaped. A LoRA deployment reports each
-scenario's ``adapter_runtime_load_id`` under it.
+``serving`` is runtime-wide but recipe-shaped: a LoRA deployment reports the
+engine's shared adapter residency there, keyed by recipe. Each scenario's
+``adapter_runtime_load_id`` appears in its own ``scenarios`` block.
 
 Status codes
 ------------
@@ -260,8 +268,9 @@ Status codes
 |        | recipe, or a scenario that serves no files                  |
 +--------+-------------------------------------------------------------+
 | 409    | a recipe or base artifact conflicting with the binding, a   |
-|        | record id resent with different content, or an engine that  |
-|        | reports no serving runtime load ID                           |
+|        | record id resent with different content, a rollback naming  |
+|        | a release that is not restorable, or an engine that reports |
+|        | no serving runtime load ID                                  |
 +--------+-------------------------------------------------------------+
 | 502    | the upstream provider failed on its own account             |
 +--------+-------------------------------------------------------------+
@@ -269,4 +278,6 @@ Status codes
 |        | the weight-update race until its deadline                   |
 +--------+-------------------------------------------------------------+
 
-Reef relays upstream 4xx responses with the provider's original message.
+Reef relays upstream 4xx failures with the provider's original message; the
+common client statuses (400, 401, 403, 404, 408, 409, 422, 429) keep their
+status code, and any other upstream 4xx comes back as 400.

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -62,6 +62,7 @@ behavior.
    │   ├── TTTDRecipe                                       recipes.tttd.recipe
    │   └── OpenClawRLRecipe                                 recipes.openclawrl.recipe
    └── CordisRecipe             harness tree + episodes  reef.train.cordis_backend
+       └── SkillClawRecipe                               recipes.skillclaw.harness
 
 Choose the narrowest class whose assumptions all hold. Inheriting ``Recipe``
 starts without the extra contracts of a specialized base; it does not force the
@@ -114,10 +115,11 @@ Common members
 |                                                   |                             | ``/reef/status``               |
 +---------------------------------------------------+-----------------------------+--------------------------------+
 
-Weight-training recipes add ``training_spec()``, which binds the processor, the
-registered or dotted step preparer, and the backend loss family;
-``report_type``, the declared ``ReportBase`` subclass; ``max_staleness``, the
-accepted producing-to-serving version lag, which must match the runtime; and
+Every recipe may declare ``report_type``, the ``ReportBase`` subclass its
+reports parse as (``None`` keeps ingress open). Weight-training recipes add
+``training_spec()``, which binds the processor, the registered or dotted step
+preparer, and the backend loss family; ``max_staleness``, the accepted
+producing-to-serving version lag, which must match the runtime; and
 ``candidate_evaluation``, the optional plugin configured by the deployment's
 ``evaluation`` section.
 
@@ -154,10 +156,11 @@ parser, and an optional environment fallback:
    batch_size: int = config_field(4, env="REEF_MY_METHOD_BATCH_SIZE")
 
 Precedence is explicit configuration, then environment, then the default.
-``from_environment()`` builds the recipe; ``service_config()`` forwards declared
-fields and shared artifact settings from the service configuration. Override
-``processor_config()`` when a processor needs renamed or derived keys. Never
-read deployment YAML from inside a processor.
+``from_environment()`` builds the recipe. On weight-training recipes,
+``service_config()`` forwards declared fields and shared artifact settings
+from the service configuration; override ``processor_config()`` when a
+processor needs renamed or derived keys. Never read deployment YAML from
+inside a processor.
 
 Report
 ------
@@ -422,7 +425,8 @@ its module must be importable in both the service and the training process.
 +--------------------------+-------------------------------------------------+
 | ``scheduling``           | how a runtime materializes a grouped batch:     |
 |                          | ``unit`` is ``comparison_set`` or ``sample``,   |
-|                          | ``batch_size`` is ``configured`` or ``actual``  |
+|                          | ``batch_size`` is ``configured``, ``actual``,   |
+|                          | or a positive int                               |
 +--------------------------+-------------------------------------------------+
 
 A preparer owns method math and nothing else. It must not import a runtime, Ray,

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -61,14 +61,19 @@ The loop
    :loop: publish the winner, or restore the snapshot
 
    Batch :: scored reports retained by the score window
-   ``propose`` :: one mutation, or ``None``
+   ``propose`` :: one proposal, a mutation or a sequence applied as one, or ``None``
    Episodes* :: run the candidate and current tree on the same tasks
    Verdict :: publish the candidate or restore the snapshot
 
-No evolution runs while traffic flows. A report whose score is at or below
-``max_score`` enters the *window*; the default for harness evolution keeps
-only failures. When ``batch_size`` such reports have accumulated, one step
-runs the loop once. Both keys live under ``data:`` in the recipe config.
+No evolution runs while traffic flows. A report enters the *window* when it
+references exactly one receipt and its score is at or below ``max_score``;
+the default for harness evolution keeps only failures. A report that
+references several receipts never batches, whatever its score. ``reef-pi
+report`` sends every receipt from the last run in one report, so only a run
+with a single model call can trigger a step; report each result against its
+own receipt, as ``run.py`` does. When ``batch_size`` such reports have
+accumulated, one step runs the loop once. ``batch_size`` and ``max_score``
+live under ``data:`` in the recipe config.
 
 Most of a step's cost is the evaluation. Every task runs twice, once against
 the candidate tree and once against the current one, which makes
@@ -175,10 +180,15 @@ task fails, the failing report opens the window, one evolve step runs, and
 shows a published version.
 
 If ``/reef/harness`` still returns 404 after a few minutes, the run has
-failed. A missing model server or a missing ``pi`` binary does not fail at
-config time. Instead every episode fails, both sides tie, no candidate ever
-wins, and the route stays 404. Confirm that the endpoint answers and that
-``pi --version`` runs before suspecting the recipe.
+failed. A missing ``pi`` binary or a server without tool calling does not
+fail at config time: every episode fails, both sides tie, no candidate ever
+wins, and the route stays 404. Confirm that ``pi --version`` runs and that
+the server accepts tool calls before suspecting the recipe; vLLM needs
+``--enable-auto-tool-choice --tool-call-parser hermes``, and without those
+flags it rejects pi's ``tool_choice: "auto"`` requests with a 400 while
+still answering plain requests. A missing model server does not produce
+this symptom: the record phase raises on its first call and ``run.py``
+exits with the upstream error before any evolve step runs.
 
 A model that answers all three tasks correctly also leaves the route at 404,
 because nothing fails, so nothing batches and no step runs. ``run.py`` prints


### PR DESCRIPTION
## Motivation

The restructure landed in paths and names, but several pages still describe behavior the engine no longer has, and behavior the engine gained is missing. A six-pair check of every harness evolution page against reef/train/cordis_backend, the harness core, the service routes, and the tutorial found 38 mismatches; 34 survived independent adversarial verification (each re-derived from the code), and 4 were refuted as doc-legitimate simplifications.

## Changes

- Lane guide: propose may return a mutation sequence applied as one; the batching window admits only single-reference reports (reef-pi report bundles every receipt of a run into one report, which can never batch); the troubleshooting paragraph now separates the silent 404 causes (missing pi binary, server without tool calling, with the vLLM flags) from a missing model server, which raises loudly at the record phase before any step
- Adapters: env substitutes {root}; install pins kind/package/version/binary_path; model_binding is keyed by API dialect with {base_url}/{api_key}/{model} templates; cleanup_whitelist covers run-time writes and its glob semantics (dir/**, right-anchored globs, bare names match nothing) are spelled out; version_check lives under evolution. in the recipe config
- Processors: the cordis row of the cookbook table was silently dropped by the RST parser over a 43-char cell in a 39-char column, the table is redrawn and all four rows render; methods that delegate to an engine backend ship no processor file; the SAO row covers multi-turn assembly; the requirement lists are pointed at where they actually live
- Surface: loader.activate has more than one call site, stated instead of "exactly one place"
- HTTP API: x-reef-release-id binds a starting release and never pins inference; references is optional at ingress but a report without one reference never trains; the inference proxy adds lora_path and return_meta_info on weight deployments; serving reports engine-shared residency keyed by recipe; the 409 row gains the non-restorable rollback; upstream 4xx relay keeps only the eight common statuses and folds the rest to 400
- Configuration: the stack table gains the tutorial stack; unrecognized keys are handed to the recipe only for dotted weight classes and ignored for presets; presets may carry a runtime section; evolution.models documents all five keys and both credential spellings; services[].ready_timeout documented; the evaluation section states it serves weight recipes only and fails any other deployment at startup
- Python API: report_type moves to the base Recipe; service_config/processor_config scoped to weight recipes; scheduling batch_size also takes a positive int; SkillClawRecipe joins the class tree under CordisRecipe

## Compatibility and operational impact

None. Documentation only.

## Verification

check:docs (116 Markdown, 34 RST, route contracts), eslint, and the site build (35/35) all pass; pre-commit clean on the changed files. The rebuilt processors table renders all four cookbook rows in the browser where it previously rendered three. Every corrected claim carries a code citation from the verification pass, and I re-derived the wire-contract ones (references default, upstream 4xx map, release row keys) against the source directly.

## AI assistance

Claude Code ran the page-vs-code check, verified each finding, and wrote the edits. I reviewed the diff.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
