### PR TITLE
refactor(skillclaw): align recipe entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ and do not ship in the Reef wheel.
 | Agent traffic with useful next-state signals and no explicit reports | <code>recipes.openclawrl.recipe:OpenClawRLRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [Example](recipes/openclawrl/examples/openclawrl/README.md) |
 | Repeated, scored attempts at one problem | <code>recipes.tttd.recipe:TTTDRecipe</code> | Model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/tttd/README.md) |
 | Scored code search with a trainable guidance model and a frozen executor | <code>recipes.tttd.recipe:TTTDRecipe</code> | Guidance-model weights | [Guide](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [Example](recipes/tttd/examples/guidance_ttt/README.md) |
-| Agent feedback used to evolve its skill pool | <code>harness.skillclaw_recipe:SkillClawRecipe</code> | Skill pool (harness tree); no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/recipes/skillclaw/) · [Example](recipes/skillclaw/README.md) |
+| Agent feedback used to evolve its skill pool | <code>recipes.skillclaw.recipe:SkillClawRecipe</code> | Skill pool (harness tree); no GPU required | [Guide](https://reefinfra.ai/docs/user-guide/recipes/skillclaw/) · [Example](recipes/skillclaw/README.md) |
 
 
 ## How is Reef different?

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -62,7 +62,7 @@ behavior.
    │   ├── TTTDRecipe                                       recipes.tttd.recipe
    │   └── OpenClawRLRecipe                                 recipes.openclawrl.recipe
    └── CordisRecipe             harness tree + episodes  reef.train.cordis_backend
-       └── SkillClawRecipe                               recipes.skillclaw.harness
+       └── SkillClawRecipe                                recipes.skillclaw.recipe
 
 Choose the narrowest class whose assumptions all hold. Inheriting ``Recipe``
 starts without the extra contracts of a specialized base; it does not force the

--- a/docs/user-guide/recipes/skillclaw.rst
+++ b/docs/user-guide/recipes/skillclaw.rst
@@ -53,15 +53,15 @@ Two choices distinguish it from the tutorial method. ``selection: always``
 publishes every night that produces a proposal, because the next day is the
 gate. And the skill catalog must reach the model on every live request, so the
 recipe overrides ``build_surface``, the hook controlling how a published
-artifact reaches the request path (`skillclaw_recipe.py
-<../../../recipes/skillclaw/harness/skillclaw_recipe.py>`__). That override is
+artifact reaches the request path (`recipe.py
+<../../../recipes/skillclaw/recipe.py>`__). That override is
 the one extension point beyond the method's own callables.
 
 Configuration
 -------------
 
 ``recipes/skillclaw/skillclaw.yaml`` is the recipe config the driver boots. It
-names ``harness.skillclaw_recipe:SkillClawRecipe`` as its ``implementation``
+names ``recipes.skillclaw.recipe:SkillClawRecipe`` as its ``implementation``
 and sets ``batch_size: 60`` with ``max_score: .inf``, so every report of the
 day batches and the day's last one triggers the night. The engine's keys are
 in `Recipe configuration

--- a/recipes/skillclaw/README.md
+++ b/recipes/skillclaw/README.md
@@ -8,6 +8,10 @@ This example rebuilds the SkillClaw method from [Evolving Skills for Autonomous 
 skillclaw/
   skillclaw.yaml      the recipe the driver boots: explicit implementation, selection
                       always, batch_size 60, probe tasks, seed composition
+  recipe.py           the Reef recipe subclass: build_surface returns
+                      create_skill_surface([SkillCatalogModule(...)]) so every /v1
+                      request carries the pool catalog; seed_skills seeds
+                      the benchmark's shipped skills library
   harbor/             one Harbor-format task (the standard layout the
                       sibling examples follow): the benchmark's
                       meeting-negotiation task vendored at the pin -
@@ -22,10 +26,6 @@ skillclaw/
     day.py            the pinned WildClawBench checkout (ensure_benchmark),
                       the docker task lifecycle, and the benchmark's
                       grading loop
-    skillclaw_recipe.py the recipe subclass: build_surface returns
-                      create_skill_surface([SkillCatalogModule(...)]) so every /v1
-                      request carries the pool catalog; seed_skills seeds
-                      the benchmark's shipped skills library
     catalog.py        SkillCatalogModule, ported from the sealed campaign:
                       the OpenClaw catalog format, eligibility rules, and
                       the catalog_names inverse
@@ -106,7 +106,7 @@ Each run resumes after its last sealed round, so a crashed or interrupted campai
 
 ## The Harbor smoke task
 
-`harbor/` is one task in the Harbor format every sibling example uses, and `python3 run.py solve` is the standard one-episode smoke over it (`pip install -e .` first; docker required, the campaign env vars apply). The task is the benchmark's own `03_Social_Interaction/task_1_meeting_negotiation`, vendored in full at the campaign pin: the prompt is `instruction.md`, its Warmup block is the container startup (mock Gmail and Calendar services on localhost, ground-truth fixtures deleted before the agent starts), and its Automated Checks block is `tests/grade.py`, writing `overall_score` to the verifier reward. This task was chosen because it grades fully programmatically (fixture-driven audit endpoints, no LLM judge, no external hosts), so unlike the campaign day it needs neither the multi gigabyte dataset download nor the benchmark's release image: the environment builds standalone and `lab.run` works anywhere docker does. WildClawBench is MIT licensed; the vendored content carries its notice (`harbor/LICENSE`, `task.toml`'s `license_note`).
+`harbor/` is one task in the Harbor format every sibling example uses, and `PYTHONPATH=../.. python3 run.py solve` is the standard one-episode smoke over it (`pip install -e .` first; docker required, the campaign env vars apply). The repository root on `PYTHONPATH` exposes the cookbook's canonical `recipes.skillclaw.recipe` entry point. The task is the benchmark's own `03_Social_Interaction/task_1_meeting_negotiation`, vendored in full at the campaign pin: the prompt is `instruction.md`, its Warmup block is the container startup (mock Gmail and Calendar services on localhost, ground-truth fixtures deleted before the agent starts), and its Automated Checks block is `tests/grade.py`, writing `overall_score` to the verifier reward. This task was chosen because it grades fully programmatically (fixture-driven audit endpoints, no LLM judge, no external hosts), so unlike the campaign day it needs neither the multi gigabyte dataset download nor the benchmark's release image: the environment builds standalone and `lab.run` works anywhere docker does. WildClawBench is MIT licensed; the vendored content carries its notice (`harbor/LICENSE`, `task.toml`'s `license_note`).
 
 The solve agent (`harness/harbor_agent.py`) is deliberately minimal, one recorded model call through the same embedded service the campaign runs - the smoke proves the task contract end to end, not agent quality. Expect a low reward: a one-shot completion cannot work the mock APIs.
 

--- a/recipes/skillclaw/__init__.py
+++ b/recipes/skillclaw/__init__.py
@@ -1,0 +1,1 @@
+"""SkillClaw cookbook method."""

--- a/recipes/skillclaw/harness/__init__.py
+++ b/recipes/skillclaw/harness/__init__.py
@@ -1,13 +1,13 @@
-"""The SkillClaw method package: what skillclaw.yaml's dotted references name.
+"""The SkillClaw harness package: what skillclaw.yaml's callable references name.
 
 ``harness.skillclaw`` supplies the mechanism's three callables - ``propose``
 (the sealed night flow mapped to one composite mutation sequence),
 ``evaluate`` (exact-answer probe grading), and the ``selection: always``
-policy set in skillclaw.yaml. ``harness.skillclaw_recipe`` is the recipe
-subclass the yaml boots (``harness.skillclaw_recipe:SkillClawRecipe``); its
-surface (``harness.catalog``) injects the served pool's catalog into every
-proxied request. The remaining modules are the sealed campaign's night
-internals (``night``, ``evolver``, ``sessions``, ``prompts``), the
+policy set in skillclaw.yaml. The cookbook recipe entry point lives at
+``recipes.skillclaw.recipe``; its surface uses this package's ``catalog``
+module to inject the served pool's catalog into every proxied request. The
+remaining modules are the sealed campaign's night internals (``night``,
+``evolver``, ``sessions``, ``prompts``), the
 preregistered gain criterion (``stats``), and the shared constants
 (``config``).
 

--- a/recipes/skillclaw/recipe.py
+++ b/recipes/skillclaw/recipe.py
@@ -1,7 +1,7 @@
-"""SkillClaw's recipe: harness evolution plus the pool's own delivery surface.
+"""SkillClaw's recipe: harness evolution plus the pool's delivery surface.
 
 ``skillclaw.yaml`` names this class as its dotted recipe reference
-(``harness.skillclaw_recipe:SkillClawRecipe``). It changes exactly two things over
+(``recipes.skillclaw.recipe:SkillClawRecipe``). It changes three things over
 the stock ``CordisRecipe`` implementation:
 
 - ``build_surface`` returns ``create_skill_surface([SkillCatalogModule(...)])``, so
@@ -23,13 +23,12 @@ from dataclasses import KW_ONLY, dataclass
 from pathlib import Path
 from typing import Any
 
+from recipes.skillclaw.harness.catalog import SkillCatalogModule
+from recipes.skillclaw.harness.config import PUBLIC_SKILL_ROOT
 from reef.recipe.errors import RecipeConfigError
 from reef.surface import Surface
 from reef.surface.skills import SkillValidator, create_skill_surface
 from reef.train.cordis_backend import CordisRecipe
-
-from .catalog import SkillCatalogModule
-from .config import PUBLIC_SKILL_ROOT
 
 
 def seed_skill_entries(skills_dir: Path) -> tuple[dict[str, Any], ...]:

--- a/recipes/skillclaw/run.py
+++ b/recipes/skillclaw/run.py
@@ -24,9 +24,11 @@ and the served pool survives restarts as pool-current with the commit log as
 the authority (_committed_pool).
 
 ``python3 run.py report`` prints the gain table over both runs' sealed
-rounds (``stats.py``, the preregistered criterion). ``python3 run.py solve``
-runs the bundled ``harbor/`` task once through reef-eval instead - the sibling
-examples' smoke idiom - against the same embedded service.
+rounds (``stats.py``, the preregistered criterion).
+``PYTHONPATH=../.. python3 run.py solve`` runs the bundled ``harbor/`` task
+once through reef-eval instead - the sibling examples' smoke idiom - against
+the same embedded service. The repository root on ``PYTHONPATH`` exposes the
+cookbook recipe's canonical ``recipes.skillclaw.recipe`` module.
 """
 
 from __future__ import annotations

--- a/recipes/skillclaw/skillclaw.yaml
+++ b/recipes/skillclaw/skillclaw.yaml
@@ -7,10 +7,10 @@
 # loader; run.sh exports the defaults and REEF_SC_SKILLS (the benchmark's
 # shipped skills library) after materializing the WildClawBench checkout.
 
-# The method package's own recipe class: harness_evolve plus the
-# catalog-injecting delivery surface (harness/skillclaw_recipe.py, imported
-# from this directory - the driver runs with it as the working directory).
-implementation: harness.skillclaw_recipe:SkillClawRecipe
+# The cookbook method's recipe class: harness_evolve plus the
+# catalog-injecting delivery surface. The entry point follows the same
+# recipes.<method>.recipe convention as the other cookbook methods.
+implementation: recipes.skillclaw.recipe:SkillClawRecipe
 
 model:
   path: ${REEF_MODEL}

--- a/tests/reef_service/test_skillclaw.py
+++ b/tests/reef_service/test_skillclaw.py
@@ -108,8 +108,10 @@ def example(monkeypatch: pytest.MonkeyPatch) -> dict[str, ModuleType]:
     # example's cached import so this file's syspath entry wins.
     for name in [name for name in sys.modules if name == "harness" or name.startswith("harness.")]:
         del sys.modules[name]
-    names = ("skillclaw", "evolver", "prompts", "night", "skillclaw_recipe")
-    return {name: importlib.import_module(f"harness.{name}") for name in names}
+    names = ("skillclaw", "evolver", "prompts", "night")
+    modules = {name: importlib.import_module(f"harness.{name}") for name in names}
+    modules["skillclaw_recipe"] = importlib.import_module("recipes.skillclaw.recipe")
+    return modules
 
 
 @pytest.fixture
@@ -334,7 +336,7 @@ def test_example_yaml_boots_the_recipe_with_the_paper_wiring(example, tmp_path, 
     monkeypatch.setenv("REEF_SC_SKILLS", str(skills))
     config = load_config(EXAMPLE_DIR / "skillclaw.yaml")
     sections = {key: config[key] for key in ("implementation", "model", "evolution", "data")}
-    assert sections["implementation"] == "harness.skillclaw_recipe:SkillClawRecipe"
+    assert sections["implementation"] == "recipes.skillclaw.recipe:SkillClawRecipe"
 
     built = build_recipe(str(sections["implementation"]), {}, config=sections, runtime=runtime())
     assert type(built).__name__ == "SkillClawRecipe"


### PR DESCRIPTION
## Summary

- move `SkillClawRecipe` to the cookbook-standard `recipes.skillclaw.recipe` module
- keep `harness/` focused on SkillClaw method and runtime code
- update configuration, documentation, and tests to use `recipes.skillclaw.recipe:SkillClawRecipe`
- document the repository-root `PYTHONPATH` required by the direct smoke command

## Testing

- `python -m pytest tests/reef_service/test_reef_recipes.py tests/reef_service/test_skillclaw.py -q` (51 passed)
- `python -m ruff check recipes/skillclaw/recipe.py recipes/skillclaw/__init__.py recipes/skillclaw/run.py tests/reef_service/test_skillclaw.py`
- `git diff --check`