### PR TITLE
docs: list SkillClaw in cookbook recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ and do not ship in the Reef wheel.
 | Agent traffic with useful next-state signals and no explicit reports | <code>recipes.openclawrl.recipe:OpenClawRLRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
 | Repeated, scored attempts at one problem | <code>recipes.tttd.recipe:TTTDRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
 | Scored code search with a trainable guidance model and a frozen executor | <code>recipes.tttd.recipe:TTTDRecipe</code> | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
-| Scored agent interactions used to improve prompts, rules, skills, or configuration | <code>reef.train.cordis_backend.recipe:CordisRecipe</code> | Harness tree; no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/evolve-your-harness/) · [Example](tutorials/harness_evolve/README.md) |
+| Agent feedback used to evolve its skill pool | <code>harness.skillclaw_recipe:SkillClawRecipe</code> | Skill pool (harness tree); no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/recipes/skillclaw/) · [Example](recipes/skillclaw/README.md) |
 
 
 ## How is Reef different?


### PR DESCRIPTION
## Motivation

The cookbook recipes table should list the concrete SkillClaw method rather than the built-in Cordis harness-evolution mechanism.

## Changes

- Replace CordisRecipe with SkillClawRecipe in the cookbook table.
- Describe the updated artifact as the skill pool harness tree.
- Link to the SkillClaw guide and reproduction.

## Compatibility and operational impact

None.

## Verification

- `git diff --check origin/main...HEAD` passes.
- No tests run; documentation-only change.

## AI assistance

Codex inspected the recipe hierarchy, updated the README row, and prepared this pull request. The author remains responsible for the change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.