### PR TITLE
Make SSE framing incremental

### DIFF
--- a/reef/service/routes/inference.py
+++ b/reef/service/routes/inference.py
@@ -66,7 +66,15 @@ def register_inference_routes(
                         if terminal is not None:
                             break
                     if terminal is None:
-                        remainder = decoder.finish()
+                        final_frames, remainder = decoder.finalize()
+                        for frame in final_frames:
+                            if is_terminal_sse_event(request.path, frame):
+                                terminal = frame
+                                break
+                            if not chat_identity:
+                                chat_identity = chat_completion_chunk_identity(frame)
+                            await response.write(frame)
+                    if terminal is None:
                         if remainder:
                             await response.write(remainder)
                         error = "upstream SSE ended without a terminal event"

--- a/reef/service/streaming.py
+++ b/reef/service/streaming.py
@@ -11,29 +11,70 @@ from reef.runtime.inference import InferenceStream
 class SSEFrameDecoder:
     """Split arbitrarily chunked SSE bytes without changing event bytes."""
 
-    _SEPARATORS = (b"\r\n\r\n", b"\n\n", b"\r\r")
+    _CR = ord("\r")
+    _LF = ord("\n")
 
     def __init__(self) -> None:
         self._buffer = bytearray()
+        self._after_line_end = False
+        self._pending_cr = False
+        self._pending_frame = False
 
     def feed(self, chunk: bytes) -> tuple[bytes, ...]:
-        self._buffer.extend(chunk)
         frames: list[bytes] = []
-        while True:
-            boundaries = tuple(
-                (index, separator) for separator in self._SEPARATORS if (index := self._buffer.find(separator)) >= 0
-            )
-            if not boundaries:
-                return tuple(frames)
-            index, separator = min(boundaries, key=lambda boundary: boundary[0])
-            end = index + len(separator)
-            frames.append(bytes(self._buffer[:end]))
-            self._buffer[:end] = b""
+        for value in chunk:
+            # A CR that ends an empty line may still be the first byte of CRLF.
+            # Delay that frame until the following byte makes the choice clear.
+            if self._pending_frame:
+                if value == self._LF:
+                    self._buffer.append(value)
+                    frames.append(self._take_frame())
+                    continue
+                frames.append(self._take_frame())
+
+            self._buffer.append(value)
+            if self._pending_cr:
+                self._pending_cr = False
+                if value == self._LF:
+                    continue
+
+            if value == self._CR:
+                self._pending_frame = self._after_line_end
+                self._after_line_end = True
+                self._pending_cr = True
+            elif value == self._LF:
+                if self._after_line_end:
+                    frames.append(self._take_frame())
+                else:
+                    self._after_line_end = True
+            else:
+                self._after_line_end = False
+        return tuple(frames)
+
+    def finalize(self) -> tuple[tuple[bytes, ...], bytes]:
+        """Resolve a trailing CR at EOF and return complete frames plus remainder."""
+
+        frames = (bytes(self._buffer),) if self._pending_frame else ()
+        remainder = b"" if frames else bytes(self._buffer)
+        self._reset()
+        return frames, remainder
 
     def finish(self) -> bytes:
-        remainder = bytes(self._buffer)
-        self._buffer.clear()
-        return remainder
+        """Return every byte not already emitted, including a final complete frame."""
+
+        frames, remainder = self.finalize()
+        return b"".join(frames) + remainder
+
+    def _take_frame(self) -> bytes:
+        frame = bytes(self._buffer)
+        self._reset()
+        return frame
+
+    def _reset(self) -> None:
+        self._buffer = bytearray()
+        self._after_line_end = False
+        self._pending_cr = False
+        self._pending_frame = False
 
 
 def _sse_data(frame: bytes) -> str:

--- a/tests/reef_service/test_reef_contracts.py
+++ b/tests/reef_service/test_reef_contracts.py
@@ -441,8 +441,8 @@ def test_http_app_forwards_inference_stream_before_upstream_finishes(tmp_path) -
 
         from aiohttp import web
 
-        first_chunk = b'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n'
-        final_chunk = b"data: [DONE]\n\n"
+        first_chunk = b'data: {"choices":[{"delta":{"content":"hello"}}]}\r\n\n'
+        final_chunk = b"data: [DONE]\n\r"
         finish_upstream = asyncio.Event()
         received = {}
 

--- a/tests/reef_service/test_skill_delivery.py
+++ b/tests/reef_service/test_skill_delivery.py
@@ -99,6 +99,42 @@ def test_sse_frame_decoder_finds_split_openai_terminator_and_builds_receipt_chun
     assert terminal == b"data: [DONE]\n\n"
 
 
+def test_sse_frame_decoder_accepts_mixed_line_endings_across_single_byte_chunks() -> None:
+    separators = (
+        b"\r\n\r\n",
+        b"\r\n\r",
+        b"\r\n\n",
+        b"\r\r\n",
+        b"\r\r",
+        b"\n\r\n",
+        b"\n\r",
+        b"\n\n",
+    )
+
+    for separator in separators:
+        decoder = SSEFrameDecoder()
+        frames: list[bytes] = []
+        expected = b"data: value" + separator
+        for value in expected:
+            frames.extend(decoder.feed(bytes((value,))))
+        final_frames, remainder = decoder.finalize()
+        frames.extend(final_frames)
+
+        assert frames == [expected]
+        assert remainder == b""
+
+
+def test_sse_frame_decoder_preserves_multiple_frames_and_unfinished_bytes() -> None:
+    decoder = SSEFrameDecoder()
+
+    assert decoder.feed(b"data: one\r\n\ndata: two\n\r\ndata: unfinished") == (
+        b"data: one\r\n\n",
+        b"data: two\n\r\n",
+    )
+    assert decoder.finish() == b"data: unfinished"
+    assert decoder.finish() == b""
+
+
 def test_anthropic_receipt_is_attached_to_message_stop() -> None:
     terminal = b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
     assert is_terminal_sse_event("/v1/messages", terminal)


### PR DESCRIPTION
## Motivation

Closes #120.

`SSEFrameDecoder.feed()` rescanned the complete incomplete-event buffer for every transport fragment, making highly fragmented streams approach quadratic CPU cost. Its three literal separator searches also covered only uniform SSE line endings and could split a valid mixed `CR + CRLF` terminator before its final LF.

## Changes

- Replace repeated separator searches and front-buffer mutation with a single-pass incremental line-ending state machine.
- Treat CRLF as one line ending while accepting lone CR, lone LF, and every valid mixed event terminator without changing frame bytes.
- Resolve a trailing CR at EOF before classifying the provider terminal event.
- Cover every line-ending combination under single-byte fragmentation, unfinished remainders, and the HTTP streaming/receipt path.

## Compatibility and operational impact

Previously supported streams retain byte-identical wire output. Valid mixed-line-ending streams are now framed correctly. There are no configuration, persistence, dependency, or deployment changes. Decoder CPU work now scales linearly with received bytes; buffering remains limited to the current incomplete frame.

## Verification

- `python -m pre_commit run --files reef/service/streaming.py reef/service/routes/inference.py tests/reef_service/test_skill_delivery.py tests/reef_service/test_reef_contracts.py` — passed, including the Python design and assert/del statement policies.
- `python -m mypy reef/service/streaming.py reef/service/routes/inference.py` — passed.
- `python -m pytest tests/reef_service/test_skill_delivery.py tests/reef_service/test_reef_contracts.py tests/test_reef_client_serve.py -q` — 59 passed.
- `python -m pytest tests -q` — 1617 passed, 2 skipped; the sole failure was the existing real-LFS integration test because Git LFS is not installed on the local host.
- 50,000 randomized payload/chunk-boundary differential cases against an independent batch parser — passed.
- Single-byte incomplete-event benchmark: 10,000 fragments in 2.85 ms and 50,000 in 14.29 ms on macOS/Python 3.10, approximately linear scaling.

## AI assistance

OpenAI Codex helped analyze the framing complexity, implement the state machine, construct correctness and integration tests, and run the reported verification. The author remains responsible for the submitted change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.
