### PR TITLE
feat: report last committed training step in status

### DIFF
--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -232,6 +232,11 @@ an update is being trained or published.
      "scenarios": {
        "hello-reef": {
          "scenario_step": 3,
+         "last_committed_step": {
+           "step": 3,
+           "recorded_at": 1756400000.0,
+           "metrics": {"published": false, "selection": {"reason": "candidate lost"}}
+         },
          "current_runtime_load_id": "7f2a:12",
          "checkpoint_storage": {"...": "..."},
          "batch_ready": false,
@@ -244,6 +249,14 @@ an update is being trained or published.
 
 ``error`` and ``preload_errors`` report asynchronous training and preload
 failures. ``batch_ready`` says whether the processor has a batch waiting.
+``last_committed_step`` reports the latest durable training step number,
+commit time, and its recipe-owned metrics; it is ``null`` before the first
+training commit. This distinguishes a step still in flight from a completed
+step that skipped or rejected its candidate. A rollback advances
+``scenario_step`` without replacing the latest training outcome. A deployment
+without an agent-record directory has no historical commit log, so after a
+restart from a rollback checkpoint this field is ``null`` until the next
+training commit.
 ``serving`` is runtime-wide but recipe-shaped: a LoRA deployment reports the
 engine's shared adapter residency there, keyed by recipe. Each scenario's
 ``adapter_runtime_load_id`` appears in its own ``scenarios`` block.

--- a/docs/user-guide/operate.rst
+++ b/docs/user-guide/operate.rst
@@ -18,7 +18,7 @@ Check health and status
    curl -f "$REEF_URL/healthz"
    curl -sS -H "Authorization: Bearer $REEF_TOKEN" "$REEF_URL/reef/status"
 
-``/healthz`` answers as soon as the HTTP service is up; it says nothing about training. ``/reef/status`` is the training side: the last asynchronous error, model preload failures, and for every scenario its step counter, the runtime load ID being served, checkpoint storage state, whether a batch is waiting, the processor's state, and whether inference is admitted or paused for a weight update. It is the first place to look when requests keep being served by an old version.
+``/healthz`` answers as soon as the HTTP service is up; it says nothing about training. ``/reef/status`` is the training side: the last asynchronous error, model preload failures, and for every scenario its step counter, latest committed step outcome, runtime load ID being served, checkpoint storage state, whether a batch is waiting, the processor's state, and whether inference is admitted or paused for a weight update. The committed outcome includes the recipe-owned metrics, so a skipped or rejected update is distinguishable from one that is still running. It is the first place to look when requests keep being served by an old version.
 
 The service and every process ``reef serve`` started write logs under ``run_dir`` (``/tmp/reef-stack/`` by default), one ``<service>.log`` and one ``<service>.pid`` each.
 

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -393,11 +393,15 @@ class Dispatcher:
             while self._process_local_backend_step(scenario):
                 pass
         except Exception as exc:
-            # Keep the in-memory pending batch intact. A later record wakes
-            # this worker to retry it; replacing the scenario here could lose
-            # records in deployments that intentionally use an in-memory store.
             logger.exception("local backend failed to commit for scenario %r", scenario)
             self._record_training_error(scenario, self._error_text(exc))
+
+    def _reload_durable_local_scenario(self, scenario: str, current: Scenario) -> None:
+        if current.commit_log is None:
+            return
+        with self._registry.lock_for(scenario):
+            if self._registry.get_optional(scenario) is current:
+                self._registry.reload(scenario)
 
     def _process_local_backend_step(self, scenario: str) -> bool:
         current = self._registry.get_optional(scenario)
@@ -406,10 +410,30 @@ class Dispatcher:
         if current.trainer.training_backend is None:
             raise RuntimeContractError(f"scenario {scenario!r} has no local backend")
         self._record_training_error(scenario, None)
-        result = current.prepare_training_step()
+        try:
+            result = current.prepare_training_step()
+        except Exception:
+            # Durable records let recovery reconstruct the reserved batch. A
+            # logless deployment must retain its in-memory pending batch for a
+            # later wake instead.
+            self._reload_durable_local_scenario(scenario, current)
+            raise
         if result is None:
             return False
-        self._commit_result(scenario, result)
+        # Keep only the short commit and recovery window under the scenario
+        # registry lock. Candidate generation above can take minutes and must
+        # not block record acceptance for this scenario.
+        with self._registry.lock_for(scenario):
+            if self._registry.get_optional(scenario) is not current:
+                raise RuntimeContractError(f"local backend scenario {scenario!r} changed before commit")
+            try:
+                self._commit_result(scenario, result)
+            except Exception:
+                # A record may already have crossed the fsync commit point.
+                # Reload before rollback or acceptance can observe the stale
+                # in-memory step and append the same step number again.
+                self._reload_durable_local_scenario(scenario, current)
+                raise
         return True
 
     def _run_training(self) -> None:
@@ -589,7 +613,7 @@ class Dispatcher:
     @property
     def training_status(self) -> Mapping[str, Any]:
         name = self._registry.training_scenario_name
-        names = self._training_scenario_names()
+        names = self._registry.training_status_scenario_names
         preload_errors = self._registry.preload_errors
         with self._training.lock:
             storage_status = self._training.storage_status
@@ -606,7 +630,7 @@ class Dispatcher:
                     if batch_ready:
                         self._warn_if_undrained(scenario_name, last_drain)
                     block: dict[str, Any] = {
-                        "scenario_step": current.scenario_step,
+                        **current.commit_status,
                         # A version is current only after Reef commits its head
                         # and reopens admission. The backend may report it
                         # earlier while the update is still being published.

--- a/reef/scenario/commit_log.py
+++ b/reef/scenario/commit_log.py
@@ -31,6 +31,7 @@ import json
 import os
 import time
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -103,7 +104,7 @@ class CommitRecord:
         self.rollback_target_release_id = rollback_target_release_id
         if metrics is not None and not isinstance(metrics, Mapping):
             raise CommitLogError("commit record metrics must be an object or null")
-        self.metrics = None if metrics is None else dict(metrics)
+        self.metrics = None if metrics is None else deepcopy(dict(metrics))
         if training_job_id is not None and (not isinstance(training_job_id, str) or not training_job_id):
             raise CommitLogError("commit record training_job_id must be a non-empty string or null")
         if operation != "training" and training_job_id is not None:
@@ -133,7 +134,7 @@ class CommitRecord:
         if not self.operation_verified:
             value["operation_verified"] = False
         if self.metrics is not None:
-            value["metrics"] = self.metrics
+            value["metrics"] = deepcopy(self.metrics)
         if self.training_job_id is not None:
             value["training_job_id"] = self.training_job_id
         return value

--- a/reef/scenario/commit_protocol.py
+++ b/reef/scenario/commit_protocol.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 from threading import RLock
 from typing import Any
@@ -54,6 +55,7 @@ class ScenarioCommitProtocol:
         trainer: Trainer,
         scenario_step: int = 0,
         commit_log: CommitLog | None = None,
+        recovered_head_record: CommitRecord | None = None,
     ) -> None:
         if not isinstance(scenario_step, int) or scenario_step < 0:
             raise ValueError("scenario_step must be non-negative")
@@ -66,6 +68,16 @@ class ScenarioCommitProtocol:
         self._commit_log = commit_log
         self._creation_artifact = self._resolve_creation_artifact()
         self._lock = RLock()
+        records = (
+            (() if recovered_head_record is None else (recovered_head_record,))
+            if commit_log is None
+            else commit_log.records()
+        )
+        self._latest_training_record = next(
+            (record for record in reversed(records) if record.operation == "training"),
+            None,
+        )
+        self._commit_status_snapshot = (scenario_step, self._latest_training_record)
 
     @property
     def lock(self) -> RLock:
@@ -87,10 +99,28 @@ class ScenarioCommitProtocol:
     def step(self) -> int:
         return self._step
 
+    @property
+    def commit_status(self) -> Mapping[str, Any]:
+        """Current step and latest training outcome from one non-blocking snapshot."""
+        step, record = self._commit_status_snapshot
+        return {
+            "scenario_step": step,
+            "last_committed_step": (
+                None
+                if record is None
+                else {
+                    "step": record.step,
+                    "recorded_at": record.recorded_at,
+                    "metrics": None if record.metrics is None else deepcopy(record.metrics),
+                }
+            ),
+        }
+
     def advance_to(self, step: int) -> None:
         if step != self._step + 1:
             raise ValueError(f"scenario step must advance from {self._step} to {self._step + 1}")
         self._step = step
+        self._commit_status_snapshot = (step, self._latest_training_record)
 
     def releases(self) -> tuple[dict[str, Any], ...]:
         """List committed releases newest first."""
@@ -327,9 +357,7 @@ class ScenarioCommitProtocol:
         prepared: PreparedCommit,
         operation: str = "training",
         rollback_target_release_id: str | None = None,
-    ) -> CommitRecord | None:
-        if self._commit_log is None:
-            return None
+    ) -> CommitRecord:
         record = CommitRecord(
             scenario=self._name,
             step=step,
@@ -345,7 +373,10 @@ class ScenarioCommitProtocol:
             metrics=prepared.metrics,
             training_job_id=prepared.training_job_id,
         )
-        self._commit_log.append(record)
+        if self._commit_log is not None:
+            self._commit_log.append(record)
+        if record.operation == "training":
+            self._latest_training_record = record
         return record
 
     def _find_release_id(self, release_id: str) -> tuple[ArtifactRef, bool] | None:
@@ -468,6 +499,7 @@ class ScenarioCommitProtocol:
         snapshot_record_progress: RecordProgress | None,
         checkpoint_head: ArtifactRef,
         snapshot_training_job_id: str | None = None,
+        snapshot_metrics: Mapping[str, Any] | None = None,
         snapshot_operation: str | None = None,
         snapshot_rollback_target_release_id: str | None = None,
     ) -> CommitRecord | None:
@@ -520,6 +552,7 @@ class ScenarioCommitProtocol:
                 operation=snapshot_operation or "training",
                 operation_verified=snapshot_operation is not None,
                 rollback_target_release_id=snapshot_rollback_target_release_id,
+                metrics=snapshot_metrics,
                 training_job_id=snapshot_training_job_id,
             )
             if commit_log is not None:

--- a/reef/scenario/factory.py
+++ b/reef/scenario/factory.py
@@ -243,6 +243,7 @@ class ScenarioFactory:
             snapshot_state=snapshot.algorithm_state,
             snapshot_record_progress=snapshot.record_progress,
             snapshot_training_job_id=snapshot.training_job_id,
+            snapshot_metrics=snapshot.metrics,
             snapshot_operation=snapshot.operation,
             snapshot_rollback_target_release_id=snapshot.rollback_target_release_id,
             checkpoint_head=checkpoint_head,
@@ -279,6 +280,7 @@ class ScenarioFactory:
             scenario_step=head.step,
             algorithm_state=head.algorithm_state,
             commit_log=commit_log,
+            recovered_head_record=head_record,
         )
         # Derive the record store and trainer progress from the recovered
         # head: re-apply any compaction the crash interrupted, rebuild
@@ -316,6 +318,7 @@ class ScenarioFactory:
         scenario_step: int = 0,
         algorithm_state: Mapping[str, Any] | None = None,
         commit_log: CommitLog | None = None,
+        recovered_head_record: CommitRecord | None = None,
     ) -> Scenario:
         database = None
         if self._agent_record_dir is not None:
@@ -357,6 +360,7 @@ class ScenarioFactory:
             trainer=trainer,
             scenario_step=scenario_step,
             commit_log=commit_log,
+            recovered_head_record=recovered_head_record,
         )
 
     @staticmethod

--- a/reef/scenario/registry.py
+++ b/reef/scenario/registry.py
@@ -87,6 +87,19 @@ class ScenarioRegistry:
             return tuple(self._training_scenarios)
 
     @property
+    def training_status_scenario_names(self) -> tuple[str, ...]:
+        """Every loaded scenario with a local or dispatched training backend."""
+        with self._lock:
+            scenarios = tuple(self._scenarios.values())
+            dispatched = tuple(self._training_scenarios)
+        local = tuple(
+            scenario.name
+            for scenario in scenarios
+            if scenario.name not in dispatched and scenario.trainer.training_backend is not None
+        )
+        return (*dispatched, *local)
+
+    @property
     def preload_errors(self) -> dict[str, str]:
         with self._lock:
             return dict(self._preload_errors)

--- a/reef/scenario/scenario.py
+++ b/reef/scenario/scenario.py
@@ -14,7 +14,7 @@ from reef.runtime.base import InferenceRuntime
 from reef.runtime.inference import InferenceBackend
 from reef.scenario.binding import ScenarioBinding
 from reef.scenario.checkpoint_strategy import CheckpointStrategy
-from reef.scenario.commit_log import CommitLog
+from reef.scenario.commit_log import CommitLog, CommitRecord
 from reef.scenario.commit_protocol import ScenarioCommitProtocol
 from reef.scenario.snapshot import SCENARIO_SNAPSHOT_METADATA_KEY, snapshot_metadata_for
 from reef.surface.base import Surface
@@ -38,6 +38,7 @@ class Scenario:
         scenario_step: int = 0,
         process_id: str | None = None,
         commit_log: CommitLog | None = None,
+        recovered_head_record: CommitRecord | None = None,
     ) -> None:
         self._name = name
         self._binding = binding
@@ -53,6 +54,7 @@ class Scenario:
             trainer=trainer,
             scenario_step=scenario_step,
             commit_log=commit_log,
+            recovered_head_record=recovered_head_record,
         )
 
     @property
@@ -145,6 +147,11 @@ class Scenario:
     def commit_log(self) -> CommitLog | None:
         """The commit protocol's durable journal, for read-only inspection."""
         return self._commit_protocol.commit_log
+
+    @property
+    def commit_status(self) -> Mapping[str, Any]:
+        """The non-blocking step and durable training-outcome snapshot."""
+        return self._commit_protocol.commit_status
 
     @property
     def committed_training_job_id(self) -> str | None:

--- a/reef/scenario/snapshot.py
+++ b/reef/scenario/snapshot.py
@@ -12,6 +12,7 @@ snapshot summarizes the last checkpointed one.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any
@@ -76,6 +77,7 @@ class ScenarioSnapshot:
     training_job_id: str | None = None
     operation: str | None = None
     rollback_target_release_id: str | None = None
+    metrics: Mapping[str, Any] | None = None
 
 
 def snapshot_metadata_for(
@@ -118,6 +120,8 @@ def snapshot_metadata_for(
         }
         if prepared.training_job_id is not None:
             metadata["training_job_id"] = prepared.training_job_id
+        if prepared.metrics is not None:
+            metadata["metrics"] = deepcopy(dict(prepared.metrics))
     return metadata
 
 
@@ -154,6 +158,11 @@ def parse_snapshot_metadata(value: Mapping[str, Any]) -> ScenarioSnapshot:
     training_job_id = value.get("training_job_id")
     if training_job_id is not None and (not isinstance(training_job_id, str) or not training_job_id):
         raise ValueError("scenario snapshot training_job_id must be a non-empty string or null")
+    metrics = value.get("metrics")
+    if metrics is not None:
+        if not isinstance(metrics, Mapping):
+            raise ValueError("scenario snapshot metrics must be an object or null")
+        metrics = MappingProxyType(deepcopy(dict(metrics)))
     operation = value.get("operation")
     rollback_target_release_id = value.get("rollback_target_release_id")
     if operation is not None and operation not in ("training", "rollback"):
@@ -173,6 +182,7 @@ def parse_snapshot_metadata(value: Mapping[str, Any]) -> ScenarioSnapshot:
         algorithm_state=algorithm_state,
         record_progress=record_progress,
         training_job_id=training_job_id,
+        metrics=metrics,
         operation=operation,
         rollback_target_release_id=rollback_target_release_id,
     )

--- a/reef/train/trainer.py
+++ b/reef/train/trainer.py
@@ -206,19 +206,25 @@ class Trainer:
                 return None
             if self._pending is not None:
                 result = self._pending.result
-                if result is None:
-                    raise RuntimeError("inline trainer has a pending batch without a result")
-                return result
-            self._consume_data()
-            if not self._processor.ready():
-                return None
-            batch = self._build_validated_batch()
-            execution = self._execute_backend_step(batch, scenario_step)
-            if execution.outcome != "commit" or execution.result is None:
-                raise RuntimeError(f"inline training backend returned {execution.outcome!r}")
-            result = execution.result
-            self._pending = _PendingStep(batch=batch, result=result)
-            return result
+                if result is not None:
+                    return result
+                batch = self._pending.batch
+            else:
+                self._consume_data()
+                if not self._processor.ready():
+                    return None
+                batch = self._build_validated_batch()
+                self._pending = _PendingStep(batch=batch, result=None)
+        # Local candidate generation and evaluation can take minutes. Keep the
+        # batch reserved, but release the trainer lock so status remains live.
+        execution = self._execute_backend_step(batch, scenario_step)
+        if execution.outcome != "commit" or execution.result is None:
+            raise RuntimeError(f"inline training backend returned {execution.outcome!r}")
+        with self._lock:
+            if self._pending is None or self._pending.batch_id != batch.batch_id:
+                raise RuntimeError("inline trainer reservation changed while its backend was executing")
+            self._pending.result = execution.result
+            return execution.result
 
     def _execute_backend_step(self, batch: TrainingBatch, scenario_step: int) -> StepExecution:
         backend = self._training_backend

--- a/tests/reef_service/test_artifact_versions.py
+++ b/tests/reef_service/test_artifact_versions.py
@@ -172,6 +172,7 @@ def test_versions_are_wal_backed_and_rollback_appends_a_new_commit(tmp_path) -> 
     assert all(version["restorable"] for version in before)
     assert before[-1]["release_id"] == created
     target_version = before[-2]["release_id"]
+    last_training_step = value.training_status["scenarios"]["math"]["last_committed_step"]
 
     published = value.rollback("math", target_version)
 
@@ -185,6 +186,9 @@ def test_versions_are_wal_backed_and_rollback_appends_a_new_commit(tmp_path) -> 
     assert record.operation == "rollback"
     assert record.rollback_target_release_id == target_version
     assert record.artifact_ref == published
+    status = value.training_status["scenarios"]["math"]
+    assert status["scenario_step"] == 4
+    assert status["last_committed_step"] == last_training_step
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_async_pipeline_core.py
+++ b/tests/reef_service/test_async_pipeline_core.py
@@ -339,6 +339,9 @@ def test_two_jobs_form_one_deterministic_release_chain(start_dispatcher) -> None
 def test_training_result_metrics_reach_the_durable_commit(start_dispatcher) -> None:
     metrics = {"staleness/samples_fresh": 1, "staleness/samples_admitted_stale": 0}
     _, dispatcher = start_dispatcher(complete_metrics=metrics)
+    dispatcher.get_or_create_scenario("math", "test_policy")
+
+    assert dispatcher.training_status["scenarios"]["math"]["last_committed_step"] is None
 
     _submit_pair(dispatcher)
     _wait_for_step(dispatcher, 1)
@@ -348,6 +351,13 @@ def test_training_result_metrics_reach_the_durable_commit(start_dispatcher) -> N
     assert committed is not None
     assert {key: committed[key] for key in metrics} == metrics
     assert committed["selection"]["outcome"] == "select"
+    status = dispatcher.training_status["scenarios"]["math"]["last_committed_step"]
+    assert status["step"] == 1
+    assert isinstance(status["recorded_at"], float)
+    assert status["metrics"] == committed
+    status["metrics"]["selection"]["outcome"] = "mutated by caller"
+    refreshed = dispatcher.training_status["scenarios"]["math"]["last_committed_step"]
+    assert refreshed["metrics"]["selection"]["outcome"] == "select"
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_commit_log.py
+++ b/tests/reef_service/test_commit_log.py
@@ -46,6 +46,7 @@ def sample_record(
     runtime_load_id: str = "w1",
     checkpoint: bool = False,
     training_job_id: str | None = None,
+    metrics: dict | None = None,
 ) -> CommitRecord:
     return CommitRecord(
         scenario="math",
@@ -63,6 +64,7 @@ def sample_record(
         compacted_ids=frozenset({f"i{step}"}),
         recorded_at=1000.0 + step,
         training_job_id=training_job_id,
+        metrics=metrics,
     )
 
 
@@ -93,13 +95,23 @@ def test_commit_record_round_trips_gate_metrics(tmp_path) -> None:
     log = CommitLog(tmp_path / "commits.jsonl")
     log.append(sample_record(step=1))
     metrics = {"changed": "config/format.json", "wins": 3, "losses": 1, "ties": 0, "published": True}
-    record = sample_record(step=2, runtime_load_id="w2")
-    record.metrics = dict(metrics)
-    log.append(record)
+    log.append(sample_record(step=2, runtime_load_id="w2", metrics=metrics))
 
     first, second = CommitLog(tmp_path / "commits.jsonl").records()
     assert first.metrics is None  # pre-metrics records stay readable
     assert second.metrics == metrics
+
+
+@pytest.mark.unit
+def test_commit_record_detaches_nested_metrics() -> None:
+    metrics = {"selection": {"outcome": "select"}}
+    record = sample_record(metrics=metrics)
+
+    metrics["selection"]["outcome"] = "mutated source"
+    encoded = record.to_dict()
+    encoded["metrics"]["selection"]["outcome"] = "mutated encoding"
+
+    assert record.metrics == {"selection": {"outcome": "select"}}
 
 
 @pytest.mark.unit
@@ -609,6 +621,9 @@ def test_recovery_adopts_a_checkpoint_whose_record_was_lost(tmp_path) -> None:
     first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
     wait_for_step(first, 1)
     assert first.get_or_create_scenario("math").scenario_step == 1
+    committed = first.training_status["scenarios"]["math"]["last_committed_step"]
+    assert committed["step"] == 1
+    assert committed["metrics"]["selected"] is True
 
     # Simulate the crash: the log loses its last (only) record.
     path = commit_log_path(agent_record_dir)
@@ -635,6 +650,10 @@ def test_recovery_adopts_a_checkpoint_whose_record_was_lost(tmp_path) -> None:
     assert adopted.training_job_id == "job-0"
     assert adopted.operation == "training"
     assert adopted.operation_verified is True
+    assert adopted.metrics == committed["metrics"]
+    recovered_status = second.training_status["scenarios"]["math"]["last_committed_step"]
+    assert recovered_status["step"] == 1
+    assert recovered_status["metrics"] == committed["metrics"]
 
 
 @pytest.mark.unit
@@ -727,6 +746,9 @@ def test_no_commit_log_without_an_agent_record_dir(tmp_path) -> None:
     wait_for_step(first, 1)
 
     assert first.get_or_create_scenario("math").commit_log is None
+    committed = first.training_status["scenarios"]["math"]["last_committed_step"]
+    assert committed["step"] == 1
+    assert committed["metrics"]["selected"] is True
     assert not list(tmp_path.rglob("*.commits.jsonl"))
 
     # Recovery still works from the release chain: the live head is forgotten, as
@@ -734,7 +756,42 @@ def test_no_commit_log_without_an_agent_record_dir(tmp_path) -> None:
     second = build_training_dispatcher(RecordingRuntime(), tmp_path, backend_factory)
     recovered = second.get_or_create_scenario("math", "test_policy")
     assert recovered.scenario_step == 0
+    assert second.training_status["scenarios"]["math"]["last_committed_step"] is None
     assert not isinstance(recovered.repository.require_current_artifact(), LiveWeightArtifactRef)
+
+
+@pytest.mark.unit
+def test_checkpoint_status_metrics_survive_without_a_commit_log(tmp_path) -> None:
+    initial = tmp_path / "initial"
+    initial.mkdir()
+    backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
+    runtime = RecordingRuntime()
+    runtime._checkpoint_dir = tmp_path / "exported"
+    first = build_training_dispatcher(
+        runtime,
+        tmp_path,
+        backend_factory,
+        checkpoint_strategy=EveryNVersions(1),
+    )
+    first.accept_record(sft_inference("i1"), recipe="test_policy")
+    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    wait_for_step(first, 1)
+    committed = first.training_status["scenarios"]["math"]["last_committed_step"]
+
+    second = build_training_dispatcher(
+        RecordingRuntime(),
+        tmp_path,
+        backend_factory,
+        checkpoint_strategy=EveryNVersions(1),
+    )
+    recovered = second.get_or_create_scenario("math", "test_policy")
+
+    assert recovered.scenario_step == 1
+    assert recovered.commit_log is None
+    recovered_status = second.training_status["scenarios"]["math"]["last_committed_step"]
+    assert recovered_status["step"] == 1
+    assert recovered_status["metrics"] == committed["metrics"]
+    assert not list(tmp_path.rglob("*.commits.jsonl"))
 
 
 @dataclass(frozen=True)
@@ -870,8 +927,25 @@ def test_harness_growth_does_not_block_acceptance_or_other_scenarios(tmp_path) -
     request = Thread(target=accept_report)
     request.start()
     assert started.wait(1)
+    status_values = []
+    status_returned = Event()
+
+    def read_status() -> None:
+        try:
+            status_values.append(dispatcher.training_status)
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            status_returned.set()
+
+    status_request = Thread(target=read_status)
+    status_request.start()
     try:
         assert returned.wait(0.1), "report acceptance waited for harness growth"
+        assert status_returned.wait(0.5), "status waited for harness growth"
+        status = status_values[0]["scenarios"]["skills-a"]
+        assert status["scenario_step"] == 0
+        assert status["last_committed_step"] is None
         dispatcher.accept_record(trace_inference("b-i1", scenario="skills-b"), recipe="harness_evolve")
         dispatcher.accept_record(
             trace_report("b-r1", "b-i1", scenario="skills-b"),
@@ -881,6 +955,7 @@ def test_harness_growth_does_not_block_acceptance_or_other_scenarios(tmp_path) -
     finally:
         release.set()
         request.join()
+        status_request.join()
 
     assert errors == []
     scenario = dispatcher.get_or_create_scenario("skills-a")
@@ -925,6 +1000,94 @@ def test_local_backend_failure_reaches_status_and_retries_pending_batch(tmp_path
     wait_for_step(dispatcher, 1, scenario="skills")
     assert calls == failed_attempts + 1
     assert dispatcher.training_status["error"] is None
+    dispatcher.close()
+
+
+@pytest.mark.unit
+def test_durable_local_backend_recovers_after_post_commit_compaction_failure(tmp_path) -> None:
+    initial = tmp_path / "initial"
+    (initial / "skills").mkdir(parents=True)
+    (initial / "skills" / "SKILL.md").write_text("skill v0", encoding="utf-8")
+    agent_record_dir = tmp_path / "agent-record"
+    backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
+    dispatcher = build_harness_evolve_dispatcher(
+        None,
+        tmp_path,
+        backend_factory,
+        agent_record_dir=agent_record_dir,
+    )
+    original = dispatcher.get_or_create_scenario("skills", "harness_evolve")
+    assert original is not None
+    rollback_target = original.current_artifact_ref().release_id
+    compaction_failed = Event()
+    reload_started = Event()
+    allow_reload = Event()
+    reload_scenario = dispatcher._registry.reload
+
+    def fail_compaction(self, compacted_ids) -> None:
+        del self, compacted_ids
+        compaction_failed.set()
+        raise RuntimeError("simulated failure after commit record append")
+
+    def blocking_reload(scenario: str):
+        reload_started.set()
+        assert allow_reload.wait(1)
+        return reload_scenario(scenario)
+
+    original.trainer.apply_compaction = fail_compaction.__get__(original.trainer, Trainer)
+    dispatcher._registry.reload = blocking_reload
+    dispatcher.accept_record(trace_inference("i1"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_report("r1", "i1"), recipe="harness_evolve")
+
+    assert compaction_failed.wait(1)
+    assert reload_started.wait(1)
+    rollback_started = Event()
+    rollback_returned = Event()
+    rollback_errors: list[Exception] = []
+
+    def rollback() -> None:
+        rollback_started.set()
+        try:
+            dispatcher.rollback("skills", rollback_target)
+        except Exception as exc:
+            rollback_errors.append(exc)
+        finally:
+            rollback_returned.set()
+
+    rollback_thread = Thread(target=rollback)
+    rollback_thread.start()
+    assert rollback_started.wait(1)
+    try:
+        assert not rollback_returned.wait(0.05), "rollback entered before durable recovery"
+    finally:
+        allow_reload.set()
+    rollback_thread.join(1)
+    assert not rollback_thread.is_alive()
+    assert rollback_errors == []
+
+    wait_for_step(dispatcher, 1, scenario="skills")
+    recovered = dispatcher.get_or_create_scenario("skills")
+    assert recovered is not original
+    assert recovered.records.get("skills", "i1") is None
+    assert recovered.records.get("skills", "r1") is None
+    status = dispatcher.training_status["scenarios"]["skills"]
+    assert status["scenario_step"] == 1
+    assert status["last_committed_step"]["step"] == 1
+    assert status["last_committed_step"]["metrics"]["skipped"] == "no proposal"
+    log = CommitLog(commit_log_path(agent_record_dir, scenario="skills"))
+    records = log.records()
+    assert [record.step for record in records] == [1]
+    assert records[0].metrics is not None
+    assert records[0].metrics["skipped"] == "no proposal"
+
+    dispatcher.accept_record(trace_inference("i2"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_report("r2", "i2"), recipe="harness_evolve")
+    wait_for_step(dispatcher, 2, scenario="skills")
+
+    assert [record.step for record in log.records()] == [1, 2]
+    status = dispatcher.training_status["scenarios"]["skills"]
+    assert status["scenario_step"] == 2
+    assert status["last_committed_step"]["step"] == 2
     dispatcher.close()
 
 
@@ -979,11 +1142,15 @@ def test_no_artifact_commit_survives_a_restart(tmp_path) -> None:
     first.accept_record(trace_report("r1", "i1"), recipe="harness_evolve")
     wait_for_step(first, 1, scenario="skills")
     assert first.get_or_create_scenario("skills").scenario_step == 1
+    committed = first.training_status["scenarios"]["skills"]["last_committed_step"]
+    assert committed["step"] == 1
+    assert committed["metrics"]["skipped"] == "no proposal"
 
     second = build_harness_evolve_dispatcher(None, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
     recovered = second.get_or_create_scenario("skills", "harness_evolve")
     assert recovered.scenario_step == 1
     assert recovered.trainer.state["steps"] == 1
+    assert second.training_status["scenarios"]["skills"]["last_committed_step"] == committed
     # Record progress resumes at the committed watermark, not sequence 0.
     assert recovered.trainer.data_offset == 2
     first.close()

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -210,6 +210,100 @@ async def _gate_step(client: TestClient) -> dict:
 
 
 @pytest.mark.unit
+def test_status_reports_a_committed_step_that_published_no_harness(tmp_path) -> None:
+    async def run() -> None:
+        client = TestClient(TestServer(create_app(_dispatcher(tmp_path, ()), inference_backend=_EchoBackend())))
+        await client.start_server()
+        try:
+            response = await client.get("/reef/status")
+            assert response.status == 200
+            assert (await response.json())["scenarios"]["delivery"]["last_committed_step"] is None
+
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"x-reef-scenario": "delivery"},
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert response.status == 200
+            receipt = response.headers["x-reef-agent-record-id"]
+            response = await client.post(
+                "/reef/report",
+                headers={"x-reef-scenario": "delivery"},
+                json={"score": 0.0, "references": [receipt]},
+            )
+            assert response.status == 200
+
+            deadline = asyncio.get_running_loop().time() + _ASYNC_UPDATE_TIMEOUT_S
+            while True:
+                response = await client.get("/reef/status")
+                assert response.status == 200
+                scenario = (await response.json())["scenarios"]["delivery"]
+                committed = scenario["last_committed_step"]
+                if committed is not None:
+                    break
+                if asyncio.get_running_loop().time() >= deadline:
+                    pytest.fail("no-proposal step did not commit")
+                await asyncio.sleep(_ASYNC_UPDATE_POLL_S)
+
+            assert scenario["scenario_step"] == committed["step"] == 1
+            assert isinstance(committed["recorded_at"], float)
+            assert committed["metrics"]["skipped"] == "no proposal"
+            response = await client.get("/reef/harness", headers={"x-reef-scenario": "delivery"})
+            assert response.status == 404
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
+def test_status_reports_a_committed_gate_rejection(tmp_path) -> None:
+    async def run() -> None:
+        mutation = Mutation("create", "r1", {"name": "rules", "config": {"text": "no help"}})
+        client = TestClient(
+            TestServer(create_app(_dispatcher(tmp_path, (mutation,)), inference_backend=_EchoBackend()))
+        )
+        await client.start_server()
+        try:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"x-reef-scenario": "delivery"},
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert response.status == 200
+            receipt = response.headers["x-reef-agent-record-id"]
+            response = await client.post(
+                "/reef/report",
+                headers={"x-reef-scenario": "delivery"},
+                json={"score": 0.0, "references": [receipt]},
+            )
+            assert response.status == 200
+
+            deadline = asyncio.get_running_loop().time() + _ASYNC_UPDATE_TIMEOUT_S
+            while True:
+                response = await client.get("/reef/status")
+                assert response.status == 200
+                scenario = (await response.json())["scenarios"]["delivery"]
+                committed = scenario["last_committed_step"]
+                if committed is not None:
+                    break
+                if asyncio.get_running_loop().time() >= deadline:
+                    pytest.fail("rejected gate step did not commit")
+                await asyncio.sleep(_ASYNC_UPDATE_POLL_S)
+
+            assert scenario["scenario_step"] == committed["step"] == 1
+            assert committed["metrics"]["published"] is False
+            assert committed["metrics"]["selected"] is False
+            assert committed["metrics"]["selection"]["outcome"] == "reject"
+            response = await client.get("/reef/harness", headers={"x-reef-scenario": "delivery"})
+            assert response.status == 404
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
 def test_pulled_tree_is_byte_identical_to_the_gated_composition(tmp_path) -> None:
     async def run() -> None:
         client = TestClient(

--- a/tests/reef_service/test_training_wait.py
+++ b/tests/reef_service/test_training_wait.py
@@ -47,6 +47,7 @@ def _bind(
     batch_ready: bool = False,
     processor_status: dict | None = None,
     runtime=None,
+    last_committed_step: dict | None = None,
 ) -> None:
     processor = SimpleNamespace(derivation_pending=lambda: pending)
     trainer = SimpleNamespace(
@@ -54,9 +55,15 @@ def _bind(
         batch_ready=lambda: batch_ready,
         processor_status=lambda: dict(processor_status or {}),
     )
-    scenario = SimpleNamespace(trainer=trainer, scenario_step=0, runtime=runtime)
+    scenario = SimpleNamespace(
+        trainer=trainer,
+        scenario_step=0,
+        runtime=runtime,
+        commit_status={"scenario_step": 0, "last_committed_step": last_committed_step},
+    )
     dispatcher._registry = SimpleNamespace(
         training_scenario_name="s",
+        training_status_scenario_names=("s",),
         get_optional=lambda name: scenario if name == "s" else None,
         preload_errors=(),
     )
@@ -97,6 +104,18 @@ def test_status_exposes_the_last_drain_time_and_ready_state() -> None:
     status = dispatcher.training_status
     assert status["last_drain_at"] == drained_at
     assert status["scenarios"]["s"]["batch_ready"] is True
+
+
+def test_status_exposes_the_last_committed_step_outcome() -> None:
+    dispatcher = _dispatcher()
+    committed = {
+        "step": 3,
+        "recorded_at": 1_756_400_000.0,
+        "metrics": {"skipped": "no proposal", "selection": {"reason": "candidate lost"}},
+    }
+    _bind(dispatcher, pending=False, last_committed_step=committed)
+
+    assert dispatcher.training_status["scenarios"]["s"]["last_committed_step"] == committed
 
 
 def test_status_keeps_the_published_version_until_inference_reopens(monkeypatch) -> None:


### PR DESCRIPTION
## Motivation

Closes #69.

Harness clients currently cannot distinguish an evolve step that is still running from one that committed without publishing (for example, a skipped proposal or a rejected candidate): `/reef/harness` returns 404 in all three cases, while `/reef/status` omits local harness scenarios and their committed outcome.

## Changes

- Add an additive `last_committed_step` object to each training scenario in `/reef/status`, containing `step`, `recorded_at`, and the recipe-owned `metrics`; it is `null` before the first training commit.
- Include loaded local training backends as well as dispatched training runtimes in status.
- Cache an atomic, O(1) scenario-step/outcome snapshot so polling does not rescan the WAL and cannot pair a new step with an older outcome.
- Keep status responsive during long local candidate generation/evaluation, while retaining scenario-level serialization for commit and rollback.
- Preserve the last training outcome across restart, checkpoint-log healing, and rollback; detach nested metrics at persistence and response boundaries.
- Recover durable local scenarios after a post-WAL commit failure so a later wake cannot append a duplicate step.
- Document the public contract and cover null, skip, real gate rejection, selected metrics, in-flight responsiveness, restart, rollback, logless operation, and failure recovery.

## Compatibility and operational impact

The HTTP change is additive. Existing fields are unchanged, and `scenarios` can now also contain loaded scenarios backed by local trainers. Scenario snapshot metadata gains an optional `metrics` field; older snapshots remain valid.

Inline/local evaluation now reserves its batch and runs outside the trainer lock so read-only status remains responsive. The scenario commit lock still excludes rollback and duplicate execution, and the short commit/recovery window is serialized by the per-scenario registry lock. After a durable local failure, Reef reloads from the WAL; deployments without a commit log retain their existing in-memory pending-batch retry behavior.

Each scenario retains one latest training record in memory, and status deep-copies that record's metrics for the response. No configuration or dependency changes are required. A logless restart from a rollback checkpoint cannot recover earlier training history; the reference docs now state that `last_committed_step` is then `null` until the next training commit.

## Verification

- `pre-commit run --all-files --show-diff-on-failure` — passed all hooks.
- `python -m mypy` — success across 174 source files.
- `PYTHONPATH="../slime-src:." python -m pytest -q tests/ --deselect=tests/reef_service/test_harness_episode.py::test_pi_episode_collects_exit_stdout_and_trajectory --deselect=tests/reef_service/test_harness_episode.py::test_opencode_episode_whitelists_boot_mutations_and_reports_residue --deselect=tests/reef_service/test_reef_git_lfs.py::test_fresh_scenario_forks_latest_artifact_with_real_lfs --deselect=tests/reef_service/test_slime_bridge.py::test_bridge_catalogs_paired_checkpoint_metrics_and_blocks_before_second_optimizer` — 1,616 passed, 3 skipped. The deselected checks require Git LFS, a filesystem above Reef's free-space floor, or Linux-style Python cache behavior on this macOS host.
- `python -m pytest -q tests/reef_service/test_commit_log.py tests/reef_service/test_async_pipeline_core.py tests/reef_service/test_reef_scenarios.py tests/reef_service/test_artifact_versions.py` — 55 passed against the final tree.
- `npm run check:docs && npm run lint && npm run build` — passed; generated all 35 documentation pages.
- `git diff --check` — passed after rebasing onto the current `main`.

## AI assistance

OpenAI Codex assisted with repository and issue triage, implementation, test design, fault-injection review, and validation. Multiple independent Codex review agents audited the final concurrency, durability, API, and documentation changes; no review blockers remained before submission.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
