### PR TITLE
docs: add launch post to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ better and better results without having to do anything.
 </div>
 
 **[Get started](https://reefinfra.ai/docs/getting-started/quickstart/) ·
+[Launch post](https://x.com/ao_qu18465/status/2094867930081337730) ·
 [Join Discord](https://discord.gg/5y8e5f937k)**
 
 </div>

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ better and better results without having to do anything.
 
 </div>
 
-**[Get started](https://reefinfra.ai/docs/getting-started/quickstart/) ·
-[Launch post](https://x.com/ao_qu18465/status/2094867930081337730) ·
+**[Get started](https://reefinfra.ai/docs/getting-started/quickstart/) |
+[Launch post](https://x.com/ao_qu18465/status/2094867930081337730) |
 [Join Discord](https://discord.gg/5y8e5f937k)**
 
 </div>


### PR DESCRIPTION
Adds the Reef launch post alongside the existing Get started and Discord links in the README.