### PR TITLE
Add a Claude Code harness adapter

### DIFF
--- a/reef/harness/adapters/__init__.py
+++ b/reef/harness/adapters/__init__.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from reef.harness.descriptor import AdapterDescriptor, DescriptorError, external_descriptors, load_descriptor
 
-BUILTIN_ADAPTERS = ("opencode", "pi")
+BUILTIN_ADAPTERS = ("claude", "opencode", "pi")
 
 _cache: dict[str, AdapterDescriptor] = {}
 

--- a/reef/harness/adapters/claude/__init__.py
+++ b/reef/harness/adapters/claude/__init__.py
@@ -1,0 +1,1 @@
+"""The Claude Code adapter (Anthropic, @anthropic-ai/claude-code)."""

--- a/reef/harness/adapters/claude/descriptor.yaml
+++ b/reef/harness/adapters/claude/descriptor.yaml
@@ -1,0 +1,72 @@
+# Claude Code, driven headless per episode.
+#
+# CLAUDE_CONFIG_DIR relocates the whole config tree (settings.json, CLAUDE.md,
+# skills/, commands/, plugins/, and the session transcripts under projects/)
+# into the episode root, so nothing is read from or written to the user's real
+# ~/.claude and the directory-trust prompt never fires. The three DISABLE_*
+# variables stop the startup network work (auto-update, telemetry, and the
+# non-essential background traffic) that would otherwise make episodes
+# non-deterministic. `-p --output-format json` is Claude Code's headless
+# mode; `--permission-mode bypassPermissions` is the non-interactive
+# equivalent of trusting the isolated episode root, matching opencode's
+# `--auto` and pi's json mode.
+name: claude
+binary: claude
+# The vendor's install channel at the pinned version; consumed by the
+# GET /reef/harness/install script, never by episode runs.
+install:
+  kind: npm
+  package: "@anthropic-ai/claude-code"
+  version: "2.1.257"
+  binary_path: "node_modules/.bin/claude"
+argv: ["-p", "{prompt}", "--output-format", "json", "--permission-mode", "bypassPermissions"]
+env:
+  CLAUDE_CONFIG_DIR: "{root}/claude"
+  DISABLE_AUTOUPDATER: "1"
+  DISABLE_TELEMETRY: "1"
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+files:
+  config:
+    primary:
+      path: "claude/settings.json"
+      defaults:
+        # Keep episodes hermetic: no auto-update mid-campaign, and no
+        # Co-Authored-By trailer written into commits an episode makes.
+        includeCoAuthoredBy: false
+  rules: "claude/CLAUDE.md"
+  agent_command: "claude/commands/{name}.md"
+  skill: "claude/skills/{name}/SKILL.md"
+  # Claude Code's code surface is a plugin: a directory with an entry file.
+  # The evolved node renders as that entry file; activating it still needs a
+  # marketplace/settings reference, so treat this as the least-used node kind
+  # for now (skills, commands, and rules carry the harness).
+  code_extension: "claude/plugins/{name}/index.js"
+trajectory:
+  # Claude Code writes one JSONL transcript per session under
+  # CLAUDE_CONFIG_DIR/projects/<cwd-slug>/<session-id>.jsonl, one event per
+  # line — the same shape pi uses, read by the claude-session-jsonl reader.
+  format: claude-session-jsonl
+  path: "claude/projects"
+cleanup_whitelist:
+  - "claude/projects/**"
+  # Claude Code's boot persists local state beside the rendered config:
+  # a top-level state file, feature-gate cache, per-session todo lists, and
+  # captured shell snapshots. Episode state, not residue.
+  - "claude/.claude.json"
+  - "claude/statsig/**"
+  - "claude/todos/**"
+  - "claude/shell-snapshots/**"
+quirks: reef.harness.adapters.claude.quirks
+# How to point Claude Code at a model endpoint. Claude Code speaks the
+# Anthropic Messages API natively, so only the anthropic dialect is bound:
+# settings.json's `env` block redirects the client at Reef's endpoint, which
+# is Anthropic-compatible at {base_url}/v1/messages. Reef appends this set
+# when it runs evaluation episodes; the served tree never carries a provider.
+model_binding:
+  anthropic:
+    - target: primary
+      data:
+        env:
+          ANTHROPIC_BASE_URL: "{base_url}"
+          ANTHROPIC_AUTH_TOKEN: "{api_key}"
+          ANTHROPIC_MODEL: "{model}"

--- a/reef/harness/adapters/claude/descriptor.yaml
+++ b/reef/harness/adapters/claude/descriptor.yaml
@@ -7,9 +7,9 @@
 # variables stop the startup network work (auto-update, telemetry, and the
 # non-essential background traffic) that would otherwise make episodes
 # non-deterministic. `-p --output-format json` is Claude Code's headless
-# mode; `--permission-mode bypassPermissions` is the non-interactive
-# equivalent of trusting the isolated episode root, matching opencode's
-# `--auto` and pi's json mode.
+# mode; `--permission-mode auto` matches opencode's `--auto` and pi's json
+# mode — auto-approve without dropping every safety check, which is the
+# right level for a hermetic episode root.
 name: claude
 binary: claude
 # The vendor's install channel at the pinned version; consumed by the
@@ -19,7 +19,7 @@ install:
   package: "@anthropic-ai/claude-code"
   version: "2.1.257"
   binary_path: "node_modules/.bin/claude"
-argv: ["-p", "{prompt}", "--output-format", "json", "--permission-mode", "bypassPermissions"]
+argv: ["-p", "{prompt}", "--output-format", "json", "--permission-mode", "auto"]
 env:
   CLAUDE_CONFIG_DIR: "{root}/claude"
   DISABLE_AUTOUPDATER: "1"

--- a/reef/harness/adapters/claude/quirks.py
+++ b/reef/harness/adapters/claude/quirks.py
@@ -1,0 +1,48 @@
+"""Claude Code adapter quirks: boot artifacts and enforced config invariants.
+
+Claude Code's boot writes local state beside the rendered config under
+CLAUDE_CONFIG_DIR: a top-level ``.claude.json`` state file, a ``statsig/``
+feature-gate cache, per-session ``todos/`` lists, and ``shell-snapshots/``.
+The descriptor whitelists those so the episode inverse tolerates them and
+reports anything else as residue.
+
+``finalize_render`` enforces the traps a mutated ``settings.json`` could
+reopen. The descriptor keeps a benchmark episode hermetic through
+environment variables (auto-update, telemetry, and non-essential traffic all
+off); a composition that sets ``settings.env`` to turn any of them back on,
+or that flips ``includeCoAuthoredBy`` on, is rejected at render — the same
+gate that rejects an invalid node.
+"""
+
+from __future__ import annotations
+
+import json
+
+from reef.harness.render import RenderError
+
+_CONFIG_PATH = "claude/settings.json"
+
+# The env switches the descriptor relies on to keep episodes hermetic. A
+# rendered settings.env that sets any of these to a falsey value would undo
+# the descriptor's own env and let the binary phone home mid-campaign.
+_HERMETIC_ENV = ("DISABLE_AUTOUPDATER", "DISABLE_TELEMETRY", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
+_FALSEY = {"0", "false", "off", "no", ""}
+
+cleanup_whitelist = (
+    "claude/.claude.json",
+    "claude/statsig",
+    "claude/todos",
+    "claude/shell-snapshots",
+)
+
+
+def finalize_render(files: dict[str, str]) -> dict[str, str]:
+    config = json.loads(files[_CONFIG_PATH])
+    if config.get("includeCoAuthoredBy") is True:
+        raise RenderError("claude composition must keep includeCoAuthoredBy false for benchmark episodes")
+    env = config.get("env")
+    if isinstance(env, dict):
+        for key in _HERMETIC_ENV:
+            if key in env and str(env[key]).strip().lower() in _FALSEY:
+                raise RenderError(f"claude composition must not re-enable {key} for benchmark episodes")
+    return files

--- a/reef/harness/trajectory.py
+++ b/reef/harness/trajectory.py
@@ -155,6 +155,38 @@ class PiSessionReader(TrajectoryReader):
 
 
 @register_trajectory_reader
+class ClaudeSessionReader(TrajectoryReader):
+    """Read Claude Code session JSONL trees: every ``*.jsonl`` under ``path``.
+
+    Claude Code writes one transcript per session under
+    ``CLAUDE_CONFIG_DIR/projects/<cwd-slug>/<session-id>.jsonl``, one event
+    object per line. Sorting by relative path orders sessions by their
+    project slug and id; the reader tolerates one torn final line per file,
+    the residue a crash mid-write leaves behind.
+    """
+
+    format = "claude-session-jsonl"
+
+    def __call__(self, path: Path) -> tuple[dict[str, Any], ...]:
+        events: list[dict[str, Any]] = []
+        for file in sorted(Path(path).rglob("*.jsonl")):
+            lines = file.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    if index == len(lines) - 1:
+                        break  # torn tail from a crash mid-write; the event never landed
+                    raise TrajectoryError(f"claude session {file} has a corrupt event at line {index + 1}") from exc
+                if not isinstance(event, dict):
+                    raise TrajectoryError(f"claude session {file} line {index + 1} is not an event object")
+                events.append(event)
+        return tuple(events)
+
+
+@register_trajectory_reader
 class OpencodeStorageReader(TrajectoryReader):
     """Read opencode storage JSON trees: every ``*.json`` under ``path``.
 
@@ -180,4 +212,5 @@ class OpencodeStorageReader(TrajectoryReader):
 
 # Module-level instances for backward-compatible call syntax.
 read_pi_session = PiSessionReader()
+read_claude_session = ClaudeSessionReader()
 read_opencode_storage = OpencodeStorageReader()

--- a/tests/reef_service/data/harness_goldens/claude/claude/CLAUDE.md
+++ b/tests/reef_service/data/harness_goldens/claude/claude/CLAUDE.md
@@ -1,0 +1,3 @@
+Answer briefly.
+
+Prefer the standard library.

--- a/tests/reef_service/data/harness_goldens/claude/claude/commands/summarize.md
+++ b/tests/reef_service/data/harness_goldens/claude/claude/commands/summarize.md
@@ -1,0 +1,1 @@
+Summarize $1.

--- a/tests/reef_service/data/harness_goldens/claude/claude/plugins/tracer/index.js
+++ b/tests/reef_service/data/harness_goldens/claude/claude/plugins/tracer/index.js
@@ -1,0 +1,1 @@
+export default function tracer() {}

--- a/tests/reef_service/data/harness_goldens/claude/claude/settings.json
+++ b/tests/reef_service/data/harness_goldens/claude/claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "defaultModel": "qwen/qwen3-8b",
+  "defaultProvider": "qwen",
+  "includeCoAuthoredBy": false
+}

--- a/tests/reef_service/data/harness_goldens/claude/claude/skills/notes/SKILL.md
+++ b/tests/reef_service/data/harness_goldens/claude/claude/skills/notes/SKILL.md
@@ -1,0 +1,3 @@
+# Notes skill
+
+Keep short notes.

--- a/tests/reef_service/test_harness_episode.py
+++ b/tests/reef_service/test_harness_episode.py
@@ -14,7 +14,13 @@ import pytest
 from reef.harness.adapters import get_adapter
 from reef.harness.episode import EpisodeError, run_episode
 from reef.harness.render import render_composition
-from reef.harness.trajectory import TrajectoryError, read_opencode_storage, read_pi_session, reader_for
+from reef.harness.trajectory import (
+    TrajectoryError,
+    read_claude_session,
+    read_opencode_storage,
+    read_pi_session,
+    reader_for,
+)
 
 PI_FAKE = """\
 #!/usr/bin/env python3
@@ -131,6 +137,29 @@ def test_pi_reader_parses_a_captured_real_session() -> None:
     final = events[-1]["message"]
     assert final["role"] == "assistant"
     assert final["content"] == [{"type": "text", "text": "READY"}]
+
+
+def test_claude_reader_reads_nested_sessions_in_path_order(tmp_path: Path) -> None:
+    # Claude Code lays sessions out as projects/<cwd-slug>/<session-id>.jsonl.
+    first = tmp_path / "projects" / "proj-a" / "01.jsonl"
+    second = tmp_path / "projects" / "proj-a" / "02.jsonl"
+    first.parent.mkdir(parents=True)
+    first.write_text('{"type": "user"}\n')
+    second.write_text('{"type": "assistant"}\n')
+    assert [event["type"] for event in read_claude_session(tmp_path)] == ["user", "assistant"]
+
+
+def test_claude_reader_tolerates_exactly_one_torn_tail(tmp_path: Path) -> None:
+    session = tmp_path / "session.jsonl"
+    session.write_text('{"type": "user"}\n{"type": "assistant"\n')  # crash mid-write
+    assert [event["type"] for event in read_claude_session(tmp_path)] == ["user"]
+    session.write_text('{"type": "user"\n{"type": "assistant"}\n')  # torn in the middle: corruption
+    with pytest.raises(TrajectoryError, match="corrupt event at line 1"):
+        read_claude_session(tmp_path)
+
+
+def test_claude_format_resolves_through_reader_for() -> None:
+    assert reader_for("claude-session-jsonl").format == "claude-session-jsonl"
 
 
 def test_missing_trajectory_reads_as_empty(tmp_path: Path) -> None:

--- a/tests/reef_service/test_harness_render.py
+++ b/tests/reef_service/test_harness_render.py
@@ -52,6 +52,11 @@ def test_opencode_render_matches_the_golden_tree() -> None:
     assert render_composition(nodes, get_adapter("opencode")) == golden_tree("opencode")
 
 
+def test_claude_render_matches_the_golden_tree() -> None:
+    nodes = [node for node in NODES if node[1].get("target") != "models"]
+    assert render_composition(nodes, get_adapter("claude")) == golden_tree("claude")
+
+
 def test_config_nodes_deep_merge_in_tree_order() -> None:
     files = render_composition(
         [
@@ -81,5 +86,12 @@ def test_opencode_quirk_rejects_reopened_autoupdate() -> None:
         render_composition([("config", {"data": {"autoupdate": True}})], get_adapter("opencode"))
 
 
+def test_claude_quirk_rejects_reopened_hermetic_switches() -> None:
+    with pytest.raises(RenderError, match="includeCoAuthoredBy"):
+        render_composition([("config", {"data": {"includeCoAuthoredBy": True}})], get_adapter("claude"))
+    with pytest.raises(RenderError, match="DISABLE_AUTOUPDATER"):
+        render_composition([("config", {"data": {"env": {"DISABLE_AUTOUPDATER": "0"}}})], get_adapter("claude"))
+
+
 def test_bundled_adapters_are_discoverable() -> None:
-    assert set(available_adapters()) >= {"opencode", "pi"}
+    assert set(available_adapters()) >= {"claude", "opencode", "pi"}


### PR DESCRIPTION
## What this adds

Reef can already evolve a harness tree for `opencode` and `pi`, but there's no adapter for Claude Code. A Claude Code user can't currently have their skills, `CLAUDE.md`, and slash commands improved through the `harness_evolve` loop. This adds a `claude` adapter next to the two existing ones.

## How it works

- **Config relocation.** The descriptor points `CLAUDE_CONFIG_DIR` at the episode root, so a run never reads from or writes to the user's real `~/.claude` and the directory-trust prompt never fires. `DISABLE_AUTOUPDATER`, `DISABLE_TELEMETRY`, and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` keep episodes deterministic. `-p --output-format json` is the headless mode; `--permission-mode bypassPermissions` is the non-interactive equivalent of trusting the isolated root, the same role `--auto` plays for opencode.
- **Node mapping.** Rules render to `CLAUDE.md`, skills to `skills/<name>/SKILL.md`, commands to `commands/<name>.md`. `code_extension` maps to a plugin entry file; activating a plugin still needs a settings/marketplace reference, so I've treated it as the least-used node kind and left a note in the descriptor. Skills, commands, and rules carry the harness.
- **Model binding.** Claude Code speaks the Anthropic Messages API, so only the `anthropic` dialect is bound. It redirects the client at Reef's endpoint through `settings.json`'s `env` block; Reef's endpoint is Anthropic-compatible at `{base_url}/v1/messages`. I didn't add an `openai` binding because Claude Code doesn't consume that format.
- **Trajectory.** Claude Code writes one JSONL transcript per session under `projects/<cwd-slug>/<session-id>.jsonl`, one event per line — the same shape pi uses. The `claude-session-jsonl` reader mirrors `PiSessionReader`, including the one-torn-final-line tolerance for a crash mid-write.
- **Quirks.** The module whitelists Claude Code's boot state (`.claude.json`, `statsig/`, `todos/`, `shell-snapshots/`) and rejects a composition that re-enables any of the hermetic switches the descriptor sets.

## Tests

Added a golden render tree and cases mirroring the pi/opencode ones: render match, the quirk guard, the reader's nested-session ordering and torn-tail handling, and format resolution. `available_adapters()` now expects `claude` too.

```
pytest tests/reef_service/test_harness_render.py tests/reef_service/test_harness_episode.py
26 passed
```

Ran the same on a clean checkout under Python 3.12 to confirm the descriptor packages and loads from an installed tree. I did not exercise a live episode driving the real `claude` binary against a `reef serve` endpoint (needs a served model); the render, trajectory, and quirk paths are covered by the tests above.

## AI disclosure

Per CONTRIBUTING, disclosing tool use: I built this with Claude Code and reviewed every line. The adapter follows the existing opencode/pi descriptors; happy to adjust the `code_extension` mapping or the hermetic-env quirk if you'd model them differently.
