### PR TITLE
docs: add the standard header README to each weight recipe package

### DIFF
--- a/recipes/openclawrl/README.md
+++ b/recipes/openclawrl/README.md
@@ -3,7 +3,7 @@
 Reproduction of [OpenClaw-RL](https://arxiv.org/abs/2603.10165)'s personal-agent experiment as a Reef weight-training recipe. OpenClaw-RL trains an agent from its ordinary usage: each turn is scored by what the user did next, a follow-up that moves on counts as acceptance and a complaint as rejection, and the policy updates while it keeps serving. The agent only has to use Reef as its inference endpoint; the package holds the method, and the simulated-student experiment around it lives in [examples/openclawrl](examples/openclawrl/README.md).
 
 - Paper: [arXiv:2603.10165](https://arxiv.org/abs/2603.10165)
-- Pins: the repo's `third_party/slime` submodule for training; the completed run used a Qwen3-4B thinking student, a hermes-agent image pinned to a commit in the example's Dockerfile, and a 72-session GSM8K homework stream
+- Pins: `slime` pinned to `THUDM/slime@41014d1f29e201137fdffce737bb8bac65bc5219` (via `pyproject.toml` `dependency-groups.runtime`); the completed run used `Qwen3-4B-Thinking-2507` as the policy and PRM, `Qwen3-32B` as the student, and `hermes-agent@b6bcb3e791c673e63974029bbab40cc9326803ff` (see the example Dockerfiles), over a 72-session GSM8K homework stream
 - Claim scope: one recorded run over the first 36 sessions of the stream. The run reached the paper's adaptation criterion, three passed sessions in a row, at session 14, and the bold and list rates fall over the run. One student persona, one task family; this is an adaptation result, not a benchmark-wide reproduction.
 
 ## Layout

--- a/recipes/openclawrl/README.md
+++ b/recipes/openclawrl/README.md
@@ -1,0 +1,24 @@
+# openclawrl
+
+Reproduction of [OpenClaw-RL](https://arxiv.org/abs/2603.10165)'s personal-agent experiment as a Reef weight-training recipe. OpenClaw-RL trains an agent from its ordinary usage: each turn is scored by what the user did next, a follow-up that moves on counts as acceptance and a complaint as rejection, and the policy updates while it keeps serving. The agent only has to use Reef as its inference endpoint; the package holds the method, and the simulated-student experiment around it lives in [examples/openclawrl](examples/openclawrl/README.md).
+
+- Paper: [arXiv:2603.10165](https://arxiv.org/abs/2603.10165)
+- Pins: the repo's `third_party/slime` submodule for training; the completed run used a Qwen3-4B thinking student, a hermes-agent image pinned to a commit in the example's Dockerfile, and a 72-session GSM8K homework stream
+- Claim scope: one recorded run over the first 36 sessions of the stream. The run reached the paper's adaptation criterion, three passed sessions in a row, at session 14, and the bold and list rates fall over the run. One student persona, one task family; this is an adaptation result, not a benchmark-wide reproduction.
+
+## Layout
+
+```text
+openclawrl/
+  recipe.py        OpenClawRLRecipe: training spec, loss family "openclawrl"
+  processor.py     computed feedback: rebuilds sessions from recorded traffic, judges turns
+  preparer.py      builds the policy batch from accepted turns and hindsight hints
+  sessions.py      session reconstruction from the records Reef already keeps
+  prm.py           the PRM judge the processor runs on a private worker
+  slime/           the training-plane objective and the hint-conditioned teacher
+  examples/openclawrl/  the runnable experiment: student simulator, Harbor sessions, results
+```
+
+## Where the rest is documented
+
+[The openclawrl recipe page](../../docs/user-guide/recipes/openclawrl.rst) covers configuration and the serving stack, and the [example README](examples/openclawrl/README.md) records implementation details, the stream protocol, and the recorded run.

--- a/recipes/sao/README.md
+++ b/recipes/sao/README.md
@@ -1,0 +1,22 @@
+# sao
+
+Reproduction of [Single-Rollout Asynchronous Optimization](https://arxiv.org/abs/2607.07508) as a Reef weight-training recipe. SAO trains on one graded rollout at a time: there is no comparison group and no barrier, a rollout enters training the moment its score arrives, and the next request is served by the updated weights. The package holds the method; the loop that drives it lives in [examples/sao](examples/sao/README.md).
+
+- Paper: [arXiv:2607.07508](https://arxiv.org/abs/2607.07508)
+- Pins: the repo's `third_party/slime` submodule for training; the completed comparison ran Qwen3-30B-A3B on three IMOAnswerBench problems with 48 scored rollouts per run
+- Claim scope: the mean rewards order as the paper predicts at the paper's model scale, SAO at 0.479 above the untrained base at 0.458 above a GRPO(+DIS) control at 0.417. Three problems, one run each; this is an ordering result, not a benchmark-wide reproduction.
+
+## Layout
+
+```text
+sao/
+  recipe.py       SAORecipe: training spec, loss family "sao", runtime binding
+  processor.py    reported feedback, singleton: one scored rollout is one unit
+  preparer.py     builds the per-rollout policy batch for the driver
+  slime/          the training-plane objective: DIS ratio, colocated critic
+  examples/sao/   the runnable loop: Harbor tasks, agent, serve.yaml, results
+```
+
+## Where the rest is documented
+
+[The sao recipe page](../../docs/user-guide/recipes/sao.rst) covers configuration and runtime metrics, [Evolve your model](../../docs/user-guide/evolve-your-model.rst) walks the training stack, and the [example README](examples/sao/README.md) records implementation details, distance from the paper's protocol, and the completed comparison.

--- a/recipes/sao/README.md
+++ b/recipes/sao/README.md
@@ -3,7 +3,7 @@
 Reproduction of [Single-Rollout Asynchronous Optimization](https://arxiv.org/abs/2607.07508) as a Reef weight-training recipe. SAO trains on one graded rollout at a time: there is no comparison group and no barrier, a rollout enters training the moment its score arrives, and the next request is served by the updated weights. The package holds the method; the loop that drives it lives in [examples/sao](examples/sao/README.md).
 
 - Paper: [arXiv:2607.07508](https://arxiv.org/abs/2607.07508)
-- Pins: the repo's `third_party/slime` submodule for training; the completed comparison ran Qwen3-30B-A3B on three IMOAnswerBench problems with 48 scored rollouts per run
+- Pins: `slime` pinned to `THUDM/slime@41014d1f29e201137fdffce737bb8bac65bc5219` (via `pyproject.toml` `dependency-groups.runtime`); the completed comparison ran `Qwen3-30B-A3B-Thinking-2507` on three IMOAnswerBench problems with 48 scored rollouts per run
 - Claim scope: the mean rewards order as the paper predicts at the paper's model scale, SAO at 0.479 above the untrained base at 0.458 above a GRPO(+DIS) control at 0.417. Three problems, one run each; this is an ordering result, not a benchmark-wide reproduction.
 
 ## Layout

--- a/recipes/tttd/README.md
+++ b/recipes/tttd/README.md
@@ -3,7 +3,7 @@
 Reproduction of [Learning to Discover at Test Time](https://arxiv.org/abs/2601.16175) as a Reef weight-training recipe. TTT-Discover makes repeated attempts at one hard problem at test time: rollouts arrive as a fixed grid of sibling attempts, the step trains on the whole group, and the next grid runs on the weights it produced. The package holds the method; the search loop that drives it lives in [examples/tttd](examples/tttd/README.md).
 
 - Paper: [arXiv:2601.16175](https://arxiv.org/abs/2601.16175)
-- Pins: the repo's `third_party/slime` submodule for training; the completed run used `Qwen/Qwen3-8B` with thinking, rank-32 LoRA, the paper's Adam learning rate, and the Erdos minimum-overlap task
+- Pins: `slime` pinned to `THUDM/slime@41014d1f29e201137fdffce737bb8bac65bc5219` (via `pyproject.toml` `dependency-groups.runtime`); the completed run used `Qwen/Qwen3-8B` with thinking, rank-32 LoRA, Adam lr `4e-5`, and the Erdos minimum-overlap task
 - Claim scope: a result-level reproduction of the paper's Qwen3-8B Erdos experiment at half its rollout budget (eight groups of 32 against the paper's 64 per group). 50 steps in about 22.6 hours on one four-B200 node reached a best certified C5 upper bound of 0.380916 against 0.380932 in the paper's Table 2.
 
 ## Layout

--- a/recipes/tttd/README.md
+++ b/recipes/tttd/README.md
@@ -1,0 +1,24 @@
+# tttd
+
+Reproduction of [Learning to Discover at Test Time](https://arxiv.org/abs/2601.16175) as a Reef weight-training recipe. TTT-Discover makes repeated attempts at one hard problem at test time: rollouts arrive as a fixed grid of sibling attempts, the step trains on the whole group, and the next grid runs on the weights it produced. The package holds the method; the search loop that drives it lives in [examples/tttd](examples/tttd/README.md).
+
+- Paper: [arXiv:2601.16175](https://arxiv.org/abs/2601.16175)
+- Pins: the repo's `third_party/slime` submodule for training; the completed run used `Qwen/Qwen3-8B` with thinking, rank-32 LoRA, the paper's Adam learning rate, and the Erdos minimum-overlap task
+- Claim scope: a result-level reproduction of the paper's Qwen3-8B Erdos experiment at half its rollout budget (eight groups of 32 against the paper's 64 per group). 50 steps in about 22.6 hours on one four-B200 node reached a best certified C5 upper bound of 0.380916 against 0.380932 in the paper's Table 2.
+
+## Layout
+
+```text
+tttd/
+  recipe.py        TTTDRecipe: training spec, loss family "tttd", grid configuration
+  processor.py     reported feedback, grouped: the step is the full grid of sibling attempts
+  preparer.py      builds the grouped policy batch for the driver
+  report.py        TTTDGroupedRolloutReport, the declared report schema
+  slime/           the training-plane objective: the grouped entropic loss
+  examples/tttd/   the runnable search: Harbor tasks, PUCT archive, serve.yaml, results
+  examples/guidance_ttt/  the summary-only guidance variant on the same recipe
+```
+
+## Where the rest is documented
+
+[The tttd recipe page](../../docs/user-guide/recipes/tttd.rst) covers the runtime sequence, a reduced smoke, and recovery behavior, and the [example README](examples/tttd/README.md) records implementation details, paper fidelity, and the completed reproduction.


### PR DESCRIPTION
## Motivation

RFC #56 requires a standard header on every recipe README: the paper link, the exact pins, and the claim scope. skillclaw carries one; sao, tttd, and openclawrl had no package README at all, with their anchors buried in the example READMEs. This is the last unfinished item of the RFC besides recipes/gepa, which #47 tracks.

## Changes

- Add recipes/sao/README.md, recipes/tttd/README.md, and recipes/openclawrl/README.md, each with the paper link, the pins the completed run used, and an explicit claim scope stating what the reproduction shows and what it does not
- Each README carries the package layout and points to the docs recipe page and the example README instead of duplicating them

## Compatibility and operational impact

None. New documentation files only.

## Verification

Every claim is copied from the corresponding example README or docs recipe page (SAO ordering result 0.479/0.458/0.417 on Qwen3-30B-A3B; TTTD best certified bound 0.380916 against the paper's 0.380932 at half the rollout budget; OpenClawRL adaptation at session 14 over the first 36 sessions). check:docs validates all 119 Markdown files including the three new ones, and every relative link was resolved against the tree. pre-commit clean.

## AI assistance

Claude Code wrote the READMEs from the recorded results. I reviewed the diff.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
