### PR TITLE
docs: skip Vercel builds outside main

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -2,12 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "npm run build",
-  "git": {
-    "deploymentEnabled": {
-      "*": false,
-      "main": true
-    }
-  },
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "redirects": [
     {
       "source": "/docs/concepts",


### PR DESCRIPTION
## Summary

- replace the ineffective `deploymentEnabled` wildcard with an ignored-build command
- skip Vercel builds for every branch except `main`
- keep production builds running after merges to `main`

## Validation

- parsed `docs/site/vercel.json` with `jq`
- verified the ignore command exits 1 for `main` and 0 for a feature branch
- ran `git diff --check`