### PR TITLE
feat: reproduce Meta-Harness in Reef harness evolution

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -1,15 +1,15 @@
 name: harness-smoke
 
-# Runs the real pinned pi binary through render, run_episode, and the
-# trajectory reader against a stub model server (tests/smoke/test_real_pi.py):
-# the guard against a pi release changing a format the hermetic fakes only
-# imitate. Non-blocking: not in the required check set until stable.
+# Runs the real pinned pi binary through the core episode contract and the
+# Meta-Harness Harbor bridge against stub model servers. These guard formats
+# that hermetic fakes only imitate. Non-blocking until stable.
 
 on:
   pull_request:
     paths:
       - "reef/harness/**"
       - "reef/train/cordis_backend/**"
+      - "recipes/meta_harness/**"
       - "tests/smoke/**"
       - ".github/workflows/harness-smoke.yml"
   workflow_dispatch:
@@ -39,7 +39,7 @@ jobs:
       - run: python -m pip install ./third_party/reef-client
       - run: python -m pip install -e . aiohttp pyyaml huggingface_hub pytest
       - run: npm install --prefix "$RUNNER_TEMP/pi" @earendil-works/pi-coding-agent@0.84.2
-      - run: python -m pytest tests/smoke/test_real_pi.py
+      - run: python -m pytest tests/smoke/test_real_pi.py tests/smoke/test_meta_harness_pi_bridge.py
         env:
           REEF_REAL_PI_BINARY: ${{ runner.temp }}/pi/node_modules/.bin/pi
           REEF_REAL_PI_SESSION_OUT: ${{ runner.temp }}/real-pi-session.jsonl

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -85,6 +85,14 @@ WildClawBench task vendored in the standard Harbor format (self-contained
 image, the benchmark's own programmatic grader), and `run.py solve` is the
 one-episode reef-eval smoke over it.
 
+[Meta-Harness](meta_harness/examples/terminal_bench/README.md) adapts
+persistent-population harness search to provider-free Reef compositions. A
+Codex proposer branches from retained candidates, Pi runs the rendered harness
+against a pinned Terminal-Bench subset through Harbor, and frozen,
+incumbent-only, and full-history cells receive equal target-episode budgets.
+The runner keeps proposals, trajectories, selection decisions, held-out
+results, and the published tree in a resumable experiment record.
+
 [OpenClaw-RL](openclawrl/examples/openclawrl/README.md) runs the paper's
 personal-agent experiment as a reef-eval task stream: a simulated student brings
 72 GSM8K homework problems to a Hermes agent whose model calls go through

--- a/recipes/meta_harness/examples/terminal_bench/README.md
+++ b/recipes/meta_harness/examples/terminal_bench/README.md
@@ -1,0 +1,217 @@
+# Meta-Harness through Reef harness evolution
+
+This experiment adapts Meta-Harness's persistent-population search to
+declarative Reef compositions. OpenAI Codex proposes complete candidate trees
+inside a durable workspace. Reef validates and renders each tree for Pi,
+evaluates it with the Terminal-Bench verifier, retains every valid and invalid
+attempt, and publishes the selected provider-free composition. It tests the
+full-history mechanism through Reef; it does not reproduce Meta-Harness's
+reported model setting or benchmark score exactly.
+
+The experiment has three equal target-episode-budget cells:
+
+1. a frozen genesis composition;
+2. an incumbent-only control whose proposer sees the current winner and a
+   compact summary; and
+3. full-history Meta-Harness whose proposer can inspect and branch from every
+   retained candidate, train trajectory, dev score, and prior proposer session.
+
+The proposer runs locally under a restricted filesystem profile. Candidate
+trees are limited to declarative `rules`, `skill`, and `agent_command` nodes.
+`config` and executable `code_extension` nodes are rejected so an evaluated
+candidate cannot load host resources or inspect controller files and held-out
+task IDs.
+
+## What maps to Reef
+
+The candidate is a content-addressed sequence of the three allowed Reef node
+kinds. It contains no provider or credential. For each trial, Reef renders that
+composition for Pi and adds a transient model binding. A fixed,
+controller-owned runtime extension replaces Pi's `bash` tool and forwards
+commands to Harbor's task container; Harbor, not the harness or proposer, runs
+the Terminal-Bench verifier.
+
+The full-history cell gives Codex a durable filesystem containing every
+candidate, raw train trajectories, aggregate-only dev feedback, rejected
+attempts, and prior proposer sessions. The incumbent-only cell gets a separate
+view with only the current winner and compact score history. The outer loop
+validates proposals, runs train and dev evaluation, promotes strict dev-score
+improvements, and withholds test evaluation until selection is fixed.
+An evaluated non-winner is explicitly recorded as `rejected` by selection but
+remains `retained` in the population, so a later full-history round may still
+branch from it.
+
+## Directory layout
+
+```text
+terminal_bench/
+  harness/       candidate, workspace, proposer, Harbor bridge, search, reports
+  run.py         three-cell controller, pin checks, resume, and publication
+  run.sh         locked launcher from the Reef repository root
+  pyproject.toml standalone Harbor and Terminal-Bench dependencies
+  uv.lock        exact Python dependency resolution
+  README.md      protocol, commands, trust boundary, and retained records
+```
+
+## Pinned adaptation
+
+- Reef base commit:
+  [`6b0d9a1345191a0df1a7e324fa09875e8581a83f`](https://github.com/Human-Agent-Society/reef/commit/6b0d9a1345191a0df1a7e324fa09875e8581a83f)
+- Meta-Harness:
+  [`95175f70c758dd1145b395edfe8b67e6f9d80fbd`](https://github.com/stanford-iris-lab/meta-harness/commit/95175f70c758dd1145b395edfe8b67e6f9d80fbd)
+- Terminal-Bench historical source recorded in the
+  [pinned reference environment](https://github.com/stanford-iris-lab/meta-harness/blob/95175f70c758dd1145b395edfe8b67e6f9d80fbd/reference_examples/terminal_bench_2/pyproject.toml):
+  `1a6ffa9674b571da0ed040c470cb40c4d85f9b9b`; that rewritten-history commit
+  is no longer fetchable, so the runnable lock uses its declared
+  `terminal-bench==0.2.18` release artifact
+- Harbor: `0.3.0`
+- Terminal-Bench: `0.2.18`, `terminal-bench@2.0` hard subset. Harbor's
+  registry currently resolves all 30 task paths to
+  [`69671fbaac6d67a7ef0dfec016cc38a64ef7a77c`](https://github.com/laude-institute/terminal-bench-2/commit/69671fbaac6d67a7ef0dfec016cc38a64ef7a77c),
+  and trials fetch that immutable Git tree directly
+- Pi: `0.84.2`
+- target model: `gpt-5.4-mini-2026-03-17`
+- target-model pricing snapshot (observed 2026-08-30):
+  [$0.75/M input, $0.075/M cached input, and $4.50/M output tokens](https://developers.openai.com/api/docs/models/gpt-5.4-mini)
+- proposer: the locally installed Codex CLI, with its exact version captured
+  in every live run
+- proposer model request: mutable Codex alias `gpt-5.5`, high reasoning
+  effort; the CLI version and requested alias are retained, but backend alias
+  resolution is not an immutable model snapshot
+- search: two rounds and two trials per task
+
+This differs materially from the pinned upstream release: it uses OpenAI
+models instead of the released Claude setting, a fixed 10/10/10 partition of
+the 30-task hard subset instead of the full upstream evaluation, two rounds,
+one proposal per round, and one strict dev-score incumbent. The three cells are
+a Reef-specific ablation, not an official-reference arm. Pi uses the pinned
+model provider's request defaults; reasoning effort, temperature, and output
+limit are not overridden. A single run validates implementation behavior and
+reports score differences descriptively; it does not establish a statistically
+reliable full-history advantage.
+
+## Validate without model calls
+
+From the Reef repository root:
+
+```bash
+recipes/meta_harness/examples/terminal_bench/run.sh --dry-run
+recipes/meta_harness/examples/terminal_bench/run.sh \
+  --cell full_history \
+  --smoke \
+  --dry-run
+uv run --locked \
+  --project recipes/meta_harness/examples/terminal_bench \
+  --with-editable . \
+  --with pytest \
+  python -m pytest -q tests/test_meta_harness_reproduction.py
+```
+
+The dry run checks the locked Harbor and Terminal-Bench releases, resolves all
+30 named tasks through Harbor's registry and verifies their exact Git commit,
+then checks the Pi version, Docker daemon, Codex binary, and Reef base commit.
+It also proves that the pinned Codex permission profile can write inside a
+temporary proposal surface while denying reads from its sibling, and verifies
+Git LFS before publication can be reached. It prints the exact plan without
+reading a target-model credential or starting a Codex proposer turn. With the
+default 10/10/10 task split, two rounds, and two trials, every cell receives 140
+target episodes; all three cells plan 420 target episodes and four Codex
+proposer turns.
+
+`--smoke` selects the first pinned task from each existing train, dev, and test
+split. It deliberately keeps two search rounds and two trials per task, so a
+full-history smoke still exercises 14 target episodes, two Codex proposer
+turns, later-round history access, held-out test sealing, and publication. An
+all-cell smoke plans 42 target episodes and four proposer turns. This is a
+bounded end-to-end implementation check, not a benchmark result: the complete
+10/10/10 split remains the adaptation experiment.
+
+## Run the experiment
+
+The Codex proposer uses the local Codex login. Set `REEF_CODEX_BINARY` when
+`codex` is not on `PATH`; the macOS app binary is the final fallback. The Pi
+target needs a fresh OpenAI project credential in `OPENAI_API_KEY`. Supply it
+outside chat and set a hard project budget in the OpenAI dashboard before
+running. Then launch one cell or all cells:
+
+```bash
+# Bounded end-to-end validation before the full experiment.
+recipes/meta_harness/examples/terminal_bench/run.sh \
+  --cell full_history \
+  --smoke \
+  --max-observed-cost-usd 5 \
+  --output-dir /absolute/path/to/meta-harness-smoke
+
+# Complete full-history adaptation cell. The cap is a stop threshold, not an estimate.
+recipes/meta_harness/examples/terminal_bench/run.sh \
+  --cell full_history \
+  --max-observed-cost-usd 25 \
+  --output-dir /absolute/path/to/meta-harness-run
+
+recipes/meta_harness/examples/terminal_bench/run.sh \
+  --cell all \
+  --max-observed-cost-usd 75 \
+  --output-dir /absolute/path/to/meta-harness-run
+```
+
+`--max-observed-cost-usd` is a resumable local stop threshold. The example
+values above are ceilings, not projected costs. The runner prices each
+completed Pi trial from its measured uncached-input, cached-input, and output
+tokens using the pinned snapshot above; it does not trust a custom provider's
+possibly absent native cost metadata. Once those estimates reach the limit,
+the runner starts no new trial. It can overshoot by the cost of one in-flight
+trial and does not price the subscription-backed Codex proposer. A provider
+failure before Pi returns token usage cannot be charged to this ledger, so the
+guard is not a replacement for the external project budget. Pi's
+provider-reported cost is kept separately in Harbor metadata for auditing. The
+target credential is withheld from Codex, retained records, and the published composition. Codex
+tool commands run with a filesystem profile that exposes only minimal system
+files and the current proposal surface; source files containing test IDs and
+sibling cells are outside that readable view.
+
+Cells may be staged into one compatible output directory. Finish every staged
+experiment with the exact `--cell all` invocation shown above: completed
+cells are integrity-checked and skipped, then `plan.json` and `results.json`
+are regenerated for the authoritative three-cell comparison. Changing smoke
+mode, rounds, trials, task splits, models, source commit, or dependency pins
+requires a new output directory.
+
+## Retained records
+
+The two search cells write `workspace/`: proposer-visible population,
+candidate history, round journal, frozen proposals, train history, aggregate
+dev scores, and Codex JSONL sessions. Every cell writes:
+
+- `private-evaluations/`: all Harbor trial records and the held-out result,
+  never exposed through the evolution workspace;
+- `summary.json`, `learning-curve.json`, and `candidate-parents.dot`: scores,
+  candidate counts, status counts, token use, observed cost, and wall time;
+- `workspace/proposal-events.jsonl`: invalid, selection-rejected, selected,
+  duplicate, and failed proposal decisions, including retention disposition and
+  the incumbent before and after each evaluated proposal;
+- `published-composition/` and `artifacts.git/`: the selected provider-free
+  tree published through Reef; and
+- `done.json`: written only after the equal episode budget, held-out test,
+  publication, and—for full history—later-round history-access proof all
+  pass validation. It hashes every retained cell file outside transient Git
+  work/cache directories, so a changed or incomplete result is not skipped.
+
+Runs are restartable. Existing trial identities, completed search rounds,
+Codex sessions, publication metadata, and observed costs are reused rather
+than silently repeated. If evaluation stops partway through a search round,
+the frozen proposal and its proposer session remain pending; the next run
+continues that same proposal from its cached Harbor trials instead of asking
+Codex for a replacement. Interrupted proposal validation also resumes without
+another proposer turn, while a failed proposer turn remains retryable and does
+not consume its round. Harbor infrastructure failures are retained as separate
+attempt records and retried rather than silently scored as benchmark failures.
+Failures with returned usage are charged; failures before usage is available
+are visible in the attempt log but absent from the local spend ledger.
+
+## Status
+
+The provider-independent adaptation, locked environment, dry run,
+deterministic tests, and real Pi-to-Harbor bridge smoke work without provider
+calls. No paid benchmark result is recorded yet. The first paid run is an
+exploratory implementation validation; neutral and negative results are
+retained and reported unchanged.

--- a/recipes/meta_harness/examples/terminal_bench/harness/__init__.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Self-contained Meta-Harness reproduction over Reef compositions."""

--- a/recipes/meta_harness/examples/terminal_bench/harness/budget.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/budget.py
@@ -1,0 +1,83 @@
+"""Persistent observed-cost guard for resumable live experiments."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+from pathlib import Path
+
+
+class SpendCapReached(RuntimeError):
+    """The recorded target-model spend reached the operator's local cap."""
+
+
+class ObservedCostLedger:
+    """Idempotently account completed trials and stop before the next one at cap."""
+
+    def __init__(self, path: Path, max_observed_cost_usd: float) -> None:
+        if not math.isfinite(max_observed_cost_usd) or max_observed_cost_usd <= 0:
+            raise ValueError("observed cost cap must be finite and positive")
+        self.path = Path(path).resolve()
+        self.cap = float(max_observed_cost_usd)
+        if self.path.is_file():
+            state = self._read()
+            spent = float(state.get("observed_cost_usd", 0.0))
+            if not math.isfinite(spent) or spent < 0:
+                raise RuntimeError(f"invalid recorded spend in observed-cost ledger: {self.path}")
+            if self.cap < spent:
+                raise ValueError(f"observed cost cap {self.cap:.2f} is below already recorded spend {spent:.2f}")
+            state["max_observed_cost_usd"] = self.cap
+            self._write(state)
+        else:
+            self._write(
+                {
+                    "schema_version": 1,
+                    "max_observed_cost_usd": self.cap,
+                    "observed_cost_usd": 0.0,
+                    "trials": {},
+                }
+            )
+
+    @property
+    def observed_cost_usd(self) -> float:
+        return float(self._read()["observed_cost_usd"])
+
+    def before_trial(self, identity: str) -> None:
+        state = self._read()
+        if identity in state["trials"]:
+            return
+        if float(state["observed_cost_usd"]) >= self.cap:
+            raise SpendCapReached(f"recorded target-model cost reached ${self.cap:.2f}; no new trial was started")
+
+    def record_trial(self, identity: str, cost_usd: float) -> None:
+        if not math.isfinite(cost_usd) or cost_usd < 0:
+            raise ValueError("recorded trial cost must be finite and non-negative")
+        state = self._read()
+        previous = state["trials"].get(identity)
+        if previous is not None:
+            if float(previous) != float(cost_usd):
+                raise RuntimeError(f"trial cost changed across restart: {identity}")
+            return
+        state["trials"][identity] = float(cost_usd)
+        state["observed_cost_usd"] = sum(float(value) for value in state["trials"].values())
+        self._write(state)
+
+    def _read(self) -> dict:
+        value = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict) or not isinstance(value.get("trials"), dict):
+            raise RuntimeError(f"invalid observed-cost ledger: {self.path}")
+        return value
+
+    def _write(self, value: dict) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                json.dump(value, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            os.replace(temporary, self.path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)

--- a/recipes/meta_harness/examples/terminal_bench/harness/codex.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/codex.py
@@ -1,0 +1,434 @@
+"""Audited non-interactive Codex proposer for Meta-Harness search."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import uuid
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from .search import ProposerSession
+
+_CODEX_FROM_PATH = shutil.which("codex")
+DEFAULT_CODEX_PATH = Path(
+    os.environ.get("REEF_CODEX_BINARY") or _CODEX_FROM_PATH or "/Applications/ChatGPT.app/Contents/Resources/codex"
+)
+_SAFE_ENVIRONMENT_KEYS = {
+    "CODEX_HOME",
+    "HOME",
+    "LANG",
+    "LOGNAME",
+    "NO_COLOR",
+    "PATH",
+    "SHELL",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+}
+_PERMISSION_PROFILE = "meta_harness"
+_FILESYSTEM_POLICY = 'permissions.meta_harness.filesystem={":minimal"="read",":workspace_roots"={"."="write"}}'
+_NETWORK_POLICY = "permissions.meta_harness.network={enabled=false}"
+_SHELL_HISTORY_READER = re.compile(
+    r"(?:^|[;&|]\s*)(?:awk|bat|cat|grep|head|jq|less|more|rg|sed|tail)\b[^;&|\n]*\bhistory/"
+)
+_PYTHON_HISTORY_READER = re.compile(
+    r"(?:open\(\s*['\"]history/|path\(\s*['\"]history/[^'\"]*['\"]\s*\)\.(?:read|read_text)\()",
+    re.IGNORECASE,
+)
+
+
+class CodexProposerError(RuntimeError):
+    """Codex did not produce a complete, auditable proposer turn."""
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    wall_time_s: float
+
+
+class ProcessRunner(Protocol):
+    def __call__(
+        self,
+        command: Sequence[str],
+        environment: Mapping[str, str],
+        timeout_s: float,
+    ) -> ProcessResult: ...
+
+
+class VersionReader(Protocol):
+    def __call__(self, path: Path) -> str: ...
+
+
+class CodexProposer:
+    """Run one isolated Codex turn and retain its machine-readable evidence."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        reasoning_effort: str,
+        codex_path: Path = DEFAULT_CODEX_PATH,
+        timeout_s: float = 1800.0,
+        process_runner: ProcessRunner | None = None,
+        version_reader: VersionReader | None = None,
+    ) -> None:
+        if not model:
+            raise ValueError("Codex proposer model must not be empty")
+        if reasoning_effort not in {"low", "medium", "high", "xhigh"}:
+            raise ValueError("unsupported Codex reasoning effort")
+        if timeout_s <= 0:
+            raise ValueError("Codex proposer timeout must be positive")
+        self.model = model
+        self.reasoning_effort = reasoning_effort
+        self.codex_path = Path(codex_path).resolve()
+        self.timeout_s = float(timeout_s)
+        self._process_runner = process_runner or _run_process
+        self._version_reader = version_reader or _read_version
+
+    def propose(
+        self,
+        *,
+        surface: Path,
+        prompt: str,
+        session_dir: Path,
+        round_index: int,
+    ) -> ProposerSession:
+        surface = Path(surface).resolve()
+        if not surface.is_dir():
+            raise ValueError(f"proposal surface does not exist: {surface}")
+        session_dir = Path(session_dir).resolve()
+        artifact_dir = session_dir / f"invocation-{uuid.uuid4().hex}"
+        artifact_dir.mkdir(parents=True, exist_ok=False)
+        last_message = artifact_dir / "last-message.txt"
+        version = self._version_reader(self.codex_path)
+        command = self._command(surface, prompt, last_message)
+        try:
+            result = self._process_runner(command, _codex_environment(), self.timeout_s)
+        except Exception as exc:
+            failed = ProcessResult(returncode=-1, stdout="", stderr=str(exc), wall_time_s=0.0)
+            (artifact_dir / "events.jsonl").write_text("", encoding="utf-8")
+            (artifact_dir / "stderr.log").write_text(str(exc), encoding="utf-8")
+            self._write_metadata(
+                artifact_dir,
+                version=version,
+                command=command,
+                round_index=round_index,
+                result=failed,
+                status="process_exception",
+                error=str(exc),
+            )
+            if isinstance(exc, CodexProposerError):
+                raise
+            raise CodexProposerError(f"Codex execution failed: {exc}") from exc
+        (artifact_dir / "events.jsonl").write_text(result.stdout, encoding="utf-8")
+        (artifact_dir / "stderr.log").write_text(result.stderr, encoding="utf-8")
+
+        try:
+            events = _parse_events(result.stdout)
+            evidence = _summarize_events(events)
+        except Exception as exc:
+            self._write_metadata(
+                artifact_dir,
+                version=version,
+                command=command,
+                round_index=round_index,
+                result=result,
+                status="invalid_jsonl",
+                error=str(exc),
+            )
+            raise CodexProposerError(f"Codex returned invalid JSONL: {exc}") from exc
+
+        error_events = [event for event in events if event.get("type") == "error"]
+        total_tokens = evidence["usage"]["input_tokens"] + evidence["usage"]["output_tokens"]
+        status = "complete"
+        error: str | None = None
+        if result.returncode != 0:
+            status = "process_failed"
+            error = f"Codex exited with status {result.returncode}"
+        elif error_events:
+            status = "event_failed"
+            error = str(error_events[-1].get("message") or "Codex emitted an error event")
+        elif not evidence["session_id"]:
+            status = "missing_session"
+            error = "Codex emitted no thread.started session id"
+        elif evidence["completed_turns"] < 1:
+            status = "incomplete_turn"
+            error = "Codex emitted no turn.completed event"
+        elif total_tokens <= 0:
+            status = "missing_usage"
+            error = "Codex completed without non-zero token usage"
+
+        self._write_metadata(
+            artifact_dir,
+            version=version,
+            command=command,
+            round_index=round_index,
+            result=result,
+            status=status,
+            error=error,
+            evidence=evidence,
+        )
+        if error is not None:
+            raise CodexProposerError(error)
+
+        return ProposerSession(
+            session_id=evidence["session_id"],
+            input_tokens=evidence["usage"]["input_tokens"],
+            output_tokens=evidence["usage"]["output_tokens"],
+            wall_time_s=result.wall_time_s,
+            artifact_dir=artifact_dir.relative_to(session_dir.parent.parent).as_posix(),
+        )
+
+    def _command(self, surface: Path, prompt: str, last_message: Path) -> list[str]:
+        return [
+            str(self.codex_path),
+            "exec",
+            "--json",
+            "--color",
+            "never",
+            "--cd",
+            str(surface),
+            "--skip-git-repo-check",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--ephemeral",
+            "--sandbox",
+            "workspace-write",
+            "--config",
+            f'default_permissions="{_PERMISSION_PROFILE}"',
+            "--config",
+            _FILESYSTEM_POLICY,
+            "--config",
+            _NETWORK_POLICY,
+            "--model",
+            self.model,
+            "--config",
+            f'model_reasoning_effort="{self.reasoning_effort}"',
+            "--config",
+            "sandbox_workspace_write.network_access=false",
+            "--output-last-message",
+            str(last_message),
+            prompt,
+        ]
+
+    @staticmethod
+    def _write_metadata(
+        artifact_dir: Path,
+        *,
+        version: str,
+        command: Sequence[str],
+        round_index: int,
+        result: ProcessResult,
+        status: str,
+        error: str | None,
+        evidence: Mapping[str, Any] | None = None,
+    ) -> None:
+        payload = {
+            "schema_version": 1,
+            "round": round_index,
+            "status": status,
+            "error": error,
+            "codex_version": version,
+            "command": list(command),
+            "returncode": result.returncode,
+            "wall_time_s": result.wall_time_s,
+            "evidence": dict(evidence or {}),
+        }
+        (artifact_dir / "metadata.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+def _codex_environment() -> dict[str, str]:
+    """Pass only process essentials; target credentials never reach the proposer."""
+    return {key: value for key, value in os.environ.items() if key in _SAFE_ENVIRONMENT_KEYS or key.startswith("LC_")}
+
+
+def _parse_events(stdout: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_number} is not JSON") from exc
+        if not isinstance(value, dict) or not isinstance(value.get("type"), str):
+            raise ValueError(f"line {line_number} is not a Codex event object")
+        events.append(value)
+    if not events:
+        raise ValueError("event stream is empty")
+    return events
+
+
+def _summarize_events(events: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    session_id = ""
+    usage = {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+    item_types: Counter[str] = Counter()
+    tool_evidence: list[dict[str, Any]] = []
+    history_accesses: list[dict[str, Any]] = []
+    completed_turns = 0
+    for event in events:
+        event_type = str(event.get("type") or "")
+        if event_type == "thread.started":
+            session_id = str(event.get("thread_id") or "")
+        if event_type == "turn.completed":
+            completed_turns += 1
+            raw_usage = event.get("usage")
+            if isinstance(raw_usage, Mapping):
+                for key in usage:
+                    usage[key] += int(raw_usage.get(key) or 0)
+        item = event.get("item")
+        if not isinstance(item, Mapping):
+            continue
+        item_type = str(item.get("type") or "unknown")
+        item_types[item_type] += 1
+        if event_type != "item.completed" or item_type not in {"command_execution", "file_change"}:
+            continue
+        row = {"type": item_type, "status": item.get("status")}
+        if item_type == "command_execution":
+            row["command"] = item.get("command")
+            row["exit_code"] = item.get("exit_code")
+            if _is_completed_history_content_read(item):
+                history_accesses.append(
+                    {
+                        "event_type": event_type,
+                        "item_type": item_type,
+                        "command": item.get("command"),
+                    }
+                )
+        else:
+            changes = item.get("changes")
+            row["paths"] = (
+                [change.get("path") for change in changes if isinstance(change, Mapping)]
+                if isinstance(changes, list)
+                else []
+            )
+        tool_evidence.append(row)
+    return {
+        "session_id": session_id,
+        "completed_turns": completed_turns,
+        "usage": usage,
+        "item_types": dict(sorted(item_types.items())),
+        "tool_evidence": tool_evidence,
+        "history_accesses": history_accesses,
+    }
+
+
+def _is_completed_history_content_read(item: Mapping[str, Any]) -> bool:
+    """Recognize logged commands that read candidate or trajectory content."""
+    if item.get("status") != "completed" or item.get("exit_code") not in (None, 0):
+        return False
+    command = item.get("command")
+    if isinstance(command, list):
+        command = " ".join(str(part) for part in command)
+    if not isinstance(command, str):
+        return False
+    normalized = command.lower()
+    return bool(_SHELL_HISTORY_READER.search(normalized) or _PYTHON_HISTORY_READER.search(normalized))
+
+
+def verify_permission_profile(codex_path: Path) -> None:
+    """Prove this Codex build denies sibling reads while allowing surface writes."""
+    with tempfile.TemporaryDirectory(prefix="reef-meta-harness-sandbox-") as temporary:
+        root = Path(temporary)
+        surface = root / "surface"
+        surface.mkdir()
+        (surface / "inside.txt").write_text("inside\n", encoding="utf-8")
+        (root / "sealed.txt").write_text("sealed\n", encoding="utf-8")
+        command = [
+            str(Path(codex_path).resolve()),
+            "sandbox",
+            "--cd",
+            str(surface),
+            "--permission-profile",
+            _PERMISSION_PROFILE,
+            "--config",
+            _FILESYSTEM_POLICY,
+            "--config",
+            _NETWORK_POLICY,
+            "--",
+            "sh",
+            "-c",
+            (
+                'test "$(cat inside.txt)" = inside && ! cat ../sealed.txt >/dev/null 2>&1 '
+                "&& printf writable > writable.txt"
+            ),
+        ]
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_codex_environment(),
+        )
+        if completed.returncode != 0 or not (surface / "writable.txt").is_file():
+            raise CodexProposerError("Codex permission profile did not enforce the sealed proposal surface")
+
+
+def _read_version(codex_path: Path) -> str:
+    try:
+        result = subprocess.run(
+            [str(codex_path), "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=_codex_environment(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise CodexProposerError(f"could not read Codex version: {exc}") from exc
+    version = result.stdout.strip()
+    if not version:
+        raise CodexProposerError("Codex version output was empty")
+    return version
+
+
+def _run_process(command: Sequence[str], environment: Mapping[str, str], timeout_s: float) -> ProcessResult:
+    started = time.monotonic()
+    try:
+        process = subprocess.Popen(
+            list(command),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=dict(environment),
+            start_new_session=True,
+        )
+    except OSError as exc:
+        raise CodexProposerError(f"could not start Codex: {exc}") from exc
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired as exc:
+        os.killpg(process.pid, signal.SIGTERM)
+        try:
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            stdout, stderr = process.communicate()
+        raise CodexProposerError(f"Codex timed out after {timeout_s:g} seconds") from exc
+    return ProcessResult(
+        returncode=process.returncode,
+        stdout=stdout,
+        stderr=stderr,
+        wall_time_s=time.monotonic() - started,
+    )

--- a/recipes/meta_harness/examples/terminal_bench/harness/composition.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/composition.py
@@ -1,0 +1,142 @@
+"""Content-addressed declarative Reef composition candidates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from reef.harness import AdapterDescriptor, render_composition
+from reef.harness.nodes import NODE_KINDS
+
+MAX_NODES = 32
+ALLOWED_NODE_KINDS = frozenset({"agent_command", "rules", "skill"})
+
+
+@dataclass(frozen=True)
+class CompositionCandidate:
+    """Immutable candidate identity derived only from normalized tree content."""
+
+    canonical_json: str
+    parent_hashes: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_value(
+        cls,
+        value: Mapping[str, Any],
+        *,
+        parent_hashes: Sequence[str] = (),
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CompositionCandidate:
+        normalized = normalize_composition(value)
+        canonical = json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        parents = tuple(dict.fromkeys(str(parent) for parent in parent_hashes if parent))
+        if any(len(parent) != 64 for parent in parents):
+            raise ValueError("candidate parent hashes must be full SHA-256 values")
+        return cls(canonical, parents, dict(metadata or {}))
+
+    @classmethod
+    def from_path(
+        cls,
+        path: Path,
+        *,
+        parent_hashes: Sequence[str] = (),
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CompositionCandidate:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(raw, Mapping):
+            raise ValueError("composition file must contain a JSON object")
+        return cls.from_value(raw, parent_hashes=parent_hashes, metadata=metadata)
+
+    @property
+    def content_hash(self) -> str:
+        return hashlib.sha256(self.canonical_json.encode()).hexdigest()
+
+    @property
+    def composition(self) -> dict[str, Any]:
+        return json.loads(self.canonical_json)
+
+    @property
+    def nodes(self) -> tuple[tuple[str, Mapping[str, Any]], ...]:
+        return tuple((node["kind"], node["config"]) for node in self.composition["nodes"])
+
+    def render(self, descriptor: AdapterDescriptor) -> dict[str, str]:
+        return render_composition(self.nodes, descriptor)
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "content_hash": self.content_hash,
+            "parent_hashes": list(self.parent_hashes),
+            "metadata": dict(self.metadata),
+            "composition": self.composition,
+        }
+
+
+def normalize_composition(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the public Reef node vocabulary and return stable JSON data."""
+    if set(value) - {"schema_version", "nodes"}:
+        unknown = sorted(set(value) - {"schema_version", "nodes"})
+        raise ValueError(f"composition contains unknown top-level fields: {unknown!r}")
+    schema_version = value.get("schema_version", 1)
+    if schema_version != 1:
+        raise ValueError("composition schema_version must be 1")
+    raw_nodes = value.get("nodes")
+    if not isinstance(raw_nodes, list) or not raw_nodes:
+        raise ValueError("composition requires a non-empty nodes list")
+    if len(raw_nodes) > MAX_NODES:
+        raise ValueError(f"composition may contain at most {MAX_NODES} nodes")
+
+    normalized_nodes: list[dict[str, Any]] = []
+    for index, raw_node in enumerate(raw_nodes):
+        if not isinstance(raw_node, Mapping) or set(raw_node) != {"kind", "config"}:
+            raise ValueError(f"composition node {index} must contain exactly kind and config")
+        kind = raw_node.get("kind")
+        config = raw_node.get("config")
+        if kind not in NODE_KINDS:
+            raise ValueError(f"composition node {index} has unknown kind {kind!r}")
+        if kind not in ALLOWED_NODE_KINDS:
+            raise ValueError(
+                f"composition node {index} uses unsupported kind {kind!r}; "
+                "the sealed experiment permits only declarative nodes"
+            )
+        NODE_KINDS[str(kind)](None, config)
+        try:
+            stable_config = json.loads(json.dumps(config, sort_keys=True))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"composition node {index} config must be JSON-serializable") from exc
+        normalized_nodes.append({"kind": str(kind), "config": stable_config})
+    return {"schema_version": 1, "nodes": normalized_nodes}
+
+
+def genesis_composition() -> CompositionCandidate:
+    return CompositionCandidate.from_value(
+        {
+            "schema_version": 1,
+            "nodes": [
+                {
+                    "kind": "rules",
+                    "config": {
+                        "text": (
+                            "Work carefully in the terminal until the task is complete. "
+                            "Inspect the environment, verify changes, and do not stop at a plan."
+                        )
+                    },
+                },
+                {
+                    "kind": "skill",
+                    "config": {
+                        "name": "terminal-task",
+                        "text": (
+                            "# Terminal task\n\nUse the bash tool to inspect and modify the task environment. "
+                            "Run the available tests or verifier-facing checks before finishing."
+                        ),
+                    },
+                },
+            ],
+        },
+        metadata={"role": "genesis"},
+    )

--- a/recipes/meta_harness/examples/terminal_bench/harness/config.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/config.py
@@ -1,0 +1,149 @@
+"""Pinned inputs shared by the Meta-Harness runner and deterministic tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+
+REEF_COMMIT = "6b0d9a1345191a0df1a7e324fa09875e8581a83f"
+META_HARNESS_COMMIT = "95175f70c758dd1145b395edfe8b67e6f9d80fbd"
+TERMINAL_BENCH_COMMIT = "1a6ffa9674b571da0ed040c470cb40c4d85f9b9b"
+TERMINAL_BENCH_DATASET_URL = "https://github.com/laude-institute/terminal-bench-2.git"
+TERMINAL_BENCH_DATASET_COMMIT = "69671fbaac6d67a7ef0dfec016cc38a64ef7a77c"
+HARBOR_VERSION = "0.3.0"
+TERMINAL_BENCH_VERSION = "0.2.18"
+PI_VERSION = "0.84.2"
+TARGET_MODEL = "gpt-5.4-mini-2026-03-17"
+TARGET_MODEL_PRICING_SOURCE = "https://developers.openai.com/api/docs/models/gpt-5.4-mini"
+TARGET_MODEL_PRICING_OBSERVED_AT = "2026-08-30"
+PROPOSER_MODEL = "gpt-5.5"
+PROPOSER_REASONING_EFFORT = "high"
+SEARCH_ROUNDS = 2
+TRIALS_PER_TASK = 2
+
+# Exact 30-task development subset shipped at the pinned Meta-Harness commit.
+HARD_TASKS = (
+    "bn-fit-modify",
+    "cancel-async-tasks",
+    "circuit-fibsqrt",
+    "configure-git-webserver",
+    "dna-assembly",
+    "extract-moves-from-video",
+    "feal-differential-cryptanalysis",
+    "feal-linear-cryptanalysis",
+    "fix-code-vulnerability",
+    "fix-ocaml-gc",
+    "gpt2-codegolf",
+    "install-windows-3.11",
+    "llm-inference-batching-scheduler",
+    "make-doom-for-mips",
+    "make-mips-interpreter",
+    "mcmc-sampling-stan",
+    "model-extraction-relu-logits",
+    "password-recovery",
+    "path-tracing",
+    "path-tracing-reverse",
+    "polyglot-rust-c",
+    "protein-assembly",
+    "regex-chess",
+    "sam-cell-seg",
+    "sparql-university",
+    "torch-pipeline-parallelism",
+    "torch-tensor-parallelism",
+    "train-fasttext",
+    "video-processing",
+    "write-compressor",
+)
+
+# A fixed 10/10/10 partition of the pinned hard subset. The proposer receives
+# train trajectories and aggregate dev scores; test ids are withheld until the
+# search loop returns its fixed selection.
+TRAIN_TASKS = HARD_TASKS[:10]
+DEV_TASKS = HARD_TASKS[10:20]
+TEST_TASKS = HARD_TASKS[20:]
+
+# The live smoke keeps one task from each fixed split while preserving the
+# reproduction's two rounds and two trials. This exercises later-round history,
+# held-out sealing, and publication without silently changing search semantics.
+SMOKE_TRAIN_TASKS = TRAIN_TASKS[:1]
+SMOKE_DEV_TASKS = DEV_TASKS[:1]
+SMOKE_TEST_TASKS = TEST_TASKS[:1]
+
+
+@dataclass(frozen=True)
+class TokenPricing:
+    """Reproducible text-token pricing snapshot for one exact model."""
+
+    model: str
+    input_usd_per_million: float
+    cached_input_usd_per_million: float
+    output_usd_per_million: float
+    source_url: str
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        if not self.model or not self.source_url or not self.observed_at:
+            raise ValueError("token pricing requires model, source URL, and observation date")
+        rates = (
+            self.input_usd_per_million,
+            self.cached_input_usd_per_million,
+            self.output_usd_per_million,
+        )
+        if any(rate < 0 for rate in rates):
+            raise ValueError("token prices must be non-negative")
+
+    def estimate_usd(self, usage: Mapping[str, int]) -> float:
+        counts = {
+            "input_tokens": int(usage.get("input_tokens", 0)),
+            "cached_input_tokens": int(usage.get("cached_input_tokens", 0)),
+            "output_tokens": int(usage.get("output_tokens", 0)),
+        }
+        if any(count < 0 for count in counts.values()):
+            raise ValueError("token usage must be non-negative")
+        return (
+            counts["input_tokens"] * self.input_usd_per_million
+            + counts["cached_input_tokens"] * self.cached_input_usd_per_million
+            + counts["output_tokens"] * self.output_usd_per_million
+        ) / 1_000_000
+
+    def to_jsonable(self) -> dict[str, str | float]:
+        return asdict(self)
+
+
+TARGET_MODEL_PRICING = TokenPricing(
+    model=TARGET_MODEL,
+    input_usd_per_million=0.75,
+    cached_input_usd_per_million=0.075,
+    output_usd_per_million=4.50,
+    source_url=TARGET_MODEL_PRICING_SOURCE,
+    observed_at=TARGET_MODEL_PRICING_OBSERVED_AT,
+)
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    """One auditable Meta-Harness reproduction configuration."""
+
+    target_model: str = TARGET_MODEL
+    proposer_model: str = PROPOSER_MODEL
+    proposer_reasoning_effort: str = PROPOSER_REASONING_EFFORT
+    rounds: int = SEARCH_ROUNDS
+    trials_per_task: int = TRIALS_PER_TASK
+    target_api_key_env: str = "OPENAI_API_KEY"
+    target_base_url: str = "https://api.openai.com"
+
+    def __post_init__(self) -> None:
+        if not self.target_model or not self.proposer_model:
+            raise ValueError("target and proposer model names must be non-empty")
+        if self.proposer_reasoning_effort not in {"low", "medium", "high", "xhigh"}:
+            raise ValueError("unsupported proposer reasoning effort")
+        if self.rounds < 2:
+            raise ValueError("the reproduction requires at least two rounds")
+        if self.trials_per_task < 2:
+            raise ValueError("the reproduction requires at least two trials per task")
+        if not self.target_base_url.startswith(("http://", "https://")):
+            raise ValueError("target_base_url must be an HTTP(S) URL")
+        if not self.target_api_key_env:
+            raise ValueError("target_api_key_env must be non-empty")
+        if self.target_model != TARGET_MODEL_PRICING.model:
+            raise ValueError("target_model has no pinned token-pricing snapshot")

--- a/recipes/meta_harness/examples/terminal_bench/harness/evaluation.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/evaluation.py
@@ -1,0 +1,85 @@
+"""Evaluation values retained in the Meta-Harness workspace."""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+SEARCH_SPLITS = ("train", "dev")
+ALL_SPLITS = (*SEARCH_SPLITS, "test")
+
+
+@dataclass(frozen=True)
+class TrialEvidence:
+    """One verifier-owned task trial and its auditable execution evidence."""
+
+    task_id: str
+    trial: int
+    reward: float
+    trajectory: tuple[Mapping[str, Any], ...] = ()
+    usage: Mapping[str, int] = field(default_factory=dict)
+    estimated_cost_usd: float = 0.0
+    wall_time_s: float = 0.0
+    status: str = "completed"
+    error: str | None = None
+    verifier: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.task_id:
+            raise ValueError("trial evidence requires a task id")
+        if self.trial < 0:
+            raise ValueError("trial index must be non-negative")
+        if not 0.0 <= float(self.reward) <= 1.0:
+            raise ValueError("trial reward must be between zero and one")
+        if self.estimated_cost_usd < 0 or self.wall_time_s < 0:
+            raise ValueError("trial cost and wall time must be non-negative")
+        if not self.status:
+            raise ValueError("trial evidence requires a status")
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    """One candidate's results on exactly one named task split."""
+
+    split: str
+    trials: tuple[TrialEvidence, ...]
+
+    def __post_init__(self) -> None:
+        if self.split not in ALL_SPLITS:
+            raise ValueError(f"evaluation split must be one of {ALL_SPLITS}")
+        if not self.trials:
+            raise ValueError("evaluation result requires at least one trial")
+        identities = [(trial.task_id, trial.trial) for trial in self.trials]
+        if len(set(identities)) != len(identities):
+            raise ValueError("evaluation result contains a duplicate task trial")
+
+    @property
+    def score(self) -> float:
+        return statistics.fmean(trial.reward for trial in self.trials)
+
+    @property
+    def task_ids(self) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(trial.task_id for trial in self.trials))
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "split": self.split,
+            "score": self.score,
+            "trials": [trial.to_jsonable() for trial in self.trials],
+            "usage": aggregate_usage(trial.usage for trial in self.trials),
+            "estimated_cost_usd": sum(trial.estimated_cost_usd for trial in self.trials),
+            "wall_time_s": sum(trial.wall_time_s for trial in self.trials),
+        }
+
+
+def aggregate_usage(items: Iterable[Mapping[str, int]]) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for item in items:
+        for key, value in item.items():
+            totals[key] = totals.get(key, 0) + int(value)
+    return totals

--- a/recipes/meta_harness/examples/terminal_bench/harness/harbor_agent.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/harbor_agent.py
@@ -1,0 +1,110 @@
+"""Harbor BaseAgent that evaluates a rendered Reef composition through Pi."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from reef.harness.adapters import get_adapter
+from reef.harness.model_binding import ModelBinding
+from reef.harness.render import render_composition
+
+from .composition import CompositionCandidate
+from .config import PI_VERSION
+from .pi_bridge import HarborExecBridge, PiEpisodeRunner
+
+
+class HarborAgent(BaseAgent):
+    """Keep Harbor's verifier/container fixed while Pi supplies the harness loop."""
+
+    def __init__(
+        self,
+        *args: Any,
+        composition_path: str,
+        target_base_url: str,
+        target_api_key_env: str,
+        pi_binary: str,
+        pi_timeout_s: float = 1800.0,
+        pi_runner: PiEpisodeRunner | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._composition_path = Path(composition_path).resolve()
+        self._target_base_url = target_base_url
+        self._target_api_key_env = target_api_key_env
+        self._pi_binary = Path(pi_binary).resolve()
+        self._pi_timeout_s = float(pi_timeout_s)
+        self._pi_runner = pi_runner
+
+    @staticmethod
+    def name() -> str:
+        return "reef-meta-harness-pi"
+
+    def version(self) -> str | None:
+        return PI_VERSION
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        """Pi runs on the trusted host; Harbor owns the task container."""
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        api_key = os.environ.get(self._target_api_key_env, "").strip()
+        if not api_key:
+            raise RuntimeError(f"target credential environment {self._target_api_key_env!r} is empty")
+        candidate = CompositionCandidate.from_path(self._composition_path)
+        descriptor = get_adapter("pi")
+        binding = ModelBinding(
+            base_url=self._target_base_url,
+            model=self.model_name or "",
+            api_key=api_key,
+            api="openai",
+            timeout_s=self._pi_timeout_s,
+        )
+        files = render_composition((*candidate.nodes, *binding.compose_nodes(descriptor)), descriptor)
+        runner = self._pi_runner or PiEpisodeRunner(
+            descriptor,
+            binary=self._pi_binary,
+            timeout_s=self._pi_timeout_s,
+        )
+        loop = asyncio.get_running_loop()
+        with HarborExecBridge(environment.exec, loop) as bridge:
+            result = await asyncio.to_thread(
+                runner.run,
+                files,
+                instruction,
+                bridge_url=bridge.url,
+                bridge_token=bridge.token,
+            )
+
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        trajectory_path = self.logs_dir / "pi-trajectory.json"
+        trajectory_path.write_text(
+            json.dumps(list(result.trajectory), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        usage = result.usage
+        cached = int(usage.get("cached_input_tokens", 0))
+        context.n_input_tokens = int(usage.get("input_tokens", 0)) + cached
+        context.n_cache_tokens = cached
+        context.n_output_tokens = int(usage.get("output_tokens", 0))
+        context.cost_usd = result.estimated_cost_usd
+        context.metadata = {
+            **(context.metadata or {}),
+            "reef_meta_harness": {
+                "pi_version": PI_VERSION,
+                "pi_exit_code": result.exit_code,
+                "pi_stderr": result.stderr.replace(api_key, "[REDACTED]")[-4000:],
+                "provider_reported_cost_usd": result.provider_reported_cost_usd,
+                "trajectory_path": str(trajectory_path),
+            },
+        }

--- a/recipes/meta_harness/examples/terminal_bench/harness/harbor_eval.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/harbor_eval.py
@@ -1,0 +1,434 @@
+"""Terminal-Bench evaluation owned by Harbor's task verifier."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from .composition import CompositionCandidate
+from .config import HARD_TASKS, TERMINAL_BENCH_DATASET_COMMIT, TERMINAL_BENCH_DATASET_URL
+from .evaluation import ALL_SPLITS, EvaluationResult, TrialEvidence
+
+_SAFE_SEGMENT = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class HarborTrialOutcome:
+    reward: float
+    trajectory: tuple[Mapping[str, Any], ...] = ()
+    usage: Mapping[str, int] = field(default_factory=dict)
+    estimated_cost_usd: float = 0.0
+    wall_time_s: float = 0.0
+    status: str = "completed"
+    error: str | None = None
+    verifier: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= float(self.reward) <= 1.0:
+            raise ValueError("Harbor trial reward must be between zero and one")
+        if self.estimated_cost_usd < 0 or self.wall_time_s < 0:
+            raise ValueError("Harbor trial cost and wall time must be non-negative")
+        if not self.status:
+            raise ValueError("Harbor trial outcome requires a status")
+
+
+class TrialExecutor(Protocol):
+    def __call__(
+        self,
+        candidate: CompositionCandidate,
+        candidate_path: Path,
+        task_id: str,
+        trial_index: int,
+        round_index: int,
+        trial_dir: Path,
+    ) -> HarborTrialOutcome: ...
+
+
+class TrialHook(Protocol):
+    def __call__(self, trial_id: str) -> None: ...
+
+
+class TrialCostHook(Protocol):
+    def __call__(self, trial_id: str, cost_usd: float) -> None: ...
+
+
+class HarborInfrastructureError(RuntimeError):
+    """Harbor did not return complete, verifier-owned benchmark evidence."""
+
+
+async def verify_dataset_registry_pin(
+    task_ids: Sequence[str] = HARD_TASKS,
+    *,
+    dataset_config_factory: Callable[..., Any] | None = None,
+) -> None:
+    """Fail if Harbor's named dataset no longer resolves to the recorded Git tree."""
+    if dataset_config_factory is None:
+        from harbor.models.job.config import DatasetConfig
+
+        dataset_config_factory = DatasetConfig
+    requested = tuple(str(task_id) for task_id in task_ids)
+    if not requested or len(set(requested)) != len(requested):
+        raise RuntimeError("dataset registry verification requires unique task ids")
+    task_configs = await dataset_config_factory(
+        name="terminal-bench",
+        version="2.0",
+        task_names=list(requested),
+    ).get_task_configs()
+    resolved: dict[str, Any] = {}
+    for task_config in task_configs:
+        path = getattr(task_config, "path", None)
+        name = Path(path).name if path is not None else ""
+        if not name or name in resolved:
+            raise RuntimeError("Terminal-Bench registry returned an invalid or duplicate task path")
+        resolved[name] = task_config
+    if set(resolved) != set(requested):
+        missing = sorted(set(requested) - set(resolved))
+        extra = sorted(set(resolved) - set(requested))
+        raise RuntimeError(f"Terminal-Bench registry task mismatch: missing={missing}, extra={extra}")
+    for task_id in requested:
+        task_config = resolved[task_id]
+        if Path(task_config.path) != Path(task_id):
+            raise RuntimeError(f"Terminal-Bench task {task_id!r} resolved to {task_config.path!s}")
+        if task_config.git_url != TERMINAL_BENCH_DATASET_URL:
+            raise RuntimeError(f"Terminal-Bench task {task_id!r} resolved to unexpected URL {task_config.git_url!r}")
+        if task_config.git_commit_id != TERMINAL_BENCH_DATASET_COMMIT:
+            raise RuntimeError(
+                f"Terminal-Bench task {task_id!r} resolved to unexpected commit {task_config.git_commit_id!r}"
+            )
+
+
+def _pinned_task_config(task_id: str) -> Any:
+    """Build a Harbor task config from immutable inputs, not mutable registry state."""
+    from harbor.models.trial.config import TaskConfig
+
+    if task_id not in HARD_TASKS:
+        raise RuntimeError(f"Terminal-Bench task {task_id!r} is outside the pinned hard subset")
+    return TaskConfig(
+        path=Path(task_id),
+        git_url=TERMINAL_BENCH_DATASET_URL,
+        git_commit_id=TERMINAL_BENCH_DATASET_COMMIT,
+        source="terminal-bench",
+    )
+
+
+class HarborEvaluator:
+    """Evaluate fixed task splits without exposing verifier ownership to search."""
+
+    def __init__(
+        self,
+        *,
+        splits: Mapping[str, Sequence[str]],
+        trials_per_task: int,
+        output_dir: Path,
+        target_model: str,
+        target_base_url: str,
+        target_api_key_env: str,
+        pi_binary: Path,
+        pi_timeout_s: float = 1800.0,
+        trial_executor: TrialExecutor | None = None,
+        before_trial: TrialHook | None = None,
+        after_trial: TrialCostHook | None = None,
+        budget_namespace: str = "default",
+    ) -> None:
+        if set(splits) != set(ALL_SPLITS):
+            raise ValueError(f"Harbor evaluator requires exactly the splits {ALL_SPLITS}")
+        normalized = {name: tuple(str(task) for task in splits[name]) for name in ALL_SPLITS}
+        if any(not tasks or any(not task for task in tasks) for tasks in normalized.values()):
+            raise ValueError("each Harbor task split must be non-empty")
+        all_tasks = sum(normalized.values(), ())
+        if len(set(all_tasks)) != len(all_tasks):
+            raise ValueError("Harbor task splits must be disjoint")
+        if len({_safe_segment(task) for task in all_tasks}) != len(all_tasks):
+            raise ValueError("Harbor task ids collide after path normalization")
+        if trials_per_task < 1:
+            raise ValueError("Harbor trials per task must be positive")
+        if not target_model or not target_base_url or not target_api_key_env:
+            raise ValueError("Harbor target model, base URL, and credential environment are required")
+        if pi_timeout_s <= 0:
+            raise ValueError("Pi timeout must be positive")
+        if not budget_namespace or ":" in budget_namespace:
+            raise ValueError("budget namespace must be non-empty and contain no colon")
+        self.splits = normalized
+        self.trials_per_task = trials_per_task
+        self.output_dir = Path(output_dir).resolve()
+        self.target_model = target_model
+        self.target_base_url = target_base_url.rstrip("/")
+        self.target_api_key_env = target_api_key_env
+        self.pi_binary = Path(pi_binary).resolve()
+        self.pi_timeout_s = float(pi_timeout_s)
+        self._trial_executor = trial_executor or self._execute_harbor_trial
+        self._before_trial = before_trial
+        self._after_trial = after_trial
+        self._budget_namespace = budget_namespace
+
+    def evaluate(
+        self,
+        candidate: CompositionCandidate,
+        *,
+        split: str,
+        round_index: int,
+    ) -> EvaluationResult:
+        if split not in self.splits:
+            raise ValueError(f"unknown evaluation split {split!r}")
+        candidate_path = self._persist_candidate(candidate)
+        trials: list[TrialEvidence] = []
+        for task_id in self.splits[split]:
+            for trial_index in range(self.trials_per_task):
+                trial_dir = (
+                    self.output_dir
+                    / "trials"
+                    / candidate.content_hash
+                    / f"round-{round_index:04d}"
+                    / split
+                    / _safe_segment(task_id)
+                    / f"trial-{trial_index:02d}"
+                )
+                trial_dir.mkdir(parents=True, exist_ok=True)
+                evidence_path = trial_dir / "evidence.json"
+                identity = (
+                    f"{self._budget_namespace}:{candidate.content_hash}:round-{round_index:04d}:"
+                    f"{split}:{task_id}:trial-{trial_index:02d}"
+                )
+                if evidence_path.is_file():
+                    evidence = _read_evidence(evidence_path, task_id=task_id, trial_index=trial_index)
+                    _validate_completed_evidence(evidence)
+                    if self._after_trial is not None:
+                        self._after_trial(identity, evidence.estimated_cost_usd)
+                    trials.append(evidence)
+                    continue
+                if self._before_trial is not None:
+                    self._before_trial(identity)
+                try:
+                    outcome = self._trial_executor(
+                        candidate,
+                        candidate_path,
+                        task_id,
+                        trial_index,
+                        round_index,
+                        trial_dir,
+                    )
+                except Exception as exc:
+                    attempt = len(tuple(trial_dir.glob("executor-error-*.json"))) + 1
+                    self._write_once(
+                        trial_dir / f"executor-error-{attempt:02d}.json",
+                        {"error_type": type(exc).__name__, "error": str(exc)},
+                    )
+                    raise HarborInfrastructureError(f"Harbor trial execution failed: {exc}") from exc
+                evidence = TrialEvidence(
+                    task_id=task_id,
+                    trial=trial_index,
+                    reward=outcome.reward,
+                    trajectory=outcome.trajectory,
+                    usage=outcome.usage,
+                    estimated_cost_usd=outcome.estimated_cost_usd,
+                    wall_time_s=outcome.wall_time_s,
+                    status=outcome.status,
+                    error=outcome.error,
+                    verifier=outcome.verifier,
+                )
+                try:
+                    _validate_completed_evidence(evidence)
+                except HarborInfrastructureError:
+                    attempt = len(tuple(trial_dir.glob("infrastructure-attempt-*.json"))) + 1
+                    failure_path = trial_dir / f"infrastructure-attempt-{attempt:02d}.json"
+                    self._write_once(failure_path, evidence.to_jsonable())
+                    if self._after_trial is not None:
+                        self._after_trial(f"{identity}:infrastructure-{attempt:02d}", evidence.estimated_cost_usd)
+                    raise
+                self._write_once(evidence_path, evidence.to_jsonable())
+                if self._after_trial is not None:
+                    self._after_trial(identity, evidence.estimated_cost_usd)
+                trials.append(evidence)
+        return EvaluationResult(split=split, trials=tuple(trials))
+
+    def completed_evaluations(self, split: str) -> int:
+        """Count complete candidate/round split batches for restart and budget fill."""
+        if split not in self.splits:
+            raise ValueError(f"unknown evaluation split {split!r}")
+        trial_root = self.output_dir / "trials"
+        expected = len(self.splits[split]) * self.trials_per_task
+        groups: dict[tuple[str, str], int] = {}
+        for path in trial_root.glob(f"*/round-*/{split}/*/trial-*/evidence.json"):
+            relative = path.relative_to(trial_root)
+            key = (relative.parts[0], relative.parts[1])
+            groups[key] = groups.get(key, 0) + 1
+        return sum(count == expected for count in groups.values())
+
+    def _persist_candidate(self, candidate: CompositionCandidate) -> Path:
+        path = self.output_dir / "candidates" / candidate.content_hash / "composition.json"
+        self._write_text_once(path, candidate.canonical_json + "\n")
+        return path
+
+    def _execute_harbor_trial(
+        self,
+        candidate: CompositionCandidate,
+        candidate_path: Path,
+        task_id: str,
+        trial_index: int,
+        round_index: int,
+        trial_dir: Path,
+    ) -> HarborTrialOutcome:
+        return asyncio.run(
+            self._execute_harbor_trial_async(
+                candidate,
+                candidate_path,
+                task_id,
+                trial_index,
+                round_index,
+                trial_dir,
+            )
+        )
+
+    async def _execute_harbor_trial_async(
+        self,
+        _candidate: CompositionCandidate,
+        candidate_path: Path,
+        task_id: str,
+        _trial_index: int,
+        _round_index: int,
+        trial_dir: Path,
+    ) -> HarborTrialOutcome:
+        from harbor.models.environment_type import EnvironmentType
+        from harbor.models.job.config import AgentConfig
+        from harbor.models.trial.config import EnvironmentConfig, TrialConfig
+        from harbor.trial.trial import Trial
+
+        config = TrialConfig(
+            task=_pinned_task_config(task_id),
+            trial_name=trial_dir.name,
+            trials_dir=trial_dir.parent,
+            agent=AgentConfig(
+                import_path="harness.harbor_agent:HarborAgent",
+                model_name=self.target_model,
+                kwargs={
+                    "composition_path": str(candidate_path),
+                    "target_base_url": self.target_base_url,
+                    "target_api_key_env": self.target_api_key_env,
+                    "pi_binary": str(self.pi_binary),
+                    "pi_timeout_s": self.pi_timeout_s,
+                },
+            ),
+            environment=EnvironmentConfig(type=EnvironmentType.DOCKER, delete=True),
+        )
+        result = await (await Trial.create(config)).run()
+        return _outcome_from_trial_result(result)
+
+    @staticmethod
+    def _write_once(path: Path, payload: Any) -> None:
+        HarborEvaluator._write_text_once(path, json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n")
+
+    @staticmethod
+    def _write_text_once(path: Path, text: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            if path.read_text(encoding="utf-8") != text:
+                raise RuntimeError(f"evaluation evidence changed across restart: {path}")
+            return
+        path.write_text(text, encoding="utf-8")
+
+
+def _outcome_from_trial_result(result: Any) -> HarborTrialOutcome:
+    verifier_result = getattr(result, "verifier_result", None)
+    rewards = dict(getattr(verifier_result, "rewards", None) or {})
+    reward = float(rewards.get("reward", 0.0))
+    context = getattr(result, "agent_result", None)
+    metadata = getattr(context, "metadata", None) if context is not None else None
+    reef_metadata = metadata.get("reef_meta_harness", {}) if isinstance(metadata, Mapping) else {}
+    trajectory: tuple[Mapping[str, Any], ...] = ()
+    trajectory_path = reef_metadata.get("trajectory_path") if isinstance(reef_metadata, Mapping) else None
+    if trajectory_path:
+        raw_trajectory = json.loads(Path(str(trajectory_path)).read_text(encoding="utf-8"))
+        if not isinstance(raw_trajectory, list) or not all(isinstance(event, Mapping) for event in raw_trajectory):
+            raise RuntimeError("Pi trajectory artifact is not a list of events")
+        trajectory = tuple(raw_trajectory)
+
+    exception = getattr(result, "exception_info", None)
+    pi_exit_code = reef_metadata.get("pi_exit_code") if isinstance(reef_metadata, Mapping) else None
+    status = "completed"
+    error = None
+    if exception is not None:
+        status = f"trial_failed:{getattr(exception, 'exception_type', 'unknown')}"
+        error = str(getattr(exception, "exception_message", ""))
+    elif pi_exit_code not in (None, 0):
+        status = f"pi_failed:{pi_exit_code}"
+        error = str(reef_metadata.get("pi_stderr") or "")
+    elif context is None:
+        status = "agent_context_missing"
+        error = "Harbor returned no agent context"
+    elif not trajectory_path:
+        status = "trajectory_missing"
+        error = "Harbor agent returned no Pi trajectory artifact"
+    elif verifier_result is None or "reward" not in rewards:
+        status = "verifier_missing"
+        error = "Harbor returned no verifier reward"
+
+    started = getattr(result, "started_at", None)
+    finished = getattr(result, "finished_at", None)
+    wall_time_s = max((finished - started).total_seconds(), 0.0) if started and finished else 0.0
+    usage = {
+        "input_tokens": int(getattr(context, "n_input_tokens", 0) or 0),
+        "cached_input_tokens": int(getattr(context, "n_cache_tokens", 0) or 0),
+        "output_tokens": int(getattr(context, "n_output_tokens", 0) or 0),
+    }
+    return HarborTrialOutcome(
+        reward=reward,
+        trajectory=trajectory,
+        usage=usage,
+        estimated_cost_usd=float(getattr(context, "cost_usd", 0.0) or 0.0),
+        wall_time_s=wall_time_s,
+        status=status,
+        error=error,
+        verifier={
+            "rewards": rewards,
+            "task_checksum": str(getattr(result, "task_checksum", "")),
+            "source": getattr(result, "source", None),
+        },
+    )
+
+
+def _safe_segment(value: str) -> str:
+    safe = _SAFE_SEGMENT.sub("-", value).strip("-.")
+    return safe[:96] or "task"
+
+
+def _validate_completed_evidence(evidence: TrialEvidence) -> None:
+    verifier = evidence.verifier
+    rewards = verifier.get("rewards") if isinstance(verifier, Mapping) else None
+    if evidence.status != "completed":
+        raise HarborInfrastructureError(f"Harbor trial returned infrastructure status {evidence.status!r}")
+    if not evidence.trajectory:
+        raise HarborInfrastructureError("Harbor trial returned no Pi trajectory")
+    if not isinstance(rewards, Mapping) or "reward" not in rewards:
+        raise HarborInfrastructureError("Harbor trial returned no verifier reward")
+    if not verifier.get("task_checksum"):
+        raise HarborInfrastructureError("Harbor trial returned no task checksum")
+
+
+def _read_evidence(path: Path, *, task_id: str, trial_index: int) -> TrialEvidence:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, Mapping):
+        raise RuntimeError(f"trial evidence is not an object: {path}")
+    if value.get("task_id") != task_id or value.get("trial") != trial_index:
+        raise RuntimeError(f"trial evidence identity does not match its path: {path}")
+    trajectory = value.get("trajectory")
+    usage = value.get("usage")
+    verifier = value.get("verifier")
+    if not isinstance(trajectory, list) or not all(isinstance(event, Mapping) for event in trajectory):
+        raise RuntimeError(f"trial evidence trajectory is invalid: {path}")
+    return TrialEvidence(
+        task_id=task_id,
+        trial=trial_index,
+        reward=float(value["reward"]),
+        trajectory=tuple(trajectory),
+        usage=dict(usage) if isinstance(usage, Mapping) else {},
+        estimated_cost_usd=float(value.get("estimated_cost_usd", 0.0)),
+        wall_time_s=float(value.get("wall_time_s", 0.0)),
+        status=str(value.get("status") or "completed"),
+        error=str(value["error"]) if value.get("error") is not None else None,
+        verifier=dict(verifier) if isinstance(verifier, Mapping) else {},
+    )

--- a/recipes/meta_harness/examples/terminal_bench/harness/pi_bridge.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/pi_bridge.py
@@ -1,0 +1,379 @@
+"""Run Pi locally while delegating its only terminal tool to Harbor."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hmac
+import json
+import os
+import secrets
+import signal
+import subprocess
+import tempfile
+import time
+from collections.abc import Awaitable, Mapping, Sequence
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+from reef.harness import AdapterDescriptor
+from reef.harness.trajectory import reader_for
+
+from .config import TARGET_MODEL_PRICING, TokenPricing
+
+BRIDGE_EXTENSION_PATH = "pi-agent/extensions/zzzz-reef-harbor-bridge.ts"
+MAX_REQUEST_BYTES = 1_048_576
+BRIDGE_EXTENSION = r"""import {
+  createBashToolDefinition,
+  type BashOperations,
+  type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+
+const endpoint = process.env.REEF_HARBOR_BRIDGE_URL;
+const token = process.env.REEF_HARBOR_BRIDGE_TOKEN;
+if (!endpoint || !token) throw new Error("Reef Harbor bridge environment is missing");
+
+const operations: BashOperations = {
+  async exec(command, _cwd, { onData, signal, timeout }) {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    signal?.addEventListener("abort", abort, { once: true });
+    const timer = timeout ? setTimeout(abort, timeout * 1000) : undefined;
+    try {
+      const response = await fetch(`${endpoint}/exec`, {
+        method: "POST",
+        headers: {
+          "authorization": `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ command, timeout_sec: timeout }),
+        signal: controller.signal,
+      });
+      const body = await response.json() as {
+        stdout?: string;
+        stderr?: string;
+        return_code?: number;
+        error?: string;
+      };
+      if (!response.ok) throw new Error(body.error || `bridge HTTP ${response.status}`);
+      if (body.stdout) onData(Buffer.from(body.stdout));
+      if (body.stderr) onData(Buffer.from(body.stderr));
+      return { exitCode: Number.isInteger(body.return_code) ? body.return_code! : 1 };
+    } finally {
+      if (timer) clearTimeout(timer);
+      signal?.removeEventListener("abort", abort);
+    }
+  },
+};
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool(createBashToolDefinition("/", {
+    operations,
+    exposeSessionEnvironment: false,
+  }));
+  pi.on("before_agent_start", async (event) => ({
+    systemPrompt: `${event.systemPrompt}\n\nThe bash tool executes inside the isolated benchmark task environment. ` +
+      "Use bash for every task file operation; the host-side working directory is not the task filesystem.",
+  }));
+}
+"""
+
+
+class PiBridgeError(RuntimeError):
+    """The Pi process or its Harbor execution bridge failed."""
+
+
+@dataclass(frozen=True)
+class PiProcessResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    wall_time_s: float
+
+
+@dataclass(frozen=True)
+class PiEpisodeResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    trajectory: tuple[dict[str, Any], ...]
+    usage: Mapping[str, int]
+    estimated_cost_usd: float
+    provider_reported_cost_usd: float
+    wall_time_s: float
+
+
+class PiProcessRunner(Protocol):
+    def __call__(
+        self,
+        command: Sequence[str],
+        workspace: Path,
+        environment: Mapping[str, str],
+        timeout_s: float,
+    ) -> PiProcessResult: ...
+
+
+class ExecCoroutine(Protocol):
+    def __call__(self, *, command: str, timeout_sec: int) -> Awaitable[Any]: ...
+
+
+class HarborExecBridge:
+    """Authenticated loopback HTTP bridge into one Harbor environment."""
+
+    def __init__(
+        self,
+        executor: ExecCoroutine,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        request_timeout_s: float = 3600.0,
+    ) -> None:
+        self._executor = executor
+        self._loop = loop
+        self._request_timeout_s = request_timeout_s
+        self.token = secrets.token_urlsafe(32)
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler())
+        self._thread = None
+
+    @property
+    def url(self) -> str:
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"
+
+    def start(self) -> HarborExecBridge:
+        if self._thread is not None:
+            raise PiBridgeError("Harbor execution bridge is already running")
+        import threading
+
+        self._thread = threading.Thread(target=self._server.serve_forever, name="reef-harbor-bridge", daemon=True)
+        self._thread.start()
+        return self
+
+    def close(self) -> None:
+        if self._thread is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        self._thread = None
+
+    def __enter__(self) -> HarborExecBridge:
+        return self.start()
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
+
+    def _handler(self) -> type[BaseHTTPRequestHandler]:
+        bridge = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                if self.path != "/exec":
+                    self._reply(HTTPStatus.NOT_FOUND, {"error": "unknown bridge path"})
+                    return
+                supplied = self.headers.get("authorization", "")
+                if not hmac.compare_digest(supplied, f"Bearer {bridge.token}"):
+                    self._reply(HTTPStatus.UNAUTHORIZED, {"error": "invalid bridge token"})
+                    return
+                try:
+                    length = int(self.headers.get("content-length", "0"))
+                except ValueError:
+                    length = 0
+                if not 0 < length <= MAX_REQUEST_BYTES:
+                    self._reply(HTTPStatus.BAD_REQUEST, {"error": "invalid request size"})
+                    return
+                try:
+                    body = json.loads(self.rfile.read(length))
+                    command = body.get("command") if isinstance(body, Mapping) else None
+                    if not isinstance(command, str) or not command.strip():
+                        raise ValueError("command must be a non-empty string")
+                    timeout_raw = body.get("timeout_sec")
+                    timeout_sec = min(max(int(timeout_raw or 600), 1), int(bridge._request_timeout_s))
+                    future = asyncio.run_coroutine_threadsafe(
+                        bridge._executor(command=command, timeout_sec=timeout_sec),
+                        bridge._loop,
+                    )
+                    result = future.result(timeout=timeout_sec + 5)
+                    self._reply(
+                        HTTPStatus.OK,
+                        {
+                            "stdout": getattr(result, "stdout", None) or "",
+                            "stderr": getattr(result, "stderr", None) or "",
+                            "return_code": int(result.return_code),
+                        },
+                    )
+                except Exception as exc:
+                    self._reply(
+                        HTTPStatus.INTERNAL_SERVER_ERROR,
+                        {"error": f"{type(exc).__name__}: {exc}"[:1000]},
+                    )
+
+            def log_message(self, format: str, *args: Any) -> None:
+                return
+
+            def _reply(self, status: HTTPStatus, payload: Mapping[str, Any]) -> None:
+                data = json.dumps(dict(payload)).encode("utf-8")
+                self.send_response(status.value)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+        return Handler
+
+
+class PiEpisodeRunner:
+    """Materialize one transient Pi composition and collect its native session."""
+
+    def __init__(
+        self,
+        descriptor: AdapterDescriptor,
+        *,
+        binary: Path,
+        timeout_s: float,
+        process_runner: PiProcessRunner | None = None,
+        pricing: TokenPricing = TARGET_MODEL_PRICING,
+    ) -> None:
+        if descriptor.name != "pi":
+            raise ValueError("PiEpisodeRunner requires the Pi adapter")
+        if timeout_s <= 0:
+            raise ValueError("Pi timeout must be positive")
+        self.descriptor = descriptor
+        self.binary = Path(binary).resolve()
+        self.timeout_s = timeout_s
+        self._process_runner = process_runner or _run_pi_process
+        self.pricing = pricing
+
+    def run(
+        self,
+        files: Mapping[str, str],
+        instruction: str,
+        *,
+        bridge_url: str,
+        bridge_token: str,
+    ) -> PiEpisodeResult:
+        root = Path(tempfile.mkdtemp(prefix="reef-meta-pi-"))
+        try:
+            rendered = dict(files)
+            if BRIDGE_EXTENSION_PATH in rendered:
+                raise PiBridgeError(f"candidate uses reserved runtime path {BRIDGE_EXTENSION_PATH!r}")
+            rendered[BRIDGE_EXTENSION_PATH] = BRIDGE_EXTENSION
+            for relative, text in rendered.items():
+                relative_path = PurePosixPath(relative)
+                if relative_path.is_absolute() or ".." in relative_path.parts:
+                    raise PiBridgeError(f"render path escapes the episode root: {relative!r}")
+                path = root / relative_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(text, encoding="utf-8")
+
+            workspace = root / "workspace"
+            workspace.mkdir()
+            env = _pi_environment(self.descriptor, root, bridge_url, bridge_token)
+            extension_paths = sorted(
+                path
+                for path in (root / "pi-agent" / "extensions").glob("*.ts")
+                if path.name != Path(BRIDGE_EXTENSION_PATH).name
+            )
+            bridge_path = root / BRIDGE_EXTENSION_PATH
+            command = [str(self.binary), "--mode", "json", "--no-extensions"]
+            for extension_path in extension_paths:
+                command.extend(("--extension", str(extension_path)))
+            command.extend(
+                (
+                    "--extension",
+                    str(bridge_path),
+                    "--tools",
+                    "bash",
+                    "--print",
+                    instruction,
+                )
+            )
+            result = self._process_runner(command, workspace, env, self.timeout_s)
+            trajectory = reader_for(self.descriptor.trajectory_format)(root / self.descriptor.trajectory_path)
+            usage, provider_reported_cost = _trajectory_usage(trajectory)
+            return PiEpisodeResult(
+                exit_code=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                trajectory=trajectory,
+                usage=usage,
+                estimated_cost_usd=self.pricing.estimate_usd(usage),
+                provider_reported_cost_usd=provider_reported_cost,
+                wall_time_s=result.wall_time_s,
+            )
+        finally:
+            import shutil
+
+            shutil.rmtree(root, ignore_errors=True)
+
+
+def _pi_environment(
+    descriptor: AdapterDescriptor,
+    root: Path,
+    bridge_url: str,
+    bridge_token: str,
+) -> dict[str, str]:
+    inherited = {key: value for key, value in os.environ.items() if key in {"PATH", "SYSTEMROOT", "TMPDIR"}}
+    configured = {key: value.replace("{root}", str(root)) for key, value in descriptor.env.items()}
+    return {
+        **inherited,
+        **configured,
+        "HOME": str(root),
+        "REEF_HARBOR_BRIDGE_URL": bridge_url,
+        "REEF_HARBOR_BRIDGE_TOKEN": bridge_token,
+    }
+
+
+def _trajectory_usage(trajectory: Sequence[Mapping[str, Any]]) -> tuple[dict[str, int], float]:
+    usage = {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+    cost = 0.0
+    for event in trajectory:
+        message = event.get("message")
+        if not isinstance(message, Mapping) or message.get("role") != "assistant":
+            continue
+        raw = message.get("usage")
+        if not isinstance(raw, Mapping):
+            continue
+        usage["input_tokens"] += int(raw.get("input") or 0)
+        usage["cached_input_tokens"] += int(raw.get("cacheRead") or 0)
+        usage["output_tokens"] += int(raw.get("output") or 0)
+        raw_cost = raw.get("cost")
+        if isinstance(raw_cost, Mapping):
+            cost += float(raw_cost.get("total") or 0.0)
+    return usage, cost
+
+
+def _run_pi_process(
+    command: Sequence[str],
+    cwd: Path,
+    environment: Mapping[str, str],
+    timeout_s: float,
+) -> PiProcessResult:
+    started = time.monotonic()
+    try:
+        process = subprocess.Popen(
+            list(command),
+            cwd=cwd,
+            env=dict(environment),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        raise PiBridgeError(f"could not start Pi: {exc}") from exc
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired as exc:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+        raise PiBridgeError(f"Pi timed out after {timeout_s:g} seconds") from exc
+    return PiProcessResult(
+        returncode=process.returncode,
+        stdout=stdout,
+        stderr=stderr,
+        wall_time_s=time.monotonic() - started,
+    )

--- a/recipes/meta_harness/examples/terminal_bench/harness/publication.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/publication.py
@@ -1,0 +1,176 @@
+"""Publish one selected provider-free composition through Reef artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from reef.artifact import Artifact, GitLFSRepositoryBackend
+from reef.harness import AdapterDescriptor
+
+from .composition import CompositionCandidate
+
+
+def publish_candidate(
+    candidate: CompositionCandidate,
+    *,
+    descriptor: AdapterDescriptor,
+    output_dir: Path,
+    scenario: str,
+    metadata: Mapping[str, Any],
+) -> dict[str, Any]:
+    output_dir = Path(output_dir)
+    manifest_path = output_dir / "publication.json"
+    files = candidate.render(descriptor)
+    render_sha256 = _mapping_sha256(files)
+    _ensure_tree(output_dir / "published-composition", files)
+    if manifest_path.is_file():
+        manifest = _read_manifest(manifest_path)
+        if (
+            manifest.get("candidate_hash") != candidate.content_hash
+            or manifest.get("render_sha256") != render_sha256
+            or manifest.get("scenario") != scenario
+            or manifest.get("files") != sorted(files)
+        ):
+            raise RuntimeError("published candidate does not match resumed selection")
+        return manifest
+
+    tree_dir = output_dir / "published-composition"
+    repository_path = output_dir / "artifacts.git"
+    backend = GitLFSRepositoryBackend(
+        scenario,
+        repository_path,
+        work_dir=output_dir / "artifact-work",
+        cache_dir=output_dir / "artifact-cache",
+    )
+    publication_identity = {
+        "method": "meta-harness",
+        "scenario": scenario,
+        "candidate_hash": candidate.content_hash,
+        "render_sha256": render_sha256,
+    }
+    existing_metadata = backend.metadata()
+    if existing_metadata is None:
+        parent = backend.fork(metadata={**publication_identity, "publication_state": "pending"})
+    else:
+        if any(existing_metadata.get(key) != value for key, value in publication_identity.items()):
+            raise RuntimeError("existing artifact publication does not match the selected candidate")
+        state = existing_metadata.get("publication_state")
+        if state == "published":
+            published = backend.current()
+            manifest = _manifest_payload(
+                candidate.content_hash,
+                render_sha256,
+                scenario,
+                published.content_id,
+                published.release_id,
+                published.parent_release_id,
+                repository_path,
+                files,
+            )
+            _write_json_atomic(manifest_path, manifest)
+            return manifest
+        if state != "pending":
+            raise RuntimeError(f"unknown artifact publication state {state!r}")
+        parent = backend.current()
+    published = backend.publish(
+        Artifact.local(
+            tree_dir,
+            metadata={**dict(metadata), **publication_identity, "publication_state": "published"},
+        ),
+        expected_parent=parent,
+    )
+    manifest = _manifest_payload(
+        candidate.content_hash,
+        render_sha256,
+        scenario,
+        published.content_id,
+        published.release_id,
+        published.parent_release_id,
+        repository_path,
+        files,
+    )
+    _write_json_atomic(manifest_path, manifest)
+    return manifest
+
+
+def _ensure_tree(root: Path, files: Mapping[str, str]) -> None:
+    if root.exists():
+        observed = {
+            path.relative_to(root).as_posix(): path.read_text(encoding="utf-8")
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+        if observed != dict(files):
+            raise RuntimeError("existing published composition does not match the selected candidate")
+        return
+    root.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{root.name}-", dir=root.parent))
+    try:
+        _write_tree(temporary, files)
+        try:
+            temporary.rename(root)
+        except OSError:
+            if not root.is_dir():
+                raise
+    finally:
+        shutil.rmtree(temporary, ignore_errors=True)
+    _ensure_tree(root, files)
+
+
+def _mapping_sha256(value: Mapping[str, str]) -> str:
+    serialized = json.dumps(dict(value), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def _manifest_payload(
+    candidate_hash: str,
+    render_sha256: str,
+    scenario: str,
+    content_id: str,
+    release_id: str,
+    parent_release_id: str | None,
+    repository_path: Path,
+    files: Mapping[str, str],
+) -> dict[str, Any]:
+    return {
+        "candidate_hash": candidate_hash,
+        "render_sha256": render_sha256,
+        "scenario": scenario,
+        "content_id": content_id,
+        "release_id": release_id,
+        "parent_release_id": parent_release_id,
+        "repository": repository_path.name,
+        "files": sorted(files),
+    }
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"invalid publication manifest: {path}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"invalid publication manifest: {path}")
+    return value
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _write_tree(root: Path, files: Mapping[str, str]) -> None:
+    for relative, text in files.items():
+        path = PurePosixPath(relative)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"published render path {relative!r} escapes its root")
+        target = root.joinpath(*path.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")

--- a/recipes/meta_harness/examples/terminal_bench/harness/reporting.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/reporting.py
@@ -1,0 +1,160 @@
+"""Machine-readable cell and aggregate Meta-Harness reports."""
+
+from __future__ import annotations
+
+import json
+import statistics
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .composition import CompositionCandidate
+from .evaluation import EvaluationResult
+from .search import CandidateRecord, ProposerSession
+
+
+def write_cell_report(
+    *,
+    output_dir: Path,
+    cell: str,
+    selected: CompositionCandidate,
+    population: Sequence[CandidateRecord],
+    proposer_sessions: Sequence[ProposerSession],
+    test_result: EvaluationResult,
+    selected_dev_score: float,
+    resumed: bool,
+    budget_fill_evaluations: int,
+    wall_time_s: float,
+    config: Mapping[str, Any],
+) -> dict[str, Any]:
+    evidence = _private_evidence(output_dir / "private-evaluations")
+    target_usage = _aggregate_usage(row.get("usage", {}) for row in evidence)
+    proposer_usage = {
+        "input_tokens": sum(session.input_tokens for session in proposer_sessions),
+        "output_tokens": sum(session.output_tokens for session in proposer_sessions),
+    }
+    statuses = Counter(str(row.get("status") or "unknown") for row in evidence)
+    target_cost = sum(float(row.get("estimated_cost_usd", 0.0)) for row in evidence)
+    later_history_read = _later_round_history_read(proposer_sessions, output_dir / "workspace")
+    task_checksums = _task_checksums(evidence)
+    summary = {
+        "cell": cell,
+        "selected_candidate_hash": selected.content_hash,
+        "selected_dev_score": selected_dev_score,
+        "test_score": test_result.score,
+        "test_trial_count": len(test_result.trials),
+        "candidate_count": len(population),
+        "candidate_outcomes": dict(Counter(record.outcome for record in population)),
+        "proposer_session_count": len(proposer_sessions),
+        "later_round_history_read": later_history_read,
+        "target_episode_count": len(evidence),
+        "budget_fill_evaluations": budget_fill_evaluations,
+        "usage": {"target": target_usage, "proposer": proposer_usage},
+        "estimated_cost_usd": {"target": target_cost, "proposer": 0.0, "total": target_cost},
+        "trial_statuses": dict(sorted(statuses.items())),
+        "task_checksums": task_checksums,
+        "wall_time_s": wall_time_s,
+        "resumed": resumed,
+    }
+    _write_json(output_dir / "summary.json", summary)
+    _write_json(output_dir / "config.json", config)
+    _write_json(output_dir / "selected-candidate.json", selected.to_jsonable())
+    _write_json(output_dir / "heldout.json", test_result.to_jsonable())
+    _write_json(
+        output_dir / "learning-curve.json",
+        [
+            {
+                "round": record.round_index,
+                "candidate_hash": record.candidate.content_hash,
+                "parent_hashes": list(record.candidate.parent_hashes),
+                "train_score": record.train_score,
+                "dev_score": record.dev_score,
+                "outcome": record.outcome,
+                "proposal_id": record.proposal_id,
+            }
+            for record in population
+        ],
+    )
+    (output_dir / "candidate-parents.dot").write_text(_parent_graph_dot(population), encoding="utf-8")
+    return summary
+
+
+def write_aggregate_report(output_dir: Path, cells: Sequence[str]) -> dict[str, Any]:
+    summaries = {cell: json.loads((output_dir / cell / "summary.json").read_text(encoding="utf-8")) for cell in cells}
+    episode_counts = {int(summary["target_episode_count"]) for summary in summaries.values()}
+    checksum_manifests = [summary.get("task_checksums", {}) for summary in summaries.values()]
+    payload = {
+        "equal_target_episode_budget": len(episode_counts) == 1,
+        "target_episode_counts": {cell: summary["target_episode_count"] for cell, summary in summaries.items()},
+        "equal_task_checksums": all(manifest == checksum_manifests[0] for manifest in checksum_manifests),
+        "task_checksums": checksum_manifests[0],
+        "cells": summaries,
+        "test_score_mean": statistics.fmean(float(summary["test_score"]) for summary in summaries.values()),
+    }
+    _write_json(output_dir / "results.json", payload)
+    return payload
+
+
+def _private_evidence(root: Path) -> list[dict[str, Any]]:
+    rows = []
+    for path in sorted(root.glob("trials/*/round-*/*/*/trial-*/evidence.json")):
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise RuntimeError(f"trial evidence is not an object: {path}")
+        rows.append(value)
+    return rows
+
+
+def _aggregate_usage(items: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        for key, value in item.items():
+            totals[str(key)] = totals.get(str(key), 0) + int(value)
+    return totals
+
+
+def _parent_graph_dot(population: Sequence[CandidateRecord]) -> str:
+    lines = ["digraph meta_harness {"]
+    for record in population:
+        short = record.candidate.content_hash[:12]
+        lines.append(f'  "{short}" [label="r{record.round_index} {short}\\n{record.dev_score:.4f}"];')
+        lines.extend(f'  "{parent[:12]}" -> "{short}";' for parent in record.candidate.parent_hashes)
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def _task_checksums(evidence: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for row in evidence:
+        verifier = row.get("verifier")
+        checksum = verifier.get("task_checksum") if isinstance(verifier, Mapping) else None
+        if not checksum:
+            continue
+        task_id = str(row.get("task_id") or "")
+        previous = checksums.setdefault(task_id, str(checksum))
+        if previous != checksum:
+            raise RuntimeError(f"Terminal-Bench task checksum changed within the cell: {task_id}")
+    return dict(sorted(checksums.items()))
+
+
+def _later_round_history_read(sessions: Sequence[ProposerSession], workspace_dir: Path) -> bool | None:
+    if len(sessions) < 2:
+        return None
+    for session in sessions[1:]:
+        if not session.artifact_dir:
+            continue
+        path = workspace_dir / session.artifact_dir / "metadata.json"
+        if not path.is_file():
+            continue
+        metadata = json.loads(path.read_text(encoding="utf-8"))
+        evidence = metadata.get("evidence")
+        if isinstance(evidence, Mapping) and evidence.get("history_accesses"):
+            return True
+    return False
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")

--- a/recipes/meta_harness/examples/terminal_bench/harness/search.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/search.py
@@ -1,0 +1,491 @@
+"""Meta-Harness population search with full-history and greedy controls."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from .composition import CompositionCandidate
+from .evaluation import EvaluationResult
+from .workspace import EvolutionWorkspace, WorkspaceIntegrityError, WorkspaceProposal
+
+SEARCH_MODES = ("incumbent_only", "full_history")
+
+
+class CandidateEvaluator(Protocol):
+    def evaluate(self, candidate: CompositionCandidate, *, split: str, round_index: int) -> EvaluationResult: ...
+
+
+@dataclass(frozen=True)
+class ProposerSession:
+    session_id: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    wall_time_s: float = 0.0
+    artifact_dir: str | None = None
+
+
+class WorkspaceProposer(Protocol):
+    def propose(
+        self,
+        *,
+        surface: Path,
+        prompt: str,
+        session_dir: Path,
+        round_index: int,
+    ) -> ProposerSession: ...
+
+
+@dataclass(frozen=True)
+class CandidateRecord:
+    candidate: CompositionCandidate
+    round_index: int
+    alias: str
+    train_score: float
+    dev_score: float
+    outcome: str
+    proposal_id: str | None = None
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "candidate": self.candidate.to_jsonable(),
+            "candidate_hash": self.candidate.content_hash,
+            "round": self.round_index,
+            "alias": self.alias,
+            "train_score": self.train_score,
+            "dev_score": self.dev_score,
+            "outcome": self.outcome,
+            "proposal_id": self.proposal_id,
+        }
+
+    @classmethod
+    def from_jsonable(cls, value: Mapping[str, Any]) -> CandidateRecord:
+        candidate_value = value.get("candidate")
+        if not isinstance(candidate_value, Mapping) or not isinstance(candidate_value.get("composition"), Mapping):
+            raise ValueError("search state contains an invalid candidate")
+        candidate = CompositionCandidate.from_value(
+            candidate_value["composition"],
+            parent_hashes=tuple(candidate_value.get("parent_hashes") or ()),
+            metadata=candidate_value.get("metadata") if isinstance(candidate_value.get("metadata"), Mapping) else {},
+        )
+        expected_hash = value.get("candidate_hash")
+        if expected_hash != candidate.content_hash:
+            raise ValueError("search state candidate hash does not match its composition")
+        return cls(
+            candidate=candidate,
+            round_index=int(value["round"]),
+            alias=str(value["alias"]),
+            train_score=float(value["train_score"]),
+            dev_score=float(value["dev_score"]),
+            outcome=str(value["outcome"]),
+            proposal_id=str(value["proposal_id"]) if value.get("proposal_id") else None,
+        )
+
+
+class Population:
+    """Every unique source remains selectable; only the incumbent is promoted."""
+
+    def __init__(self, records: Sequence[CandidateRecord] = (), *, incumbent_hash: str | None = None) -> None:
+        self.records = list(records)
+        self._by_hash = {record.candidate.content_hash: record for record in self.records}
+        if len(self._by_hash) != len(self.records):
+            raise ValueError("population records must contain unique candidate sources")
+        self.incumbent_hash = incumbent_hash
+        if self.records and incumbent_hash not in self._by_hash:
+            raise ValueError("population incumbent is missing")
+
+    @property
+    def incumbent(self) -> CandidateRecord:
+        if self.incumbent_hash is None:
+            raise ValueError("population has no incumbent")
+        return self._by_hash[self.incumbent_hash]
+
+    def add(self, record: CandidateRecord) -> tuple[CandidateRecord, bool, bool]:
+        existing = self._by_hash.get(record.candidate.content_hash)
+        if existing is not None:
+            return existing, False, False
+        previous_score = self.incumbent.dev_score if self.incumbent_hash else float("-inf")
+        moved = record.dev_score > previous_score
+        outcome = "selected" if moved else "retained"
+        normalized = CandidateRecord(
+            candidate=record.candidate,
+            round_index=record.round_index,
+            alias=record.alias,
+            train_score=record.train_score,
+            dev_score=record.dev_score,
+            outcome=outcome,
+            proposal_id=record.proposal_id,
+        )
+        self.records.append(normalized)
+        self._by_hash[normalized.candidate.content_hash] = normalized
+        if moved:
+            self.incumbent_hash = normalized.candidate.content_hash
+        return normalized, True, moved
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "incumbent_hash": self.incumbent_hash,
+            "records": [record.to_jsonable() for record in self.records],
+        }
+
+    @classmethod
+    def from_jsonable(cls, value: Mapping[str, Any]) -> Population:
+        rows = value.get("records")
+        if not isinstance(rows, list):
+            raise ValueError("search state population records must be a list")
+        return cls(
+            [CandidateRecord.from_jsonable(row) for row in rows if isinstance(row, Mapping)],
+            incumbent_hash=str(value["incumbent_hash"]) if value.get("incumbent_hash") else None,
+        )
+
+    def catalog_rows(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "candidate_hash": record.candidate.content_hash,
+                "alias": record.alias,
+                "round": record.round_index,
+                "train_score": record.train_score,
+                "dev_score": record.dev_score,
+                "outcome": record.outcome,
+                "proposal_id": record.proposal_id,
+            }
+            for record in self.records
+        ]
+
+
+@dataclass(frozen=True)
+class SearchOutcome:
+    selected: CompositionCandidate
+    population: tuple[CandidateRecord, ...]
+    proposer_sessions: tuple[ProposerSession, ...]
+    resumed: bool
+
+
+class MetaHarnessSearch:
+    """Outer loop that owns validation, evaluation, promotion, and restart."""
+
+    def __init__(
+        self,
+        *,
+        workspace: EvolutionWorkspace,
+        evaluator: CandidateEvaluator,
+        proposer: WorkspaceProposer,
+        mode: str,
+        rounds: int,
+    ) -> None:
+        if mode not in SEARCH_MODES:
+            raise ValueError(f"search mode must be one of {SEARCH_MODES}")
+        if rounds < 1:
+            raise ValueError("search rounds must be positive")
+        self.workspace = workspace
+        self.evaluator = evaluator
+        self.proposer = proposer
+        self.mode = mode
+        self.rounds = rounds
+
+    def run(self, genesis: CompositionCandidate) -> SearchOutcome:
+        state = self.workspace.read_search_state()
+        resumed = state is not None
+        if state is None:
+            population = self._initialize(genesis)
+            sessions: list[ProposerSession] = []
+            completed_rounds = 0
+        else:
+            completed_rounds = int(state.get("completed_rounds", 0))
+            if state.get("mode") != self.mode or self.rounds < completed_rounds:
+                raise ValueError("existing search state does not match this run configuration")
+            population_value = state.get("population")
+            if not isinstance(population_value, Mapping):
+                raise ValueError("existing search state has no population")
+            population = Population.from_jsonable(population_value)
+            sessions = [_session_from_json(row) for row in state.get("proposer_sessions", [])]
+
+        for round_index in range(completed_rounds + 1, self.rounds + 1):
+            self._run_round(population, sessions, round_index)
+            self._persist(population, sessions, completed_rounds=round_index)
+        return SearchOutcome(
+            selected=population.incumbent.candidate,
+            population=tuple(population.records),
+            proposer_sessions=tuple(sessions),
+            resumed=resumed,
+        )
+
+    def _initialize(self, genesis: CompositionCandidate) -> Population:
+        train = self.evaluator.evaluate(genesis, split="train", round_index=0)
+        dev = self.evaluator.evaluate(genesis, split="dev", round_index=0)
+        self.workspace.record_candidate(genesis, train, round_index=0, role="genesis")
+        self.workspace.record_candidate(genesis, dev, round_index=0, role="genesis")
+        population = Population()
+        population.add(
+            CandidateRecord(
+                candidate=genesis,
+                round_index=0,
+                alias="genesis",
+                train_score=train.score,
+                dev_score=dev.score,
+                outcome="selected",
+            )
+        )
+        self._persist(population, [], completed_rounds=0)
+        return population
+
+    def _run_round(self, population: Population, sessions: list[ProposerSession], round_index: int) -> None:
+        resumable = self.workspace.resumable_proposal(round_index)
+        if resumable is not None:
+            self._validate_parent(resumable, population)
+            self.workspace.transition_round(
+                round_index,
+                "evaluating",
+                proposal_id=resumable.proposal_id,
+                resumed=True,
+            )
+            self._evaluate_round(resumable, population, sessions, round_index)
+            return
+
+        state = self.workspace.round_state(round_index)
+        if state in {"proposed", "validating"}:
+            self._resume_validation(population, sessions, round_index, state)
+            return
+        if state == "invalid":
+            return
+        if state in {"proposing", "proposer_failed"}:
+            sessions[:] = sessions[: round_index - 1]
+            self.workspace.restart_proposer(round_index)
+            state = "created"
+        if state is None:
+            self.workspace.begin_round(round_index)
+        elif state != "created":
+            raise WorkspaceIntegrityError(f"round {round_index} cannot resume from state {state!r}")
+        self.workspace.transition_round(round_index, "proposing")
+        surface = self._surface(population, round_index)
+        before = self.workspace.readonly_snapshot(writable_round=round_index)
+        surface_before = self.workspace.proposal_surface_snapshot(surface, writable_round=round_index)
+        try:
+            session = self.proposer.propose(
+                surface=surface,
+                prompt=self._prompt(surface, round_index),
+                session_dir=self.workspace.session_dir(round_index),
+                round_index=round_index,
+            )
+            sessions.append(session)
+            self.workspace.assert_readonly_unchanged(before, writable_round=round_index)
+            self.workspace.assert_proposal_surface_unchanged(
+                surface,
+                surface_before,
+                writable_round=round_index,
+            )
+            self._persist(population, sessions, completed_rounds=round_index - 1)
+            self.workspace.transition_round(round_index, "proposed", session_id=session.session_id)
+        except WorkspaceIntegrityError as exc:
+            self.workspace.record_attempt(
+                {
+                    "proposal_id": f"round-{round_index:04d}:proposer",
+                    "round": round_index,
+                    "status": "integrity_failed",
+                    "error": str(exc),
+                }
+            )
+            self.workspace.transition_round(
+                round_index,
+                "proposer_failed",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            raise
+        except Exception as exc:
+            self.workspace.record_attempt(
+                {
+                    "proposal_id": f"round-{round_index:04d}:proposer",
+                    "round": round_index,
+                    "status": f"proposer_failed:{type(exc).__name__}",
+                    "error": str(exc),
+                }
+            )
+            self.workspace.transition_round(
+                round_index,
+                "proposer_failed",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            raise
+
+        self._resume_validation(population, sessions, round_index, "proposed")
+
+    def _resume_validation(
+        self,
+        population: Population,
+        sessions: list[ProposerSession],
+        round_index: int,
+        state: str,
+    ) -> None:
+        surface = self._surface(population, round_index)
+        if state == "proposed":
+            self.workspace.transition_round(round_index, "validating")
+        try:
+            proposals = self.workspace.collect_proposals(round_index, surface=surface)
+            if len(proposals) != 1:
+                raise ValueError("the pinned reproduction requires exactly one candidate per round")
+            proposal = proposals[0]
+            self._validate_parent(proposal, population)
+        except Exception as exc:
+            self.workspace.record_attempt(
+                {
+                    "proposal_id": f"round-{round_index:04d}:invalid",
+                    "round": round_index,
+                    "status": f"invalid:{type(exc).__name__}",
+                    "error": str(exc),
+                }
+            )
+            self.workspace.transition_round(round_index, "invalid", error_type=type(exc).__name__, error=str(exc))
+            return
+
+        self._persist(population, sessions, completed_rounds=round_index - 1)
+        self.workspace.transition_round(round_index, "evaluating", proposal_id=proposal.proposal_id)
+        self._evaluate_round(proposal, population, sessions, round_index)
+
+    def _evaluate_round(
+        self,
+        proposal: WorkspaceProposal,
+        population: Population,
+        sessions: list[ProposerSession],
+        round_index: int,
+    ) -> None:
+        try:
+            self._evaluate_proposal(proposal, population, round_index)
+        except Exception as exc:
+            self.workspace.record_attempt(
+                {
+                    "proposal_id": proposal.proposal_id,
+                    "round": round_index,
+                    "candidate_hash": proposal.candidate.content_hash,
+                    "status": f"failed:{type(exc).__name__}",
+                    "error": str(exc),
+                }
+            )
+            self.workspace.transition_round(round_index, "failed", error_type=type(exc).__name__, error=str(exc))
+            raise
+        self.workspace.write_population(population.catalog_rows(), population.incumbent.candidate.content_hash)
+        self._persist(population, sessions, completed_rounds=round_index)
+        self.workspace.transition_round(round_index, "committed", incumbent_hash=population.incumbent_hash)
+
+    def _evaluate_proposal(self, proposal: WorkspaceProposal, population: Population, round_index: int) -> None:
+        train = self.evaluator.evaluate(proposal.candidate, split="train", round_index=round_index)
+        dev = self.evaluator.evaluate(proposal.candidate, split="dev", round_index=round_index)
+        previous = population.incumbent
+        record = CandidateRecord(
+            candidate=proposal.candidate,
+            round_index=round_index,
+            alias=proposal.name,
+            train_score=train.score,
+            dev_score=dev.score,
+            outcome="retained",
+            proposal_id=proposal.proposal_id,
+        )
+        normalized, is_new, moved = population.add(record)
+        status = "selected" if moved else ("rejected" if is_new else "duplicate")
+        retention_status = "retained" if is_new else "existing"
+        self.workspace.record_candidate(
+            proposal.candidate,
+            train,
+            round_index=round_index,
+            role="candidate",
+            proposal={
+                "proposal_id": proposal.proposal_id,
+                "name": proposal.name,
+                "hypothesis": proposal.hypothesis,
+                "changes": proposal.changes,
+                "status": status,
+                "retention_status": retention_status,
+            },
+        )
+        self.workspace.record_candidate(
+            proposal.candidate,
+            dev,
+            round_index=round_index,
+            role="candidate",
+            proposal={
+                "proposal_id": proposal.proposal_id,
+                "status": status,
+                "retention_status": retention_status,
+            },
+        )
+        self.workspace.record_attempt(
+            {
+                "proposal_id": proposal.proposal_id,
+                "round": round_index,
+                "candidate_hash": normalized.candidate.content_hash,
+                "parent_hashes": list(proposal.candidate.parent_hashes),
+                "hypothesis": proposal.hypothesis,
+                "changes": proposal.changes,
+                "status": status,
+                "retention_status": retention_status,
+                "train_score": train.score,
+                "dev_score": dev.score,
+                "incumbent_before": previous.candidate.content_hash,
+                "incumbent_score_before": previous.dev_score,
+                "incumbent_after": population.incumbent.candidate.content_hash,
+            }
+        )
+
+    def _surface(self, population: Population, round_index: int) -> Path:
+        if self.mode == "full_history":
+            return self.workspace.root
+        return self.workspace.build_incumbent_surface(
+            round_index,
+            population.incumbent.candidate,
+            population.catalog_rows(),
+        )
+
+    def _validate_parent(self, proposal: WorkspaceProposal, population: Population) -> None:
+        known = {record.candidate.content_hash for record in population.records}
+        if not proposal.candidate.parent_hashes or not set(proposal.candidate.parent_hashes) <= known:
+            raise ValueError("proposal parent selection is not in the retained population")
+        if self.mode == "incumbent_only" and proposal.candidate.parent_hashes != (
+            population.incumbent.candidate.content_hash,
+        ):
+            raise ValueError("incumbent-only proposals must branch solely from the current winner")
+
+    def _persist(self, population: Population, sessions: Sequence[ProposerSession], *, completed_rounds: int) -> None:
+        self.workspace.write_population(population.catalog_rows(), population.incumbent.candidate.content_hash)
+        self.workspace.write_search_state(
+            {
+                "schema_version": 1,
+                "mode": self.mode,
+                "round_limit": self.rounds,
+                "completed_rounds": completed_rounds,
+                "population": population.to_jsonable(),
+                "proposer_sessions": [session.__dict__ for session in sessions],
+            }
+        )
+
+    def _prompt(self, surface: Path, round_index: int) -> str:
+        history = (
+            "Inspect the complete retained population and read candidate or train-trajectory content under "
+            "history/; you may branch from any candidate."
+            if self.mode == "full_history"
+            else "Use only the incumbent composition and compact score history shown in this control surface."
+        )
+        return (
+            f"Run Meta-Harness iteration {round_index}. Read {surface / 'WORKSPACE.md'}. {history} "
+            "Produce exactly one complete, general-purpose Reef composition and the required pending_eval.json. "
+            "Do not run Terminal-Bench or access held-out test tasks; the outer loop owns evaluation."
+        )
+
+
+def _session_from_json(value: Any) -> ProposerSession:
+    if not isinstance(value, Mapping):
+        raise ValueError("search state contains an invalid proposer session")
+    artifact_dir = Path(str(value["artifact_dir"])) if value.get("artifact_dir") else None
+    if artifact_dir is not None and (artifact_dir.is_absolute() or ".." in artifact_dir.parts):
+        raise ValueError("search state proposer artifact path must stay within the workspace")
+    return ProposerSession(
+        session_id=str(value["session_id"]),
+        input_tokens=int(value.get("input_tokens", 0)),
+        output_tokens=int(value.get("output_tokens", 0)),
+        estimated_cost_usd=float(value.get("estimated_cost_usd", 0.0)),
+        wall_time_s=float(value.get("wall_time_s", 0.0)),
+        artifact_dir=artifact_dir.as_posix() if artifact_dir is not None else None,
+    )

--- a/recipes/meta_harness/examples/terminal_bench/harness/workspace.py
+++ b/recipes/meta_harness/examples/terminal_bench/harness/workspace.py
@@ -1,0 +1,505 @@
+"""Durable proposer-visible state for Meta-Harness search."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from reef.harness import AdapterDescriptor
+
+from .composition import CompositionCandidate
+from .evaluation import SEARCH_SPLITS, EvaluationResult
+
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_ROUND_STATES = {
+    None: {"created"},
+    "created": {"proposing"},
+    "proposing": {"created", "proposed", "proposer_failed"},
+    "proposer_failed": {"created"},
+    "proposed": {"validating"},
+    "validating": {"evaluating", "invalid"},
+    "evaluating": {"evaluating", "committed", "failed"},
+    "failed": {"evaluating"},
+}
+
+
+class WorkspaceIntegrityError(RuntimeError):
+    """The proposer modified immutable history or coordinator state."""
+
+
+@dataclass(frozen=True)
+class WorkspaceProposal:
+    name: str
+    proposal_id: str
+    candidate: CompositionCandidate
+    hypothesis: str
+    changes: str
+    source_path: Path
+
+    @property
+    def primary_parent_hash(self) -> str | None:
+        return self.candidate.parent_hashes[0] if self.candidate.parent_hashes else None
+
+
+class EvolutionWorkspace:
+    """Persistent population, feedback, proposal, and session filesystem."""
+
+    def __init__(self, root: Path, descriptor: AdapterDescriptor) -> None:
+        self.root = Path(root).resolve()
+        self.descriptor = descriptor
+        self.history_dir = self.root / "history"
+        self.proposals_dir = self.root / "proposals"
+        self.frozen_dir = self.root / "frozen-proposals"
+        self.sessions_dir = self.root / "sessions"
+        self.rounds_dir = self.root / "rounds"
+        for path in (
+            self.root,
+            self.history_dir,
+            self.proposals_dir,
+            self.frozen_dir,
+            self.sessions_dir,
+            self.rounds_dir,
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        self._write_contract_if_missing()
+
+    def record_candidate(
+        self,
+        candidate: CompositionCandidate,
+        result: EvaluationResult,
+        *,
+        round_index: int,
+        role: str,
+        proposal: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Append train/dev evidence without ever admitting held-out test data."""
+        if result.split not in SEARCH_SPLITS:
+            raise ValueError("test results are sealed and cannot enter the evolution workspace")
+        candidate_dir = self.history_dir / candidate.content_hash
+        candidate_dir.mkdir(parents=True, exist_ok=True)
+        self._write_once(
+            candidate_dir / "candidate.json",
+            {"content_hash": candidate.content_hash, "composition": candidate.composition},
+        )
+        rendered = candidate.render(self.descriptor)
+        for relative, text in rendered.items():
+            self._write_text_once(candidate_dir / "rendered" / relative, text)
+        evaluation_path = candidate_dir / "evaluations" / f"round-{round_index:04d}-{result.split}.json"
+        evaluation_payload = result.to_jsonable()
+        if result.split == "dev":
+            evaluation_payload = {
+                "split": "dev",
+                "score": result.score,
+                "trial_count": len(result.trials),
+                "usage": evaluation_payload["usage"],
+                "estimated_cost_usd": evaluation_payload["estimated_cost_usd"],
+                "wall_time_s": evaluation_payload["wall_time_s"],
+            }
+        self._write_once(evaluation_path, evaluation_payload)
+        self._append_jsonl_once(
+            self.root / "evolution-summary.jsonl",
+            {
+                "candidate_hash": candidate.content_hash,
+                "parent_hashes": list(candidate.parent_hashes),
+                "round": round_index,
+                "role": role,
+                "split": result.split,
+                "score": result.score,
+                "proposal": dict(proposal or {}),
+            },
+            identity=(candidate.content_hash, round_index, result.split),
+        )
+
+    def write_population(self, rows: Sequence[Mapping[str, Any]], incumbent_hash: str) -> None:
+        known = {str(row.get("candidate_hash")) for row in rows}
+        if incumbent_hash not in known:
+            raise ValueError("incumbent must be present in the candidate population")
+        self._write_json(
+            self.root / "candidate-catalog.json",
+            {"incumbent_hash": incumbent_hash, "candidates": [dict(row) for row in rows]},
+        )
+
+    def write_search_state(self, state: Mapping[str, Any]) -> None:
+        self._write_json(self.root / "search-state.json", dict(state))
+
+    def read_search_state(self) -> dict[str, Any] | None:
+        path = self.root / "search-state.json"
+        if not path.is_file():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError("search-state.json must contain an object")
+        return value
+
+    def begin_round(self, round_index: int) -> Path:
+        round_dir = self.proposals_dir / f"round-{round_index:04d}"
+        round_dir.mkdir(parents=True, exist_ok=True)
+        pending = self.root / "pending_eval.json"
+        if pending.exists():
+            pending.unlink()
+        self.transition_round(round_index, "created")
+        return round_dir
+
+    def restart_proposer(self, round_index: int) -> Path:
+        """Clear only the failed round's declared outputs before a fresh turn."""
+        state = self.round_state(round_index)
+        if state not in {"proposing", "proposer_failed"}:
+            raise ValueError(f"round {round_index} is not retryable from proposer state {state!r}")
+        round_dir = self.proposals_dir / f"round-{round_index:04d}"
+        if round_dir.exists():
+            shutil.rmtree(round_dir)
+        round_dir.mkdir(parents=True)
+        (self.root / "pending_eval.json").unlink(missing_ok=True)
+        self.transition_round(round_index, "created", retry_from=state)
+        return round_dir
+
+    def transition_round(self, round_index: int, state: str, **details: Any) -> None:
+        path = self.rounds_dir / f"round-{round_index:04d}.json"
+        previous = json.loads(path.read_text()) if path.exists() else None
+        previous_state = previous.get("state") if previous else None
+        if state not in _ROUND_STATES.get(previous_state, set()):
+            raise ValueError(f"invalid round transition {previous_state!r} -> {state!r}")
+        history = list(previous.get("history", [])) if previous else []
+        history.append(
+            {
+                "sequence": len(history),
+                "state": state,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                **details,
+            }
+        )
+        self._write_json(
+            path,
+            {"schema_version": 1, "round": round_index, "state": state, "history": history},
+        )
+
+    def completed_rounds(self) -> tuple[int, ...]:
+        completed: list[int] = []
+        for path in sorted(self.rounds_dir.glob("round-*.json")):
+            state = json.loads(path.read_text()).get("state")
+            if state == "committed":
+                completed.append(int(path.stem.removeprefix("round-")))
+        return tuple(completed)
+
+    def round_state(self, round_index: int) -> str | None:
+        path = self.rounds_dir / f"round-{round_index:04d}.json"
+        if not path.is_file():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return str(value.get("state")) if value.get("state") else None
+
+    def session_dir(self, round_index: int) -> Path:
+        path = self.sessions_dir / f"round-{round_index:04d}"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def build_incumbent_surface(
+        self,
+        round_index: int,
+        incumbent: CompositionCandidate,
+        population: Sequence[Mapping[str, Any]],
+    ) -> Path:
+        """Materialize the greedy control's summarized, incumbent-only view."""
+        surface = self.root / "incumbent-views" / f"round-{round_index:04d}"
+        proposal_dir = surface / "proposals" / f"round-{round_index:04d}"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        self._write_json(surface / "incumbent" / "composition.json", incumbent.composition)
+        self._write_json(
+            surface / "search-summary.json",
+            {
+                "incumbent_hash": incumbent.content_hash,
+                "candidate_count": len(population),
+                "score_history": [
+                    {
+                        "round": row.get("round"),
+                        "candidate_hash": row.get("candidate_hash"),
+                        "dev_score": row.get("dev_score"),
+                        "outcome": row.get("outcome"),
+                    }
+                    for row in population
+                ],
+            },
+        )
+        (surface / "WORKSPACE.md").write_text(
+            "# Incumbent-only control\n\n"
+            "Use only `incumbent/composition.json` and the compact score history in "
+            "`search-summary.json`. Write one complete candidate under the current `proposals/` "
+            "round and declare the incumbent hash as its sole base in `pending_eval.json`.\n",
+            encoding="utf-8",
+        )
+        return surface
+
+    def proposal_surface_snapshot(self, surface: Path, *, writable_round: int) -> dict[str, str]:
+        """Hash proposer-visible inputs while excluding its declared outputs."""
+        surface = Path(surface).resolve()
+        writable = (surface / "proposals" / f"round-{writable_round:04d}").resolve()
+        writable_session = (surface / "sessions" / f"round-{writable_round:04d}").resolve()
+        paths = []
+        for path in surface.rglob("*"):
+            if not path.is_file() or path.name == "pending_eval.json":
+                continue
+            try:
+                path.resolve().relative_to(writable)
+            except ValueError:
+                try:
+                    path.resolve().relative_to(writable_session)
+                except ValueError:
+                    paths.append(path)
+        return {str(path.relative_to(surface)): _sha256(path) for path in sorted(paths)}
+
+    def assert_proposal_surface_unchanged(
+        self,
+        surface: Path,
+        before: Mapping[str, str],
+        *,
+        writable_round: int,
+    ) -> None:
+        after = self.proposal_surface_snapshot(surface, writable_round=writable_round)
+        changed = sorted(path for path in set(before) | set(after) if before.get(path) != after.get(path))
+        if changed:
+            raise WorkspaceIntegrityError(f"proposer modified read-only surface: {', '.join(changed[:5])}")
+
+    def collect_proposals(self, round_index: int, *, surface: Path | None = None) -> list[WorkspaceProposal]:
+        surface = Path(surface or self.root).resolve()
+        pending = surface / "pending_eval.json"
+        if not pending.is_file():
+            raise ValueError("proposer did not write pending_eval.json")
+        raw = json.loads(pending.read_text(encoding="utf-8"))
+        if not isinstance(raw, Mapping) or raw.get("iteration") != round_index:
+            raise ValueError("pending_eval.json has the wrong or missing iteration")
+        items = raw.get("candidates")
+        if not isinstance(items, list) or not items:
+            raise ValueError("pending_eval.json requires a non-empty candidates list")
+
+        round_dir = (surface / "proposals" / f"round-{round_index:04d}").resolve()
+        known = self._candidate_refs()
+        proposals: list[WorkspaceProposal] = []
+        seen_names: set[str] = set()
+        for index, item in enumerate(items):
+            if not isinstance(item, Mapping):
+                raise ValueError("each pending candidate must be an object")
+            name = str(item.get("name") or "")
+            if not _SAFE_NAME.fullmatch(name) or name in seen_names:
+                raise ValueError(f"invalid or duplicate proposal name {name!r}")
+            relative = Path(str(item.get("path") or name))
+            source_dir = (round_dir / relative).resolve()
+            try:
+                source_dir.relative_to(round_dir)
+            except ValueError as exc:
+                raise ValueError(f"proposal path escapes its round: {relative}") from exc
+            if any(path.is_symlink() for path in source_dir.rglob("*")):
+                raise ValueError(f"proposal {name!r} contains a symlink")
+            source_path = source_dir / "composition.json"
+            if not source_path.is_file():
+                raise ValueError(f"proposal {name!r} has no composition.json")
+            parent_refs = item.get("base_candidates", item.get("parent_hashes", []))
+            if isinstance(parent_refs, str):
+                parent_refs = [parent_refs]
+            if not isinstance(parent_refs, list) or not parent_refs:
+                raise ValueError(f"proposal {name!r} must select at least one base candidate")
+            try:
+                parents = tuple(dict.fromkeys(known[str(ref)] for ref in parent_refs))
+            except KeyError as exc:
+                raise ValueError(f"proposal {name!r} selects unknown base candidate {exc.args[0]!r}") from exc
+            hypothesis = str(item.get("hypothesis") or "").strip()
+            changes = str(item.get("changes") or "").strip()
+            if not hypothesis or not changes:
+                raise ValueError(f"proposal {name!r} requires hypothesis and changes")
+            candidate = CompositionCandidate.from_path(
+                source_path,
+                parent_hashes=parents,
+                metadata={"proposal_name": name, "round": round_index},
+            )
+            frozen_root = self.frozen_dir / f"round-{round_index:04d}" / f"{index:03d}-{name}"
+            self._write_text_once(frozen_root / "composition.json", candidate.canonical_json + "\n")
+            self._write_once(
+                frozen_root / "manifest.json",
+                {
+                    "proposal_id": f"round-{round_index:04d}:{index:03d}:{name}",
+                    "name": name,
+                    "candidate_hash": candidate.content_hash,
+                    "parent_hashes": list(parents),
+                    "hypothesis": hypothesis,
+                    "changes": changes,
+                },
+            )
+            proposals.append(
+                WorkspaceProposal(
+                    name=name,
+                    proposal_id=f"round-{round_index:04d}:{index:03d}:{name}",
+                    candidate=candidate,
+                    hypothesis=hypothesis,
+                    changes=changes,
+                    source_path=frozen_root / "composition.json",
+                )
+            )
+            seen_names.add(name)
+        return proposals
+
+    def resumable_proposal(self, round_index: int) -> WorkspaceProposal | None:
+        """Load the one immutable proposal whose evaluation did not commit."""
+        if self.round_state(round_index) not in {"evaluating", "failed"}:
+            return None
+        roots = sorted((self.frozen_dir / f"round-{round_index:04d}").glob("*/manifest.json"))
+        if not roots:
+            return None
+        if len(roots) != 1:
+            raise WorkspaceIntegrityError("a resumable round must contain exactly one frozen proposal")
+        manifest_path = roots[0]
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        composition_path = manifest_path.parent / "composition.json"
+        name = str(manifest.get("name") or manifest_path.parent.name.split("-", 1)[-1])
+        candidate = CompositionCandidate.from_path(
+            composition_path,
+            parent_hashes=tuple(str(value) for value in manifest.get("parent_hashes", ())),
+            metadata={"proposal_name": name, "round": round_index},
+        )
+        if candidate.content_hash != manifest.get("candidate_hash"):
+            raise WorkspaceIntegrityError("frozen proposal hash does not match its manifest")
+        return WorkspaceProposal(
+            name=name,
+            proposal_id=str(manifest["proposal_id"]),
+            candidate=candidate,
+            hypothesis=str(manifest["hypothesis"]),
+            changes=str(manifest["changes"]),
+            source_path=composition_path,
+        )
+
+    def record_attempt(self, row: Mapping[str, Any]) -> None:
+        proposal_id = str(row.get("proposal_id") or "")
+        if not proposal_id:
+            raise ValueError("attempt requires proposal_id")
+        self._append_jsonl_once(
+            self.root / "proposal-events.jsonl",
+            {"schema_version": 1, **dict(row)},
+            identity=(proposal_id, str(row.get("status") or "unknown")),
+            identity_keys=("proposal_id", "status"),
+        )
+
+    def readonly_snapshot(self, *, writable_round: int | None = None) -> dict[str, str]:
+        paths: list[Path] = []
+        for root in (self.history_dir, self.frozen_dir, self.rounds_dir):
+            paths.extend(path for path in root.rglob("*") if path.is_file())
+        for round_dir in self.proposals_dir.glob("round-*"):
+            if writable_round is not None and round_dir.name == f"round-{writable_round:04d}":
+                continue
+            paths.extend(path for path in round_dir.rglob("*") if path.is_file())
+        for session_dir in self.sessions_dir.glob("round-*"):
+            if writable_round is not None and session_dir.name == f"round-{writable_round:04d}":
+                continue
+            paths.extend(path for path in session_dir.rglob("*") if path.is_file())
+        for name in (
+            "WORKSPACE.md",
+            "candidate-catalog.json",
+            "evolution-summary.jsonl",
+            "proposal-events.jsonl",
+            "search-state.json",
+        ):
+            path = self.root / name
+            if path.is_file():
+                paths.append(path)
+        return {str(path.relative_to(self.root)): _sha256(path) for path in sorted(set(paths))}
+
+    def assert_readonly_unchanged(self, before: Mapping[str, str], *, writable_round: int) -> None:
+        after = self.readonly_snapshot(writable_round=writable_round)
+        changed = sorted(path for path in set(before) | set(after) if before.get(path) != after.get(path))
+        if changed:
+            raise WorkspaceIntegrityError(f"proposer modified read-only state: {', '.join(changed[:5])}")
+
+    def _candidate_refs(self) -> dict[str, str]:
+        catalog_path = self.root / "candidate-catalog.json"
+        catalog = json.loads(catalog_path.read_text()) if catalog_path.is_file() else {"candidates": []}
+        refs: dict[str, str] = {}
+        for row in catalog.get("candidates", []):
+            candidate_hash = str(row.get("candidate_hash") or "")
+            if not candidate_hash:
+                continue
+            refs[candidate_hash] = candidate_hash
+            for key in ("alias", "proposal_id", "name"):
+                if row.get(key):
+                    ref = str(row[key])
+                    if ref in refs and refs[ref] != candidate_hash:
+                        raise ValueError(f"ambiguous candidate reference {ref!r}")
+                    refs[ref] = candidate_hash
+        return refs
+
+    def _write_contract_if_missing(self) -> None:
+        path = self.root / "WORKSPACE.md"
+        if path.exists():
+            return
+        path.write_text(
+            "# Meta-Harness evolution workspace\n\n"
+            "Read candidate source and train/dev evidence under `history/`, the population in "
+            "`candidate-catalog.json`, and prior session logs under `sessions/`. Historical files "
+            "are immutable observations. Write each new complete Reef tree to the current "
+            "`proposals/round-NNNN/<name>/composition.json`, then declare its name, path, explicit "
+            "base candidate reference(s), hypothesis, and changes in `pending_eval.json`. The outer "
+            "loop owns validation and evaluation. Test tasks are never available during search.\n",
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _write_json(path: Path, payload: Any) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+                handle.write("\n")
+            os.replace(temporary, path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    @classmethod
+    def _write_once(cls, path: Path, payload: Any) -> None:
+        text = json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n"
+        cls._write_text_once(path, text)
+
+    @staticmethod
+    def _write_text_once(path: Path, text: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            if path.read_text(encoding="utf-8") != text:
+                raise WorkspaceIntegrityError(f"immutable workspace file changed: {path}")
+            return
+        path.write_text(text, encoding="utf-8")
+
+    @classmethod
+    def _append_jsonl_once(
+        cls,
+        path: Path,
+        row: Mapping[str, Any],
+        *,
+        identity: tuple[Any, ...],
+        identity_keys: tuple[str, ...] | None = None,
+    ) -> None:
+        keys = identity_keys or _identity_keys(len(identity))
+        if len(keys) != len(identity):
+            raise ValueError("JSONL identity keys and values must have equal length")
+        if path.exists():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                existing = json.loads(line)
+                existing_id = tuple(existing.get(key) for key in keys)
+                if existing_id == identity:
+                    return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(dict(row), sort_keys=True, default=str) + "\n")
+
+
+def _identity_keys(length: int) -> tuple[str, ...]:
+    return ("proposal_id",) if length == 1 else ("candidate_hash", "round", "split")[:length]
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/recipes/meta_harness/examples/terminal_bench/pyproject.toml
+++ b/recipes/meta_harness/examples/terminal_bench/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "reef-meta-harness-reproduction"
+version = "0.1.0"
+description = "Pinned Meta-Harness reproduction over Reef harness compositions"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "harbor==0.3.0",
+    "terminal-bench==0.2.18",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["harness*"]

--- a/recipes/meta_harness/examples/terminal_bench/run.py
+++ b/recipes/meta_harness/examples/terminal_bench/run.py
@@ -1,0 +1,471 @@
+"""Run the pinned frozen, incumbent-only, and full-history experiment cells."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import shutil
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from harness.budget import ObservedCostLedger
+from harness.codex import DEFAULT_CODEX_PATH, CodexProposer, verify_permission_profile
+from harness.composition import genesis_composition
+from harness.config import (
+    DEV_TASKS,
+    HARBOR_VERSION,
+    HARD_TASKS,
+    META_HARNESS_COMMIT,
+    PI_VERSION,
+    REEF_COMMIT,
+    SMOKE_DEV_TASKS,
+    SMOKE_TEST_TASKS,
+    SMOKE_TRAIN_TASKS,
+    TARGET_MODEL_PRICING,
+    TERMINAL_BENCH_COMMIT,
+    TERMINAL_BENCH_DATASET_COMMIT,
+    TERMINAL_BENCH_DATASET_URL,
+    TERMINAL_BENCH_VERSION,
+    TEST_TASKS,
+    TRAIN_TASKS,
+    ExperimentConfig,
+)
+from harness.harbor_eval import HarborEvaluator, verify_dataset_registry_pin
+from harness.publication import publish_candidate
+from harness.reporting import write_aggregate_report, write_cell_report
+from harness.search import CandidateRecord, MetaHarnessSearch, Population
+from harness.workspace import EvolutionWorkspace
+from reef.harness.adapters import get_adapter
+
+HERE = Path(__file__).resolve().parent
+CELLS = ("frozen", "incumbent_only", "full_history")
+SPLIT_NAMES = ("train", "dev", "test")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cell", choices=(*CELLS, "all"), default="all")
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--pi-binary", default=os.environ.get("REEF_PI_BINARY", "pi"))
+    parser.add_argument("--codex-binary", type=Path, default=DEFAULT_CODEX_PATH)
+    parser.add_argument("--rounds", type=int, default=ExperimentConfig().rounds)
+    parser.add_argument("--trials-per-task", type=int, default=ExperimentConfig().trials_per_task)
+    parser.add_argument(
+        "--max-observed-cost-usd",
+        type=float,
+        default=None,
+        help="Required for live runs; stops before a new target trial once recorded cost reaches this value",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Validate exact pins and print the plan without calls")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Use one pinned task per split while preserving rounds and trials",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = ExperimentConfig(rounds=args.rounds, trials_per_task=args.trials_per_task)
+    selected_cells = CELLS if args.cell == "all" else (args.cell,)
+    splits = selected_task_splits(args.smoke)
+    pi_binary = verify_runtime_pins(args.pi_binary, args.codex_binary)
+    output_root = args.output_dir or HERE / "outputs" / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    plan = build_plan(
+        config,
+        selected_cells,
+        output_root,
+        pi_binary,
+        args.codex_binary,
+        splits=splits,
+        smoke=args.smoke,
+    )
+    if args.dry_run:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return
+    if plan["pins"]["reef_source_dirty"]:
+        raise SystemExit("tracked Reef source has uncommitted changes; commit or stash them before a live run")
+    if (
+        args.max_observed_cost_usd is None
+        or not math.isfinite(args.max_observed_cost_usd)
+        or args.max_observed_cost_usd <= 0
+    ):
+        raise SystemExit("--max-observed-cost-usd must be finite and positive; no model calls were made")
+    if not os.environ.get(config.target_api_key_env, "").strip():
+        raise SystemExit(f"{config.target_api_key_env} is empty; no model calls were made")
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    run_identity_sha256 = ensure_run_identity(output_root / "run-identity.json", plan)
+    _write_json(output_root / "plan.json", plan)
+    ledger = ObservedCostLedger(output_root / "observed-cost.json", args.max_observed_cost_usd)
+    descriptor = get_adapter("pi")
+    for cell in selected_cells:
+        cell_dir = output_root / cell
+        if completed_cell(cell_dir, cell, run_identity_sha256):
+            print(f"skip completed cell {cell}: {cell_dir}")
+            continue
+        run_cell(
+            cell,
+            cell_dir,
+            config=config,
+            descriptor=descriptor,
+            pi_binary=Path(pi_binary),
+            codex_binary=args.codex_binary,
+            ledger=ledger,
+            splits=splits,
+            run_identity_sha256=run_identity_sha256,
+        )
+    _write_json(
+        output_root / "task-splits.json",
+        splits,
+    )
+    aggregate = write_aggregate_report(output_root, selected_cells)
+    if not aggregate["equal_target_episode_budget"] or not aggregate["equal_task_checksums"]:
+        raise RuntimeError("completed cells do not have equal target budgets and pinned task checksums")
+
+
+def run_cell(
+    cell: str,
+    output_dir: Path,
+    *,
+    config: ExperimentConfig,
+    descriptor: Any,
+    pi_binary: Path,
+    codex_binary: Path,
+    ledger: ObservedCostLedger,
+    splits: Mapping[str, Sequence[str]] | None = None,
+    run_identity_sha256: str = "test-run",
+) -> None:
+    started = time.monotonic()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    selected_splits = _normalize_task_splits(splits)
+    evaluator = HarborEvaluator(
+        splits=selected_splits,
+        trials_per_task=config.trials_per_task,
+        output_dir=output_dir / "private-evaluations",
+        target_model=config.target_model,
+        target_base_url=config.target_base_url,
+        target_api_key_env=config.target_api_key_env,
+        pi_binary=pi_binary,
+        before_trial=ledger.before_trial,
+        after_trial=ledger.record_trial,
+        budget_namespace=cell,
+    )
+    genesis = genesis_composition()
+    if cell == "frozen":
+        resumed = evaluator.completed_evaluations("train") > 0
+        train = dev = None
+        for round_index in range(config.rounds + 1):
+            train = evaluator.evaluate(genesis, split="train", round_index=round_index)
+            dev = evaluator.evaluate(genesis, split="dev", round_index=round_index)
+        if train is None or dev is None:
+            raise RuntimeError("frozen cell produced no search evaluations")
+        population = Population()
+        record, _, _ = population.add(
+            CandidateRecord(
+                candidate=genesis,
+                round_index=0,
+                alias="genesis",
+                train_score=train.score,
+                dev_score=dev.score,
+                outcome="selected",
+            )
+        )
+        selected = genesis
+        records = tuple(population.records)
+        sessions = ()
+        selected_dev_score = record.dev_score
+    else:
+        workspace = EvolutionWorkspace(output_dir / "workspace", descriptor)
+        proposer = CodexProposer(
+            model=config.proposer_model,
+            reasoning_effort=config.proposer_reasoning_effort,
+            codex_path=codex_binary,
+        )
+        outcome = MetaHarnessSearch(
+            workspace=workspace,
+            evaluator=evaluator,
+            proposer=proposer,
+            mode=cell,
+            rounds=config.rounds,
+        ).run(genesis)
+        selected = outcome.selected
+        records = outcome.population
+        sessions = outcome.proposer_sessions
+        selected_dev_score = next(
+            record.dev_score for record in records if record.candidate.content_hash == selected.content_hash
+        )
+        resumed = outcome.resumed
+
+    fill_count = _fill_target_budget(evaluator, selected, config.rounds)
+    test_result = evaluator.evaluate(selected, split="test", round_index=9000)
+    publish_candidate(
+        selected,
+        descriptor=descriptor,
+        output_dir=output_dir,
+        scenario=f"meta-harness-{cell}",
+        metadata={"cell": cell, "test_score": test_result.score},
+    )
+    summary = write_cell_report(
+        output_dir=output_dir,
+        cell=cell,
+        selected=selected,
+        population=records,
+        proposer_sessions=sessions,
+        test_result=test_result,
+        selected_dev_score=selected_dev_score,
+        resumed=resumed,
+        budget_fill_evaluations=fill_count,
+        wall_time_s=time.monotonic() - started,
+        config={**asdict(config), "cell": cell},
+    )
+    expected = planned_target_episodes(config, selected_splits)
+    if summary["target_episode_count"] != expected:
+        raise RuntimeError(
+            f"cell {cell} retained {summary['target_episode_count']} target episodes; expected {expected}"
+        )
+    if len(summary["task_checksums"]) != sum(len(tasks) for tasks in selected_splits.values()):
+        raise RuntimeError("cell did not retain a checksum for every Terminal-Bench task")
+    if cell == "full_history" and summary["later_round_history_read"] is not True:
+        raise RuntimeError("later full-history proposer round did not retain evidence of reading prior history")
+    mark_done(output_dir, cell, run_identity_sha256)
+
+
+def _fill_target_budget(evaluator: HarborEvaluator, selected: Any, rounds: int) -> int:
+    expected = rounds + 1
+    fills = 0
+    for split in ("train", "dev"):
+        completed = evaluator.completed_evaluations(split)
+        while completed < expected:
+            evaluator.evaluate(selected, split=split, round_index=8000 + completed)
+            completed += 1
+            fills += 1
+        if completed > expected:
+            raise RuntimeError(f"{split} evaluation budget exceeded before held-out testing")
+    return fills
+
+
+def build_plan(
+    config: ExperimentConfig,
+    cells: tuple[str, ...],
+    output_dir: Path,
+    pi_binary: str,
+    codex_binary: Path,
+    *,
+    splits: Mapping[str, Sequence[str]] | None = None,
+    smoke: bool = False,
+) -> dict[str, Any]:
+    selected_splits = _normalize_task_splits(splits)
+    per_cell = planned_target_episodes(config, selected_splits)
+    return {
+        "cells": cells,
+        "smoke": smoke,
+        "output_dir": str(output_dir),
+        "config": asdict(config),
+        "target_model_pricing": TARGET_MODEL_PRICING.to_jsonable(),
+        "pins": {
+            "reef_source_commit": _command_output(["git", "rev-parse", "HEAD"]),
+            "reef_source_dirty": bool(_command_output(["git", "status", "--porcelain", "--untracked-files=no"])),
+            "reef_base_commit": REEF_COMMIT,
+            "meta_harness_commit": META_HARNESS_COMMIT,
+            "terminal_bench_historical_commit": TERMINAL_BENCH_COMMIT,
+            "terminal_bench_dataset_url": TERMINAL_BENCH_DATASET_URL,
+            "terminal_bench_dataset_commit": TERMINAL_BENCH_DATASET_COMMIT,
+            "terminal_bench_version": TERMINAL_BENCH_VERSION,
+            "harbor_version": HARBOR_VERSION,
+            "pi_version": PI_VERSION,
+        },
+        "binaries": {
+            "pi": pi_binary,
+            "codex": str(Path(codex_binary).resolve()),
+            "codex_version": _command_output([str(codex_binary), "--version"]),
+        },
+        "split_sizes": {name: len(tasks) for name, tasks in selected_splits.items()},
+        "split_identity_sha256": hashlib.sha256(json.dumps(selected_splits, sort_keys=True).encode()).hexdigest(),
+        "planned_target_episodes_per_cell": per_cell,
+        "planned_target_episodes_total": per_cell * len(cells),
+        "planned_proposer_turns": config.rounds * sum(cell != "frozen" for cell in cells),
+    }
+
+
+def planned_target_episodes(
+    config: ExperimentConfig,
+    splits: Mapping[str, Sequence[str]] | None = None,
+) -> int:
+    selected_splits = _normalize_task_splits(splits)
+    search = (
+        (config.rounds + 1) * (len(selected_splits["train"]) + len(selected_splits["dev"])) * config.trials_per_task
+    )
+    heldout = len(selected_splits["test"]) * config.trials_per_task
+    return search + heldout
+
+
+def selected_task_splits(smoke: bool) -> dict[str, tuple[str, ...]]:
+    """Return either the exact reproduction split or its bounded live smoke."""
+    if smoke:
+        return {
+            "train": SMOKE_TRAIN_TASKS,
+            "dev": SMOKE_DEV_TASKS,
+            "test": SMOKE_TEST_TASKS,
+        }
+    return {"train": TRAIN_TASKS, "dev": DEV_TASKS, "test": TEST_TASKS}
+
+
+def _normalize_task_splits(
+    splits: Mapping[str, Sequence[str]] | None,
+) -> dict[str, tuple[str, ...]]:
+    source = selected_task_splits(False) if splits is None else splits
+    if set(source) != set(SPLIT_NAMES):
+        raise ValueError(f"task splits must contain exactly {SPLIT_NAMES}")
+    normalized = {name: tuple(source[name]) for name in SPLIT_NAMES}
+    if any(not tasks for tasks in normalized.values()):
+        raise ValueError("task splits must be non-empty")
+    flattened = tuple(task for name in SPLIT_NAMES for task in normalized[name])
+    if len(flattened) != len(set(flattened)):
+        raise ValueError("task splits must be disjoint")
+    unknown = set(flattened).difference(HARD_TASKS)
+    if unknown:
+        raise ValueError(f"task splits contain unpinned tasks: {sorted(unknown)}")
+    return normalized
+
+
+def verify_runtime_pins(pi_binary: str, codex_binary: Path) -> str:
+    if importlib.metadata.version("harbor") != HARBOR_VERSION:
+        raise SystemExit(f"Harbor must be exactly {HARBOR_VERSION}")
+    if importlib.metadata.version("terminal-bench") != TERMINAL_BENCH_VERSION:
+        raise SystemExit(f"terminal-bench must be exactly {TERMINAL_BENCH_VERSION}")
+    try:
+        asyncio.run(verify_dataset_registry_pin())
+    except Exception as exc:
+        raise SystemExit(f"Terminal-Bench registry pin verification failed: {exc}") from exc
+    resolved_pi = shutil.which(pi_binary) if not Path(pi_binary).is_absolute() else str(Path(pi_binary).resolve())
+    if not resolved_pi:
+        raise SystemExit(f"Pi binary {pi_binary!r} was not found")
+    if _command_output([resolved_pi, "--version"]) != PI_VERSION:
+        raise SystemExit(f"Pi must be exactly {PI_VERSION}")
+    if not Path(codex_binary).is_file():
+        raise SystemExit(f"Codex binary was not found: {codex_binary}")
+    try:
+        verify_permission_profile(codex_binary)
+    except Exception as exc:
+        raise SystemExit(f"Codex permission-profile verification failed: {exc}") from exc
+    _command_output(["docker", "info", "--format", "{{.ServerVersion}}"])
+    _command_output(["git", "lfs", "version"])
+    base_ok = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", REEF_COMMIT, "HEAD"],
+        cwd=HERE,
+        check=False,
+    ).returncode
+    if base_ok != 0:
+        raise SystemExit(f"current Reef source does not descend from pinned base {REEF_COMMIT}")
+    return resolved_pi
+
+
+def _command_output(command: list[str]) -> str:
+    try:
+        return subprocess.run(command, check=True, capture_output=True, text=True, timeout=30).stdout.strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SystemExit(f"runtime check failed for {command[0]!r}: {exc}") from exc
+
+
+def ensure_run_identity(path: Path, plan: Mapping[str, Any]) -> str:
+    identity = {
+        "schema_version": 1,
+        "smoke": bool(plan["smoke"]),
+        "config": plan["config"],
+        "target_model_pricing": plan["target_model_pricing"],
+        "pins": {key: value for key, value in plan["pins"].items() if key != "reef_source_dirty"},
+        "binary_versions": {
+            "pi": plan["pins"]["pi_version"],
+            "codex": plan["binaries"]["codex_version"],
+        },
+        "split_sizes": plan["split_sizes"],
+        "split_identity_sha256": plan["split_identity_sha256"],
+    }
+    serialized = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(serialized.encode()).hexdigest()
+    payload = {**identity, "sha256": digest}
+    if path.exists():
+        if _read_json_object(path) != payload:
+            raise RuntimeError(f"existing run identity does not match this invocation: {path}")
+    else:
+        _write_json(path, payload)
+    return digest
+
+
+def completed_cell(output_dir: Path, cell: str, run_identity_sha256: str) -> bool:
+    marker_path = output_dir / "done.json"
+    if not marker_path.is_file():
+        return False
+    marker = _read_json_object(marker_path)
+    if (
+        marker.get("complete") is not True
+        or marker.get("cell") != cell
+        or marker.get("run_identity_sha256") != run_identity_sha256
+    ):
+        raise RuntimeError(f"completed cell marker does not match this run: {marker_path}")
+    expected_hashes = marker.get("files")
+    if not isinstance(expected_hashes, dict) or expected_hashes != cell_evidence_hashes(output_dir):
+        raise RuntimeError(f"completed cell evidence changed after completion: {output_dir}")
+    publication = _read_json_object(output_dir / "publication.json")
+    repository = Path(str(publication.get("repository") or ""))
+    if not repository.is_absolute():
+        repository = output_dir / repository
+    if not repository.is_dir():
+        raise RuntimeError(f"completed cell artifact repository is unavailable: {output_dir}")
+    return True
+
+
+def mark_done(output_dir: Path, cell: str, run_identity_sha256: str) -> None:
+    _write_json(
+        output_dir / "done.json",
+        {
+            "complete": True,
+            "cell": cell,
+            "run_identity_sha256": run_identity_sha256,
+            "files": cell_evidence_hashes(output_dir),
+        },
+    )
+
+
+def cell_evidence_hashes(output_dir: Path) -> dict[str, str]:
+    excluded_roots = {"artifacts.git", "artifact-work", "artifact-cache"}
+    hashes = {}
+    for path in sorted(output_dir.rglob("*")):
+        relative = path.relative_to(output_dir)
+        if not path.is_file() or path.name == "done.json" or excluded_roots.intersection(relative.parts):
+            continue
+        hashes[relative.as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashes
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"invalid JSON object: {path}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"invalid JSON object: {path}")
+    return value
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/meta_harness/examples/terminal_bench/run.sh
+++ b/recipes/meta_harness/examples/terminal_bench/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../../.." && pwd)"
+export UV_PROJECT_ENVIRONMENT="$REPO_ROOT/.venv-meta-harness"
+exec uv run --locked --project "$HERE" --with-editable "$REPO_ROOT" python "$HERE/run.py" "$@"

--- a/recipes/meta_harness/examples/terminal_bench/uv.lock
+++ b/recipes/meta_harness/examples/terminal_bench/uv.lock
@@ -1,0 +1,2849 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/d4/eb96299230e20acf2efae207cb8d69051f1f68e357e5ea5e479bf6fb097a/aiohttp-3.14.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39aded8c7f3b935b54aab1d8d73c70ec0ee2d3ec3b943e0e86611bc150ba47f5", size = 754690, upload-time = "2026-07-23T01:53:47.332Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5bcb6ff3fdab1258a192679ff1a05d44f59626430aa05cd1a9d2447423599228", size = 509484, upload-time = "2026-07-23T01:53:51.159Z" },
+    { url = "https://files.pythonhosted.org/packages/30/07/4bbc222cc8dbe31d4c3e8a5baad2286e4d42026ac0c570027b89afce6344/aiohttp-3.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:617105e2c3018ee38d0c8ce5ee3c84f621a6d8b9f723202aacaff28449ca91ee", size = 511949, upload-time = "2026-07-23T01:53:55.083Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b9/42e74c46b7b7c794b995bbc1f573fb48950c38b19d8600c62a6804ee2d67/aiohttp-3.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f631fe87a6f30df5fbe6d79640b25e4cffb38c31c7fb6f10871517b84b0f8c1a", size = 1765282, upload-time = "2026-07-23T01:53:59.662Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/62bc4d74363ad346d518e0720363a949f63e2e23439a79eb5813d4d29bb3/aiohttp-3.14.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a94dbaae5ae27bd849c93570669bff91e0510f33a80805738e3de72a7be0447b", size = 1741511, upload-time = "2026-07-23T01:54:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9f/181e8a8bc79e47d13c7fc4540bd7a3b729d9505609c61f392a8dd2fbfe55/aiohttp-3.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f2f1c4c032c7cedd7d8da6f54c97b70266c6570c3108d3fdffee7188bb70529", size = 1810680, upload-time = "2026-07-23T01:54:09.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/dec94d6ad694552fe3424e3f1928d7a606a5d9d9433a04e7ecdd9d38ae7f/aiohttp-3.14.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea05e1f97ceea523942d9b2a7d7c0359d781d683d6b043f5943a602b14da4787", size = 1905646, upload-time = "2026-07-23T01:54:13.475Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42", size = 1792122, upload-time = "2026-07-23T01:54:15.752Z" },
+    { url = "https://files.pythonhosted.org/packages/66/73/10b1ef93afa61f4963c746257b70ced619cf31a4798671de5fdb2608501d/aiohttp-3.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0a5ff2dfbb9ce645fa5b8ef3e02c6c0b9cc3f6030ff863d0c51fffc50cb5541b", size = 1591127, upload-time = "2026-07-23T01:54:19.489Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ed/3b203fa6de1b338c14acdc06bf6ca9b043b7944f005966958c2ced932cde/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:041badb8f84396357c4d3ad26de6afd7a32b112f43d3c63045c0c8278cfd2043", size = 1725210, upload-time = "2026-07-23T01:54:24.129Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b7/1c2aab8c706436dcc28598452488ac9cd7c409da815237c28c27d58993e6/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:530125ee1163c4219af35dc3aa1206e541e7b31b6efc1a3f93b70a136f65d427", size = 1764848, upload-time = "2026-07-23T01:54:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/54/50/94c28f08b131c4bf10984ea2c7a536c9920608bb2d6e7f95642c30cc87b7/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c8653fd547c93a61aadc612007790f5555cdd18946fa48cf45e26d8ea4ea473d", size = 1777102, upload-time = "2026-07-23T01:54:31.775Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d4/e7d09ba7d345fb2d74440fd2fa033c5e079fac05552927705986f41a364f/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:89176250f686cb9853c0fb7ead90e639e915b84a6f43eedc2a4e7ec21f1037f0", size = 1580205, upload-time = "2026-07-23T01:54:34.518Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/072a91d68e1e1eb587985b54baab94221277f877e8ef274fc213a0ceae28/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3a26434dafe408229ff3403458ca58de24fb51936504decac49ce6755f77e59d", size = 1797219, upload-time = "2026-07-23T01:54:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/eb/aad34e897e668424d6e995da5dff8a4a09af93363d3392488772957a63aa/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19", size = 1768629, upload-time = "2026-07-23T01:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/6bb88ddba0fecd9122aa3ebcad25996cf6c083a4a7040dbb3a4f97972af6/aiohttp-3.14.3-cp312-cp312-win32.whl", hash = "sha256:16100ad3ab8d649fdfbee87602d9d2dcdca9df0b9eda8a1b5fdc0d41f96da559", size = 451481, upload-time = "2026-07-23T01:54:42.547Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:33a2d7c28d33797a2e99923dffa63f83d908a19b6bf26cfe80fa790aa5e1a75a", size = 476845, upload-time = "2026-07-23T01:54:44.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/44/28dac80a8941b604f4da10ce21097614ca1bf905ce93dca28d8d7de9c1e7/aiohttp-3.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:362a3fd481769cac1a824514bcd86fda51c65e8fe6e051099e008fddde6db17c", size = 448050, upload-time = "2026-07-23T01:54:47.087Z" },
+]
+
+[[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "altair"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/a1/5e6cc638a66da48cfc89a79c2f4810dfec00b63385f9b009ab1f069779bb/altair-6.2.2.tar.gz", hash = "sha256:a1ff9d9cfe81c75414641826312b9471780e19d39293ba0b012933f6b6cba0fe", size = 766606, upload-time = "2026-06-23T12:47:13.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/99/d6031f4f146298951c46b1bf1cc160c2a63f6e44b3c13a30054add100d5f/altair-6.2.2-py3-none-any.whl", hash = "sha256:94014f8ad8617c3cb163d1137359cd6db5ba134b9b46d93cfd8b609fd245a583", size = 797613, upload-time = "2026-06-23T12:47:11.451Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "ansicon"
+version = "1.89.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/e2/1c866404ddbd280efedff4a9f15abfe943cb83cde6e895022370f3a61f85/ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1", size = 67312, upload-time = "2019-04-29T20:23:57.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/f9/f1c10e223c7b56a38109a3f2eb4e7fe9a757ea3ed3a166754fb30f65e466/ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec", size = 63675, upload-time = "2019-04-29T20:23:53.83Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "docstring-parser" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/1a/b5af41cc1fa14da277ec20ca5554dd2fcbc09b8523ac59b7a97fbb88e452/anthropic-1.2.0.tar.gz", hash = "sha256:12f8eedee7b7fb5685837b1371b7bfae1b281703f62355f4632598ec2fc53b34", size = 1137443, upload-time = "2026-08-27T20:29:12.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/78/3f8b52708b03309e511990700bb8d0ec7a0c9db3d2a1e0d1c3ca417a4604/anthropic-1.2.0-py3-none-any.whl", hash = "sha256:b60642b3e3cd6b8e3e328a2d3f2863ad2b6e743f1037e42cc0143f7df99f63c6", size = 1289535, upload-time = "2026-08-27T20:29:11.01Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "asciinema"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/19/45b405438e90ad5b9618f3df62e9b3edaa2b115b530e60bd4b363465c704/asciinema-2.4.0.tar.gz", hash = "sha256:828e04c36ba622a7b8f8f912c8f0c1329538b6c7ed1c0d1b131bbbfe3a221707", size = 88768, upload-time = "2023-10-23T15:46:22.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/72/d79812aa210d411f7659fde4bbb1d5ef0e80950ff70f98bfdc57e12787dc/asciinema-2.4.0-py3-none-any.whl", hash = "sha256:249ccf108509d643ddaf38979dac48c99e9e251f597173d8553a30d7a6423104", size = 97332, upload-time = "2023-10-23T15:46:19.691Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bidict"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/f2/8d2dd8276ca05e1f5157b6a0d34efb2f585f47a0fbed61e8aad04b221f0b/bidict-0.24.1.tar.gz", hash = "sha256:4dca6c17f0b01700e9f24359daa5ebabf7be022d99f4cb2a257b6af2a5076c88", size = 30818, upload-time = "2026-08-25T23:45:52.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/53/2a3c7d562271ec6b6e38e7216b3104899f8aa4180c0713cb8aaf69e29cd5/bidict-0.24.1-py3-none-any.whl", hash = "sha256:fd3eaa737917d8a14f4baa391670c433c4e3f6f5fd2cd99d4bf436437f432364", size = 36175, upload-time = "2026-08-25T23:45:51.096Z" },
+]
+
+[[package]]
+name = "blessed"
+version = "1.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinxed" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/1b/b7c3971c1b34e6fe32ffcb00be769769cbb8ccaf0678aa9bb6f23aea677a/blessed-1.48.0.tar.gz", hash = "sha256:5ed4c0d40d0121669ef949e4f23465982614eb821bd110d1d5a98ed97dea13d8", size = 14036135, upload-time = "2026-08-07T17:35:44.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/3e/6e6ba6c809688332d2f8450371e672c76f7e8e73574aba9dfe89b55eb900/blessed-1.48.0-py3-none-any.whl", hash = "sha256:c4ce01cba220f41d2ff244e9829cb4ef2390a26ace8ce1687b8bced1613676e5", size = 131267, upload-time = "2026-08-07T17:35:42.469Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/30/96cf7d324e75cd2c349e2911ae2334d987fb8525d551495a2ef6758c26f3/boto3-1.43.83.tar.gz", hash = "sha256:6413d6e99f716af5d333a732db140e4b3359cac005a1271b11777b6d9ca82194", size = 112686, upload-time = "2026-08-28T19:35:52.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/4b/843f30dc77324778efa90c4169d503963668760b8d8abdf26a61bd090141/boto3-1.43.83-py3-none-any.whl", hash = "sha256:73a3564f737d4516625964eee709a498fa98ccee6aca929febad2b0b5fbeae1e", size = 140025, upload-time = "2026-08-28T19:35:49.228Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6f/cf16418004c832e6eb9abc6905fa323a3bf96a76ca7f2e97858801a4103e/botocore-1.43.83.tar.gz", hash = "sha256:d9389b3b74400c34219965a2fb858c1d48744718865ee0496fd03bd5b21b943f", size = 16010078, upload-time = "2026-08-28T19:35:46.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/50/332d6713fa09b05ff0882f5d194569fa70d1c8735aca9829b1286fef32ba/botocore-1.43.83-py3-none-any.whl", hash = "sha256:bf75a6cf587c22d968e43e79fe122c39f82deafbe9c3422bc5d3e80b6210fc98", size = 15704489, upload-time = "2026-08-28T19:35:40.603Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "6.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/14/b02446bacfe44351b1689c04937ade007588f44570431880a6937e525e6c/cbor2-6.1.4.tar.gz", hash = "sha256:01ecc79a28f33d17331943ce508fc1e21f4b06553c73f874f4c77120d72b2ef9", size = 90840, upload-time = "2026-08-01T20:41:39.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/76/fb64293c19cafb860060310c57b768fd9cfb7cf592449660b756538cc116/cbor2-6.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1fc15061553e4494dc10883237501e3402c645fe509248dd698e1faf2460d68b", size = 404608, upload-time = "2026-08-01T20:40:50.219Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ac/f58b3bafce7c86ada2ad8eaf189453136d2cf5bae526ea0540e1b9bc9d06/cbor2-6.1.4-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d9ada5a6ccfbb8ea7a3aa2aeb028421b52d8e0cd9323f0a2aeaa9c09d25fbce2", size = 449851, upload-time = "2026-08-01T20:40:51.725Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a5/10c6c126d59b07f2bd005094dd12a20afa46146f7e2673ed6f61a57641a7/cbor2-6.1.4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:310f3dfb296ba48fe9b63c5cf26e691e3548a1eae6901d2f0c18e941d151f220", size = 461193, upload-time = "2026-08-01T20:40:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e4/4445e6237088d1cca3b8536daeb90d6b4e23776de5609c9fa46773874757/cbor2-6.1.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e6c76004d674ad1c620660cb0bc5a8a0b72a5d8c7b70926d8e09e6d7e87332f", size = 516937, upload-time = "2026-08-01T20:40:54.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/87/9c0959510f7a402e5995c81ccfd82cb9f314140dc0cce88c12836e5b93f1/cbor2-6.1.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32a4663425fbca4a4a7aa918eb5789d844c406439e58424cf34511f79f559242", size = 529229, upload-time = "2026-08-01T20:40:56.365Z" },
+    { url = "https://files.pythonhosted.org/packages/91/8e/6811e4ee84203ac657f6f461a37c7c9ba0287bde80eb83c7971e9b3fe156/cbor2-6.1.4-cp312-cp312-win32.whl", hash = "sha256:2310f07db3f9ba26f2a623774ff9f3dc7185af54f732ea119785a6b1bf7e1e7e", size = 278810, upload-time = "2026-08-01T20:40:57.76Z" },
+    { url = "https://files.pythonhosted.org/packages/da/27/87440788fc0d9513534c3c699238e2a9ca6010f8cb72e9c203b7af20a9f6/cbor2-6.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:cc8cd300e236e9797b2e1ce306109dc481fcccf78bfa2682bf36d99e6eab1ec6", size = 299971, upload-time = "2026-08-01T20:40:59.256Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f9/77981e6e63092de19d7306a09a12b0eb3fd2907dc22c10dd5d389eb27faf/cbor2-6.1.4-cp312-cp312-win_arm64.whl", hash = "sha256:553a46bda7d09552631a714e22b91e6ff2c867ecd91511596ce290d8879b8d5b", size = 290662, upload-time = "2026-08-01T20:41:00.89Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
+name = "claude-agent-sdk"
+version = "0.2.148"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f4/fb7f81b31e44f69af9f53b93c32e2047f3ca15cd6311cfe72bfdf420f1f5/claude_agent_sdk-0.2.148.tar.gz", hash = "sha256:45c9972fa72dc6006745239c6838cc3cea7a9b42d6927c89f7bdb6996a1983b0", size = 344717, upload-time = "2026-08-28T18:33:51.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/f5/f4affb9f882bcf61422ea48491effb6ee2de28bfbdafd0ec90d1b959dad2/claude_agent_sdk-0.2.148-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026e2b54bb3f3909712ff462b8469e2b1fc5471cfde796abc23f32d30b2c8ba1", size = 83882833, upload-time = "2026-08-28T18:33:56.238Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cf/e1b11dd9fac877c8b44f022cf895f54f23854b916e09b32360e71209904c/claude_agent_sdk-0.2.148-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:c8cca1f4e4eb4e0c9f44ccfca6f651cf35e8f3914e483632ae8867c5619818a0", size = 88314490, upload-time = "2026-08-28T18:34:01.284Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d4/53de4727576fa6b5a261414d420895f4eb5f0369e232d403f1096205709e/claude_agent_sdk-0.2.148-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:3fbbea7cc30099d14f894e12fef68b0ee42fa9982567df94e59499b6aff55959", size = 94014630, upload-time = "2026-08-28T18:34:06.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e9/2ea469751ed4df75a911c4bf4dcad1ff5b71ccc9aa1a4aa108583a2a66b5/claude_agent_sdk-0.2.148-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:221efbc0f583c80258189ab93e4f0d6b6a61ad61335de1fdf3e2331ad423dbeb", size = 94210928, upload-time = "2026-08-28T18:34:11.592Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ea/86ccd7a34446c37174e53f03c389b25f168c7f4fd4f00f3e130baae9c902/claude_agent_sdk-0.2.148-py3-none-win_amd64.whl", hash = "sha256:f155252940fd77f1bcc707836924ca3a9691d19bbc464914ae2b7ccf17f0410f", size = 96875177, upload-time = "2026-08-28T18:34:16.378Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "connectrpc"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/b5/63e14ab9d4d4cc58818562db4120a35fa7454e3035633da41bdc6b712abd/connectrpc-0.11.1.tar.gz", hash = "sha256:18277f7838847b4271ca38d40c7d2387b5a2ea6a29f240689c19e1ec84aaff66", size = 46222, upload-time = "2026-07-15T06:33:31.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/ac/aa647675812cd075f2cb9acb00d62f4f2cbcbc6736049a62342b7371ce5b/connectrpc-0.11.1-py3-none-any.whl", hash = "sha256:8a52e2e92a485fa9681c1101a79a5ebeb31807e3ea3d5aabd41f484a6398bc7b", size = 64991, upload-time = "2026-07-15T06:33:29.396Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+]
+
+[[package]]
+name = "datasets"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/5b/836516269d4f618efe621661cfb6f9acc57e6f95265db3efaee48a5ffe04/datasets-5.0.1.tar.gz", hash = "sha256:ce22bb851efd7494f08aad33b940803784434f6e77763d00679a0dc45fcf686a", size = 641498, upload-time = "2026-07-28T11:09:12.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/0b/98fc6eb83333508ca5f44c52b3e287ea8137a0ad582714e2cbc67a02154b/datasets-5.0.1-py3-none-any.whl", hash = "sha256:9fbf73688f8c18f7529b4fe592abd04015f81d1e58001e4bac73ffb2b39d7cc4", size = 559079, upload-time = "2026-07-28T11:09:10.266Z" },
+]
+
+[[package]]
+name = "daytona"
+version = "0.207.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "daytona-analytics-api-client" },
+    { name = "daytona-analytics-api-client-async" },
+    { name = "daytona-api-client" },
+    { name = "daytona-api-client-async" },
+    { name = "daytona-toolbox-api-client" },
+    { name = "daytona-toolbox-api-client-async" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "httpx-ws" },
+    { name = "obstore" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "python-socketio", extra = ["asyncio-client", "client"] },
+    { name = "toml" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/f2/f86e6fa2eb36474a924d9fdbe02862a8eeb789d0a859ef710fc7ec3acdb5/daytona-0.207.0.tar.gz", hash = "sha256:70ba628c3b1a148216f467adb2f5c6949c2444a71a3b5ac45f9c61ad55d37a56", size = 188616, upload-time = "2026-08-24T12:14:27.527Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/48/e9be7e06518e7dd2a93b42773b71c9e367021b62467801e109c2960c5d74/daytona-0.207.0-py3-none-any.whl", hash = "sha256:a5dc672232fb6b1d74a39f1f5719a8fefc39bd153c11ebde2d7730db8c2a1cdf", size = 225978, upload-time = "2026-08-24T12:14:28.725Z" },
+]
+
+[[package]]
+name = "daytona-analytics-api-client"
+version = "0.207.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/a3/939106f65e0d051d0612e99629691919b0bd653241a4f373e6a386344c99/daytona_analytics_api_client-0.207.0.tar.gz", hash = "sha256:290101ea18284b9984313d803b2ee841c9ae34676225cb05471907a6bc6ae1f4", size = 30106, upload-time = "2026-08-24T12:13:52.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/37/5b76af532995fa6cbf8dae7c36e07af47a61a99385663a2d1e9846e20491/daytona_analytics_api_client-0.207.0-py3-none-any.whl", hash = "sha256:c8d0e5851fff197cc9552199041a365a1b89e06b0da7be1d847af467492fbd05", size = 45012, upload-time = "2026-08-24T12:13:53.504Z" },
+]
+
+[[package]]
+name = "daytona-analytics-api-client-async"
+version = "0.207.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/d9/8840c814ec60bb354a3640a5d2a789e7088b86091b90f21f06599b2fddde/daytona_analytics_api_client_async-0.207.0.tar.gz", hash = "sha256:0f495c78d3acab6d46d0630450d0a018aa6f189e0e7471c0685e37d0744b938f", size = 30121, upload-time = "2026-08-24T12:13:55.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/f4/773b25b1c1012abe9b408c639e14a95dd36cddf5932fa76e8c0c59c957b3/daytona_analytics_api_client_async-0.207.0-py3-none-any.whl", hash = "sha256:23bc3e73d4af2744a47c33cc7b2075a502fbe9dba6d02a67a8b995cfdac687a8", size = 45285, upload-time = "2026-08-24T12:13:56.356Z" },
+]
+
+[[package]]
+name = "daytona-api-client"
+version = "0.207.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/62/1fa20ad83c76787419ce08f410675ea71585ebb91e3bcf2ad5650ad43ad8/daytona_api_client-0.207.0.tar.gz", hash = "sha256:b89cf48362f4ea998ca3737a42dd77309c5c1bd9c72d55c7855413c01c78c77b", size = 141802, upload-time = "2026-08-24T12:13:48.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/43/4c8b81d9273fc8defa20802f1dcad4e6b9b4e5eb4952fcaf763a6238dfb2/daytona_api_client-0.207.0-py3-none-any.whl", hash = "sha256:a37fb2a60b6d0ceb3522a79b232369e8ec9fe357f4e56b3c003fe29e6e43de70", size = 356121, upload-time = "2026-08-24T12:13:49.932Z" },
+]
+
+[[package]]
+name = "daytona-api-client-async"
+version = "0.207.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/71/eec4822501c4b110c6f723054397f4b33c4d49db01d79b05fe871da3c7a8/daytona_api_client_async-0.207.0.tar.gz", hash = "sha256:13325da6d8a9e9160848d8973b6df5a067bc773d0630df0206f7d76cafb35a79", size = 142195, upload-time = "2026-08-24T12:13:50.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/a4/373ff6a90e3d5109043322d745a11d5c29cb631c61f025b3b4522c26f672/daytona_api_client_async-0.207.0-py3-none-any.whl", hash = "sha256:7d57bd76d5b881722badccc96cf97b5105d3a859731dc467443da63cfe8f48cb", size = 358953, upload-time = "2026-08-24T12:13:53.036Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client"
+version = "0.207.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/86/66bb06312b1c73360b97912af8a56129b7f8eae47c9258816fad89363cee/daytona_toolbox_api_client-0.207.0.tar.gz", hash = "sha256:7b42e7ba0d4873dcfbaad6702a9ef01a6a1909ccc426162eab171a6207afc73d", size = 88166, upload-time = "2026-08-24T12:13:48.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/6b/c822cb6b640d0404413805b4039630be8b4ef472f18da1935e74c2c5ae02/daytona_toolbox_api_client-0.207.0-py3-none-any.whl", hash = "sha256:b98e30661cfe6d81dff18c92835553a2ef9193767e4765077a6ce9591b2342e6", size = 252415, upload-time = "2026-08-24T12:13:50.713Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client-async"
+version = "0.207.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/b2/9baf0925ce767aac83500ea48f631cfd5d709b7f48817c0eb88f6fadc985/daytona_toolbox_api_client_async-0.207.0.tar.gz", hash = "sha256:c64a47394bc8741f6191f24b83bc3878e3ae610462f74e231cd367a0ec1553f5", size = 82033, upload-time = "2026-08-24T12:13:53.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/62/411128c02f5852f93f3d0c85677a42f3fc8d3f627201a0e4f24bd8e62e9b/daytona_toolbox_api_client_async-0.207.0-py3-none-any.whl", hash = "sha256:45bfa6396889185e37dc4163e831e6236d2a939a2afe1dc57fbd53e5108c490d", size = 250909, upload-time = "2026-08-24T12:13:55.08Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "dirhash"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "scantree" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/1f/c8bf92552b7f0a13b9f12b85e3de8df6d9814240e0f8ce8f37433df028b3/dirhash-0.5.0-py3-none-any.whl", hash = "sha256:523dfd6b058c64f45b31604376926c6e2bd2ea301d0df23095d4055674e38b09", size = 13119, upload-time = "2024-08-03T22:14:11.688Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
+]
+
+[[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/5d/5f8571bd5dedc80863191621ac4be001f3f3dd8315d2ec078705dab7dec1/durationpy-0.11.tar.gz", hash = "sha256:181898e1ae282e288f0a2291829656bf1b6b3aadf30a97993b85db4943642905", size = 3582, upload-time = "2026-08-26T13:56:00.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/c4/ebdf7837bc4ef6fd98cfb013c28855bb358467bf86c1af011bbc21e21df0/durationpy-0.11-py3-none-any.whl", hash = "sha256:a739fe2b8972c250ff72f8e2c488d18cf25f7b852f49ee76048775d5171df30c", size = 4133, upload-time = "2026-08-26T13:55:59.456Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "connectrpc" },
+    { name = "dockerfile-parse" },
+    { name = "h2" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/4d/2d6a05bce9a0e48297aa452d62b554e3630bdbcea8ecb12575f3f1cd2aac/e2b-2.46.0.tar.gz", hash = "sha256:7733f2e011038836d1b972ae46837562e3f5938c43f3756d10e349c0f08ce5f9", size = 227610, upload-time = "2026-08-25T11:21:00.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/03/a7f1b9da9a26f94529e52c2361b5244f7b1061d43b55a3089d5b888f5be0/e2b-2.46.0-py3-none-any.whl", hash = "sha256:92611d2f9a0cd97516b16d7ebaf9f633d953549698a4c0ac545cdd719a3878f0", size = 401696, upload-time = "2026-08-25T11:21:01.883Z" },
+]
+
+[[package]]
+name = "editor"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "runs" },
+    { name = "xmod" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/fe06c2a13a5282dcef4c7133bb348d4125a9aa69c5fb49037a004599d73a/editor-1.8.0.tar.gz", hash = "sha256:b07e1bbcb8b33f05c2e6ed3ce77ee9756354ada840a18aad7c0536d967fe4c0b", size = 27455, upload-time = "2026-05-09T13:42:59.796Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/b8/6648cadf38b61045262bf2a534e526f04eb833275ad1fc77a2026e9f7e3a/editor-1.8.0-py3-none-any.whl", hash = "sha256:7d47ff88ae6c5f6c43d28c30b6f7fd59a24741175a1771ab06c969d946d7dfd0", size = 4012, upload-time = "2026-05-09T13:43:00.847Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz", hash = "sha256:2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30", size = 222126, upload-time = "2026-08-23T17:37:55.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl", hash = "sha256:22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd", size = 99864, upload-time = "2026-08-23T17:37:53.913Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+]
+
+[[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "harbor"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "claude-agent-sdk" },
+    { name = "datasets" },
+    { name = "daytona" },
+    { name = "dirhash" },
+    { name = "dockerfile-parse" },
+    { name = "e2b" },
+    { name = "fastapi" },
+    { name = "jinja2" },
+    { name = "kubernetes" },
+    { name = "litellm" },
+    { name = "modal" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "ruff" },
+    { name = "runloop-api-client" },
+    { name = "shortuuid" },
+    { name = "supabase" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/3f/58880773b733ba1a0184b5a92dd66ded02c12807f8566aaa7a4ccb176c51/harbor-0.3.0.tar.gz", hash = "sha256:19532c651cabc82787f1ce8683e5296401117091dfb668128b947a01b607df00", size = 754808, upload-time = "2026-03-30T17:46:42.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/af/179443069bf354e1fd035578c012a1bfaf55e412bf285e8706ec7452dc14/harbor-0.3.0-py3-none-any.whl", hash = "sha256:b2b4679489df6f752bc7b22b926b06f0ace7148944510e218fadd53a0c7afc34", size = 867388, upload-time = "2026-03-30T17:46:43.43Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "httpx-ws"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/35/42316e8f6908b6d21bc8df017cc6efba94fb5edbf99b64e28dd142325e20/huggingface_hub-1.29.0.tar.gz", hash = "sha256:6ebb385a581435325cf6d5c5b233d5d4bc91175834d99fd65dae14379b36e9ad", size = 963121, upload-time = "2026-08-27T12:18:37.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a5/47c2ea9b228ccbcba8467e9a64823146e8ebbad29855e591d8f5eedcc9c7/huggingface_hub-1.29.0-py3-none-any.whl", hash = "sha256:b00f7782afc14db4bc6572763810a635bdfbab8623d957bfb553bd18e03852cd", size = 795768, upload-time = "2026-08-27T12:18:35.431Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
+]
+
+[[package]]
+name = "inquirer"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blessed" },
+    { name = "editor" },
+    { name = "readchar" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/79/165579fdcd3c2439503732ae76394bf77f5542f3dd18135b60e808e4813c/inquirer-3.4.1.tar.gz", hash = "sha256:60d169fddffe297e2f8ad54ab33698249ccfc3fc377dafb1e5cf01a0efb9cbe5", size = 14069, upload-time = "2025-08-02T18:36:27.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/fd/7c404169a3e04a908df0644893a331f253a7f221961f2b6c0cf44430ae5a/inquirer-3.4.1-py3-none-any.whl", hash = "sha256:717bf146d547b595d2495e7285fd55545cff85e5ce01decc7487d2ec6a605412", size = 18152, upload-time = "2025-08-02T18:36:26.753Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jinxed"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d7/6e6d474ec5eaeca6a61acc17766bb19563b3a372b4b9d92910078f5fe49f/jinxed-2.1.0.tar.gz", hash = "sha256:7e755b831faa2443d44fb4ce7c0202eb9c3ed39bd5bf1193365888f4f6092b54", size = 61287, upload-time = "2026-07-03T15:46:48.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/1d/0a6be99b69bb448448403a45a241aff0dca751832ae54f027ed940d2eb52/jinxed-2.1.0-py2.py3-none-any.whl", hash = "sha256:43b802d18b70e405d410fb66eb2837d1101e7e5ea922e666507bb43f34d11d09", size = 104999, upload-time = "2026-07-03T15:46:47.114Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "36.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.98.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "boto3" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/97/c9da198af273d700bf44d7d82eb21c5b8078c82574b31856b71b1298234b/litellm-1.98.0.tar.gz", hash = "sha256:0e6ba5d645a73ca6d0ffb4e8ec539d94b6e8fad691f2a54c6819011e6d0de8bf", size = 17577139, upload-time = "2026-08-22T22:19:21.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/90/2ef5e33b0a67b309be124a77e5098a261beffe28439221dbbc28e5f02e2e/litellm-1.98.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9fda3497f1ec4686c943ce2aeab5767f8fb4a5989305d4b28d6d5d7e488b850c", size = 24026097, upload-time = "2026-08-22T22:19:03.567Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/56/b4569b4ef3640732d5770e0d3f46a395fd20f35594db1f65629595daed00/litellm-1.98.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b89b6a0fc179d881191579f5309e622173dca802ee991b92e382acb918eea437", size = 23683944, upload-time = "2026-08-22T22:19:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a7/9f03de0e8d767ff27964ea99bbf07e4c37a12f9d3c168c09f40e068535d4/litellm-1.98.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3a95260f087a4cf763da85bbeeb2efa82caec243ad2394c9e6362ff747963738", size = 23824066, upload-time = "2026-08-22T22:19:09.714Z" },
+    { url = "https://files.pythonhosted.org/packages/69/de/ab46b521e2a6e6a94a5cb91ba3debd6c4e922feaeb47158a389400b0a0fe/litellm-1.98.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:150993180bf049feafa3e20cf46ca0978c69cc66e2ef1639a47e852c682a4721", size = 24190393, upload-time = "2026-08-22T22:19:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0a/d2f549d906b9b267b38b406dde721eb93db21b46ec907ae0a7a2a89a50f6/litellm-1.98.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54d0bc2aba84644de5e84a265f24e5d436d91592ca5b7cc61cee478db297b0c3", size = 23901211, upload-time = "2026-08-22T22:19:14.708Z" },
+    { url = "https://files.pythonhosted.org/packages/85/08/1bd1653297d9c92eaf04425f8a21da817fcde12e1d9469394c543df19d72/litellm-1.98.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5e546d4af197c257d320299af11f4619f8e5a29f9bb7ce2d9974dd4b1e045499", size = 24290140, upload-time = "2026-08-22T22:19:17.145Z" },
+    { url = "https://files.pythonhosted.org/packages/de/91/14d11ad7e290137400e5b30bcf23de86f811085f4a46756f60684ed0f064/litellm-1.98.0-cp310-abi3-win_amd64.whl", hash = "sha256:1daac9a9a9d052fdbe58ee711c9924dc81d349d4621286cbd96d77baa12158c4", size = 24079638, upload-time = "2026-08-22T22:19:19.558Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/a5/9e322043716e511b7f6c9120804f33b92e21a818bf4709b2d98b3c76d665/modal-1.5.5.tar.gz", hash = "sha256:30df363ed1898cc3d91a09ff3f95c38ab043f6b6294011b01085312c6a0ac777", size = 870356, upload-time = "2026-08-28T19:51:34.881Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/19/b3dca8baec119126058b12ca620e44022e4d08a091956668bd04180c89a7/modal-1.5.5-py3-none-any.whl", hash = "sha256:8d10d3ee09818aaba1973b73ce2521ab8961b63a29b5b52e3ff0d25e7a74808e", size = 985163, upload-time = "2026-08-28T19:51:32.404Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multiprocess"
+version = "0.70.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/72/dccb0aaf40972777283303919f613964227266d0c13adebb79ac124f1c3e/numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c", size = 16891693, upload-time = "2026-08-09T13:44:51.702Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03", size = 11903109, upload-time = "2026-08-09T13:44:55.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f4/29e78102a80601cf034d4e9767022cffeca2c3b4c926e1754572ca95593d/numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb", size = 5350202, upload-time = "2026-08-09T13:44:58.401Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4b/dcd3b7eadaf4035d2c7a4289d232523a6964f602598ef7674e4bd7291f93/numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414", size = 6687736, upload-time = "2026-08-09T13:45:00.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/21/4947e0e9d6c9fc2e2ff15b8949049ee44f63adb9cacc729ab8793f97e712/numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9", size = 15612696, upload-time = "2026-08-09T13:45:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8", size = 16722264, upload-time = "2026-08-09T13:45:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/3f0be4c1b9fdf5dd5e708a6806978564d7c46a055c000496309ff2a2f8af/numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab", size = 16974396, upload-time = "2026-08-09T13:45:11.316Z" },
+    { url = "https://files.pythonhosted.org/packages/22/72/6262cbdeeb45da9d971e40715f579d791603ba8ec0b5e2db1ac55454421d/numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7", size = 18476044, upload-time = "2026-08-09T13:45:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/29208b8b075bde62d26a81d14b358c42b0f69b6cabd98d4ff97f37f22b05/numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a", size = 6072817, upload-time = "2026-08-09T13:45:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4", size = 12464674, upload-time = "2026-08-09T13:45:20.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/032b97e00461ab0809bbe4c588b035620e5a14b8cdee47ecddefc7b17d33/numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1", size = 10397131, upload-time = "2026-08-09T13:45:23.73Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "obstore"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/27/aa7549157a4a681157e315534ba5ab8f167f77662166e792a6e836938f46/obstore-0.11.1.tar.gz", hash = "sha256:a5afe8b99e3b20cdc9133be7a1b381259acf0d470029f6b2fc79c3f9947ad436", size = 130828, upload-time = "2026-08-21T23:57:27.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/38/438f85772bfbcd2985845a5d00d1c910e98b15f587dae6cb1e435865eba9/obstore-0.11.1-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d5c50b755d781efebe4f9c70ee6d00858e44d95f0229b8b5174358f861d9bd7c", size = 5400146, upload-time = "2026-08-21T23:56:29.168Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/62/edd2613649cb6b4400f5d125223ee094d2da1c4c93636453a5360c61b865/obstore-0.11.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:093152daa5c32b70a032f231bbc6a7eff76dda4285eed5a81d272b4485032dab", size = 4596203, upload-time = "2026-08-21T23:56:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/52/09edd48251a26a65f786bf2def93994ffce501f3aea6724474d8de0a7f4f/obstore-0.11.1-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b97ee10456e65f166c030b5fbde8380ca508621e23b84efd77aad83afe99315a", size = 5003021, upload-time = "2026-08-21T23:56:32.085Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8f/89a28c75d46bbb0552d34a5e84c5bc512526d45f935321f00af2e6275a99/obstore-0.11.1-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48983a143de69b11de49212caa79b5c39acbff7f592f9e85d156a0133a0e5796", size = 5240376, upload-time = "2026-08-21T23:56:33.658Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c3/b4620899003e2472bec7baf5d2bce12cf6f6f11d02d8f17e03e093717a53/obstore-0.11.1-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b9cb988e03ff963914cf2176aee293eaaff7dcf4efcb905ce6834264b4b0884", size = 5444946, upload-time = "2026-08-21T23:56:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/de/687685ab39ae4a70cc13ac252febfe62a387836a55e046f467c9fb231880/obstore-0.11.1-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97850f68c8417f7167549bdb705c362c825ed470298c6b04faf52258c5e9234e", size = 5304065, upload-time = "2026-08-21T23:56:36.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/b962ad52031b5bfdd249923db6151ff2b665b08c017611db96838455f337/obstore-0.11.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a9f3d66dbf3c073dd6b6033c0787ef14edf78d97bff95595d6f6979692da264", size = 5556770, upload-time = "2026-08-21T23:56:38.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/04/41a0f2917fcaa1e66b754fc98c92441d5a252ff9c619941ac086f9bdb4f6/obstore-0.11.1-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:2ba3bceec4263b3a70eea873abedb82e03da9599f2326e80d6505cab0c10d401", size = 5337765, upload-time = "2026-08-21T23:56:40.279Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/0b618efe59ee4b58f16d2b9246674a70c390bebf665cd284b439bade9bd3/obstore-0.11.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e956fa8a953b7eb8580658d68cdf37e410356032c17697a06e44d0e8c4084a0f", size = 5544012, upload-time = "2026-08-21T23:56:41.754Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3b/1018f6da240f3529d1cb9a836c79a91ce45349ba3cffcd6baa73296c7e6c/obstore-0.11.1-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:159a50d0f4cc53afe6f5c695313bcaf6e92ac81d7847692c8279153483272bfa", size = 5229851, upload-time = "2026-08-21T23:56:43.367Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2c/c2fe082816b255159373b15be3f28b2515d0eb954e248e2f65449c456a14/obstore-0.11.1-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:128da07f3a1b9c70159e2b2be9e27f458a9d531d57b1856dd7c4ddb73b4c9937", size = 5361812, upload-time = "2026-08-21T23:56:44.871Z" },
+    { url = "https://files.pythonhosted.org/packages/43/9c/656eb5cce818e7e3985d27f4bd403feb0b6e620494775a55a0943c8d2fff/obstore-0.11.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:67b8acfbbab960c2cb14c34294a96556caa67fcff15ee77c716d5c1bd1558606", size = 5790855, upload-time = "2026-08-21T23:56:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/5c/94ece1c902ff5cdbe1140997d1f720221a0d5defa902fdd93715297604f5/obstore-0.11.1-cp311-abi3-win_amd64.whl", hash = "sha256:e23ea15cebe5f5be5d11005043d7b5ff56848e39499681ef52f8227bd385bd51", size = 5308846, upload-time = "2026-08-21T23:56:47.774Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.54.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/9a/8c75e8c8a5b407a0586faeb2afac91674ff955c191ecc1d6d3b6669f6788/openai-2.54.0.tar.gz", hash = "sha256:e3e6f8bc1ba30ddf381ace1a14340eed381cb984a1a59bd0f34b5be3b5d49cfa", size = 1100285, upload-time = "2026-08-11T18:46:59.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/a8/bb76c7356de8ad57f59d5ff993d434df0607f07f08bcc9c9a5c275e399c0/openai-2.54.0-py3-none-any.whl", hash = "sha256:89089789197ccdb87f173a03145ed1598d00795220c93e96cf712b1cbf5e5f2b", size = 1660351, upload-time = "2026-08-11T18:46:56.684Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiohttp-client"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/33/3ff7230b035e8b696db6be54f5c52dfa409829d634d91431c076ad789820/opentelemetry_instrumentation_aiohttp_client-0.65b0.tar.gz", hash = "sha256:85906a2806ee5641756b5c33274e9aa75c3cc2441e3b830aa5804cf0e1fa9dd1", size = 19042, upload-time = "2026-07-16T15:25:51.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/f9/5c8459224f175829601cabbcffaeab0f9041903c086e4a0368f9971093a5/opentelemetry_instrumentation_aiohttp_client-0.65b0-py3-none-any.whl", hash = "sha256:3a060efa53fa44d02ba7372a7ed2b42cdfa6be6df81b089845067ad840e25729", size = 13677, upload-time = "2026-07-16T15:24:53.361Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/54/1dc810ea558d1320b597aa140a514f2fdf1d2ea09c38cf556f13ea712ec9/pandas-3.0.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fa290c16964d4963fbfbc358928239cf3bd755b20e988ce944877def2f44471d", size = 10411717, upload-time = "2026-07-22T22:18:08.307Z" },
+    { url = "https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2e26bb46934b8a2ca0c3de1d3d606fc5f6746584791b2db264d58cf370e08dc", size = 9957095, upload-time = "2026-07-22T22:18:10.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/51/fac252f4a913ed5eabf3c11b880a9e8d5a6c10f0b2129d0462212d238b4d/pandas-3.0.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73fa87b08a7ef706f8aafda39ddaccf2a99047bea62d8c88a0361bcafb2237bc", size = 10485458, upload-time = "2026-07-22T22:18:12.834Z" },
+    { url = "https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34", size = 10998091, upload-time = "2026-07-22T22:18:15.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/8c/1f29b5be8d3fc47dd7567eb167fabba2085879b31e0287ce7cba6d3d2ff4/pandas-3.0.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a29c53d85ea98c5e792c59ef82ee9fbe6ca902c0d0adb6b23f45ef894cd7bf6", size = 11499501, upload-time = "2026-07-22T22:18:17.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e2/bd9c98ad2df7b38bde002adde4cdf353519da51881634323b126c55997f9/pandas-3.0.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a5ad3b02ed6bc7d7ae9b70804b2c6aa31827489d150f8e623ce82491b82085d7", size = 12060559, upload-time = "2026-07-22T22:18:20.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9a/ffbd852d58bd74a617fe2f8ee6a58a96982271ce41cf981eab22190b4a4b/pandas-3.0.5-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:b2acb4650527eec6822c3dadb2b771277b65e7dae7a267d4bccf65fd1bb3fbce", size = 7197652, upload-time = "2026-07-22T22:18:22.502Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b5/d2d3e9ae73362ba4229651b0ee1455cf78073a1ce585f6ff693782ce263e/pandas-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:80a611068e8a3ac23f7398c6c14eb46dc974e5cc9997f653e2dcfd1da74edd41", size = 9831691, upload-time = "2026-07-22T22:18:24.534Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/dea1e89d6a6796b9c43f85a09b484ee03edb8a4c4842e73e200a8c11301c/pandas-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:25ff585b972a18ef1fe9ffa3ac6544d9950508aa76832e5147640b6022821e49", size = 9105796, upload-time = "2026-07-22T22:18:27.064Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+]
+
+[[package]]
+name = "postgrest"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/3e/41909586cb148db0259e0208310067afda4cc097f4c7a779e829c1e68c46/postgrest-2.31.0-py3-none-any.whl", hash = "sha256:c2fd47c94e13ee8335111c4f03c9a24ea9766ce9d35fc3cd7330057c9e7ea0c3", size = 23098, upload-time = "2026-06-04T13:37:19.452Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "protobuf-py"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py-ext", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/ed/02fd902d9c51b7ff53dfc9a745eb11490722edfd30073af889e171f07b8e/protobuf_py-0.1.1.tar.gz", hash = "sha256:6bd08ac4d8f1661965bbe2685429d79043704cdd1ee720a7a89617331742240b", size = 133525, upload-time = "2026-06-24T19:02:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/00/1b3775aca1c70e3007e06ef5996f6bb9b3a32341eb0cce3ffb6effad8dec/protobuf_py-0.1.1-py3-none-any.whl", hash = "sha256:efc4f50f275ed6dae10a1f30bb81ad1a75368557b3ff22a532b7a472050368f1", size = 181656, upload-time = "2026-06-24T19:01:29.556Z" },
+]
+
+[[package]]
+name = "protobuf-py-ext"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/6dc9ccff1e8159eb9a144e6d3c4acfd2211cd4fcd20c34fe9155d17d6a7f/protobuf_py_ext-0.1.1.tar.gz", hash = "sha256:e85bfdfdb3ed50634db8ccc7429dd9286520109489c735463971a418707b4fef", size = 31912, upload-time = "2026-06-24T19:02:16.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/70/2b5d62a60a2e0d88ecde1ae98db3132bcd2672fb39c8d581b82b34ac0bd8/protobuf_py_ext-0.1.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:310039e03cb15181781a0b78017419f6d4ee302e988c3c70b87f1facdf05532d", size = 306008, upload-time = "2026-06-24T19:01:31.399Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d6/73c06bb4cac2e04c0adc154965fe8b6520224bd737fd7e73bba405056321/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ec8348d1ba045f79b2fedd14e40cca36f2a41b52f2c4fdf55a60c58add2353", size = 314769, upload-time = "2026-06-24T19:01:32.89Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c5/e4e6bc6096b66d1c82639a1b501147f16ee65d32567304b987d002e2c666/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:182798e4861aba72d05855bd06febe4926aa7265e6f444a1b8af5252beee4f7e", size = 328122, upload-time = "2026-06-24T19:01:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/1d792a40d0f0a0f914f1dfa8bb5e9573ca0ecd5fe5cecf80d77193212abd/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9eb25c3a329c0551cc86b209a5e5d8ecb8d834b9924a3aa019377853a703b6d3", size = 492338, upload-time = "2026-06-24T19:01:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/5ad329223c905e5c530cae38ae24cde3584d8ab7e09457f2a01afce80e60/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aaecbde82bef10c7c40578cbb61b7a19896bf7fa450972050a3bb302acb7d5d6", size = 541578, upload-time = "2026-06-24T19:01:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c7/01bd8a8bfe2df4b07aafac12ccfb7b7ebe2303f65296a9e02fcafa28ff3e/protobuf_py_ext-0.1.1-cp310-abi3-win_amd64.whl", hash = "sha256:6b0c615c48e95acc53cf33e9310eeaff8b30d2d7555bf93e7bca8fb4f40e9a5c", size = 251319, upload-time = "2026-06-24T19:01:38.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/914065538b5db54b6a920b5af38c1ef142252ea1eea711820435fa259fac/protobuf_py_ext-0.1.1-cp310-abi3-win_arm64.whl", hash = "sha256:72956cd0af5dee24b41c6f5ba5e42622d17e6d555002b5efc1634e27a1446de2", size = 241635, upload-time = "2026-06-24T19:01:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/0b5d73cab815fd50615cb87a02e04e8332f9e27380c890aba1459cf7e919/protobuf_py_ext-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6f0cd58620f415a3534d195358338f4999a774e12510f91c592b38d13d37388", size = 304903, upload-time = "2026-06-24T19:01:41.796Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/14c120b9ac36a0e11bb05e482fa6ae322de583a8e1068e4859035c289947/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21572764f625d829604fc4d83635f533f35775f11c6da142345b3f3c8d64bd09", size = 316148, upload-time = "2026-06-24T19:01:43.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/7c00a1a9783c3ba74f6b2f5d2f049f09037bbd489c465c09a34f32fb611b/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f14f00c2678bfbe7ad46f057b9f9938c1677bcf39e405e163e272c6f9814b8", size = 326458, upload-time = "2026-06-24T19:01:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0e/81fa50c0d6c4d664e5be6d0a3c4f2c7edfef87ab12d0bac764abca1f2955/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1610865622e2e27568277ca63d8d2d23dcc55eaa767398865c21539ddf4ce24d", size = 493596, upload-time = "2026-06-24T19:01:46.344Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/3183cf6e4de62846c20549654a1d573dae51ca06aaf7fed06accdfab74f6/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8995efba9476e1ea18ef9873306871dba697308994bc2766558fec3387acc3de", size = 539656, upload-time = "2026-06-24T19:01:48.21Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/e2/9ab15b88cbfac28e16419ce5439ec29234c5172cb8259301b4ba639bdec0/pyarrow-25.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:df961f2e7ae9cf496459259d798652c70625f6c080650d6952f8c04053c58ee9", size = 35861559, upload-time = "2026-08-10T12:38:02.567Z" },
+    { url = "https://files.pythonhosted.org/packages/58/79/a0036dbe1eabe1f73127427342f1d99982584c4a2cde2651d6c93499c6f6/pyarrow-25.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:cc4aa407fde9fc660be3939e49ea31f50f3e9fec17c0ec63159f7711edd3efc9", size = 37628383, upload-time = "2026-08-10T12:38:09.083Z" },
+    { url = "https://files.pythonhosted.org/packages/13/49/d93a57d375f4bf0cf82913dd6bb54acafde83dd993be2282c81ac5616cad/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4340f0ba6c1d2e13f21658de1d7c662ca2545018568d0030a1e9afca159d87e3", size = 46820190, upload-time = "2026-08-10T12:38:15.458Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5389cdf79447ed1515c9e31620e6e1e2302249564d603f2ad727d4f6d313e4c3", size = 50102437, upload-time = "2026-08-10T12:38:22.487Z" },
+    { url = "https://files.pythonhosted.org/packages/80/53/8fb8359ff17cfb6263a1cf3ebf7caec9fe197de118719e84fcb1d0618026/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d51592cb7561e87877c506113e7adbf1342ab579e6c21f0ef44b8ba41cb74c80", size = 49942424, upload-time = "2026-08-10T12:38:28.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/4e5ae02a9341571b18a6fca380ac7a58ce6ddae7ab3c060208c0a1e79f02/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6109c94d8b9f3b17a041daca16cacb2f651ad8f1ef70a4232c2c0f37a23da2a8", size = 53144206, upload-time = "2026-08-10T12:38:34.862Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ee/197cbf47e49f83e6ebeb946a5259a48a638dea27ac774db42fe78022179d/pyarrow-25.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8858d7bfc22e3f51529aeaa4077225029724623e4595dc9eff8c793935c34140", size = 27953934, upload-time = "2026-08-10T12:38:39.808Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516, upload-time = "2026-08-28T09:58:21.576Z" },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874, upload-time = "2026-08-28T09:58:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772, upload-time = "2026-08-28T09:58:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832, upload-time = "2026-08-28T09:58:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645, upload-time = "2026-08-28T09:58:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935, upload-time = "2026-08-28T09:58:30.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284, upload-time = "2026-08-28T09:58:32.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889, upload-time = "2026-08-28T09:58:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006, upload-time = "2026-08-28T09:58:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408, upload-time = "2026-08-28T09:58:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609, upload-time = "2026-08-28T09:58:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618, upload-time = "2026-08-28T09:58:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/468fc630568c61dcef3cd47ad32ffbeed9af643f49208d1ea86ab4f890c4/pydantic_core-2.46.5-cp312-cp312-win32.whl", hash = "sha256:5cb482e9e84c851f4e623fe4acc1ced89168cf1fe18f7089db4548c8f5bbb65b", size = 1939475, upload-time = "2026-08-28T09:58:42.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c9/4c19f41b84cf6b622a72fbeed7665b25d47a187d68d47d0d430c07f23268/pydantic_core-2.46.5-cp312-cp312-win_amd64.whl", hash = "sha256:5e81740c09e310f5aa5cbd3e434a01c154d4bef93241c7877b39f211d2b78ba8", size = 2043140, upload-time = "2026-08-28T09:58:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/af/dd/0c1a050299147c746e5256db16d645ab5efd4f78c59937d581a0524e74a2/pydantic_core-2.46.5-cp312-cp312-win_arm64.whl", hash = "sha256:f7b0ec93a2893de856652154d73b7ba622f26fa97726487dcac373de5f4c6084", size = 1997729, upload-time = "2026-08-28T09:58:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/df/dd/053c2e4303f791f3b8f8a14ab0b22008e8eb21d868c0c90b4f9be705b76a/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:013d6f3483d81e02e7c328831808f336c8596ee33b4bd4026b9ffb1e960b8942", size = 2062540, upload-time = "2026-08-28T10:01:00.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/dd/a18df751a5e37dd51bfad7f68e766999125bebe68c9e1d10a493ad01bd63/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:e9c134bb666dd54b778b9fc0d2b50cbb7f979b9e3716f26a88c9ab3b6fc1dd0f", size = 1902040, upload-time = "2026-08-28T10:01:02.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/01d40f9d07ce8a779fd6e0bd8ad4fba91309500dd67b869e2e219d261a6d/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:347ec774390c87326a2e4929d58d3f7e8763a104d5d35f4cd595a4c952366433", size = 1967479, upload-time = "2026-08-28T10:01:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/c81d4841331c2178b6fb09ae225425e110ed72d990c9fe556c4ec03d1013/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e24d8f05fa2d28513d94e877e9c75ad66175376209b3977f916e240e623193c", size = 2111034, upload-time = "2026-08-28T10:01:07.345Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
+name = "pydeck"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/c9/f71032fca47ecc09d30904d9a610234b07139f89eabc2f054b141edcc30f/pydeck-0.9.3.tar.gz", hash = "sha256:695775cbfe51f5fdffbd9735ba469987fdc5efc96bc40a0ee4808170509c78b2", size = 5900912, upload-time = "2026-07-02T23:27:08.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/34/3998411437aff304a9ed4fa37a6fe1ef3132bcd2b5eac59851b80c86123c/pydeck-0.9.3-py2.py3-none-any.whl", hash = "sha256:d8a47c11c81fb12d51b1feb42427ff4f0e13cb599e48931021b2cba98b6849a6", size = 11428091, upload-time = "2026-07-02T23:27:06.399Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyqwest"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/ee/0ff9facfa9e7a4f6df2a770d4eaf1ad0f74165da7e8c28e888461f07604c/pyqwest-0.10.0.tar.gz", hash = "sha256:6c1a693be17d57d2c2eca4085e32c2809c53090c16719a907c90ebcf1f40dc01", size = 482248, upload-time = "2026-08-21T06:09:20.656Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ee/b1a28f57c689606cfd065d8a553841150f7daaa91d20e58dcc2c5ea191f8/pyqwest-0.10.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:aa492d5777dd145a60795ed95d9d4707a3cd1091fdcdfc93a82ac7fdc43ebacd", size = 5261059, upload-time = "2026-08-21T06:08:04.999Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/13/9c5046cfd6ef705bde0b620ba8a794335bcabc0839342a2a647f2427b27e/pyqwest-0.10.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:59f3f16628e518c674102e7b5fcff2101bba6abb4f6737ec5fade9b9278e6a53", size = 5134207, upload-time = "2026-08-21T06:08:06.955Z" },
+    { url = "https://files.pythonhosted.org/packages/93/7d/50021dd88d82d6966ab1c27593ceaee9d1ed62fbe597c40e8dc187cfa5fd/pyqwest-0.10.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6e7db305a8318b1f3218053e87501f8f245ca8bd63e948e0282d04bf0883470", size = 5640730, upload-time = "2026-08-21T06:08:09.135Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/3f/5bf6c32e9e701837a8c47ce6e3ad38978cfec8eb7bc6596181e5f9e1eaeb/pyqwest-0.10.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5c757cfac5f53c8671dcb4850d5fc4c4339ea3e90636331c9318f8e3ddabc06", size = 5561462, upload-time = "2026-08-21T06:08:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/61/ca9ba5721461b7ce5cfaac373ab3a1723ddcc434af7430f8bd628da6e623/pyqwest-0.10.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:234b3f71e3f314d997c203d8cf829b7117edd041153f9c277d0060ab90134148", size = 5801847, upload-time = "2026-08-21T06:08:12.502Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/44/95593919b996a417093f598d887822b9b899e8d025588c9bfaf8c60dd812/pyqwest-0.10.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5637256a0dac0ef57e0eaa02b032014965e4a4c995e1deca1b1b97e6d1765f78", size = 5978692, upload-time = "2026-08-21T06:08:14.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/b2821ce5188457168ebb25d5ff65b1ca1bf27bc6b4a33df4bcc2357e625c/pyqwest-0.10.0-cp310-abi3-win_amd64.whl", hash = "sha256:7ea761937acf3a00d1a7e70e982949d18946e5471d1419266ab3a78bbfa19759", size = 4876627, upload-time = "2026-08-21T06:08:16.084Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/16ccef1c203fa258ce46a86aefc1a79c13b5f0b8d49627347d90eef25efd/pyqwest-0.10.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a21f1f15252a8303623b4f17b9c6de595ace11b3ade07f2adb6d07121e8191aa", size = 5274815, upload-time = "2026-08-21T06:08:17.777Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/61/6a87f84f571441ea43279587d4bfcad4543505918ae2b83a1ebdcfa98be5/pyqwest-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eb472c6e5d6833ebfec79db310e426eb17b01ac64c0e2c251bd9192c0d2ee0c5", size = 5123656, upload-time = "2026-08-21T06:08:19.501Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/ab69e581cf9b798b0e169f7b27fd3f8b6f9f1631bd4d3b6e22e5abaf8d8b/pyqwest-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83578e24cccd5e0dc04d60a0af7bfb43325b5f22d03ff74ff79ed0ecf553b50d", size = 5641253, upload-time = "2026-08-21T06:08:21.627Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/dd/f1a62eebf8321ace506bd94551a01431f6a45b882225455eae3ea6e8c6d1/pyqwest-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bb511c434f79c641efb5573e5795e56dc972252f4b96e52a9636d4ece5231a4", size = 5567341, upload-time = "2026-08-21T06:08:23.346Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/48/51d767691973e046887f5e6d96e32142fe296823b163ccba732233a6ef72/pyqwest-0.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1aaccd8a9db9430b2aedb5bad8ead80742cbc056b85c229516c70dc80539f906", size = 5803874, upload-time = "2026-08-21T06:08:25.096Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0a/d2834ccc6e59ad110718895cc65ff2a68aa6e010f0ba8fbe42a57ea33c21/pyqwest-0.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:73d9eb438ab4a957a1ce0619d3af8c1c1126bfb9181033b123d792fcf4224531", size = 5981518, upload-time = "2026-08-21T06:08:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f3/274b4c268e9a55fbdb1b3637ac50b5bf42cd3a85d1cfbdc15c602a7b0d9c/pyqwest-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:317a74d633abe3bc5bccabf479e069c515dab9e6a755274b0ccb1d8a5bbfede3", size = 4870638, upload-time = "2026-08-21T06:08:29.421Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "python-engineio"
+version = "4.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/d8/65cc479ab697a2e7fdee83a9bd8a06b61ec68bf763a58a302cf161bf38bb/python_engineio-4.13.5.tar.gz", hash = "sha256:b5764d62243e3ffbc4c76dda3d7897c329dc52294c80c27105f9faa054e76897", size = 80035, upload-time = "2026-08-12T22:52:23.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/01/f804208061b504894546fddc479f6075e0f00dfe88cb1703dafaa8c3c67e/python_engineio-4.13.5-py3-none-any.whl", hash = "sha256:05c9f4951d242ad33d613b4245299562e5f64e4199f00e5390f9888505831704", size = 59963, upload-time = "2026-08-12T22:52:22.5Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/5e/87d6b547c87c6d64f4a05f5bfaf6f42e9b786561216434290fdaa83f8667/python_socketio-5.16.4.tar.gz", hash = "sha256:f7fa4a43cc8e687930b5c6e44d6e2efc2071eca4bef49b8bb3dc0827f7f92235", size = 128140, upload-time = "2026-08-06T23:11:21.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/463feca73ec119a135d90c9f40c0172b4758150b5ed442f0ca1e8fed807a/python_socketio-5.16.4-py3-none-any.whl", hash = "sha256:0eb9c7687e7fbf59e60d714fd62afba77dfaf8ef8a06a0bff05a86c351accc2f", size = 82098, upload-time = "2026-08-06T23:11:19.851Z" },
+]
+
+[package.optional-dependencies]
+asyncio-client = [
+    { name = "aiohttp" },
+]
+client = [
+    { name = "requests" },
+    { name = "websocket-client" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "readchar"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/49/a10341024c45bed95d13197ec9ef0f4e2fd10b5ca6e7f8d7684d18082398/readchar-4.2.2.tar.gz", hash = "sha256:e3b270fe16fc90c50ac79107700330a133dd4c63d22939f5b03b4f24564d5dd8", size = 9762, upload-time = "2026-04-06T19:45:54.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ca/36133653e00939922dd1416f4c56177361289172a30563fcb9552c9ccde4/readchar-4.2.2-py3-none-any.whl", hash = "sha256:92daf7e42c52b0787e6c75d01ecfb9a94f4ceff3764958b570c1dddedd47b200", size = 9401, upload-time = "2026-04-06T19:45:52.993Z" },
+]
+
+[[package]]
+name = "realtime"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/60/164246615e8b059f6d53d34648a0784260421ec98a07eb1e45160f063221/realtime-2.31.0-py3-none-any.whl", hash = "sha256:f6e494b53d6a6e80b6efcee6711c8dd40413a52e766271de1bce8ced6c36cc1d", size = 22374, upload-time = "2026-06-04T13:37:21.162Z" },
+]
+
+[[package]]
+name = "reef-meta-harness-reproduction"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "harbor" },
+    { name = "terminal-bench" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "harbor", specifier = "==0.3.0" },
+    { name = "terminal-bench", specifier = "==0.2.18" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/b9/d11d7e501ac8fd7d617684423ebb9561e0b998481c1e4cbc0cb212c5d74a/regex-2026.7.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cc3460cedf7579948486eab03bc9ad7089df4d7281c0f47f4afe03e8d13f02d", size = 496778, upload-time = "2026-07-19T00:17:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a9/a5ab6f312f24318019170dc485d5421fe4f89e43a98640da50d95a8a7041/regex-2026.7.19-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0e9554c8785eac5cffe6300f69a91f58ba72bc88a5f8d661235ad7c6aa5b8ccd", size = 297122, upload-time = "2026-07-19T00:17:07.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/63/4cab4d7f2d384a144d420b763d97674cb70619c878ea6fcd7640d0e62143/regex-2026.7.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7da47a0f248977f08e2cb659ff3c17ddc13a4d39b3a7baa0a81bf5b415430f6", size = 292009, upload-time = "2026-07-19T00:17:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/22/85/102a81b218298957d4ea7d2f084fae537a71add9d6ff93c8e67284c5f45e/regex-2026.7.19-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93db40c8de0815baab96a06e08a984bac71f989d13bab789e382158c5d426797", size = 796708, upload-time = "2026-07-19T00:17:11.542Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/dc136af5629938a037cd2b304c12240e132ec92f38be8ff9cc89af2a1f2d/regex-2026.7.19-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:66bd62c59a5427746e8c44becae1d9b99d22fb13f30f492083dfb9ad7c45cc18", size = 865651, upload-time = "2026-07-19T00:17:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/75/67402ae3cd9c8c988a4c805d15ee3eef015e7ca4cb112cf3e640fc1f4153/regex-2026.7.19-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1649eb39fcc9ea80c4d2f110fde2b8ab2aef3877b98f02ab9b14e961f418c511", size = 911756, upload-time = "2026-07-19T00:17:15.015Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8e/096d00c7c480ef2ff4265349b14e2261d4ab787ba1f74e2e80d1c58079c3/regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9dce8ec9695f531a1b8a6f314fd4b393adcccf2ea861db480cdf97a301d01a68", size = 801798, upload-time = "2026-07-19T00:17:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/41/e7ecac6edb5722417f85cc67eaf386322fbe8acf6918ec2fdc37c20dd9d0/regex-2026.7.19-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3080a7fd38ef049bd489e01c970c97dd84ff446a885b0f1f6b26d9b1ad13ce11", size = 776933, upload-time = "2026-07-19T00:17:19.347Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/69/03c9b3f058d66403e0ca2c938696e81d51cd4c6d47ec5265f02f96948d9a/regex-2026.7.19-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d793a7988e04fcb1e2e135567443d82173225d657419ec09414a9b5a145b986", size = 784338, upload-time = "2026-07-19T00:17:21.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f7/b38ab3d43f284afbb618fcd15d0e77eb786ae461ce1f6bc7494619ddc0f2/regex-2026.7.19-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e8b0abe7d870f53ca5143895fef7d1041a0c831a140d3dc2c760dd7ba25d4a8b", size = 860452, upload-time = "2026-07-19T00:17:23.119Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/ff60ef0571121714f3cf9920bc183071e384a10b556d042e0fdb06cc07a5/regex-2026.7.19-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4e5413bd5f13d3a4e3539ca98f70f75e7fca92518dd7f117f030ebedd10b60cb", size = 765958, upload-time = "2026-07-19T00:17:24.81Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0f/bd34021162c0ab47f9a315bd56cd5642e920c8e5668a75ef6c6a6fca590d/regex-2026.7.19-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:73b133a9e6fb512858e7f065e96f1180aa46646bc74a83aea62f1d314f3dd035", size = 851765, upload-time = "2026-07-19T00:17:26.993Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/a2ca43edade0595cccfdc98636739f536d9e26898e7dbddc2b9e98898953/regex-2026.7.19-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dbe6493fbd27321b1d1f2dd4f5c7e5bd4d8b1d7cab7f32fd67db3d0b2ed8248a", size = 789714, upload-time = "2026-07-19T00:17:28.699Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/47/e02db4015d424fc83c00ea0ac8c5e5ec14397943de9abf909d5ce3a25931/regex-2026.7.19-cp312-cp312-win32.whl", hash = "sha256:ddd67571c10869f65a5d7dde536d1e066e306cc90de57d7de4d5f34802428bb5", size = 267157, upload-time = "2026-07-19T00:17:31.051Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8e/c780c131f79b42ed22d1bd7da4096c2c35f813e835acd02ef0f018bd892c/regex-2026.7.19-cp312-cp312-win_amd64.whl", hash = "sha256:e30d40268a28d54ce0437031750497004c22602b8e3ab891f759b795a003b312", size = 277777, upload-time = "2026-07-19T00:17:32.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4c/e4d7e086449bdf379d89774bf1f89dc4a41943f3c5a6125a03905b34b5fb/regex-2026.7.19-cp312-cp312-win_arm64.whl", hash = "sha256:de9208bb427130c82a5dbfd104f92c8876fc9559278c880b3002755bbbe9c83d", size = 277136, upload-time = "2026-07-19T00:17:34.803Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
+]
+
+[[package]]
+name = "runloop-api-client"
+version = "1.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/95/dcf9c49bdd06a1beca9e1734bc28440ab8197c87cfc07063ce0bba879519/runloop_api_client-1.31.0.tar.gz", hash = "sha256:674415eb5a62a08c8c9f3fd69fc5cc7a161feb02a4deb5cf939bf9f9b6a93889", size = 666916, upload-time = "2026-08-25T18:26:24.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/da/49e0b7940d2abd17d4b34c95068756cd7750c59979406e881dfc935e3a5e/runloop_api_client-1.31.0-py3-none-any.whl", hash = "sha256:e1e3dc13d27b20bf25b397050b7e22473c28ab02c8c6703e30fa2004f1755c45", size = 412406, upload-time = "2026-08-25T18:26:22.651Z" },
+]
+
+[[package]]
+name = "runs"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "xmod" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/ae/095cb626504733e288a81f871f86b10530b787d77c50193c170daaca0df1/runs-1.3.0.tar.gz", hash = "sha256:cca304b631dbefec598c7bfbcfb50d6feace6d3a968734b67fd42d3c728f5a05", size = 4585, upload-time = "2026-02-03T15:59:58.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/b6/049c75d399ccf6e25abea0652b85bf7e7e101e0300aa9c1d284ad7061c0b/runs-1.3.0-py3-none-any.whl", hash = "sha256:e71a551cfa8da9ef882cac1d5a108bda78c9edee5b8d87e37c1003da5b6a7bed", size = 6406, upload-time = "2026-02-03T15:59:59.96Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "scantree"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ce/828467ddfa0d2fe473673026442d2032d552a168e42cfbf25fd0e5264e0c/scantree-0.0.4-py3-none-any.whl", hash = "sha256:7616ab65aa6b7f16fcf8e6fa1d9afaa99a27ab72bba05c61b691853b96763174", size = 20690, upload-time = "2024-08-03T20:08:58.137Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "shortuuid"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
+]
+
+[[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/d5/1b77a026d161f98a08f11af1a5f6c47b98ee7c7e2648af525a1004826c78/sqlalchemy-2.0.52-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be8c49131665dfe2cc74c498aa1240ffb548d0fd901325dd11c2c7a18956f727", size = 2170940, upload-time = "2026-08-11T20:58:11.25Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bd/f444444adb37b5d53753fb1730ee7a421628e2e3b756c4da461af7e6394a/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2d9e507a458832adcfbd8af6e2036ddf069b7710b799448542ebccae2dceee", size = 3383415, upload-time = "2026-08-11T21:02:38.534Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/2eadf93a552568c57e8680b7e58bb5e9770d80942a1bdbaf4f2f63f0d7c8/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8738008376d22f30f411ea3efecf39b51110b6996d80bb73786f30bcfdd5fd3b", size = 3398577, upload-time = "2026-08-11T21:16:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c3/2887cf9dd111d1fbf05d22165b404c221ef43e029f7a2695e7302f27a7cc/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37a4d548327b6cab9c7d8cdb4e0e82feabee0110c4d150059068e2d1cfbd99ee", size = 3328225, upload-time = "2026-08-11T21:02:40.183Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0f/466bdf9e1feeeef5587f868c187d8687e21ff8c85b1775e9041130181132/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e49f51a5d59857a7a0dcaf9469febf7197d9394bd88f00d69c2c4e848112cdbf", size = 3357374, upload-time = "2026-08-11T21:17:01.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/20/5c2b4583904af4173076dda1c9e53c9e2ffc7a702d2efde0216bbacbf7cb/sqlalchemy-2.0.52-cp312-cp312-win32.whl", hash = "sha256:afda3ec521d0517d0de783fc70030775841900896d832de5bbd066549290470e", size = 2129366, upload-time = "2026-08-11T21:14:50.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/06/543dab8ef62d4e9fb96fb31a30c2b8b14a8763bccf48d428294d6b3041c0/sqlalchemy-2.0.52-cp312-cp312-win_amd64.whl", hash = "sha256:2d5e53e36e37129fe0be8b9d08b6e4052c10a963ee6cda56c8c10dcc194b99ca", size = 2157344, upload-time = "2026-08-11T21:14:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "storage3"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/b2/60d86a3a99ae743e8a00a6df912f85269b3bc882ba217b8ce1690881c669/storage3-2.31.0-py3-none-any.whl", hash = "sha256:4bf46e8bea320743179a6beafdc7531c5242495e00e0cc22af7c7a9d69d4ed84", size = 28492, upload-time = "2026-06-04T13:37:22.792Z" },
+]
+
+[[package]]
+name = "streamlit"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altair" },
+    { name = "anyio" },
+    { name = "blinker" },
+    { name = "click" },
+    { name = "httptools" },
+    { name = "itsdangerous" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "pyarrow" },
+    { name = "pydeck" },
+    { name = "python-multipart" },
+    { name = "requests" },
+    { name = "starlette" },
+    { name = "toml" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+    { name = "watchdog", marker = "sys_platform != 'darwin'" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/94/928c44a8b7bcd602fc4a16025e9868bcdb88b92bcdb2e53dec188d034fc4/streamlit-1.62.0.tar.gz", hash = "sha256:9d2571da6e6799cbaf0f59548f5773926260a87a69807cf3e2f0f68f9f5e4d45", size = 9883501, upload-time = "2026-08-19T18:31:22.864Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/57/78864764c53885db8a378cc1c47329b4b6e095f7ebd89cd1ffcca4027c89/streamlit-1.62.0-py3-none-any.whl", hash = "sha256:294dbcfe0d6531b0d8593a095e6872dcc6ec4b731723fbb318a0f8102e69162e", size = 10490146, upload-time = "2026-08-19T18:31:19.957Z" },
+]
+
+[[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
+name = "supabase"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "postgrest" },
+    { name = "realtime" },
+    { name = "storage3" },
+    { name = "supabase-auth" },
+    { name = "supabase-functions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/06/5e6f4bf89dedadf81f893832115c1866da1aa093142c9989c2818780dae3/supabase-2.31.0-py3-none-any.whl", hash = "sha256:25f2a99207a75f2d9377e2332783b4389cf56b02cbebdaf0c1743112dcbb704e", size = 16728, upload-time = "2026-06-04T13:37:24.278Z" },
+]
+
+[[package]]
+name = "supabase-auth"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/5e/22f3b0546bb1f0985f06fb1ebf5f6405a3b1bb7a5db01142c26cf148e988/supabase_auth-2.31.0-py3-none-any.whl", hash = "sha256:5e9c8b4ecdee6af04dbcb06455ce78cb15674806fcb6b425170455307d70b0ee", size = 48363, upload-time = "2026-06-04T13:37:26.26Z" },
+]
+
+[[package]]
+name = "supabase-functions"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "strenum" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/79/1a8162ce7d705381a4f2668c0da68e097b103c1aa701418a31da52905c7b/supabase_functions-2.31.0-py3-none-any.whl", hash = "sha256:3fdc4c4766152bfda63bdd0e286fc8a06f50e1280711fae4a1dfc9b7e9ebabc6", size = 8794, upload-time = "2026-06-04T13:37:28.022Z" },
+]
+
+[[package]]
+name = "synchronicity"
+version = "0.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1c/f51dc54bbd302991026a53f9790735540e0e9e1184e9d5939f02446aa5bc/synchronicity-0.12.5.tar.gz", hash = "sha256:94d96b1d85698e3056b96a793b8c0949af6584e4a7d877fabdeb5385efe230aa", size = 60745, upload-time = "2026-06-18T21:06:23.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/74/ad9b99520f70c0bc3318e582e359d360cfc0f7afd7bf368a7f24013cece7/synchronicity-0.12.5-py3-none-any.whl", hash = "sha256:fdbbb10d437bc08a6b0f814fc66fddd1b58ffed314533d42f1ab555801e781af", size = 41107, upload-time = "2026-06-18T21:06:22.505Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "terminal-bench"
+version = "0.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "asciinema" },
+    { name = "boto3" },
+    { name = "docker" },
+    { name = "inquirer" },
+    { name = "jinja2" },
+    { name = "litellm" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pandas" },
+    { name = "psycopg2-binary" },
+    { name = "pydantic" },
+    { name = "ruamel-yaml" },
+    { name = "sqlalchemy" },
+    { name = "streamlit" },
+    { name = "supabase" },
+    { name = "tabulate" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/04/0f32893404091a45a53662eae25099db0c9e57890ede23ba2466c8d9c608/terminal_bench-0.2.18.tar.gz", hash = "sha256:787c494a882d441a7c25b60d848c0273269451b4babb596008adcc0d2331004b", size = 109157, upload-time = "2025-09-26T22:58:48.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5a/0196c0816e45b8254f5fcf42534b18dad870c43e4ae7db9bbf7b73ee8dc7/terminal_bench-0.2.18-py3-none-any.whl", hash = "sha256:564e8f50968c91a9018edf62ed0c2cfb3a1cf068cf4f843bcaeed06d8340f2e8", size = 167423, upload-time = "2025-09-26T22:58:47.116Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/62/167a842aa0429d45f5e797354fd4343a96f6043d67d0513c675c7b8d36e6/tiktoken-0.14.0.tar.gz", hash = "sha256:231dec90efcdccf1b565a1416107736f1e09b1a08fe736ef9d6363e626d03874", size = 38898, upload-time = "2026-08-17T19:49:49.514Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/da/e273746b9d24a63c776bc60fba914351573ad9c575b52601eb5e60632564/tiktoken-0.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8e947aefe98ef74cce94923f90e48c98fe34eb1ec0a6bfdfadfc5a96359bfc36", size = 1094408, upload-time = "2026-08-17T19:48:49.269Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9f/fe6b1aca23331aa5271df5a4bd07bf68a7059254d47faee1b8272592a777/tiktoken-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d6cebe67765569df3dafac8474e4eccf5c19d24140492567a5e58a11445732a4", size = 1038499, upload-time = "2026-08-17T19:48:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/35/e9f47647c9e163bd1de30fe1a491669b7248cfc67b7404c35c009a701e1a/tiktoken-0.14.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7db45b98e94adf4173a5cd7422b150999a7ee11ff847783a14f6e1b80cc38cb6", size = 1186355, upload-time = "2026-08-17T19:48:51.93Z" },
+    { url = "https://files.pythonhosted.org/packages/51/11/9976ad86980a00cdef05e730a0127a2578a1bc6d11644d8d47246de2eb26/tiktoken-0.14.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7896eea257fe497a2b7134474d909156c6744ce8da35bce88011a960e008aa0d", size = 1204197, upload-time = "2026-08-17T19:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9c/7035b0bcfaa68d1ee4803fc5be5214ad865669b05bd20e7105ae8a18afc6/tiktoken-0.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b950248272f1b303dc32986396e2dccfa10cf6d1e83ec8f0bba1776660305482", size = 1250635, upload-time = "2026-08-17T19:48:54.392Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1d/69cabf18bed7f4366da076735816abce0d4db3fae491ae338a6612128777/tiktoken-0.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3de75343041a1c57333b1e707ac8a9769738241d7d6a55d39e12cf84548337c6", size = 1316085, upload-time = "2026-08-17T19:48:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/bd/a2e884fb1402cba5be08836590320012b2d8ada0e2eef9911a64df4bcd2d/tiktoken-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:087538c080e5ff421abd3a0785ed63c5111d06af98e6cd0d374dbe5969147ca3", size = 941208, upload-time = "2026-08-17T19:48:56.938Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
+]
+
+[[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/91/63938e0e7e7876658e5e40178e7c0735b53527886fe11797a11699c55edd/uuid_utils-0.17.0.tar.gz", hash = "sha256:abb5667a36119019b3fa320c4d10c21ebccfcc87c8a739e6a0056cee7f48dde2", size = 43220, upload-time = "2026-07-09T13:49:58.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/80/a7e685968e3cec99d6fe2fb25d0f5726310e1bba356da68c13dfd8b7d140/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9205068badf453d2f0821fd5d340389b4679992d7ff79d4f3e5608996dd1b287", size = 556403, upload-time = "2026-07-09T13:48:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/56/47/3102d93bcb7b0bfe6bede63ff8f221a7f91348e10a37f682773be27c56d9/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0fcca4e838af9ac9243b3358d7c14afa4dca286a87781124c272d6c4cad9c968", size = 285608, upload-time = "2026-07-09T13:48:28.769Z" },
+    { url = "https://files.pythonhosted.org/packages/55/fb/d59695f0f8db065b93c63316eaafa05a22d75a0486978a33736c52c646d5/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f3729e839209f3457d0d8b6a35a376fdf65577a5aecaf4cc3587d3305759ba6", size = 319926, upload-time = "2026-07-09T13:48:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/03/62fabcd1e990e07a0e220e8d552af45bc16f107fa8e55c2014a706bb1a1e/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3dac0ad0cd9a2818d1775215365a4e8c2f8ada215529dd26f3f8cceeb67a6988", size = 327172, upload-time = "2026-07-09T13:48:31.187Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/a5081391338b459e2f8d8b12581f00f8caa6317fab510e0e85c18c59e938/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e671b2322ef09106ecb1ca0f4c398b134d5e2c1f80d7a4f3336847a3072c0e94", size = 439075, upload-time = "2026-07-09T13:48:32.295Z" },
+    { url = "https://files.pythonhosted.org/packages/59/30/91795bd01e17a13661280d4899fbf38fb05e3f38e873f9aaec106ec30aa0/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8eb3e5caca8d3a6f72ea4cce024583f989f6f2e9186f98800213fff0176e8bcc", size = 320247, upload-time = "2026-07-09T13:48:33.64Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/11/09102b78303e4eb62069d6d88ef9fd661dc523e8f429e1fd67eaa78a6f44/uuid_utils-0.17.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b72c2002202038666bf647f9a790906214c7c11cd0d6efef77b7d07bef3034a", size = 344738, upload-time = "2026-07-09T13:48:34.786Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f9/be95bad6954b60328878c3800258f01a6accd24fd75112d13f023462d53f/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e2ac1c0b56f2c91b6f158e29ed96b1503223fe8aa6e79b1be1dc55bd8a5131c", size = 496845, upload-time = "2026-07-09T13:48:36.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/02/8a19a34e0530d987488a068a71576a236f5c8c746630b870b57f71eb24ef/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6c142bd0cb4dba31c10babe00d59f7ef6460f0ef55eaa9c1a9da270684af996a", size = 603233, upload-time = "2026-07-09T13:48:37.512Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a8/b1abab36ff73b0248d82179816467f6d39a2e80fd64329a895ca94f3508e/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e252db239eb41c32248e096e0d170bce5896a4fd3405556362bc3dd83d912206", size = 561401, upload-time = "2026-07-09T13:48:38.977Z" },
+    { url = "https://files.pythonhosted.org/packages/61/91/70e7b528b351cc03a9ca43e6116371cdde31bb12bcead7ca2ca1367366cc/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:237722b6581bb5b4eb4cefbcbe5c6e2980a440aabe781fbe50ebf1cb71eee4cc", size = 525314, upload-time = "2026-07-09T13:48:40.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/9167e90cf9937d6558f92d022ff3024a69d938a514d9c8faa4080f73b001/uuid_utils-0.17.0-cp312-cp312-win32.whl", hash = "sha256:46a73cacdf512f473a81f65dbf84186e08cfe6e9118fa582b6c6b33a8288a30d", size = 166831, upload-time = "2026-07-09T13:48:41.862Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7d/0b889654d9ee3413f810cf4685e241285f650d98a4103ac9f3c6bcc95f29/uuid_utils-0.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:e59b60a0a4cb7541480e02090d37dc2df3b72df4c2e776fff64ce3a4e3dd4637", size = 172944, upload-time = "2026-07-09T13:48:42.992Z" },
+    { url = "https://files.pythonhosted.org/packages/be/35/8c6e1bf65e4d400352885dadc656ad6d0af96e89231e3f04686bc2197128/uuid_utils-0.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:d561a4c5747a1e6c7fa7c49a0292e78b4e8c456332caa084fc7abad8de828652", size = 172459, upload-time = "2026-07-09T13:48:44.271Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/43/30e407989e313677dbb9d5f045f966549a7254834571e342eaa4b55cc67b/wcmatch-11.0.1.tar.gz", hash = "sha256:1ea2b4fa678b8ca268253798d5963935df39132d47c3e241c0a0732224005e7d", size = 144662, upload-time = "2026-08-14T15:20:40.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl", hash = "sha256:fd149ecddb9f0a88ea780017d6dde17c994e494e7f7303d4e3c9d6251f978f4b", size = 43449, upload-time = "2026-08-14T15:20:39.379Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/57/ed58088fafdf4c55a0ad6bde846502567645424d7ebf325230b9237f4085/wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb", size = 1458450, upload-time = "2026-08-28T18:10:06.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4", size = 331669, upload-time = "2026-08-28T18:10:04.909Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/1d/ae61bca2a99d0735311b7b11b81931279b4a45c74a45034d31b39ad565d1/websocket_client-1.9.1.tar.gz", hash = "sha256:2e0916d2e28ccc82702f2f70aa7a654588e84a5cf2f5914099638b33547f2b7c", size = 82936, upload-time = "2026-08-29T13:45:40.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/0e/7b514f6eb4bf518a9af0285c1a78297467b95fd7d1ebab08b41f8889ab2f/websocket_client-1.9.1-py3-none-any.whl", hash = "sha256:19a871b81d0022589dd9e8e1b1891e0516d32113837dfb987d7691b6a425a1e2", size = 95460, upload-time = "2026-08-29T13:45:39.255Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/22/581a0b44349d5babe526c958f365b8126e0fbd8fc2810e80446c47358050/wrapt-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef4e2d6e399ce6eecc80179a6b9ef6544f121288f95fc132bc36c9d9503903af", size = 96374, upload-time = "2026-08-30T04:39:42.335Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9b32d5e4f0a179cef5075cc79b79d6d3482c44c434c12969e48c6719e06d95", size = 96178, upload-time = "2026-08-30T04:39:43.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94", size = 227806, upload-time = "2026-08-30T04:39:45.264Z" },
+    { url = "https://files.pythonhosted.org/packages/08/75/c8dfba5e0caf17cd0718a0cbbe76cb85e637a2d65183fb728232419f6fca/wrapt-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39cd68df4dff79f5336f9c745c06259d204bcb42d504040c9c91eac9e2abb39c", size = 229004, upload-time = "2026-08-30T04:39:47.068Z" },
+    { url = "https://files.pythonhosted.org/packages/42/05/d4853fbd33e5860b10d5aec690f563547a92a82e61fb8bb2d4ece1ce3570/wrapt-2.4.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2a9f1a2f75bb95257cc5744e255e10a5a86e923f328b40ad3dbf9d8d03430013", size = 208934, upload-time = "2026-08-30T04:39:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/66/23d0e8de9b411fd198af5121627587563657370c8d509fbe5ea8adb3df79/wrapt-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8763ad01e3725b7751a4575f38bbcc19c0aa0822fec91c5c5bd21ce3ce7e1d2b", size = 225709, upload-time = "2026-08-30T04:39:50.287Z" },
+    { url = "https://files.pythonhosted.org/packages/01/37/3b357bc90530d510ae59ae7ac48265c482ae899e47637ca4436645688b40/wrapt-2.4.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9125c6dbe8b88c00dd8ef4fc1e55757e8eb4720b6b2b2cc610a45bd32bd28c57", size = 207090, upload-time = "2026-08-30T04:39:51.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0c/d8a5c6dbcc2d221308223bcea4130c6332454a855cb4dbd5dcb2360b13b2/wrapt-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:28f5de1526831b8f173889a436e289fe181ede8c66c9feb669d1aca8fd602eaf", size = 216269, upload-time = "2026-08-30T04:39:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/92/93/cc9fc8fef1d3d25edaa1c2dc2337b556dc1d0613ddc1c4a6fe9ee08ad705/wrapt-2.4.0-cp312-cp312-win32.whl", hash = "sha256:a9ca1cdb3f7facb4990c7739ea5afbaceeb6728d066feedde03a4cfe83b29b03", size = 91187, upload-time = "2026-08-30T04:39:55.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b464316489fb2fca0669ea0f8f07290054a0f26fc72982d3e4cf95469628ba9", size = 96423, upload-time = "2026-08-30T04:39:56.81Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/e838ac6463a1a1a1817b2f184ee2aa20c54692b80368c5063403c8d2461c/wrapt-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:db1285071ea09a7767fac608e7b5c7b03c09833b06186875a359905fbc659d29", size = 93003, upload-time = "2026-08-30T04:39:58.237Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "xmod"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/3b/5a0d2670bab661164e27a5c27c448ae6204458c97cb94ccf89d0c47715bc/xmod-1.10.0.tar.gz", hash = "sha256:b40b2a54d56684b01eb9627892b0c179918e8ef0bd4d7f3bac7a3fdba11cd6e6", size = 17862, upload-time = "2026-05-09T13:46:46.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/e9/c362d47ed2b1928d65d61888c1419fae8ef69417fba2067d2fd3da1d400b/xmod-1.10.0-py3-none-any.whl", hash = "sha256:bebf8493b7ac63097401590a329c9ed20da224de0583a522e7ccb634af122f5a", size = 4661, upload-time = "2026-05-09T13:46:45.776Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/a5/1386f35da1475fcaeef42581deae73417c6d2a6a0b2d2e8914de18844dcd/xxhash-4.0.1.tar.gz", hash = "sha256:d55bf4ef10eb09b8b6866790e083d26d087d84caa3cc0946ba87c3ca7ecaf7b7", size = 101513, upload-time = "2026-08-17T08:24:08.557Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/6c/dc7cffeadd06336cd934947187cd38abb263103bbc552ca0f55fe4ff595a/xxhash-4.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1ee523f51718e41753f04f7102bb4dc55a18d2ea5cbaceef8ec7ca08571bd428", size = 38444, upload-time = "2026-08-17T08:21:54.332Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c9/cf736f6db8c3273af18925061572db0d4357818a9ce425f4b5fb0021918e/xxhash-4.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:515a822c73abbf6a0b7c70976d9662be342835c9d78b8dc7c023411f39c35dbc", size = 36195, upload-time = "2026-08-17T08:35:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a2/ca1929354b6851529d0148f7f335b5e2b0281f83bab3e19f0896dc579796/xxhash-4.0.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f5d031f35962e5483a613214e61f09fe24ab523062c3646d592dc16c4a217451", size = 253113, upload-time = "2026-08-17T08:20:52.152Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bb/542005206af59518bc8d78a210f1e0172217bc53beb32f64a5b632e72b6b/xxhash-4.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da0264844a09b538c894e5eff25313d941deb4dedec2131b98418a71a3c9944e", size = 276525, upload-time = "2026-08-17T08:21:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/df/607cff25dcb0f1d35c3b04493f6ad8471edb03fd4eacbdcc5ceddef1f3e9/xxhash-4.0.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1642907941ee4b75aacc3db688af52ea02ca2305ab22af7ee686ed726b332684", size = 297703, upload-time = "2026-08-17T08:21:57.958Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ba/9d2275eea0b9d9c6b02921be23f7588356c60df95c763b25f0e045894d43/xxhash-4.0.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4af350bc3f329970c0e3a59af84a8a30998bf8a9167eb50cd48e59baaa1d7bec", size = 280252, upload-time = "2026-08-17T08:20:47.299Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/2299d9f6369e550aef2abb64945e39daa34412725aa46a20d99b74d76f67/xxhash-4.0.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ba782ca3bf1e81492611152b9a0d5264971339e95e34d69de0ac2c926be496d", size = 511041, upload-time = "2026-08-17T08:20:36.771Z" },
+    { url = "https://files.pythonhosted.org/packages/83/97/31bd8b8279e6935a0719f6910ced15e9d5a2cd554b253f6027ce1b5a1c2c/xxhash-4.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:237b8f63a2a0fcfb1ffc06e21dad23add44e6d354b2b014364a1d41e419a4dee", size = 261812, upload-time = "2026-08-17T08:22:00.469Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/d180a2da23c105d8e0b02d54f9f5841013fc81c233010ec781e31f1aee4c/xxhash-4.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:81507a68ba84c55241fb61cce1469f473a5da4205fc8ef6f698e5948eea8dd88", size = 339878, upload-time = "2026-08-17T08:35:17.626Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3d/f584cd3172fe934f0f5a0a3917d0d7ce781f74d794fd43bb72be71c3ef6f/xxhash-4.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5f1ea31d61bcd2cd2f3ec4ca80a64187bbd7948f490b63cf0dcbc6e717b4c1e9", size = 272871, upload-time = "2026-08-17T08:20:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/2c7956b2b551682e00b9aebce9ceb0a991a131d65f9850c09f5f9760be2e/xxhash-4.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:06713a5aaf1d0905c5579416c020c02e42b3ceb931e86c7d3b7fb85403dee3f3", size = 301440, upload-time = "2026-08-17T08:21:35.911Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/0739f6482184a8026f4b022718f5f815d352059312e80696825433f0a8e7/xxhash-4.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e8cda075b10bb3917b002c74a04f9e02b7d13b5bf732571404d51c52b11c7329", size = 260157, upload-time = "2026-08-17T08:22:01.416Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/25/b31a7bcf1d7d116842812e54f9b944843b4236ea4fa85634e8259f342212/xxhash-4.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c10b9206753b64aa791b35b201485477525b26fdec5bf86e8364c388a03e2592", size = 278233, upload-time = "2026-08-17T08:21:15.674Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e8/5293bae090fc6119dbc5fcf5c4cc0e1536394b52d73b7904d033836c73db/xxhash-4.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f3e1a44af01b6692de0ec6caba5f0bf93ceb36896e02b7fc00952c6ea7ef39e1", size = 330270, upload-time = "2026-08-17T08:20:51.128Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9e/e2ab12d40921f3f34c9317637d65e011aeababf8288356ea8d527de2c1d0/xxhash-4.0.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:c6fc415b5568bd9accc7187f1729a99707330c0a67a8b9f93c1149ed573ed75d", size = 478555, upload-time = "2026-08-17T08:22:04.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/32/c6148d39a49efa95f39b4cf0d41ef35a487f3b30f6fb1fc8fe8d8eab577e/xxhash-4.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:96d8de55029d42251945531f6aa7590c32b48163c66a43bf29d8657d7446a377", size = 258174, upload-time = "2026-08-17T08:35:21.18Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fb/0b04b68d6c5bc71c7a2c344f1287327b67e607f28fbcfd937697caca64b6/xxhash-4.0.1-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:0163b5d259de23ae9e07b7eabf435ce4704f6f205589a2b154e6af4be985ce1b", size = 20767, upload-time = "2026-08-17T08:21:00.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/be/476092aba34d1fcd313e1613a3bb3bc692f253d167b54bc90049043b5034/xxhash-4.0.1-cp312-cp312-win32.whl", hash = "sha256:1216f7ba5683f17a89eb7dcb4bc50a0b743dfe1902278d7b3d0786f538118433", size = 34669, upload-time = "2026-08-17T08:21:49.486Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/02/f9413d94fae43cec6d1a74c4f12156c6f4a7f5fd50e1d34defebdee3dec9/xxhash-4.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c2d525a3afabcd8e3549d85fc7e111fde6bc302d06a1893fe73adb79823415e", size = 37073, upload-time = "2026-08-17T08:22:04.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/83/6fe93c1b95acf962bc61a246df09dc2dcce895ccfc1080c9f48d0b652b92/xxhash-4.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:86b2b12bec60c678ed8f5cca0258ad93a8928ebddb6ca7732f0875afe1451d1a", size = 33299, upload-time = "2026-08-17T08:35:12.708Z" },
+    { url = "https://files.pythonhosted.org/packages/86/79/9127ff42a887a348dc4ce3211cf1a962836887adee6f57078132bfba78b4/xxhash-4.0.1-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:ff48915bf1871a1f19f74c11834c6329443d306cedc0c05fe7fe617810422a80", size = 31836, upload-time = "2026-08-17T08:36:28.261Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/f238693bfdd642adb59c99683964d46d9947fe721ff44d3bd850ae675407/xxhash-4.0.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:4a76345f5aceb4ec404918edf9c7f2b5507db864dc0d7455982009ac0890b57b", size = 34453, upload-time = "2026-08-17T08:23:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4b/796ace33cdfb75c91ba6d11615c3bd436355b9f3103e05865bbee9abce57/xxhash-4.0.1-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:31d86f9e81f3e84e00131ac7c54caf5119ae4ddd82c09c31cff597c813ce1ee2", size = 38488, upload-time = "2026-08-17T08:23:59.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/23/2d549e5d5d7759eaf9ac2d2d2ab81ff60f1bb2b52cdaae8e5ec5c6524354/xxhash-4.0.1-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deca2a30d983d240b8375ec2ee0a4288e72042827fc61df2f7671f8467e4cb2f", size = 38206, upload-time = "2026-08-17T08:36:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/1ee576b27f78e6107ee4ea8ac03e8a52888dff256e57d560f8282c195563/xxhash-4.0.1-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:7c343ee174d417a44d0c3355602c0cbbfa52a04d1bbbf1723378c7d2c8f60626", size = 37127, upload-time = "2026-08-17T08:23:42.705Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/33/ebe9e3d1f86c7a0b51094c0a146392045ca1631d2664889539dec8088a33/yarl-1.24.5.tar.gz", hash = "sha256:e81b83143bee16329c23db3c1b2d82b29892fcbcb849186d2f6e98a5abe9a57f", size = 228679, upload-time = "2026-07-20T02:07:45.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/84/71d051c850b5af41d168c679d9eb67eb7c55283ac4ee131673edf134bc4e/yarl-1.24.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d693396e5aea78db03decd60aec9ece16c9b40ba00a587f089615ff4e718a81d", size = 136035, upload-time = "2026-07-20T02:05:25.489Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4d/8ad27f9a1b7e69313cca5d695b925b48efe51208d3490e0844bae97cabc0/yarl-1.24.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3363fcc96e665878946ad7a106b9a13eac0541766a690ef287c0232ac768b6ec", size = 97642, upload-time = "2026-07-20T02:05:27.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b4/05b4131c407006cd1e410e9c6539f16a0945724677e5364447313c15ea3e/yarl-1.24.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d399bdcfb4a0f659b9b3788bbc89babe63d9a6a65aacdf4d4e7065ff2e6316c", size = 97323, upload-time = "2026-07-20T02:05:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/20/16/e618c875c73e0e39611f20a581b3d5e8d59b8857bf001bee3263044c6deb/yarl-1.24.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90333fd89b43c0d08ac85f3f1447593fc2c66de18c3d6378d7125ea118dc7a54", size = 107741, upload-time = "2026-07-20T02:05:31.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/9a/c4defeaf3ed33fcb346aacf9c6e971a8d4e2bde04a0310e79abb208e7965/yarl-1.24.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:665b0a2c463cc9423dd647e0bfd9f4ccc9b50f768c55304d5e9f80b177c1de12", size = 103570, upload-time = "2026-07-20T02:05:33.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e7/0e0e0de5865ebd5914537ef486f36c727a59865c3ac0cf5ff1b32aececbf/yarl-1.24.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e006d3a974c4ee19512e5f058abedb6eef36a5e553c14812bdeba1758d812e6d", size = 115815, upload-time = "2026-07-20T02:05:35.292Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/27/ca56b700cb170aba25a3893b75355b213935657dc5714d2383354a270e62/yarl-1.24.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e7d42c531243450ef0d4d9c172e7ed6ef052640f195629065041b5add4e058d1", size = 116025, upload-time = "2026-07-20T02:05:37.503Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f08c7513ecef5aad65687bfdf6bc601ae9fccd04a42904501f8f7141abad9eb9", size = 109835, upload-time = "2026-07-20T02:05:39.506Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a2/3a35557e4d1a79425040eba202ccaf08bdc8717680fc77e2498a1ad2e0a5/yarl-1.24.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6c95b17fe34ed802f17e205112e6e10db92275c34fee290aa9bdc55a9c724027", size = 108884, upload-time = "2026-07-20T02:05:41.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/35/ef4c26356b7913c68983bac2d72a4212b3347af551cb8d250b99b5ed7b7f/yarl-1.24.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:56b149b22de33b23b0c6077ab9518c6dcb538ad462e1830e68d06591ccf6e38b", size = 107308, upload-time = "2026-07-20T02:05:43.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/ff0dc66c2ccf3e0153ab97ff61eabab4400e6a5264af427ab30cd69f1857/yarl-1.24.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a8fe66b8f300da93798025a785a5b90b42f3810dc2b72283ff84a41aaaebc293", size = 103646, upload-time = "2026-07-20T02:05:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f0/33b9271c7f881766359d58266fa0811d2e5210ed860e28da7dc6d7786344/yarl-1.24.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:377fe3732edbaf78ee74efdf2c9f49f6e99f20e7f9d2649fda3eb4badd77d76e", size = 115305, upload-time = "2026-07-20T02:05:47.832Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/65/fd79fb1868c4a80db8661091de525bf430f63c3bea1b20e8b6a84fc7d359/yarl-1.24.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e8ffa78582120024f476a611d7befc123cee59e47e8309d470cf667d806e613b", size = 108404, upload-time = "2026-07-20T02:05:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ba/dbabe6b262f17a816c70cfc09558dbf03ece3ec76684d02f911a3d3a189c/yarl-1.24.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:daba5e594f06114e37db186efd2dd916609071e59daca901a0a2e71f02b142ce", size = 115940, upload-time = "2026-07-20T02:05:51.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/43/fab2d1dad9d340a268cdde63756a123d069723efff6a372d123fa74a9517/yarl-1.24.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:65be18ec59496c13908f02a2472751d9ef840b4f3fb5726f129306bf6a2a7bba", size = 110006, upload-time = "2026-07-20T02:05:53.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/27/41eb51bbd1b8d89546b83897cfb0164f1e109304fd408dbb151b639eec0f/yarl-1.24.5-cp312-cp312-win_amd64.whl", hash = "sha256:a929d878fec099030c292803b31e5d5540a7b6a31e6a3cc76cb4685fc2a2f51b", size = 97618, upload-time = "2026-07-20T02:05:55.57Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/25/b2553764b3d65db711d8f45416351ec4f420847558eb669edcbcaadf5780/yarl-1.24.5-cp312-cp312-win_arm64.whl", hash = "sha256:7ce27823052e2013b597e0c738b13e7e36b8ccb9400df8959417b052ab0fd92c", size = 93018, upload-time = "2026-07-20T02:05:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]

--- a/tests/smoke/test_meta_harness_pi_bridge.py
+++ b/tests/smoke/test_meta_harness_pi_bridge.py
@@ -1,0 +1,165 @@
+"""Real Pi smoke for the Meta-Harness host-to-Harbor bash bridge.
+
+No provider call is made: a local OpenAI-compatible stub asks Pi to invoke
+``bash`` once, and a fake Harbor environment records the forwarded command.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from reef.harness.adapters import get_adapter
+from reef.harness.model_binding import ModelBinding
+from reef.harness.render import render_composition
+
+REAL_PI = os.environ.get("REEF_REAL_PI_BINARY", "")
+EXAMPLE_DIR = Path(__file__).resolve().parents[2] / "recipes" / "meta_harness" / "examples" / "terminal_bench"
+MODEL = "meta-harness-bridge-smoke"
+
+pytestmark = pytest.mark.skipif(not REAL_PI, reason="REEF_REAL_PI_BINARY does not name a real Pi binary")
+
+
+class StubOpenAI(ThreadingHTTPServer):
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), StubHandler)
+        self.requests: list[dict[str, Any]] = []
+
+
+class StubHandler(BaseHTTPRequestHandler):
+    server: StubOpenAI
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:
+        self._json({"object": "list", "data": [{"id": MODEL, "object": "model"}]})
+
+    def do_POST(self) -> None:
+        body = json.loads(self.rfile.read(int(self.headers.get("content-length", "0"))))
+        self.server.requests.append(body)
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.end_headers()
+        chunks = self._tool_call_chunks() if len(self.server.requests) == 1 else self._final_chunks()
+        for chunk in chunks:
+            event = {
+                "id": "chatcmpl-meta-harness-bridge",
+                "object": "chat.completion.chunk",
+                "model": MODEL,
+                **chunk,
+            }
+            self.wfile.write(b"data: " + json.dumps(event).encode() + b"\n\n")
+        self.wfile.write(b"data: [DONE]\n\n")
+
+    @staticmethod
+    def _tool_call_chunks() -> list[dict[str, Any]]:
+        return [
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_bridge",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "bash",
+                                        "arguments": '{"command":"printf BRIDGE_OK"}',
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ]
+            },
+            {
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            },
+        ]
+
+    @staticmethod
+    def _final_chunks() -> list[dict[str, Any]]:
+        return [
+            {"choices": [{"index": 0, "delta": {"role": "assistant", "content": "done"}}]},
+            {
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 2, "total_tokens": 22},
+            },
+        ]
+
+    def _json(self, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class FakeHarborEnvironment:
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, int]] = []
+
+    async def exec(self, *, command: str, timeout_sec: int) -> SimpleNamespace:
+        self.commands.append((command, timeout_sec))
+        return SimpleNamespace(stdout="BRIDGE_OK", stderr="", return_code=0)
+
+
+def test_real_pi_executes_bash_through_harbor_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    for name in [name for name in sys.modules if name == "harness" or name.startswith("harness.")]:
+        del sys.modules[name]
+    composition = importlib.import_module("harness.composition")
+    pi_bridge = importlib.import_module("harness.pi_bridge")
+    server = StubOpenAI()
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    environment = FakeHarborEnvironment()
+
+    async def run_episode():
+        descriptor = get_adapter("pi")
+        binding = ModelBinding(
+            base_url=f"http://127.0.0.1:{server.server_address[1]}",
+            model=MODEL,
+            api_key="dummy",
+        )
+        candidate = composition.genesis_composition()
+        files = render_composition((*candidate.nodes, *binding.compose_nodes(descriptor)), descriptor)
+        runner = pi_bridge.PiEpisodeRunner(descriptor, binary=Path(REAL_PI), timeout_s=60)
+        loop = asyncio.get_running_loop()
+        with pi_bridge.HarborExecBridge(environment.exec, loop) as bridge:
+            return await asyncio.to_thread(
+                runner.run,
+                files,
+                "Use bash once, then finish.",
+                bridge_url=bridge.url,
+                bridge_token=bridge.token,
+            )
+
+    try:
+        result = asyncio.run(run_episode())
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert len(server.requests) == 2
+    assert environment.commands == [("printf BRIDGE_OK", 600)]
+    assert result.trajectory
+    assert result.usage == {"input_tokens": 30, "cached_input_tokens": 0, "output_tokens": 7}
+    assert result.estimated_cost_usd > 0
+    assert result.provider_reported_cost_usd == 0

--- a/tests/test_meta_harness_reproduction.py
+++ b/tests/test_meta_harness_reproduction.py
@@ -1,0 +1,1543 @@
+"""Deterministic coverage for the Meta-Harness reproduction example."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "recipes" / "meta_harness" / "examples" / "terminal_bench"
+
+
+@pytest.fixture
+def config_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    for name in [name for name in sys.modules if name == "harness" or name.startswith("harness.")]:
+        del sys.modules[name]
+    return importlib.import_module("harness.config")
+
+
+@pytest.fixture
+def meta_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    for name in [name for name in sys.modules if name == "harness" or name.startswith("harness.")]:
+        del sys.modules[name]
+    return SimpleNamespace(
+        budget=importlib.import_module("harness.budget"),
+        codex=importlib.import_module("harness.codex"),
+        composition=importlib.import_module("harness.composition"),
+        evaluation=importlib.import_module("harness.evaluation"),
+        harbor_eval=importlib.import_module("harness.harbor_eval"),
+        pi_bridge=importlib.import_module("harness.pi_bridge"),
+        publication=importlib.import_module("harness.publication"),
+        search=importlib.import_module("harness.search"),
+        workspace=importlib.import_module("harness.workspace"),
+    )
+
+
+@pytest.fixture
+def runner_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    sys.modules.pop("run", None)
+    for name in [name for name in sys.modules if name == "harness" or name.startswith("harness.")]:
+        del sys.modules[name]
+    run = importlib.import_module("run")
+    return SimpleNamespace(
+        run=run,
+        harbor_eval=importlib.import_module("harness.harbor_eval"),
+        search=importlib.import_module("harness.search"),
+    )
+
+
+def test_reproduction_defaults_are_exact_and_secret_free(config_module):
+    config = config_module.ExperimentConfig()
+
+    assert config_module.REEF_COMMIT == "6b0d9a1345191a0df1a7e324fa09875e8581a83f"
+    assert config_module.META_HARNESS_COMMIT == "95175f70c758dd1145b395edfe8b67e6f9d80fbd"
+    assert config_module.TERMINAL_BENCH_COMMIT == "1a6ffa9674b571da0ed040c470cb40c4d85f9b9b"
+    assert config_module.TERMINAL_BENCH_DATASET_URL == ("https://github.com/laude-institute/terminal-bench-2.git")
+    assert config_module.TERMINAL_BENCH_DATASET_COMMIT == "69671fbaac6d67a7ef0dfec016cc38a64ef7a77c"
+    assert config_module.HARBOR_VERSION == "0.3.0"
+    assert config_module.TERMINAL_BENCH_VERSION == "0.2.18"
+    assert config_module.PI_VERSION == "0.84.2"
+    assert config_module.TARGET_MODEL == "gpt-5.4-mini-2026-03-17"
+    assert config_module.TARGET_MODEL_PRICING.to_jsonable() == {
+        "model": "gpt-5.4-mini-2026-03-17",
+        "input_usd_per_million": 0.75,
+        "cached_input_usd_per_million": 0.075,
+        "output_usd_per_million": 4.5,
+        "source_url": "https://developers.openai.com/api/docs/models/gpt-5.4-mini",
+        "observed_at": "2026-08-30",
+    }
+    assert config_module.PROPOSER_MODEL == "gpt-5.5"
+    assert config_module.PROPOSER_REASONING_EFFORT == "high"
+    assert len(config_module.HARD_TASKS) == 30
+    assert len(set(config_module.HARD_TASKS)) == 30
+    assert config_module.TRAIN_TASKS + config_module.DEV_TASKS + config_module.TEST_TASKS == (config_module.HARD_TASKS)
+    assert {len(config_module.TRAIN_TASKS), len(config_module.DEV_TASKS), len(config_module.TEST_TASKS)} == {10}
+    assert config_module.TRAIN_TASKS[:1] == config_module.SMOKE_TRAIN_TASKS
+    assert config_module.DEV_TASKS[:1] == config_module.SMOKE_DEV_TASKS
+    assert config_module.TEST_TASKS[:1] == config_module.SMOKE_TEST_TASKS
+    assert set(asdict(config)) == {
+        "target_model",
+        "proposer_model",
+        "proposer_reasoning_effort",
+        "rounds",
+        "trials_per_task",
+        "target_api_key_env",
+        "target_base_url",
+    }
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"rounds": 1}, "at least two rounds"),
+        ({"trials_per_task": 1}, "at least two trials"),
+        ({"target_base_url": "api.openai.com"}, "HTTP"),
+        ({"target_model": "gpt-unpriced"}, "pricing snapshot"),
+        ({"proposer_reasoning_effort": "ultra"}, "reasoning effort"),
+    ],
+)
+def test_reproduction_config_rejects_nonconforming_inputs(config_module, overrides, message):
+    with pytest.raises(ValueError, match=message):
+        config_module.ExperimentConfig(**overrides)
+
+
+def _evaluation(modules, split, reward, task="task"):
+    trial = modules.evaluation.TrialEvidence(
+        task_id=task,
+        trial=0,
+        reward=reward,
+        trajectory=({"role": "assistant", "content": "observed"},),
+        usage={"input_tokens": 10, "output_tokens": 2},
+        estimated_cost_usd=0.01,
+        wall_time_s=1.5,
+    )
+    return modules.evaluation.EvaluationResult(split=split, trials=(trial,))
+
+
+def test_composition_is_content_addressed_validated_and_provider_free(meta_modules):
+    from reef.harness.adapters import get_adapter
+
+    candidate = meta_modules.composition.genesis_composition()
+    same = meta_modules.composition.CompositionCandidate.from_value(candidate.composition)
+    rendered = candidate.render(get_adapter("pi"))
+
+    assert candidate.content_hash == same.content_hash
+    assert len(candidate.content_hash) == 64
+    assert "pi-agent/AGENTS.md" in rendered
+    assert "pi-agent/skills/terminal-task/SKILL.md" in rendered
+    assert json.loads(rendered["pi-agent/models.json"]) == {}
+
+    for kind, config in (
+        ("config", {"data": {"skills": ["/host/path"]}}),
+        ("code_extension", {"name": "leaky", "code": "export default () => {};"}),
+    ):
+        with pytest.raises(ValueError, match="sealed experiment"):
+            meta_modules.composition.CompositionCandidate.from_value({"nodes": [{"kind": kind, "config": config}]})
+
+    with pytest.raises(ValueError, match="unknown kind"):
+        meta_modules.composition.CompositionCandidate.from_value(
+            {
+                "nodes": [
+                    {
+                        "kind": "not-a-node",
+                        "config": {},
+                    }
+                ]
+            }
+        )
+
+
+def test_workspace_retains_search_evidence_but_rejects_test_data(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    candidate = meta_modules.composition.genesis_composition()
+    workspace.record_candidate(candidate, _evaluation(meta_modules, "train", 0.5), round_index=0, role="genesis")
+    workspace.record_candidate(candidate, _evaluation(meta_modules, "dev", 0.25), round_index=0, role="genesis")
+
+    candidate_dir = workspace.history_dir / candidate.content_hash
+    assert (candidate_dir / "candidate.json").is_file()
+    assert (candidate_dir / "evaluations" / "round-0000-train.json").is_file()
+    assert (candidate_dir / "evaluations" / "round-0000-dev.json").is_file()
+    assert "observed" in (candidate_dir / "evaluations" / "round-0000-train.json").read_text()
+    assert "observed" not in (candidate_dir / "evaluations" / "round-0000-dev.json").read_text()
+    with pytest.raises(ValueError, match="sealed"):
+        workspace.record_candidate(
+            candidate,
+            _evaluation(meta_modules, "test", 1.0),
+            round_index=2,
+            role="selected",
+        )
+
+
+def test_full_history_proposal_can_branch_from_a_non_incumbent(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    genesis = meta_modules.composition.genesis_composition()
+    specialist_value = genesis.composition
+    specialist_value["nodes"][0]["config"]["text"] = "A retained non-incumbent specialist."
+    specialist = meta_modules.composition.CompositionCandidate.from_value(
+        specialist_value,
+        parent_hashes=(genesis.content_hash,),
+    )
+    workspace.write_population(
+        [
+            {"candidate_hash": genesis.content_hash, "alias": "genesis", "score": 0.8},
+            {"candidate_hash": specialist.content_hash, "alias": "specialist", "score": 0.4},
+        ],
+        incumbent_hash=genesis.content_hash,
+    )
+    proposal_dir = workspace.begin_round(1) / "branch-specialist"
+    proposal_dir.mkdir()
+    proposal_value = specialist.composition
+    proposal_value["nodes"][1]["config"]["text"] += "\n\nVerify long-running commands."
+    (proposal_dir / "composition.json").write_text(json.dumps(proposal_value))
+    (workspace.root / "pending_eval.json").write_text(
+        json.dumps(
+            {
+                "iteration": 1,
+                "candidates": [
+                    {
+                        "name": "branch-specialist",
+                        "base_candidates": ["specialist"],
+                        "hypothesis": "The retained specialist has useful terminal discipline.",
+                        "changes": "Add verification guidance without changing its other nodes.",
+                    }
+                ],
+            }
+        )
+    )
+
+    proposals = workspace.collect_proposals(1)
+
+    assert len(proposals) == 1
+    assert proposals[0].primary_parent_hash == specialist.content_hash
+    assert proposals[0].primary_parent_hash != genesis.content_hash
+    assert proposals[0].source_path.is_file()
+
+
+def test_workspace_detects_history_mutation_and_recovers_completed_rounds(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    candidate = meta_modules.composition.genesis_composition()
+    workspace.record_candidate(candidate, _evaluation(meta_modules, "train", 0.0), round_index=0, role="genesis")
+    workspace.begin_round(1)
+    workspace.transition_round(1, "proposing")
+    workspace.transition_round(1, "proposed")
+    workspace.transition_round(1, "validating")
+    workspace.transition_round(1, "evaluating")
+    workspace.transition_round(1, "committed")
+    assert workspace.completed_rounds() == (1,)
+
+    before = workspace.readonly_snapshot(writable_round=2)
+    candidate_path = workspace.history_dir / candidate.content_hash / "candidate.json"
+    candidate_path.write_text("{}\n")
+    with pytest.raises(meta_modules.workspace.WorkspaceIntegrityError, match="read-only state"):
+        workspace.assert_readonly_unchanged(before, writable_round=2)
+
+
+class _DeterministicEvaluator:
+    def __init__(self, modules):
+        self.modules = modules
+        self.calls = []
+
+    def evaluate(self, candidate, *, split, round_index):
+        self.calls.append((candidate.content_hash, split, round_index))
+        text = candidate.canonical_json
+        reward = 0.9 if "branch-improvement" in text else (0.4 if "specialist" in text else 0.8)
+        return _evaluation(self.modules, split, reward, task=f"{split}-task")
+
+
+class _ScriptedProposer:
+    def __init__(self, modules, *, branch_from_specialist=True):
+        self.modules = modules
+        self.branch_from_specialist = branch_from_specialist
+        self.surfaces = []
+
+    def propose(self, *, surface, prompt, session_dir, round_index):
+        self.surfaces.append(surface)
+        catalog = json.loads((surface / "candidate-catalog.json").read_text())
+        if round_index == 1:
+            base = "genesis"
+            source_hash = catalog["incumbent_hash"]
+            marker = "specialist"
+            name = "specialist"
+        else:
+            specialist = next(row for row in catalog["candidates"] if row["alias"] == "specialist")
+            base = "specialist" if self.branch_from_specialist else catalog["incumbent_hash"]
+            source_hash = specialist["candidate_hash"] if self.branch_from_specialist else catalog["incumbent_hash"]
+            marker = "branch-improvement"
+            name = "branch-specialist"
+            assert (surface / "history" / specialist["candidate_hash"]).is_dir()
+
+        value = json.loads((surface / "history" / source_hash / "candidate.json").read_text())["composition"]
+        value["nodes"][0]["config"]["text"] += f" {marker}"
+        proposal_dir = surface / "proposals" / f"round-{round_index:04d}" / name
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        (proposal_dir / "composition.json").write_text(json.dumps(value))
+        (surface / "pending_eval.json").write_text(
+            json.dumps(
+                {
+                    "iteration": round_index,
+                    "candidates": [
+                        {
+                            "name": name,
+                            "base_candidates": [base],
+                            "hypothesis": f"Try {marker} guidance.",
+                            "changes": f"Add the {marker} marker.",
+                        }
+                    ],
+                }
+            )
+        )
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "events.jsonl").write_text('{"type":"complete"}\n')
+        return self.modules.search.ProposerSession(session_id=f"session-{round_index}")
+
+
+def test_full_history_search_branches_from_retained_candidate_and_resumes(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    evaluator = _DeterministicEvaluator(meta_modules)
+    proposer = _ScriptedProposer(meta_modules)
+    genesis = meta_modules.composition.genesis_composition()
+
+    first = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=evaluator,
+        proposer=proposer,
+        mode="full_history",
+        rounds=1,
+    ).run(genesis)
+    resumed = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=evaluator,
+        proposer=proposer,
+        mode="full_history",
+        rounds=2,
+    ).run(genesis)
+
+    assert first.selected.content_hash == genesis.content_hash
+    assert resumed.resumed is True
+    assert len(resumed.population) == 3
+    specialist, branch = resumed.population[1:]
+    assert specialist.outcome == "retained"
+    assert branch.candidate.parent_hashes == (specialist.candidate.content_hash,)
+    assert resumed.selected.content_hash == branch.candidate.content_hash
+    assert [call[2] for call in evaluator.calls].count(0) == 2
+    assert {call[1] for call in evaluator.calls} == {"train", "dev"}
+    assert not any(call[1] == "test" for call in evaluator.calls)
+    state = workspace.read_search_state()
+    assert state["completed_rounds"] == 2
+    assert len(state["proposer_sessions"]) == 2
+
+
+def test_search_resumes_frozen_proposal_after_evaluation_interruption(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    executed_trials = []
+
+    def execute_trial(candidate, candidate_path, task_id, trial_index, round_index, trial_dir):
+        executed_trials.append((candidate.content_hash, task_id, trial_index, round_index))
+        reward = 0.4 if "specialist" in candidate.canonical_json else 0.8
+        return meta_modules.harbor_eval.HarborTrialOutcome(
+            reward=reward,
+            trajectory=({"task": task_id, "trial": trial_index},),
+            usage={"input_tokens": 10, "output_tokens": 2},
+            estimated_cost_usd=0.01,
+            wall_time_s=0.01,
+            verifier={"rewards": {"reward": reward}, "task_checksum": f"checksum-{task_id}"},
+        )
+
+    evaluation_root = tmp_path / "private-evaluations"
+
+    def evaluator_for(ledger):
+        return meta_modules.harbor_eval.HarborEvaluator(
+            splits={"train": ("train-task",), "dev": ("dev-task",), "test": ("test-task",)},
+            trials_per_task=2,
+            output_dir=evaluation_root,
+            target_model="gpt-test",
+            target_base_url="https://example.invalid",
+            target_api_key_env="META_TEST_OPENAI_KEY",
+            pi_binary=tmp_path / "pi",
+            trial_executor=execute_trial,
+            before_trial=ledger.before_trial,
+            after_trial=ledger.record_trial,
+            budget_namespace="full-history",
+        )
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    proposer = _ScriptedProposer(meta_modules)
+    genesis = meta_modules.composition.genesis_composition()
+    ledger_path = tmp_path / "observed-cost.json"
+    first_ledger = meta_modules.budget.ObservedCostLedger(ledger_path, 0.05)
+
+    with pytest.raises(meta_modules.budget.SpendCapReached, match="no new trial"):
+        meta_modules.search.MetaHarnessSearch(
+            workspace=workspace,
+            evaluator=evaluator_for(first_ledger),
+            proposer=proposer,
+            mode="full_history",
+            rounds=1,
+        ).run(genesis)
+
+    interrupted_state = workspace.read_search_state()
+    assert interrupted_state["completed_rounds"] == 0
+    assert len(interrupted_state["proposer_sessions"]) == 1
+    assert workspace.round_state(1) == "failed"
+    assert workspace.resumable_proposal(1) is not None
+    assert len(executed_trials) == 5
+
+    resumed_ledger = meta_modules.budget.ObservedCostLedger(ledger_path, 0.20)
+    resumed = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=evaluator_for(resumed_ledger),
+        proposer=proposer,
+        mode="full_history",
+        rounds=1,
+    ).run(genesis)
+
+    assert resumed.resumed is True
+    assert resumed.selected.content_hash == genesis.content_hash
+    assert len(resumed.population) == 2
+    assert len(proposer.surfaces) == 1
+    assert len(executed_trials) == 8
+    assert resumed_ledger.observed_cost_usd == pytest.approx(0.08)
+    assert workspace.round_state(1) == "committed"
+    final_state = workspace.read_search_state()
+    assert final_state["completed_rounds"] == 1
+    assert len(final_state["proposer_sessions"]) == 1
+    events = [json.loads(line) for line in (workspace.root / "proposal-events.jsonl").read_text().splitlines()]
+    assert [event["status"] for event in events] == ["failed:SpendCapReached", "rejected"]
+
+
+def test_search_retries_failed_proposer_without_consuming_round(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    scripted = _ScriptedProposer(meta_modules)
+
+    class FailOnceProposer:
+        def __init__(self):
+            self.calls = 0
+
+        def propose(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                surface = kwargs["surface"]
+                partial = surface / "proposals" / "round-0001" / "partial"
+                partial.mkdir(parents=True)
+                (partial / "composition.json").write_text("{}\n")
+                raise RuntimeError("temporary proposer failure")
+            return scripted.propose(**kwargs)
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    proposer = FailOnceProposer()
+    genesis = meta_modules.composition.genesis_composition()
+
+    with pytest.raises(RuntimeError, match="temporary proposer failure"):
+        meta_modules.search.MetaHarnessSearch(
+            workspace=workspace,
+            evaluator=_DeterministicEvaluator(meta_modules),
+            proposer=proposer,
+            mode="full_history",
+            rounds=1,
+        ).run(genesis)
+
+    assert workspace.round_state(1) == "proposer_failed"
+    assert workspace.read_search_state()["completed_rounds"] == 0
+    resumed = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=_DeterministicEvaluator(meta_modules),
+        proposer=proposer,
+        mode="full_history",
+        rounds=1,
+    ).run(genesis)
+
+    assert resumed.resumed is True
+    assert proposer.calls == 2
+    assert len(resumed.proposer_sessions) == 1
+    assert workspace.round_state(1) == "committed"
+    assert not (workspace.proposals_dir / "round-0001" / "partial").exists()
+
+
+@pytest.mark.parametrize("interrupted_state", ["proposed", "validating"])
+def test_search_resumes_proposal_validation_without_rerunning_proposer(meta_modules, tmp_path, interrupted_state):
+    from reef.harness.adapters import get_adapter
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    proposer = _ScriptedProposer(meta_modules)
+    genesis = meta_modules.composition.genesis_composition()
+    original_transition = workspace.transition_round
+
+    def interrupt_after_transition(round_index, state, **details):
+        original_transition(round_index, state, **details)
+        if state == interrupted_state:
+            raise KeyboardInterrupt("simulated process interruption")
+
+    workspace.transition_round = interrupt_after_transition
+    with pytest.raises(KeyboardInterrupt, match="simulated process interruption"):
+        meta_modules.search.MetaHarnessSearch(
+            workspace=workspace,
+            evaluator=_DeterministicEvaluator(meta_modules),
+            proposer=proposer,
+            mode="full_history",
+            rounds=1,
+        ).run(genesis)
+
+    assert workspace.round_state(1) == interrupted_state
+    workspace.transition_round = original_transition
+    resumed = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=_DeterministicEvaluator(meta_modules),
+        proposer=proposer,
+        mode="full_history",
+        rounds=1,
+    ).run(genesis)
+
+    assert resumed.resumed is True
+    assert len(proposer.surfaces) == 1
+    assert len(resumed.proposer_sessions) == 1
+    assert workspace.round_state(1) == "committed"
+
+
+def test_attempt_log_retains_invalid_rejected_and_selected_proposals(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    class AttemptProposer:
+        def propose(self, *, surface, prompt, session_dir, round_index):
+            catalog = json.loads((surface / "candidate-catalog.json").read_text())
+            if round_index == 1:
+                source_hash = catalog["incumbent_hash"]
+                base = "unknown-candidate"
+                marker = "invalid"
+                name = "invalid-parent"
+            elif round_index == 2:
+                source_hash = catalog["incumbent_hash"]
+                base = "genesis"
+                marker = "specialist"
+                name = "specialist"
+            else:
+                specialist = next(row for row in catalog["candidates"] if row["alias"] == "specialist")
+                source_hash = specialist["candidate_hash"]
+                base = "specialist"
+                marker = "branch-improvement"
+                name = "selected-branch"
+            value = json.loads((surface / "history" / source_hash / "candidate.json").read_text())["composition"]
+            value["nodes"][0]["config"]["text"] += f" {marker}"
+            proposal_dir = surface / "proposals" / f"round-{round_index:04d}" / name
+            proposal_dir.mkdir(parents=True, exist_ok=True)
+            (proposal_dir / "composition.json").write_text(json.dumps(value))
+            (surface / "pending_eval.json").write_text(
+                json.dumps(
+                    {
+                        "iteration": round_index,
+                        "candidates": [
+                            {
+                                "name": name,
+                                "base_candidates": [base],
+                                "hypothesis": f"Exercise the {marker} audit path.",
+                                "changes": f"Add the {marker} marker.",
+                            }
+                        ],
+                    }
+                )
+            )
+            return meta_modules.search.ProposerSession(session_id=f"audit-{round_index}")
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    outcome = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=_DeterministicEvaluator(meta_modules),
+        proposer=AttemptProposer(),
+        mode="full_history",
+        rounds=3,
+    ).run(meta_modules.composition.genesis_composition())
+
+    events = [json.loads(line) for line in (workspace.root / "proposal-events.jsonl").read_text().splitlines()]
+    statuses = [event["status"] for event in events]
+    assert len(outcome.population) == 3
+    assert statuses == ["invalid:ValueError", "rejected", "selected"]
+    assert events[1]["retention_status"] == "retained"
+    assert events[1]["incumbent_before"] == events[1]["incumbent_after"]
+    assert events[1]["candidate_hash"] != events[2]["candidate_hash"]
+    assert events[2]["incumbent_before"] == outcome.population[0].candidate.content_hash
+
+
+def test_full_history_search_rejects_undeclared_surface_outputs(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    class RogueProposer:
+        def propose(self, *, surface, prompt, session_dir, round_index):
+            (surface / "rogue.txt").write_text("not a declared proposer output")
+            return meta_modules.search.ProposerSession(session_id="rogue")
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    search = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=_DeterministicEvaluator(meta_modules),
+        proposer=RogueProposer(),
+        mode="full_history",
+        rounds=1,
+    )
+
+    with pytest.raises(meta_modules.workspace.WorkspaceIntegrityError, match="read-only surface"):
+        search.run(meta_modules.composition.genesis_composition())
+
+
+def test_incumbent_only_surface_omits_raw_history_and_rejects_other_parents(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    workspace = meta_modules.workspace.EvolutionWorkspace(tmp_path / "run", get_adapter("pi"))
+    evaluator = _DeterministicEvaluator(meta_modules)
+    proposer = _ScriptedProposer(meta_modules)
+    genesis = meta_modules.composition.genesis_composition()
+    search = meta_modules.search.MetaHarnessSearch(
+        workspace=workspace,
+        evaluator=evaluator,
+        proposer=proposer,
+        mode="incumbent_only",
+        rounds=1,
+    )
+    population = search._initialize(genesis)
+    surface = search._surface(population, 1)
+
+    assert not (surface / "history").exists()
+    assert (surface / "incumbent" / "composition.json").is_file()
+    proposal = meta_modules.workspace.WorkspaceProposal(
+        name="invalid-parent",
+        proposal_id="round-0001:000:invalid-parent",
+        candidate=meta_modules.composition.CompositionCandidate.from_value(
+            genesis.composition,
+            parent_hashes=("f" * 64,),
+        ),
+        hypothesis="invalid",
+        changes="invalid",
+        source_path=surface / "composition.json",
+    )
+    with pytest.raises(ValueError, match="retained population"):
+        search._validate_parent(proposal, population)
+
+
+def test_codex_proposer_is_pinned_isolated_and_audited(meta_modules, tmp_path, monkeypatch):
+    captured = {}
+
+    def run_process(command, environment, timeout_s):
+        captured.update(command=list(command), environment=dict(environment), timeout_s=timeout_s)
+        events = [
+            {"type": "thread.started", "thread_id": "thread-123"},
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "command_execution",
+                    "command": "find history -type f",
+                    "status": "completed",
+                    "exit_code": 0,
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "command_execution",
+                    "command": "sed -n '1,40p' history/abc/candidate.json",
+                    "status": "completed",
+                    "exit_code": 0,
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "file_change",
+                    "status": "completed",
+                    "changes": [{"path": "proposals/round-0001/candidate/composition.json"}],
+                },
+            },
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 30},
+            },
+        ]
+        return meta_modules.codex.ProcessResult(
+            returncode=0,
+            stdout="".join(json.dumps(event) + "\n" for event in events),
+            stderr="",
+            wall_time_s=2.5,
+        )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-codex")
+    monkeypatch.setenv("UNRELATED_SECRET", "also-withheld")
+    surface = tmp_path / "surface"
+    surface.mkdir()
+    proposer = meta_modules.codex.CodexProposer(
+        model="gpt-5.5",
+        reasoning_effort="high",
+        codex_path=tmp_path / "codex",
+        timeout_s=60,
+        process_runner=run_process,
+        version_reader=lambda path: "codex-cli test-version",
+    )
+
+    session = proposer.propose(
+        surface=surface,
+        prompt="Inspect retained history and write one proposal.",
+        session_dir=tmp_path / "sessions" / "round-0001",
+        round_index=1,
+    )
+
+    command = captured["command"]
+    assert command[:3] == [str((tmp_path / "codex").resolve()), "exec", "--json"]
+    assert command[command.index("--model") + 1] == "gpt-5.5"
+    assert 'model_reasoning_effort="high"' in command
+    assert "sandbox_workspace_write.network_access=false" in command
+    assert 'default_permissions="meta_harness"' in command
+    assert any(value.startswith("permissions.meta_harness.filesystem=") for value in command)
+    assert "permissions.meta_harness.network={enabled=false}" in command
+    assert {"--ignore-user-config", "--ignore-rules", "--ephemeral"} <= set(command)
+    assert captured["environment"].get("OPENAI_API_KEY") is None
+    assert captured["environment"].get("UNRELATED_SECRET") is None
+    assert session.session_id == "thread-123"
+    assert (session.input_tokens, session.output_tokens) == (100, 30)
+    metadata = json.loads((tmp_path / str(session.artifact_dir) / "metadata.json").read_text())
+    assert metadata["codex_version"] == "codex-cli test-version"
+    assert metadata["evidence"]["completed_turns"] == 1
+    assert metadata["evidence"]["tool_evidence"][0]["command"] == "find history -type f"
+    assert metadata["evidence"]["history_accesses"] == [
+        {
+            "event_type": "item.completed",
+            "item_type": "command_execution",
+            "command": "sed -n '1,40p' history/abc/candidate.json",
+        }
+    ]
+    assert "must-not-reach-codex" not in json.dumps(metadata)
+
+
+def test_history_read_audit_requires_reader_to_target_history(meta_modules):
+    completed = {"status": "completed", "exit_code": 0}
+
+    assert meta_modules.codex._is_completed_history_content_read(
+        {**completed, "command": "sed -n '1,40p' history/abc/candidate.json"}
+    )
+    assert not meta_modules.codex._is_completed_history_content_read(
+        {**completed, "command": "cat unrelated.txt && echo history/abc/candidate.json"}
+    )
+
+
+def test_codex_permission_profile_preflight_is_sealed(meta_modules, tmp_path, monkeypatch):
+    observed = {}
+
+    def run(command, **kwargs):
+        observed["command"] = list(command)
+        surface = Path(command[command.index("--cd") + 1])
+        (surface / "writable.txt").write_text("writable")
+        return SimpleNamespace(returncode=0)
+
+    binary = tmp_path / "codex"
+    binary.write_text("placeholder")
+    monkeypatch.setattr(meta_modules.codex.subprocess, "run", run)
+
+    meta_modules.codex.verify_permission_profile(binary)
+
+    assert observed["command"][1] == "sandbox"
+    assert observed["command"][observed["command"].index("--permission-profile") + 1] == "meta_harness"
+    assert any(value.startswith("permissions.meta_harness.filesystem=") for value in observed["command"])
+
+
+@pytest.mark.parametrize(
+    ("returncode", "events", "message"),
+    [
+        (1, [{"type": "thread.started", "thread_id": "failed"}], "status 1"),
+        (
+            0,
+            [
+                {"type": "thread.started", "thread_id": "empty"},
+                {"type": "turn.completed", "usage": {}},
+            ],
+            "non-zero token usage",
+        ),
+    ],
+)
+def test_codex_proposer_fails_loudly_on_incomplete_runs(meta_modules, tmp_path, returncode, events, message):
+    def run_process(command, environment, timeout_s):
+        return meta_modules.codex.ProcessResult(
+            returncode=returncode,
+            stdout="".join(json.dumps(event) + "\n" for event in events),
+            stderr="failure",
+            wall_time_s=0.1,
+        )
+
+    surface = tmp_path / "surface"
+    surface.mkdir()
+    proposer = meta_modules.codex.CodexProposer(
+        model="gpt-5.5",
+        reasoning_effort="high",
+        codex_path=tmp_path / "codex",
+        process_runner=run_process,
+        version_reader=lambda path: "codex-cli test-version",
+    )
+
+    with pytest.raises(meta_modules.codex.CodexProposerError, match=message):
+        proposer.propose(
+            surface=surface,
+            prompt="write proposal",
+            session_dir=tmp_path / "sessions",
+            round_index=1,
+        )
+
+
+def test_codex_proposer_audits_process_exceptions(meta_modules, tmp_path):
+    surface = tmp_path / "surface"
+    surface.mkdir()
+
+    def fail_process(command, environment, timeout_s):
+        raise meta_modules.codex.CodexProposerError("timed out")
+
+    proposer = meta_modules.codex.CodexProposer(
+        model="gpt-5.5",
+        reasoning_effort="high",
+        codex_path=tmp_path / "codex",
+        process_runner=fail_process,
+        version_reader=lambda path: "codex-cli test-version",
+    )
+    session_root = tmp_path / "sessions"
+
+    with pytest.raises(meta_modules.codex.CodexProposerError, match="timed out"):
+        proposer.propose(
+            surface=surface,
+            prompt="write proposal",
+            session_dir=session_root,
+            round_index=1,
+        )
+
+    artifact_dir = next(session_root.iterdir())
+    assert json.loads((artifact_dir / "metadata.json").read_text())["status"] == "process_exception"
+
+
+def test_harbor_exec_bridge_forwards_authenticated_commands(meta_modules):
+    from urllib.error import HTTPError
+    from urllib.request import Request, urlopen
+
+    calls = []
+
+    async def execute(*, command, timeout_sec):
+        calls.append((command, timeout_sec))
+        return SimpleNamespace(stdout="remote-out", stderr="remote-err", return_code=7)
+
+    def post(url, token):
+        request = Request(
+            f"{url}/exec",
+            data=json.dumps({"command": "pwd", "timeout_sec": 12}).encode(),
+            headers={"authorization": f"Bearer {token}", "content-type": "application/json"},
+            method="POST",
+        )
+        with urlopen(request, timeout=2) as response:
+            return json.load(response)
+
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        with meta_modules.pi_bridge.HarborExecBridge(execute, loop) as bridge:
+            result = await asyncio.to_thread(post, bridge.url, bridge.token)
+            with pytest.raises(HTTPError) as denied:
+                await asyncio.to_thread(post, bridge.url, "wrong-token")
+            assert denied.value.code == 401
+        return result
+
+    result = asyncio.run(scenario())
+
+    assert result == {"stdout": "remote-out", "stderr": "remote-err", "return_code": 7}
+    assert calls == [("pwd", 12)]
+
+
+def test_pi_episode_loads_bridge_last_and_collects_native_usage(meta_modules, tmp_path):
+    from reef.harness.adapters import get_adapter
+
+    captured = {}
+
+    def run_process(command, cwd, environment, timeout_s):
+        captured.update(command=list(command), cwd=cwd, environment=dict(environment), timeout_s=timeout_s)
+        bridge_index = command.index(str(cwd.parent / meta_modules.pi_bridge.BRIDGE_EXTENSION_PATH))
+        candidate_index = command.index(str(cwd.parent / "pi-agent/extensions/candidate.ts"))
+        assert bridge_index > candidate_index
+        assert "createBashToolDefinition" in (cwd.parent / meta_modules.pi_bridge.BRIDGE_EXTENSION_PATH).read_text()
+        sessions = Path(environment["PI_CODING_AGENT_SESSION_DIR"])
+        sessions.mkdir(parents=True)
+        event = {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "usage": {
+                    "input": 20,
+                    "cacheRead": 5,
+                    "output": 4,
+                    "cost": {"total": 0.0},
+                },
+            },
+        }
+        (sessions / "session.jsonl").write_text(json.dumps(event) + "\n")
+        return meta_modules.pi_bridge.PiProcessResult(0, '{"type":"agent_end"}\n', "", 1.25)
+
+    runner = meta_modules.pi_bridge.PiEpisodeRunner(
+        get_adapter("pi"),
+        binary=tmp_path / "pi",
+        timeout_s=90,
+        process_runner=run_process,
+    )
+    result = runner.run(
+        {
+            "pi-agent/settings.json": "{}\n",
+            "pi-agent/models.json": "{}\n",
+            "pi-agent/extensions/candidate.ts": "export default () => {};\n",
+        },
+        "solve the task",
+        bridge_url="http://127.0.0.1:1234",
+        bridge_token="bridge-secret",
+    )
+
+    assert {"--no-extensions", "--tools", "bash", "--print"} <= set(captured["command"])
+    assert captured["environment"]["REEF_HARBOR_BRIDGE_TOKEN"] == "bridge-secret"
+    assert result.usage == {"input_tokens": 20, "cached_input_tokens": 5, "output_tokens": 4}
+    assert result.estimated_cost_usd == pytest.approx((20 * 0.75 + 5 * 0.075 + 4 * 4.50) / 1_000_000)
+    assert result.provider_reported_cost_usd == 0
+    assert len(result.trajectory) == 1
+    assert not captured["cwd"].parent.exists()
+
+
+def test_harbor_agent_injects_ephemeral_binding_and_reports_pi_evidence(
+    meta_modules,
+    tmp_path,
+    monkeypatch,
+):
+    class BaseAgent:
+        def __init__(self, logs_dir, model_name=None, *args, **kwargs):
+            self.logs_dir = Path(logs_dir)
+            self.model_name = model_name
+
+    class BaseEnvironment:
+        pass
+
+    class AgentContext:
+        pass
+
+    packages = {
+        "harbor": ModuleType("harbor"),
+        "harbor.agents": ModuleType("harbor.agents"),
+        "harbor.agents.base": ModuleType("harbor.agents.base"),
+        "harbor.environments": ModuleType("harbor.environments"),
+        "harbor.environments.base": ModuleType("harbor.environments.base"),
+        "harbor.models": ModuleType("harbor.models"),
+        "harbor.models.agent": ModuleType("harbor.models.agent"),
+        "harbor.models.agent.context": ModuleType("harbor.models.agent.context"),
+    }
+    packages["harbor.agents.base"].BaseAgent = BaseAgent
+    packages["harbor.environments.base"].BaseEnvironment = BaseEnvironment
+    packages["harbor.models.agent.context"].AgentContext = AgentContext
+    for name, module in packages.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    sys.modules.pop("harness.harbor_agent", None)
+    harbor_agent = importlib.import_module("harness.harbor_agent")
+
+    candidate = meta_modules.composition.genesis_composition()
+    candidate_path = tmp_path / "composition.json"
+    candidate_path.write_text(candidate.canonical_json + "\n")
+    original = candidate_path.read_text()
+    captured = {}
+
+    class FakeRunner:
+        def run(self, files, instruction, *, bridge_url, bridge_token):
+            from urllib.request import Request, urlopen
+
+            models = json.loads(files["pi-agent/models.json"])
+            captured["api_key"] = models["providers"]["reef"]["apiKey"]
+            request = Request(
+                f"{bridge_url}/exec",
+                data=json.dumps({"command": "echo bridged", "timeout_sec": 8}).encode(),
+                headers={"authorization": f"Bearer {bridge_token}", "content-type": "application/json"},
+                method="POST",
+            )
+            with urlopen(request, timeout=2) as response:
+                captured["bridge_response"] = json.load(response)
+            return meta_modules.pi_bridge.PiEpisodeResult(
+                exit_code=0,
+                stdout="",
+                stderr="provider rejected ephemeral-test-key",
+                trajectory=({"type": "message", "message": {"role": "assistant"}},),
+                usage={"input_tokens": 20, "cached_input_tokens": 5, "output_tokens": 4},
+                estimated_cost_usd=0.03,
+                provider_reported_cost_usd=0.029,
+                wall_time_s=1.0,
+            )
+
+    class FakeEnvironment:
+        def __init__(self):
+            self.calls = []
+
+        async def exec(self, *, command, timeout_sec):
+            self.calls.append((command, timeout_sec))
+            return SimpleNamespace(stdout="inside-container", stderr="", return_code=0)
+
+    monkeypatch.setenv("META_TEST_OPENAI_KEY", "ephemeral-test-key")
+    logs_dir = tmp_path / "trial" / "agent"
+    agent = harbor_agent.HarborAgent(
+        logs_dir=logs_dir,
+        model_name="gpt-test",
+        composition_path=str(candidate_path),
+        target_base_url="https://example.invalid",
+        target_api_key_env="META_TEST_OPENAI_KEY",
+        pi_binary=str(tmp_path / "pi"),
+        pi_runner=FakeRunner(),
+    )
+    environment = FakeEnvironment()
+    context = SimpleNamespace(
+        n_input_tokens=None,
+        n_cache_tokens=None,
+        n_output_tokens=None,
+        cost_usd=None,
+        metadata=None,
+    )
+
+    asyncio.run(agent.run("solve", environment, context))
+
+    assert captured["api_key"] == "ephemeral-test-key"
+    assert captured["bridge_response"]["stdout"] == "inside-container"
+    assert environment.calls == [("echo bridged", 8)]
+    assert candidate_path.read_text() == original
+    assert "ephemeral-test-key" not in candidate_path.read_text()
+    assert (context.n_input_tokens, context.n_cache_tokens, context.n_output_tokens) == (25, 5, 4)
+    assert context.cost_usd == pytest.approx(0.03)
+    assert context.metadata["reef_meta_harness"]["provider_reported_cost_usd"] == pytest.approx(0.029)
+    assert "ephemeral-test-key" not in context.metadata["reef_meta_harness"]["pi_stderr"]
+    trajectory_path = Path(context.metadata["reef_meta_harness"]["trajectory_path"])
+    assert trajectory_path.is_file()
+    assert json.loads(trajectory_path.read_text())[0]["type"] == "message"
+
+
+def test_harbor_evaluator_runs_exact_split_trials_and_retains_evidence(meta_modules, tmp_path):
+    calls = []
+    budget_identities = []
+
+    def run_trial(candidate, candidate_path, task_id, trial_index, round_index, trial_dir):
+        calls.append((task_id, trial_index, round_index, trial_dir))
+        assert json.loads(candidate_path.read_text()) == candidate.composition
+        reward = 1.0 if task_id == "train-a" and trial_index == 1 else 0.0
+        return meta_modules.harbor_eval.HarborTrialOutcome(
+            reward=reward,
+            trajectory=({"task": task_id, "trial": trial_index},),
+            usage={"input_tokens": 10, "output_tokens": 2},
+            estimated_cost_usd=0.01,
+            wall_time_s=1.0,
+            verifier={"rewards": {"reward": reward}, "task_checksum": f"checksum-{task_id}"},
+        )
+
+    output_dir = tmp_path / "private-evaluations"
+    evaluator = meta_modules.harbor_eval.HarborEvaluator(
+        splits={
+            "train": ("train-a", "train-b"),
+            "dev": ("dev-a",),
+            "test": ("test-a",),
+        },
+        trials_per_task=2,
+        output_dir=output_dir,
+        target_model="gpt-test",
+        target_base_url="https://example.invalid",
+        target_api_key_env="META_TEST_OPENAI_KEY",
+        pi_binary=tmp_path / "pi",
+        trial_executor=run_trial,
+        before_trial=budget_identities.append,
+        budget_namespace="cell-a",
+    )
+    candidate = meta_modules.composition.genesis_composition()
+
+    result = evaluator.evaluate(candidate, split="train", round_index=3)
+    resumed = evaluator.evaluate(candidate, split="train", round_index=3)
+
+    assert result.score == pytest.approx(0.25)
+    assert resumed.to_jsonable() == result.to_jsonable()
+    assert len(result.trials) == 4
+    assert len(calls) == 4
+    assert all(identity.startswith("cell-a:") for identity in budget_identities)
+    assert {call[0] for call in calls} == {"train-a", "train-b"}
+    assert not any(call[0].startswith("dev") or call[0].startswith("test") for call in calls)
+    assert result.to_jsonable()["usage"] == {"input_tokens": 40, "output_tokens": 8}
+    evidence_paths = sorted(output_dir.rglob("evidence.json"))
+    assert len(evidence_paths) == 4
+    evidence = json.loads(evidence_paths[0].read_text())
+    assert evidence["trajectory"][0]["task"] in {"train-a", "train-b"}
+    assert evidence["verifier"]["rewards"]["reward"] in {0.0, 1.0}
+    persisted = output_dir / "candidates" / candidate.content_hash / "composition.json"
+    assert json.loads(persisted.read_text()) == candidate.composition
+
+
+def test_harbor_evaluator_retries_infrastructure_failures_without_scoring_them(meta_modules, tmp_path):
+    attempts = 0
+
+    def run_trial(candidate, candidate_path, task_id, trial_index, round_index, trial_dir):
+        nonlocal attempts
+        attempts += 1
+        return meta_modules.harbor_eval.HarborTrialOutcome(
+            reward=0.0 if attempts == 1 else 1.0,
+            trajectory=() if attempts == 1 else ({"type": "message"},),
+            estimated_cost_usd=0.02 if attempts == 1 else 0.01,
+            status="trajectory_missing" if attempts == 1 else "completed",
+            verifier={"rewards": {"reward": 1.0}, "task_checksum": "checksum-train"},
+        )
+
+    ledger = meta_modules.budget.ObservedCostLedger(tmp_path / "cost.json", 1.0)
+    evaluator = meta_modules.harbor_eval.HarborEvaluator(
+        splits={"train": ("train-a",), "dev": ("dev-a",), "test": ("test-a",)},
+        trials_per_task=1,
+        output_dir=tmp_path / "evaluations",
+        target_model="gpt-test",
+        target_base_url="https://example.invalid",
+        target_api_key_env="META_TEST_OPENAI_KEY",
+        pi_binary=tmp_path / "pi",
+        trial_executor=run_trial,
+        before_trial=ledger.before_trial,
+        after_trial=ledger.record_trial,
+    )
+    candidate = meta_modules.composition.genesis_composition()
+
+    with pytest.raises(meta_modules.harbor_eval.HarborInfrastructureError, match="infrastructure status"):
+        evaluator.evaluate(candidate, split="train", round_index=0)
+    result = evaluator.evaluate(candidate, split="train", round_index=0)
+
+    assert attempts == 2
+    assert result.score == 1.0
+    assert ledger.observed_cost_usd == pytest.approx(0.03)
+    assert len(tuple((tmp_path / "evaluations").rglob("infrastructure-attempt-01.json"))) == 1
+    assert len(tuple((tmp_path / "evaluations").rglob("evidence.json"))) == 1
+
+
+def test_harbor_evaluator_rejects_overlapping_splits(meta_modules, tmp_path):
+    with pytest.raises(ValueError, match="disjoint"):
+        meta_modules.harbor_eval.HarborEvaluator(
+            splits={"train": ("same",), "dev": ("same",), "test": ("held-out",)},
+            trials_per_task=2,
+            output_dir=tmp_path,
+            target_model="gpt-test",
+            target_base_url="https://example.invalid",
+            target_api_key_env="META_TEST_OPENAI_KEY",
+            pi_binary=tmp_path / "pi",
+        )
+
+
+def test_terminal_bench_registry_pin_rejects_drift(meta_modules):
+    class FakeDatasetConfig:
+        def __init__(self, *, task_names, **kwargs):
+            self.task_names = task_names
+
+        async def get_task_configs(self):
+            return [
+                SimpleNamespace(
+                    path=Path(task_id),
+                    git_url=meta_modules.harbor_eval.TERMINAL_BENCH_DATASET_URL,
+                    git_commit_id=(
+                        "0" * 40 if task_id == "task-b" else meta_modules.harbor_eval.TERMINAL_BENCH_DATASET_COMMIT
+                    ),
+                )
+                for task_id in self.task_names
+            ]
+
+    with pytest.raises(RuntimeError, match="unexpected commit"):
+        asyncio.run(
+            meta_modules.harbor_eval.verify_dataset_registry_pin(
+                ("task-a", "task-b"),
+                dataset_config_factory=FakeDatasetConfig,
+            )
+        )
+
+
+def test_harbor_trial_parser_retains_registry_checksum(meta_modules, tmp_path):
+    trajectory_path = tmp_path / "trajectory.json"
+    trajectory_path.write_text('[{"type":"message"}]\n')
+    started = datetime.now(timezone.utc)
+    result = SimpleNamespace(
+        verifier_result=SimpleNamespace(rewards={"reward": 1.0}),
+        agent_result=SimpleNamespace(
+            metadata={
+                "reef_meta_harness": {
+                    "pi_exit_code": 0,
+                    "trajectory_path": str(trajectory_path),
+                }
+            },
+            n_input_tokens=20,
+            n_cache_tokens=5,
+            n_output_tokens=4,
+            cost_usd=0.03,
+        ),
+        exception_info=None,
+        task_checksum="task-checksum-123",
+        source="terminal-bench",
+        started_at=started,
+        finished_at=started + timedelta(seconds=2),
+    )
+
+    outcome = meta_modules.harbor_eval._outcome_from_trial_result(result)
+
+    assert outcome.reward == 1.0
+    assert outcome.status == "completed"
+    assert outcome.verifier["task_checksum"] == "task-checksum-123"
+    assert outcome.wall_time_s == 2.0
+
+
+def test_observed_cost_ledger_is_persistent_and_idempotent(monkeypatch, tmp_path):
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    budget = importlib.import_module("harness.budget")
+    ledger = budget.ObservedCostLedger(tmp_path / "cost.json", 1.0)
+
+    ledger.before_trial("trial-a")
+    ledger.record_trial("trial-a", 0.6)
+    ledger.record_trial("trial-a", 0.6)
+    resumed = budget.ObservedCostLedger(tmp_path / "cost.json", 1.0)
+    resumed.before_trial("trial-b")
+    resumed.record_trial("trial-b", 0.5)
+
+    assert resumed.observed_cost_usd == pytest.approx(1.1)
+    with pytest.raises(budget.SpendCapReached, match="no new trial"):
+        resumed.before_trial("trial-c")
+
+    for invalid_cap in (float("nan"), float("inf"), float("-inf"), 0.0):
+        with pytest.raises(ValueError, match="finite and positive"):
+            budget.ObservedCostLedger(tmp_path / f"cost-{invalid_cap}.json", invalid_cap)
+    for invalid_cost in (float("nan"), float("inf"), float("-inf"), -0.01):
+        with pytest.raises(ValueError, match="finite and non-negative"):
+            ledger.record_trial(f"invalid-{invalid_cost}", invalid_cost)
+
+
+def test_meta_harness_plan_uses_equal_target_episode_budgets(monkeypatch, tmp_path):
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    sys.modules.pop("run", None)
+    run = importlib.import_module("run")
+    monkeypatch.setattr(run, "_command_output", lambda command: "test-version")
+    config = run.ExperimentConfig()
+
+    plan = run.build_plan(
+        config,
+        run.CELLS,
+        tmp_path / "outputs",
+        "/path/to/pi",
+        Path("/path/to/codex"),
+    )
+
+    assert run.planned_target_episodes(config) == 140
+    assert plan["planned_target_episodes_per_cell"] == 140
+    assert plan["planned_target_episodes_total"] == 420
+    assert plan["planned_proposer_turns"] == 4
+    assert plan["target_model_pricing"]["model"] == config.target_model
+    assert plan["target_model_pricing"]["output_usd_per_million"] == 4.5
+    assert plan["pins"]["terminal_bench_dataset_commit"] == ("69671fbaac6d67a7ef0dfec016cc38a64ef7a77c")
+    assert "bn-fit-modify" not in json.dumps(plan)
+
+    smoke_splits = run.selected_task_splits(True)
+    smoke_plan = run.build_plan(
+        config,
+        run.CELLS,
+        tmp_path / "smoke-outputs",
+        "/path/to/pi",
+        Path("/path/to/codex"),
+        splits=smoke_splits,
+        smoke=True,
+    )
+    assert run.planned_target_episodes(config, smoke_splits) == 14
+    assert smoke_plan["smoke"] is True
+    assert smoke_plan["split_sizes"] == {"train": 1, "dev": 1, "test": 1}
+    assert smoke_plan["split_identity_sha256"] != plan["split_identity_sha256"]
+    assert smoke_plan["planned_target_episodes_per_cell"] == 14
+    assert smoke_plan["planned_target_episodes_total"] == 42
+    assert smoke_plan["planned_proposer_turns"] == 4
+
+
+def test_run_identity_allows_staged_cells_but_rejects_configuration_drift(runner_modules, tmp_path):
+    run = runner_modules.run
+    plan = {
+        "cells": ("frozen",),
+        "smoke": False,
+        "output_dir": str(tmp_path),
+        "config": {"rounds": 2, "trials_per_task": 2},
+        "target_model_pricing": {"model": "gpt-test"},
+        "pins": {"reef_source_commit": "a", "reef_source_dirty": False, "pi_version": "1"},
+        "binaries": {"codex_version": "codex 1"},
+        "split_sizes": {"train": 10, "dev": 10, "test": 10},
+        "split_identity_sha256": "split",
+    }
+    path = tmp_path / "run-identity.json"
+    digest = run.ensure_run_identity(path, plan)
+
+    assert run.ensure_run_identity(path, {**plan, "cells": ("frozen", "full_history")}) == digest
+    changed = {**plan, "config": {**plan["config"], "rounds": 3}}
+    with pytest.raises(RuntimeError, match="does not match"):
+        run.ensure_run_identity(path, changed)
+
+
+def test_done_marker_detects_evidence_changes(runner_modules, tmp_path):
+    run = runner_modules.run
+    output_dir = tmp_path / "full_history"
+    output_dir.mkdir()
+    (output_dir / "summary.json").write_text('{"cell":"full_history"}\n')
+    repository = output_dir / "artifacts.git"
+    repository.mkdir()
+    (output_dir / "publication.json").write_text(json.dumps({"repository": str(repository)}) + "\n")
+    run.mark_done(output_dir, "full_history", "identity")
+
+    assert run.completed_cell(output_dir, "full_history", "identity")
+    (output_dir / "summary.json").write_text('{"cell":"tampered"}\n')
+    with pytest.raises(RuntimeError, match="evidence changed"):
+        run.completed_cell(output_dir, "full_history", "identity")
+
+
+@pytest.mark.parametrize("smoke", [False, True])
+def test_three_cell_runner_retains_equal_real_evaluator_budgets_and_reports(
+    runner_modules,
+    tmp_path,
+    monkeypatch,
+    smoke,
+):
+    from reef.harness.adapters import get_adapter
+
+    run = runner_modules.run
+    real_evaluator = runner_modules.harbor_eval.HarborEvaluator
+
+    def trial_executor(candidate, candidate_path, task_id, trial_index, round_index, trial_dir):
+        text = candidate.canonical_json
+        if "full-selected" in text:
+            reward = 0.9
+        elif "incumbent-selected" in text:
+            reward = 0.8
+        elif "retained-specialist" in text:
+            reward = 0.2
+        else:
+            reward = 0.5
+        return runner_modules.harbor_eval.HarborTrialOutcome(
+            reward=reward,
+            trajectory=({"task": task_id, "trial": trial_index, "round": round_index},),
+            usage={"input_tokens": 10, "output_tokens": 2},
+            estimated_cost_usd=0.001,
+            wall_time_s=0.01,
+            verifier={"rewards": {"reward": reward}, "task_checksum": f"checksum-{task_id}"},
+        )
+
+    def evaluator_factory(**kwargs):
+        return real_evaluator(**kwargs, trial_executor=trial_executor)
+
+    class ScriptedCodex:
+        def __init__(self, **kwargs):
+            pass
+
+        def propose(self, *, surface, prompt, session_dir, round_index):
+            full_history = (surface / "history").is_dir()
+            if full_history:
+                catalog = json.loads((surface / "candidate-catalog.json").read_text())
+                if round_index == 1:
+                    base_row = next(row for row in catalog["candidates"] if row["alias"] == "genesis")
+                    marker = "retained-specialist"
+                    name = "retained-specialist"
+                else:
+                    base_row = next(row for row in catalog["candidates"] if row["alias"] == "retained-specialist")
+                    marker = "full-selected"
+                    name = "full-selected"
+                base = base_row["alias"]
+                value = json.loads((surface / "history" / base_row["candidate_hash"] / "candidate.json").read_text())[
+                    "composition"
+                ]
+            else:
+                summary = json.loads((surface / "search-summary.json").read_text())
+                base = summary["incumbent_hash"]
+                value = json.loads((surface / "incumbent" / "composition.json").read_text())
+                marker = "retained-specialist" if round_index == 1 else "incumbent-selected"
+                name = marker
+            value["nodes"][0]["config"]["text"] += f" {marker}"
+            proposal_dir = surface / "proposals" / f"round-{round_index:04d}" / name
+            proposal_dir.mkdir(parents=True, exist_ok=True)
+            (proposal_dir / "composition.json").write_text(json.dumps(value))
+            (surface / "pending_eval.json").write_text(
+                json.dumps(
+                    {
+                        "iteration": round_index,
+                        "candidates": [
+                            {
+                                "name": name,
+                                "base_candidates": [base],
+                                "hypothesis": f"Evaluate {marker}.",
+                                "changes": f"Add {marker}.",
+                            }
+                        ],
+                    }
+                )
+            )
+            artifact_dir = session_dir / "scripted"
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            history_accesses = (
+                [{"command": "sed -n '1,80p' history/candidate.json"}] if full_history and round_index > 1 else []
+            )
+            (artifact_dir / "metadata.json").write_text(
+                json.dumps({"evidence": {"history_accesses": history_accesses}})
+            )
+            return runner_modules.search.ProposerSession(
+                session_id=f"scripted-{round_index}",
+                input_tokens=10,
+                output_tokens=2,
+                wall_time_s=0.01,
+                artifact_dir=artifact_dir.relative_to(session_dir.parent.parent).as_posix(),
+            )
+
+    publications = []
+
+    def publish(candidate, *, descriptor, output_dir, scenario, metadata):
+        publications.append((scenario, candidate.content_hash))
+        (output_dir / "publication.json").write_text(
+            json.dumps({"candidate_hash": candidate.content_hash, "scenario": scenario})
+        )
+        return {"candidate_hash": candidate.content_hash}
+
+    monkeypatch.setattr(run, "HarborEvaluator", evaluator_factory)
+    monkeypatch.setattr(run, "CodexProposer", ScriptedCodex)
+    monkeypatch.setattr(run, "publish_candidate", publish)
+    config = run.ExperimentConfig()
+    ledger = run.ObservedCostLedger(tmp_path / "observed-cost.json", 10.0)
+    descriptor = get_adapter("pi")
+    splits = run.selected_task_splits(smoke)
+    for cell in run.CELLS:
+        run.run_cell(
+            cell,
+            tmp_path / cell,
+            config=config,
+            descriptor=descriptor,
+            pi_binary=tmp_path / "pi",
+            codex_binary=tmp_path / "codex",
+            ledger=ledger,
+            splits=splits,
+        )
+    run.write_aggregate_report(tmp_path, run.CELLS)
+
+    results = json.loads((tmp_path / "results.json").read_text())
+    assert results["equal_target_episode_budget"] is True
+    assert results["equal_task_checksums"] is True
+    expected_episode_count = 14 if smoke else 140
+    expected_task_count = 3 if smoke else 30
+    assert results["target_episode_counts"] == dict.fromkeys(run.CELLS, expected_episode_count)
+    assert results["cells"]["frozen"]["test_score"] == pytest.approx(0.5)
+    assert results["cells"]["incumbent_only"]["test_score"] == pytest.approx(0.8)
+    assert results["cells"]["full_history"]["test_score"] == pytest.approx(0.9)
+    assert results["cells"]["full_history"]["later_round_history_read"] is True
+    assert len(results["task_checksums"]) == expected_task_count
+    assert len(publications) == 3
+    assert all((tmp_path / cell / "done.json").is_file() for cell in run.CELLS)
+
+
+def test_publication_tree_is_provider_free_and_resumable(meta_modules, tmp_path, monkeypatch):
+    from reef.harness.adapters import get_adapter
+
+    class FakeBackend:
+        def __init__(self, scenario, repository_path, **kwargs):
+            self.repository_path = repository_path
+
+        def fork(self, metadata):
+            return SimpleNamespace(
+                content_id="parent-content",
+                release_id="parent",
+                parent_release_id=None,
+            )
+
+        def metadata(self):
+            return None
+
+        def publish(self, artifact, expected_parent):
+            return SimpleNamespace(
+                content_id="published-content",
+                release_id="published",
+                parent_release_id=expected_parent.release_id,
+            )
+
+    monkeypatch.setattr(meta_modules.publication, "GitLFSRepositoryBackend", FakeBackend)
+    candidate = meta_modules.composition.genesis_composition()
+
+    first = meta_modules.publication.publish_candidate(
+        candidate,
+        descriptor=get_adapter("pi"),
+        output_dir=tmp_path,
+        scenario="test-meta-harness",
+        metadata={"cell": "test"},
+    )
+    resumed = meta_modules.publication.publish_candidate(
+        candidate,
+        descriptor=get_adapter("pi"),
+        output_dir=tmp_path,
+        scenario="test-meta-harness",
+        metadata={"cell": "test"},
+    )
+
+    assert resumed == first
+    assert first["candidate_hash"] == candidate.content_hash
+    assert first["repository"] == "artifacts.git"
+    assert json.loads((tmp_path / "published-composition/pi-agent/models.json").read_text()) == {}
+    assert "apiKey" not in (tmp_path / "published-composition/pi-agent/settings.json").read_text()
+
+
+def test_publication_recovers_from_pending_fork(meta_modules, tmp_path, monkeypatch):
+    from reef.harness.adapters import get_adapter
+
+    state = {"metadata": None, "current": None, "publish_calls": 0}
+
+    class FakeBackend:
+        def __init__(self, scenario, repository_path, **kwargs):
+            Path(repository_path).mkdir(parents=True, exist_ok=True)
+
+        def metadata(self):
+            return state["metadata"]
+
+        def current(self):
+            return state["current"]
+
+        def fork(self, metadata):
+            state["metadata"] = dict(metadata)
+            state["current"] = SimpleNamespace(
+                content_id="pending-content",
+                release_id="pending",
+                parent_release_id="initial",
+            )
+            return state["current"]
+
+        def publish(self, artifact, expected_parent):
+            state["publish_calls"] += 1
+            if state["publish_calls"] == 1:
+                raise RuntimeError("interrupted after fork")
+            state["metadata"] = dict(artifact.metadata)
+            state["current"] = SimpleNamespace(
+                content_id="published-content",
+                release_id="published",
+                parent_release_id=expected_parent.release_id,
+            )
+            return state["current"]
+
+    monkeypatch.setattr(meta_modules.publication, "GitLFSRepositoryBackend", FakeBackend)
+    candidate = meta_modules.composition.genesis_composition()
+
+    with pytest.raises(RuntimeError, match="interrupted after fork"):
+        meta_modules.publication.publish_candidate(
+            candidate,
+            descriptor=get_adapter("pi"),
+            output_dir=tmp_path,
+            scenario="test-meta-harness",
+            metadata={"cell": "test"},
+        )
+    recovered = meta_modules.publication.publish_candidate(
+        candidate,
+        descriptor=get_adapter("pi"),
+        output_dir=tmp_path,
+        scenario="test-meta-harness",
+        metadata={"cell": "test"},
+    )
+
+    assert recovered["release_id"] == "published"
+    assert state["publish_calls"] == 2
+    assert state["metadata"]["publication_state"] == "published"


### PR DESCRIPTION
Motivation

Tracks #42. Reproduce Meta-Harness’s persistent full-history search behavior over Reef harness compositions and compare it with frozen and incumbent-only controls.

## Changes

- Adds a standalone, locked Terminal-Bench experiment under `recipes/meta_harness/examples/terminal_bench/`.
- Uses Codex to propose provider-free `rules`, `skill`, and `agent_command` compositions, rendered for Pi and evaluated by Harbor.
- Gives all three cells the same target-episode budget while keeping held-out tasks sealed until selection.
- Retains candidate history, trajectories, proposer sessions, spend records, results, and the published Reef artifact.

## Compatibility and operational impact

- No public Reef API or wheel dependency changes.
- Live runs require Docker, Git LFS, Pi `0.84.2`, a Codex login, and an OpenAI API key.
- This is an OpenAI/Codex adaptation of Meta-Harness, not an exact reproduction of its original model setting or reported benchmark score.

## Verification

- Repository pre-commit checks — passed.
- Documentation checks — passed.
- Meta-Harness suite — 40 passed.
- Real Pi-to-Harbor bridge smoke — passed.
- Locked dry run — validated pins and planned 14 target episodes and two proposer turns without model calls.

Replication of the Meta-Harness between their official implementation and our reef's implementation is running on Terminal-bench, will be ready soon.

## AI assistance

Codex helped port, review, test, and document the implementation. I remain responsible for the submitted code, claims, and experiment results.

## Checklist

- The change is focused and contains no unrelated cleanup.
- Tests cover behavior changes.
- No public interface changes are present.
- Affected documentation is updated.
- An accepted RFC is linked, or this change does not require an RFC.
- Relevant pre-commit and test checks pass.
- Non-trivial AI assistance is disclosed above.

## Review and merge

This remains a draft pending the paid reproduction results and maintainer review.
