### PR TITLE
observability: monotonic train/* step axis; drop non-finite worker metrics

### DIFF
--- a/reef/observability/wandb.py
+++ b/reef/observability/wandb.py
@@ -289,11 +289,15 @@ class WandbExperimentTracker(ExperimentTracker):
         self._update_run_config(run, event.context)
         metadata = self._event_metadata(event, run_id)
         self._record_optimizer_steps(run, event)
+        # The backend's drained metrics may themselves carry a "train/step"
+        # (Slime's accumulated_step_id, which is not monotonic across jobs of
+        # varying length); list the authoritative context counters last so
+        # they win the dict merge and the train/* step axis stays monotonic.
         values: dict[str, Any] = {
-            "train/step": event.context.run_step,
-            "reef/step": event.context.step,
             **_numeric_metrics(event.metrics),
             **{f"reef/{key}": value for key, value in metadata.items() if value is not None and key != "step"},
+            "train/step": event.context.run_step,
+            "reef/step": event.context.step,
         }
         try:
             run.log(values)

--- a/reef/train/slime_backend/reef_adapters/worker_hooks.py
+++ b/reef/train/slime_backend/reef_adapters/worker_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from collections.abc import Mapping
 from typing import Any
@@ -324,9 +325,14 @@ def _install_pg_primitive(args) -> None:
 
 
 def record_worker_metrics(metrics: Mapping[str, Any]) -> None:
-    """Merge numeric worker metrics for the bridge's next drain."""
+    """Merge numeric worker metrics for the bridge's next drain.
+
+    Non-finite values are dropped: a loss family may log NaN for a metric
+    whose phase is absent from a step, and the drained metrics are written
+    into the durable training-job marker with ``allow_nan=False``.
+    """
     for name, value in metrics.items():
-        if isinstance(value, int | float) and not isinstance(value, bool):
+        if isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(value):
             _WORKER_METRICS[str(name)] = float(value)
 
 
@@ -335,7 +341,7 @@ def record_worker_step(metrics: Mapping[str, Any]) -> None:
     numeric = {
         str(name): float(value)
         for name, value in metrics.items()
-        if isinstance(value, int | float) and not isinstance(value, bool)
+        if isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(value)
     }
     if numeric:
         _WORKER_STEP_METRICS.append(numeric)

--- a/tests/reef_service/test_wandb_tracking.py
+++ b/tests/reef_service/test_wandb_tracking.py
@@ -385,3 +385,25 @@ def test_wandb_optimizer_step_counter_resumes_from_the_run_summary() -> None:
     step_rows = [m for m, _ in client.runs[0].logged if "step/step" in m]
     assert [row["step/step"] for row in step_rows] == [40]
     assert client.runs[0].summary["reef/optimizer_steps"] == 41
+
+
+@pytest.mark.unit
+def test_backend_train_step_in_metrics_never_overrides_the_run_step_axis() -> None:
+    # Slime drains its own "train/step" (rollout_id * num_steps_per_rollout +
+    # step_id) up with the job metrics; it is not monotonic when rollouts have
+    # varying step counts, so the job row must keep the context's run_step.
+    client = _StubClient()
+    tracker = _tracker(client)
+    event = dataclasses.replace(
+        _event(step=3, run_step=2),
+        metrics={"train/loss": 0.2, "train/step": 76, "train_steps": [{"train/loss": 0.3, "train/step": 76}]},
+    )
+
+    tracker.record(event)
+
+    run = client.runs[0]
+    rows = [metrics for metrics, _ in run.logged]
+    job_row = next(row for row in rows if "train/loss" in row and "step/loss" not in row)
+    assert job_row["train/step"] == 2
+    step_row = next(row for row in rows if "step/loss" in row)
+    assert step_row["step/step"] == 0


### PR DESCRIPTION
Two related observability fixes found while running OPD distillation experiments (Slime backend, variable-size rollout batches).

## 1. W&B `train/*` panels plotted against a non-monotonic step axis

Slime logs `train/step = rollout_id * num_steps_per_rollout + step_id` (`slime/backends/megatron_utils/model.py`), where `num_steps_per_rollout` is the *current* rollout's step count. With rollouts of varying length the value collides and goes backwards (observed on a live run: `[10, 19, 32, 39, 8, 19, 29, 47, ...]`). That value rides the drained worker metrics into the job row's dict literal **after** the intended `"train/step": event.context.run_step`, overwriting it — so every `train/*` panel zigzags and reads as false trends (we initially misdiagnosed a healthy run as diverging because of this).

Fix: list the authoritative context counters last so they win the merge. The per-optimizer-step `step/*` rows already had their own monotonic counter and are unchanged.

## 2. Non-finite worker metrics fail the durable training-job commit

A loss family may log NaN for a metric whose phase is absent from a step (e.g. on-policy statistics during an off-policy cold-start batch — NaN is the natural encoding, since the W&B layer's isfinite filter then leaves a gap instead of a misleading zero segment). But the drained worker metrics are also serialized into the training-job marker with `json.dump(..., allow_nan=False)`, which raises and fails the commit:

```
ValueError: Out of range float values are not JSON compliant: nan
training thread failed to commit for scenario '...'
```

Fix: drop non-finite values at `record_worker_metrics` / `record_worker_step`, so every downstream consumer (marker, W&B, status) sees finite JSON-safe metrics.

## Tests

- New regression test: a backend-supplied `train/step` in `event.metrics` never overrides the context `run_step` on the job row.
- `tests/reef_service/test_wandb_tracking.py` 9 passed; `tests/slime_backend` 130 passed (run in the reef image).

Both hit on live 8-GPU OPD cold-start runs; happy to split into two PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7wrAnakzchrLF6vWsGKs