### PR TITLE
docs: prevent Vercel previews outside main

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -2,6 +2,12 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "npm run build",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
+  },
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "redirects": [
     {


### PR DESCRIPTION
## Summary

- disable automatic Vercel deployments for every non-`main` branch
- use the `**` minimatch pattern so branch names containing `/` are covered
- retain the ignored-build command as a defense-in-depth fallback

## Why

`ignoreCommand` runs only after Vercel accepts and checks out a deployment. Fork PRs hit Git Fork Protection first, which produced an `Authorization required to deploy` failure before the ignore command could run. `git.deploymentEnabled` prevents the preview deployment from being created.

## Validation

- parsed `docs/site/vercel.json` with `jq`
- confirmed the current Vercel schema accepts `git.deploymentEnabled` as a branch-to-boolean map
- verified Minimatch behavior for `main`, simple branch names, and slash-containing branch names
- ran `npm run build` in `docs/site`
- ran `git diff --check`