### PR TITLE
docs: add PyPI version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <h3>Continual learning infra for self-improving agents</h3>
 
 [![CI](https://github.com/Human-Agent-Society/reef/actions/workflows/ci.yml/badge.svg)](https://github.com/Human-Agent-Society/reef/actions/workflows/ci.yml)
-[![reef-infra](https://img.shields.io/pypi/v/reef-infra?label=reef-infra)](https://pypi.org/project/reef-infra/)
+[![PyPI package: reef-infra](https://img.shields.io/pypi/v/reef-infra?label=PyPI%3A%20reef-infra&logo=pypi&logoColor=white)](https://pypi.org/project/reef-infra/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](pyproject.toml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <h3>Continual learning infra for self-improving agents</h3>
 
 [![CI](https://github.com/Human-Agent-Society/reef/actions/workflows/ci.yml/badge.svg)](https://github.com/Human-Agent-Society/reef/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/reef-infra)](https://pypi.org/project/reef-infra/)
+[![reef-infra](https://img.shields.io/pypi/v/reef-infra?label=reef-infra)](https://pypi.org/project/reef-infra/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](pyproject.toml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <h3>Continual learning infra for self-improving agents</h3>
 
 [![CI](https://github.com/Human-Agent-Society/reef/actions/workflows/ci.yml/badge.svg)](https://github.com/Human-Agent-Society/reef/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/reef-infra)](https://pypi.org/project/reef-infra/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](pyproject.toml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
 


### PR DESCRIPTION
## Summary

- add a live `reef-infra` version badge to the README
- link the badge to the package on PyPI

## Verification

- confirmed the Shields.io badge endpoint returns successfully
- `git diff --check`