### PR TITLE
feat: close the deployment signal loop and harden the evolution gate

### DIFF
--- a/docs/developer-guide/processors.rst
+++ b/docs/developer-guide/processors.rst
@@ -151,9 +151,9 @@ Cookbook processors
 |                                             |          | scenario's grid; the step is the group, ready only when every    |                        |
 |                                             |          | ``groups_per_step`` x ``rollouts_per_group`` slot is filled      |                        |
 +---------------------------------------------+----------+------------------------------------------------------------------+------------------------+
-| ``reef/train/cordis_backend/processor.py``  | reported | a trainable, finitely scored report with exactly one reference   | ``TraceBatch``         |
-|                                             |          | and a score inside ``[min_score, max_score]``; the recorded      |                        |
-|                                             |          | request is the sample, unmodified                                |                        |
+| ``reef/train/cordis_backend/processor.py``  | reported | a trainable, finitely scored report referencing at least one     | ``TraceBatch``         |
+|                                             |          | request, scored inside ``[min_score, max_score]``; one reference |                        |
+|                                             |          | is the sample unmodified, several are one trajectory sample      |                        |
 +---------------------------------------------+----------+------------------------------------------------------------------+------------------------+
 | ``recipes/openclawrl/processor.py``         | computed | a main turn whose next state the PRM scores +/-1, or for which   | ``PolicyBatch``        |
 |                                             |          | the teacher scored an accepted hindsight hint                    |                        |

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -164,6 +164,9 @@ zero.
    evolution.tasks | non-empty list of episode prompts, scored once per tree per step
    evolution.adapter | pi | ``opencode``, or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
+   evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
+   evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own
+   evolution.forbid_residue | false | when true, an episode leaving files outside the cleanup whitelist scores as one that could not run
    evolution.seed | entry options loaded into the tree on first boot; recovered state takes precedence
    evolution.models | auxiliary models for the method: ``url``, ``model``, optional ``api`` (default ``openai``) and ``timeout_s``, with the credential as a literal ``api_key`` or an ``api_key_env`` variable name
    evolution.version_check | appends the adapter's update notice; an interactive pulled tree offers to run the update or skip when behind

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -142,8 +142,9 @@ data inside ``metadata`` or ``feedback``.
 | ``feedback``   | string or object | no       | opaque to Reef's core: a rubric, judge    |
 |                |                  |          | output, plain text                        |
 +----------------+------------------+----------+-------------------------------------------+
-| ``references`` | list of strings  | no       | the receipts this report grades; a report |
-|                |                  |          | without them is accepted but never trains |
+| ``references`` | list of strings  | no       | the receipts this report grades; several  |
+|                |                  |          | batch as one trajectory sample, none is   |
+|                |                  |          | accepted but never trains                 |
 +----------------+------------------+----------+-------------------------------------------+
 | ``metadata``   | object           | no       | opaque, except                            |
 |                |                  |          | ``training.eligible`` (default ``true``)  |

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -66,20 +66,22 @@ The loop
    Verdict :: publish the candidate or restore the snapshot
 
 No evolution runs while traffic flows. A report enters the *window* when it
-references exactly one receipt and its score is at or below ``max_score``;
-the default for harness evolution keeps only failures. A report that
-references several receipts never batches, whatever its score. ``reef-pi
-report`` sends every receipt from the last run in one report, so only a run
-with a single model call can trigger a step; report each result against its
-own receipt, as ``run.py`` does. When ``batch_size`` such reports have
-accumulated, one step runs the loop once. ``batch_size`` and ``max_score``
-live under ``data:`` in the recipe config.
+references at least one receipt and its score is at or below ``max_score``;
+the default for harness evolution keeps only failures. A report over one
+receipt batches as that exchange; a report over several batches as one
+trajectory sample carrying every referenced exchange in order, which is what
+``reef-pi report`` sends for a whole run (``--per-receipt`` fans the score
+across the receipts as separate reports instead). When ``batch_size``
+window entries have accumulated, one step runs the loop once. ``batch_size``
+and ``max_score`` live under ``data:`` in the recipe config.
 
-Most of a step's cost is the evaluation. Every task runs twice, once against
-the candidate tree and once against the current one, which makes
-``2 x len(tasks)`` headless episodes. Each episode renders one side into a
-throwaway root, runs the agent binary with the task as its prompt under a
-600 s timeout, reads the trajectory back, and deletes the root.
+Most of a step's cost is the evaluation. Every task runs on both trees,
+``episode_repeats`` times each (once by default), which makes
+``2 x len(tasks) x episode_repeats`` headless episodes, interleaved so both
+sides of a pairing see the same upstream conditions. Each episode renders one
+side into a throwaway root, runs the agent binary with the task as its prompt
+under the ``episode_timeout_s`` limit (600 s by default), reads the
+trajectory back, and deletes the root.
 
 The throwaway root contains nothing except the rendered tree: a fresh working
 directory and a fresh ``HOME``, with no repository and no files from your
@@ -93,13 +95,6 @@ cannot win on a crash, and when both sides fail the step is a tie. When the
 verdict is a rejection, Reef restores the snapshot it took before the
 mutation. Every verdict is recorded in the scenario's commit log together
 with its mutation and both score vectors.
-
-.. note::
-
-   Paired episodes currently run batched by side: all episodes of one tree
-   first, then all of the other. Anything that drifts during the run, such as
-   upstream load or a rate limit, therefore affects one side of the pair more
-   than the other and skews the comparison.
 
 When it fits
 ------------

--- a/reef/harness/harness_wrapper.py
+++ b/reef/harness/harness_wrapper.py
@@ -14,7 +14,8 @@ When invoked with agent arguments (e.g. ``reef-pi -p "fix the bug"``):
 When invoked with ``report`` (e.g. ``reef-pi report --score 0.0 --feedback "..."``):
 
   1. Claims the oldest pending run's persisted receipts.
-  2. POSTs a report to Reef with all captured receipts as ``references``.
+  2. POSTs a report to Reef with all captured receipts as ``references``
+     (one trajectory sample), or one report per receipt with ``--per-receipt``.
   3. Clears the persisted receipts.
 
 Env vars (baked into the wrapper at install time):
@@ -266,7 +267,7 @@ def run_agent(binary: str, compose_dir: str, scenario: str, adapter: str, env_va
     sys.exit(result.returncode)
 
 
-def report(scenario: str, adapter: str, score: float, feedback: str) -> None:
+def report(scenario: str, adapter: str, score: float, feedback: str, per_receipt: bool = False) -> None:
     while True:
         claim = _claim_captures(scenario)
         if claim is None:
@@ -284,7 +285,6 @@ def report(scenario: str, adapter: str, score: float, feedback: str) -> None:
             break
         captures_file.unlink()
 
-    payload = json.dumps({"score": score, "feedback": feedback, "references": receipts}).encode()
     headers: dict[str, str] = {
         "Content-Type": "application/json",
         "x-reef-scenario": scenario,
@@ -293,25 +293,31 @@ def report(scenario: str, adapter: str, score: float, feedback: str) -> None:
     if token:
         headers["authorization"] = f"Bearer {token}"
 
-    req = urllib.request.Request(
-        f"{reef_url}/reef/report",
-        data=payload,
-        headers=headers,
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=30) as response:
-            response.read()
-    except urllib.error.HTTPError as exc:
-        os.replace(captures_file, pending_file)
-        body = exc.read().decode(errors="replace")
-        sys.exit(f"reef-{adapter}: report failed ({exc.code}): {body}")
-    except BaseException:
-        os.replace(captures_file, pending_file)
-        raise
+    # One report referencing the whole run batches as one trajectory sample;
+    # --per-receipt sends the same score against each receipt on its own.
+    reference_lists = [[receipt] for receipt in receipts] if per_receipt else [receipts]
+    for references in reference_lists:
+        payload = json.dumps({"score": score, "feedback": feedback, "references": references}).encode()
+        req = urllib.request.Request(
+            f"{reef_url}/reef/report",
+            data=payload,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                response.read()
+        except urllib.error.HTTPError as exc:
+            os.replace(captures_file, pending_file)
+            body = exc.read().decode(errors="replace")
+            sys.exit(f"reef-{adapter}: report failed ({exc.code}): {body}")
+        except BaseException:
+            os.replace(captures_file, pending_file)
+            raise
 
     captures_file.unlink()
-    print(f"reef-{adapter}: reported {len(receipts)} receipt(s) to {scenario}")
+    mode = "report per receipt" if per_receipt else "one report"
+    print(f"reef-{adapter}: reported {len(receipts)} receipt(s) to {scenario} ({mode})")
 
 
 def main() -> None:
@@ -331,8 +337,13 @@ def main() -> None:
         parser = argparse.ArgumentParser(prog=f"reef-{adapter} report")
         parser.add_argument("--score", type=float, required=True)
         parser.add_argument("--feedback", default="")
+        parser.add_argument(
+            "--per-receipt",
+            action="store_true",
+            help="send one report per captured receipt instead of one for the run",
+        )
         ns = parser.parse_args(args[1:])
-        report(scenario, adapter, ns.score, ns.feedback)
+        report(scenario, adapter, ns.score, ns.feedback, per_receipt=ns.per_receipt)
     else:
         run_agent(binary, compose, scenario, adapter, env_var, args)
 

--- a/reef/harness/harness_wrapper.py
+++ b/reef/harness/harness_wrapper.py
@@ -296,7 +296,16 @@ def report(scenario: str, adapter: str, score: float, feedback: str, per_receipt
     # One report referencing the whole run batches as one trajectory sample;
     # --per-receipt sends the same score against each receipt on its own.
     reference_lists = [[receipt] for receipt in receipts] if per_receipt else [receipts]
-    for references in reference_lists:
+
+    def restore_unsent(sent: int) -> None:
+        # A partial per-receipt failure must not resend what already posted:
+        # the retry claim keeps only the receipts that never went out.
+        posted = {receipt for references in reference_lists[:sent] for receipt in references}
+        data["turns"] = [turn for turn in data["turns"] if turn.get("receipt") not in posted]
+        captures_file.write_text(json.dumps(data), encoding="utf-8")
+        os.replace(captures_file, pending_file)
+
+    for sent, references in enumerate(reference_lists):
         payload = json.dumps({"score": score, "feedback": feedback, "references": references}).encode()
         req = urllib.request.Request(
             f"{reef_url}/reef/report",
@@ -308,11 +317,11 @@ def report(scenario: str, adapter: str, score: float, feedback: str, per_receipt
             with urllib.request.urlopen(req, timeout=30) as response:
                 response.read()
         except urllib.error.HTTPError as exc:
-            os.replace(captures_file, pending_file)
+            restore_unsent(sent)
             body = exc.read().decode(errors="replace")
             sys.exit(f"reef-{adapter}: report failed ({exc.code}): {body}")
         except BaseException:
-            os.replace(captures_file, pending_file)
+            restore_unsent(sent)
             raise
 
     captures_file.unlink()

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -158,10 +158,20 @@ class CordisBackend(TrainingBackend):
         # Checked once at boot: an out-of-tree Proposer subclass whose
         # ``__call__`` predates the manifest keyword is called without it.
         self._propose_accepts_manifest = accepts_manifest(propose.__call__)
+        if (
+            isinstance(episode_timeout_s, bool)
+            or not isinstance(episode_timeout_s, (int, float))
+            or episode_timeout_s <= 0
+        ):
+            raise ValueError("episode_timeout_s must be a positive number")
+        if isinstance(episode_repeats, bool) or not isinstance(episode_repeats, int) or episode_repeats < 1:
+            raise ValueError("episode_repeats must be an integer of at least 1")
+        if not isinstance(forbid_residue, bool):
+            raise ValueError("forbid_residue must be a boolean")
         self._binary = binary
         self._episode_timeout_s = float(episode_timeout_s)
-        self._episode_repeats = int(episode_repeats)
-        self._forbid_residue = bool(forbid_residue)
+        self._episode_repeats = episode_repeats
+        self._forbid_residue = forbid_residue
         self._seed = tuple(dict(entry) for entry in seed)
         self._validate_seed()
 

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -133,6 +133,9 @@ class CordisBackend(TrainingBackend):
         tasks: tuple[str, ...],
         models: ModelBindings | ModelBinding,
         binary: str | None = None,
+        episode_timeout_s: float = 600.0,
+        episode_repeats: int = 1,
+        forbid_residue: bool = False,
         seed: tuple[Mapping[str, Any], ...] = (),
     ) -> None:
         if not tasks:
@@ -156,6 +159,9 @@ class CordisBackend(TrainingBackend):
         # ``__call__`` predates the manifest keyword is called without it.
         self._propose_accepts_manifest = accepts_manifest(propose.__call__)
         self._binary = binary
+        self._episode_timeout_s = float(episode_timeout_s)
+        self._episode_repeats = int(episode_repeats)
+        self._forbid_residue = bool(forbid_residue)
         self._seed = tuple(dict(entry) for entry in seed)
         self._validate_seed()
 
@@ -277,10 +283,19 @@ class CordisBackend(TrainingBackend):
         # so the published artifact carries no endpoint or credential.
         candidate_files = self._render_for_episode(candidate.candidate_entries)
         current_files = self._render_for_episode(candidate.current_entries)
-        candidate_runs = tuple(self._run_and_score(candidate_files, task) for task in self._tasks)
-        current_runs = tuple(self._run_and_score(current_files, task) for task in self._tasks)
-        candidate_scores = tuple(score for score, _ in candidate_runs)
-        current_scores = tuple(score for score, _ in current_runs)
+        # Episodes interleave candidate and current inside each pairing, so
+        # anything that drifts during the run (upstream load, rate limits)
+        # lands on both sides of a pair instead of one whole side. A repeat
+        # is one more pairing of the same task; the selector compares the
+        # vectors positionally, so every pairing tallies on its own.
+        candidate_runs: list[tuple[float | None, FailureObservation | None, int]] = []
+        current_runs: list[tuple[float | None, FailureObservation | None, int]] = []
+        for task in self._tasks:
+            for _ in range(self._episode_repeats):
+                candidate_runs.append(self._run_and_score(candidate_files, task))
+                current_runs.append(self._run_and_score(current_files, task))
+        candidate_scores = tuple(score for score, _, _ in candidate_runs)
+        current_scores = tuple(score for score, _, _ in current_runs)
         return EvaluationResult(
             evaluator="harness_episode_pairs",
             evaluator_version="1",
@@ -289,9 +304,12 @@ class CordisBackend(TrainingBackend):
                 "current_scores": current_scores,
                 # Failure observations ride the evaluation so settlement can
                 # build the committed side's manifest from the decision alone.
-                "candidate_failures": tuple(f.to_dict() for _, f in candidate_runs if f is not None),
-                "current_failures": tuple(f.to_dict() for _, f in current_runs if f is not None),
+                "candidate_failures": tuple(f.to_dict() for _, f, _ in candidate_runs if f is not None),
+                "current_failures": tuple(f.to_dict() for _, f, _ in current_runs if f is not None),
                 "episode_failures": sum(score is None for score in candidate_scores + current_scores),
+                "episode_repeats": self._episode_repeats,
+                "candidate_residue": sum(residue for _, _, residue in candidate_runs),
+                "current_residue": sum(residue for _, _, residue in current_runs),
                 "candidate_score": float(sum(score for score in candidate_scores if score is not None)),
                 "current_score": float(sum(score for score in current_scores if score is not None)),
             },
@@ -376,25 +394,34 @@ class CordisBackend(TrainingBackend):
             raise TypeError(f"harness evaluation requires HarnessCandidate, got {type(candidate).__name__}")
         return candidate
 
-    def _run_and_score(self, files: Mapping[str, str], task: str) -> tuple[float | None, FailureObservation | None]:
+    def _run_and_score(
+        self, files: Mapping[str, str], task: str
+    ) -> tuple[float | None, FailureObservation | None, int]:
         """Score one side's episode; a ``None`` score marks an episode that
         could not run. The observation keeps what the exception handling
         would otherwise discard: the failure's stage and cause. A nonzero
-        exit still scores, as before, and is observed alongside the score."""
+        exit still scores, as before, and is observed alongside the score.
+        The third element counts files the episode left outside the cleanup
+        whitelist; with ``forbid_residue`` a littering episode scores as one
+        that could not run."""
         try:
-            result = run_episode(self._descriptor, files, task, binary=self._binary)
+            result = run_episode(self._descriptor, files, task, binary=self._binary, timeout=self._episode_timeout_s)
         except EpisodeError as error:
-            return None, FailureObservation(task=task, stage="launch", cause=str(error))
+            return None, FailureObservation(task=task, stage="launch", cause=str(error)), 0
         except TrajectoryError as error:
-            return None, FailureObservation(task=task, stage="trajectory", cause=str(error))
+            return None, FailureObservation(task=task, stage="trajectory", cause=str(error)), 0
+        residue = len(result.residue)
+        if residue and self._forbid_residue:
+            cause = f"{residue} file(s) outside the cleanup whitelist: {result.residue[0]}"
+            return None, FailureObservation(task=task, stage="residue", cause=cause), residue
         score = float(self._score_episode(task, result))
         if not math.isfinite(score):
             raise ValueError(f"episode scorer returned a non-finite score {score!r} for task {task!r}")
         if result.exit_code != 0:
             stderr_lines = result.stderr.strip().splitlines()
             cause = f"exit {result.exit_code}: {stderr_lines[-1] if stderr_lines else ''}".strip()
-            return score, FailureObservation(task=task, stage="exit", cause=cause)
-        return score, None
+            return score, FailureObservation(task=task, stage="exit", cause=cause), residue
+        return score, None, residue
 
     def _render_for_episode(self, entries: Sequence[Mapping[str, Any]]) -> dict[str, str]:
         return render_composition((*self._nodes_from(entries), *self._binding_nodes), self._descriptor)

--- a/reef/train/cordis_backend/processor.py
+++ b/reef/train/cordis_backend/processor.py
@@ -19,7 +19,9 @@ class CordisProcessor(ReportedFeedbackProcessor):
     Requests are recorded post-transform, so a trace shows exactly what the
     backend served. A score window in config selects which traces batch —
     harness evolution's ``max_score`` bound keeps only failures — and reports
-    outside it are terminal and release their records. The backends consume
+    outside it are terminal and release their records. A report may reference
+    one request or a whole run's worth; several references become one
+    trajectory sample. The backends consume
     the resulting trace batches without adding processor logic.
     """
 
@@ -42,23 +44,29 @@ class CordisProcessor(ReportedFeedbackProcessor):
         score = context.score
         if score is None:
             raise RuntimeError("eligible harness report has no score")
-        # 2. A trace outside the window, or one claiming more than a single
-        #    request, is terminal before its reference resolves — so both
-        #    records release immediately.
-        if len(context.references) != 1 or not self._min_score <= score <= self._max_score:
+        # 2. A trace outside the window, or one referencing nothing, is
+        #    terminal before any reference resolves — the records release
+        #    immediately.
+        if not context.references or not self._min_score <= score <= self._max_score:
             return NEVER
-        # 3. Park until the referenced request record arrives.
+        # 3. Park until every referenced request record arrives.
         if gate is not None:
             return gate
         if context.inferences is None:
             raise RuntimeError("resolved harness report has no inference")
-        inference = context.inferences[0]
-        # 4. The recorded request itself is the sample, unmodified.
+        # 4. The recorded requests themselves are the sample, unmodified: one
+        #    reference is a single-exchange sample, several are one trajectory
+        #    sample in reference order.
+        last = context.inferences[-1]
         return ReportDecision.train(
             TraceSample(
-                source_agent_record_id=inference.agent_record_id,
-                payload=inference.payload,
+                source_agent_record_id=last.agent_record_id,
+                payload=last.payload,
                 score=score,
+                feedback=context.report.payload.get("feedback"),
+                trajectory=(
+                    tuple(record.payload for record in context.inferences) if len(context.inferences) > 1 else ()
+                ),
             )
         )
 

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -127,6 +127,9 @@ class CordisRecipe(Recipe):
     tasks: tuple[str, ...]
     adapter: str = "pi"
     binary: str | None = None
+    episode_timeout_s: float = 600.0
+    episode_repeats: int = 1
+    forbid_residue: bool = False
     seed: tuple[Mapping[str, Any], ...] = ()
     model_name: str | None = None
     models: Mapping[str, ModelBinding] = field(default_factory=dict)
@@ -148,6 +151,10 @@ class CordisRecipe(Recipe):
             raise ValueError("harness evolution requires tasks")
         if self.batch_size <= 0:
             raise ValueError("batch_size must be positive")
+        if self.episode_timeout_s <= 0:
+            raise ValueError("episode_timeout_s must be positive")
+        if self.episode_repeats < 1:
+            raise ValueError("episode_repeats must be at least 1")
         if not callable(getattr(self.candidate_selector, "decide", None)):
             raise ValueError("candidate_selector must provide decide(candidate, evaluation)")
 
@@ -162,6 +169,15 @@ class CordisRecipe(Recipe):
         binary = evolution.get("binary")
         if binary is not None and (not isinstance(binary, str) or not binary):
             raise RecipeConfigError("evolution.binary must be a non-empty string when set")
+        timeout = evolution.get("episode_timeout_s", 600.0)
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or timeout <= 0:
+            raise RecipeConfigError("evolution.episode_timeout_s must be a positive number")
+        repeats = evolution.get("episode_repeats", 1)
+        if isinstance(repeats, bool) or not isinstance(repeats, int) or repeats < 1:
+            raise RecipeConfigError("evolution.episode_repeats must be an integer of at least 1")
+        forbid_residue = evolution.get("forbid_residue", False)
+        if not isinstance(forbid_residue, bool):
+            raise RecipeConfigError("evolution.forbid_residue must be a boolean")
         seed = evolution.get("seed")
         if seed is None:
             seed = ()
@@ -205,6 +221,9 @@ class CordisRecipe(Recipe):
             "tasks": tuple(str(task) for task in tasks),
             "adapter": adapter,
             "binary": binary,
+            "episode_timeout_s": float(timeout),
+            "episode_repeats": repeats,
+            "forbid_residue": forbid_residue,
             "seed": tuple(seed),
             "model_name": model_name if isinstance(model_name, str) and model_name else None,
             "models": models,
@@ -245,6 +264,9 @@ class CordisRecipe(Recipe):
             tasks=self.tasks,
             models=self.model_bindings(),
             binary=self.binary,
+            episode_timeout_s=self.episode_timeout_s,
+            episode_repeats=self.episode_repeats,
+            forbid_residue=self.forbid_residue,
             seed=self.seed,
         )
         return Trainer.build(

--- a/reef/train/types/batches.py
+++ b/reef/train/types/batches.py
@@ -101,11 +101,21 @@ def policy_samples(batch: TrainingBatch) -> tuple[PolicySample, ...]:
 
 @dataclass(frozen=True)
 class TraceSample:
-    """One recorded request, exactly as served, with its reported score."""
+    """One recorded exchange, exactly as served, with its reported score.
+
+    A report referencing one request batches as a sample whose ``payload``
+    is that request. A report referencing several batches as one sample
+    whose ``trajectory`` holds every referenced payload in reference order
+    and whose ``payload`` is the last of them, so single-payload consumers
+    keep seeing the exchange that carries the full conversation.
+    ``feedback`` is the report's feedback field, verbatim.
+    """
 
     source_agent_record_id: str
     payload: Mapping[str, Any]
     score: float
+    feedback: str | Mapping[str, Any] | None = None
+    trajectory: tuple[Mapping[str, Any], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/reef_service/test_harness_evolve_processor.py
+++ b/tests/reef_service/test_harness_evolve_processor.py
@@ -24,11 +24,14 @@ def _inference(agent_record_id: str, payload: dict) -> AgentRecord:
     )
 
 
-def _report(agent_record_id: str, score: object, references: list[str]) -> AgentRecord:
+def _report(agent_record_id: str, score: object, references: list[str], feedback: object = None) -> AgentRecord:
+    payload: dict = {"score": score, "references": references}
+    if feedback is not None:
+        payload["feedback"] = feedback
     return AgentRecord.create(
         scenario="s",
         request_type=RequestType.REPORT,
-        payload={"score": score, "references": references},
+        payload=payload,
         agent_record_id=agent_record_id,
     )
 
@@ -64,16 +67,46 @@ def test_trace_processor_ignores_reports_outside_the_score_window() -> None:
     assert "rep-1" in retention.releasable_agent_record_ids
 
 
-def test_trace_processor_rejects_multi_reference_reports_without_selecting_the_first() -> None:
+def test_trace_processor_batches_a_multi_reference_report_as_one_trajectory() -> None:
+    """A report over a whole run becomes one sample: the trajectory holds
+    every referenced payload in reference order, the payload is the last
+    exchange, and the feedback rides along verbatim."""
     processor = _processor({"max_score": 0.0})
-    processor.ingest(_inference("inf-1", {"messages": [{"role": "user", "content": "first"}]}))
-    processor.ingest(_inference("inf-2", {"messages": [{"role": "user", "content": "second"}]}))
-    processor.ingest(_report("rep-1", 0.0, ["inf-1", "inf-2"]))
+    first = {"messages": [{"role": "user", "content": "first"}]}
+    second = {"messages": [{"role": "user", "content": "second"}]}
+    processor.ingest(_inference("inf-1", first))
+    processor.ingest(_inference("inf-2", second))
+    processor.ingest(_report("rep-1", 0.0, ["inf-1", "inf-2"], feedback="wrong file"))
 
+    assert processor.ready()
+    batch = processor.build_batch()
+    (sample,) = batch.samples
+    assert sample.source_agent_record_id == "inf-2"
+    assert sample.payload == second
+    assert sample.trajectory == (first, second)
+    assert sample.feedback == "wrong file"
+    assert sample.score == 0.0
+
+
+def test_trace_processor_keeps_single_reference_samples_flat_and_carries_feedback() -> None:
+    processor = _processor({"max_score": 0.0})
+    payload = {"messages": [{"role": "user", "content": "q"}]}
+    processor.ingest(_inference("inf-1", payload))
+    processor.ingest(_report("rep-1", 0.0, ["inf-1"], feedback={"reason": "timeout"}))
+
+    batch = processor.build_batch()
+    (sample,) = batch.samples
+    assert sample.payload == payload
+    assert sample.trajectory == ()
+    assert sample.feedback == {"reason": "timeout"}
+
+
+def test_trace_processor_never_trains_a_report_without_references() -> None:
+    processor = _processor({"max_score": 0.0})
+    processor.ingest(_report("rep-1", 0.0, []))
     assert not processor.ready()
     retention = processor.retention_decision()
-    assert retention.protected_agent_record_ids == frozenset()
-    assert retention.releasable_agent_record_ids == frozenset({"inf-1", "inf-2", "rep-1"})
+    assert "rep-1" in retention.releasable_agent_record_ids
 
 
 def test_trace_processor_rejects_an_inverted_window() -> None:

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -873,3 +873,114 @@ def test_adapter_without_model_binding_refuses_boot(tmp_path: Path) -> None:
             models=MODEL,
             binary=str(make_binary(tmp_path)),
         )
+
+
+def test_gate_knobs_reach_the_episodes_and_interleave_the_sides(tmp_path: Path, monkeypatch) -> None:
+    """episode_timeout_s reaches every run_episode call, a repeat is one more
+    pairing of the same task, and episodes alternate candidate and current
+    inside each pairing instead of running batched by side."""
+    sides: list[str] = []
+    timeouts: list[float] = []
+    original = reef_cordis_backend.run_episode
+
+    def spy(descriptor, files, prompt, **kwargs):
+        timeouts.append(kwargs["timeout"])
+        sides.append("candidate" if "marker" in files.get("pi-agent/AGENTS.md", "") else "current")
+        return original(descriptor, files, prompt, **kwargs)
+
+    monkeypatch.setattr(reef_cordis_backend, "run_episode", spy)
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        episode_timeout_s=5.0,
+        episode_repeats=2,
+    )
+    result = run_backend_step(b, batch(), b.initial_state())
+
+    assert timeouts == [5.0, 5.0, 5.0, 5.0]
+    assert sides == ["candidate", "current", "candidate", "current"]
+    assert result.metrics["episode_repeats"] == 2
+    assert len(result.metrics["selection"]["evaluation"]["metrics"]["candidate_scores"]) == 2
+
+
+def test_littering_episodes_are_counted_and_forbid_residue_fails_them(tmp_path: Path) -> None:
+    """Files an episode leaves outside the cleanup whitelist are counted into
+    the evaluation; with forbid_residue a littering episode scores as one
+    that could not run, so it cannot win."""
+    litterer = tmp_path / "fake-pi-littering"
+    litterer.write_text(
+        PI_FAKE.replace(
+            '(session_dir / "session.jsonl").write_text(json.dumps(event) + "\\n")',
+            '(session_dir / "session.jsonl").write_text(json.dumps(event) + "\\n")\n'
+            '(agent_dir.parent / "junk.txt").write_text("litter")',
+        )
+    )
+    litterer.chmod(0o755)
+
+    def build(forbid: bool) -> CordisBackend:
+        return CordisBackend(
+            descriptor=get_adapter("pi"),
+            propose=resolve_proposer(
+                lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+            ),
+            score_episode=resolve_episode_scorer(evaluate),
+            tasks=("task one",),
+            models=MODEL,
+            binary=str(litterer),
+            forbid_residue=forbid,
+        )
+
+    counted = run_backend_step(build(False), batch(), build(False).initial_state())
+    assert counted.metrics["candidate_residue"] == 1
+    assert counted.metrics["current_residue"] == 1
+    assert counted.metrics["episode_failures"] == 0
+
+    forbidden = run_backend_step(build(True), batch(), build(True).initial_state())
+    assert forbidden.metrics["episode_failures"] == 2
+    assert forbidden.metrics["selected"] is False
+    evaluation = forbidden.metrics["selection"]["evaluation"]["metrics"]
+    assert {f["stage"] for f in evaluation["candidate_failures"]} == {"residue"}
+    assert {f["stage"] for f in evaluation["current_failures"]} == {"residue"}
+
+
+def test_recipe_parses_and_validates_the_episode_gate_knobs(tmp_path: Path, monkeypatch) -> None:
+    module = tmp_path / "demo_gate_knobs.py"
+    module.write_text(
+        "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def config(**evolution):
+        return {
+            "evolution": {
+                "propose": "demo_gate_knobs:propose",
+                "evaluate": "demo_gate_knobs:evaluate",
+                "tasks": ["task one"],
+                **evolution,
+            }
+        }
+
+    built = CordisRecipe.from_environment(
+        {}, config=config(episode_timeout_s=5, episode_repeats=2, forbid_residue=True)
+    )
+    assert built.episode_timeout_s == 5.0
+    assert built.episode_repeats == 2
+    assert built.forbid_residue is True
+
+    defaults = CordisRecipe.from_environment({}, config=config())
+    assert defaults.episode_timeout_s == 600.0
+    assert defaults.episode_repeats == 1
+    assert defaults.forbid_residue is False
+
+    with pytest.raises(RecipeConfigError, match=r"episode_timeout_s must be a positive number"):
+        CordisRecipe.from_environment({}, config=config(episode_timeout_s=0))
+    with pytest.raises(RecipeConfigError, match=r"episode_repeats must be an integer"):
+        CordisRecipe.from_environment({}, config=config(episode_repeats=0))
+    with pytest.raises(RecipeConfigError, match=r"forbid_residue must be a boolean"):
+        CordisRecipe.from_environment({}, config=config(forbid_residue="yes"))

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -984,3 +984,23 @@ def test_recipe_parses_and_validates_the_episode_gate_knobs(tmp_path: Path, monk
         CordisRecipe.from_environment({}, config=config(episode_repeats=0))
     with pytest.raises(RecipeConfigError, match=r"forbid_residue must be a boolean"):
         CordisRecipe.from_environment({}, config=config(forbid_residue="yes"))
+
+
+def test_backend_rejects_invalid_gate_knobs(tmp_path: Path) -> None:
+    def build(**kwargs) -> CordisBackend:
+        return CordisBackend(
+            descriptor=get_adapter("pi"),
+            propose=resolve_proposer(lambda n, s, m: None),
+            score_episode=resolve_episode_scorer(evaluate),
+            tasks=("task one",),
+            models=MODEL,
+            binary=str(make_binary(tmp_path)),
+            **kwargs,
+        )
+
+    with pytest.raises(ValueError, match="episode_timeout_s must be a positive number"):
+        build(episode_timeout_s=0)
+    with pytest.raises(ValueError, match="episode_repeats must be an integer"):
+        build(episode_repeats=0)
+    with pytest.raises(ValueError, match="forbid_residue must be a boolean"):
+        build(forbid_residue="no")

--- a/tests/reef_service/test_harness_wrapper.py
+++ b/tests/reef_service/test_harness_wrapper.py
@@ -316,6 +316,38 @@ def test_failed_report_restores_claim_for_retry(tmp_path) -> None:
 
 
 @pytest.mark.unit
+def test_per_receipt_report_posts_one_report_for_each_capture(tmp_path) -> None:
+    """--per-receipt fans the run's score across its receipts as separate
+    reports, one reference each, so every exchange batches on its own."""
+    scenario_key = hashlib.sha256(b"scenario").hexdigest()
+    captures = tmp_path / f"{scenario_key}-{1:020d}-run.pending.json"
+    captures.write_text(
+        json.dumps(
+            {
+                "reef_url": "http://reef",
+                "scenario": "scenario",
+                "turns": [{"receipt": "receipt-1"}, {"receipt": "receipt-2"}],
+            }
+        )
+    )
+    posted: list[dict] = []
+
+    def record_report(req, timeout=None):
+        posted.append(json.loads(req.data))
+        return _Response()
+
+    with (
+        patch.dict(os.environ, {"REEF_HARNESS_CAPTURES_DIR": str(tmp_path)}),
+        patch("reef.harness.harness_wrapper.urllib.request.urlopen", record_report),
+    ):
+        report("scenario", "pi", 0.0, "per turn", per_receipt=True)
+
+    assert [item["references"] for item in posted] == [["receipt-1"], ["receipt-2"]]
+    assert {item["score"] for item in posted} == {0.0}
+    assert not any(tmp_path.glob("*.json"))
+
+
+@pytest.mark.unit
 def test_report_recovers_reused_process_id_before_newer_run(tmp_path) -> None:
     claimed_file = _write_spool_entry(
         tmp_path,

--- a/tests/reef_service/test_harness_wrapper.py
+++ b/tests/reef_service/test_harness_wrapper.py
@@ -348,6 +348,45 @@ def test_per_receipt_report_posts_one_report_for_each_capture(tmp_path) -> None:
 
 
 @pytest.mark.unit
+def test_partial_per_receipt_failure_retries_only_the_unsent(tmp_path) -> None:
+    """When a later per-receipt post fails, the restored claim holds only the
+    receipts that never went out, so a retry cannot duplicate reports."""
+    scenario_key = hashlib.sha256(b"scenario").hexdigest()
+    captures = tmp_path / f"{scenario_key}-{1:020d}-run.pending.json"
+    captures.write_text(
+        json.dumps(
+            {
+                "reef_url": "http://reef",
+                "scenario": "scenario",
+                "turns": [{"receipt": "receipt-1"}, {"receipt": "receipt-2"}],
+            }
+        )
+    )
+    failure = urllib.error.HTTPError("http://reef/reef/report", 503, "unavailable", {}, io.BytesIO(b"later"))
+    posted: list[dict] = []
+
+    def flaky(req, timeout=None):
+        posted.append(json.loads(req.data))
+        if len(posted) == 2:
+            raise failure
+        return _Response()
+
+    with (
+        patch.dict(os.environ, {"REEF_HARNESS_CAPTURES_DIR": str(tmp_path)}),
+        patch("reef.harness.harness_wrapper.urllib.request.urlopen", flaky),
+    ):
+        with pytest.raises(SystemExit, match=r"report failed \(503\)"):
+            report("scenario", "pi", 0.0, "per turn", per_receipt=True)
+
+        restored = json.loads(captures.read_text())
+        assert [turn["receipt"] for turn in restored["turns"]] == ["receipt-2"]
+
+        report("scenario", "pi", 0.0, "per turn", per_receipt=True)
+
+    assert [item["references"] for item in posted] == [["receipt-1"], ["receipt-2"], ["receipt-2"]]
+
+
+@pytest.mark.unit
 def test_report_recovers_reused_process_id_before_newer_run(tmp_path) -> None:
     claimed_file = _write_spool_entry(
         tmp_path,


### PR DESCRIPTION
## Motivation

A deployed agent's ordinary sessions cannot drive harness evolution: the processor admits only reports referencing exactly one inference, while the shipped reef-pi wrapper bundles every receipt of a run into one report, so a multi-turn session delivers zero trainable signal. The gate has four defects in the same loop: one stochastic episode per task per side with no way to repeat, all episodes of one tree run before the other so upstream drift favors a side, the 600 s episode timeout is hardcoded out of config reach, and the cleanup audit is computed and then discarded. Closes #130.

## Changes

- A report referencing several receipts batches as one trajectory sample: every referenced payload in reference order, the last exchange as the payload, the report's feedback carried verbatim; a report without references still never trains
- reef-pi report gains --per-receipt, fanning the score across the receipts as separate reports; the default single report is now meaningful signal
- evolution.episode_timeout_s, evolution.episode_repeats, and evolution.forbid_residue join the recipe config with validation; repeats add pairings that tally on their own in the existing positional comparison
- Episodes interleave candidate and current inside each pairing instead of running batched by side
- Files an episode leaves outside the cleanup whitelist are counted into the evaluation (candidate_residue, current_residue), and with forbid_residue a littering episode scores as one that could not run
- Docs updated in the same change: the lane guide's window and cost paragraphs, the stale batched-by-side note removed, the configuration key table, the report references row, and the processors cookbook row

## Compatibility and operational impact

One deliberate contract change: a multi-reference report previously released terminally and now batches (the acceptance criteria of #130). The test asserting the old rejection is rewritten to the new contract. TraceSample gains two defaulted fields; existing methods and single-reference behavior are unchanged, and all knobs default to today's values.

## Verification

The CI-equivalent local sweep passes: 1147 tests, 6 skipped, including nine new ones covering the trajectory sample and feedback threading, the no-reference window, timeout passthrough, interleaving order, repeat pairings, residue counting and forbid behavior, the config knob parsing and validation, and per-receipt wrapper reporting. The docs gate (links, contracts, table geometry, build) is clean. pre-commit run twice on the changeset, both clean.

## AI assistance

Claude Code wrote the change and the tests. I reviewed the diff and set the contract in #130.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
