### PR TITLE
feat: evolve harnesses from recorded traffic without explicit reports

### DIFF
--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -85,6 +85,19 @@ This method adds a rules node the first time a batch contains a failure:
                return message["content"]
        return None
 
+Two batching modes
+~~~~~~~~~~~~~~~~~~
+
+Evolution batches in one of two modes, selected by ``data.batch_policy``.
+The default, ``reports``, batches explicitly scored reports through the
+score window; use it whenever the deployment has an outcome signal (a
+grader, a test result, a user action), because a measured result beats
+model self judgment. ``records`` batches recorded inference traffic alone,
+every ``batch_size`` requests, so a deployment that only serves still
+evolves. Samples batched this way carry ``score=None``, and ``propose``
+must handle unscored samples; the SkillClaw night backfills its own
+judgment over them and is the worked instance.
+
 Configure it
 ~~~~~~~~~~~~
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -152,6 +152,7 @@ Harness evolution keys
 
    data.batch_size | 1 | traces per mutation attempt
    data.max_score | 0.0 | upper bound of the score window that batches
+   data.batch_policy | reports | ``records`` batches recorded traffic alone, every ``batch_size`` requests, with unscored samples
 
 The window has no lower bound, so the default keeps only traces at or below
 zero.

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -73,7 +73,10 @@ trajectory sample carrying every referenced exchange in order, which is what
 ``reef-pi report`` sends for a whole run (``--per-receipt`` fans the score
 across the receipts as separate reports instead). When ``batch_size``
 window entries have accumulated, one step runs the loop once. ``batch_size``
-and ``max_score`` live under ``data:`` in the recipe config.
+and ``max_score`` live under ``data:`` in the recipe config, and
+``data.batch_policy: records`` drops the report requirement entirely:
+recorded traffic alone batches, unscored, for methods that judge for
+themselves.
 
 Most of a step's cost is the evaluation. Every task runs on both trees,
 ``episode_repeats`` times each (once by default), which makes

--- a/reef/train/cordis_backend/processor.py
+++ b/reef/train/cordis_backend/processor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from reef.core import AgentRecord, RequestType
+from reef.train.processors.base import DataProcessor, RetentionDecision
 from reef.train.processors.reported import (
     NEVER,
     BatchUnit,
@@ -75,3 +77,63 @@ class CordisProcessor(ReportedFeedbackProcessor):
             f"{self.scenario}:harness_evolve:{batch_number}",
             tuple(unit.candidates[0].value for unit in units),
         )
+
+
+class RecordDrivenTraceProcessor(DataProcessor):
+    """Batch recorded inference traffic every ``batch_size`` requests, unscored.
+
+    The report-free half of harness evolution: a deployment that only serves
+    still evolves. Each recorded inference is one unit, in arrival order;
+    when ``batch_size`` have accumulated they batch as trace samples with
+    ``score=None``, and the proposer contract requires handling unscored
+    samples. Reports that arrive under this policy are released untouched;
+    a deployment with real outcome signal selects the reported policy
+    instead, because a measured result beats model self judgment.
+    """
+
+    output_schema = TraceBatch
+
+    def __init__(self, context: ProcessorContext) -> None:
+        super().__init__(context)
+        self._records: list[AgentRecord] = []
+        self._released: set[str] = set()
+
+    def ingest(self, item: AgentRecord) -> None:
+        if item.request_type is RequestType.INFERENCE:
+            self._records.append(item)
+        else:
+            self._released.add(item.agent_record_id)
+
+    def _ready_count(self) -> int:
+        return len(self._records)
+
+    def _make_pending(self, batch_number: int) -> TraceBatch:
+        selected = self._records[: self._batch_size]
+        return TraceBatch(
+            f"{self.scenario}:harness_evolve:{batch_number}",
+            tuple(
+                TraceSample(
+                    source_agent_record_id=record.agent_record_id,
+                    payload=record.payload,
+                    score=None,
+                )
+                for record in selected
+            ),
+        )
+
+    def _consume_pending(self) -> frozenset[str]:
+        if self._pending is None or not isinstance(self._pending, TraceBatch):
+            raise RuntimeError("no pending trace batch to consume")
+        consumed = frozenset(sample.source_agent_record_id for sample in self._pending.samples)
+        self._records = [record for record in self._records if record.agent_record_id not in consumed]
+        self._released |= consumed
+        return consumed
+
+    def retention_decision(self) -> RetentionDecision:
+        return RetentionDecision(
+            protected_agent_record_ids=frozenset(record.agent_record_id for record in self._records),
+            releasable_agent_record_ids=frozenset(self._released),
+        )
+
+    def compaction_applied(self, agent_record_ids: frozenset[str]) -> None:
+        self._released -= agent_record_ids

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -29,7 +29,7 @@ from reef.records import RecordStore
 from reef.surface.base import Surface
 from reef.surface.harnesses import create_harness_surface
 from reef.train.cordis_backend import CordisBackend, EpisodeScorer, Proposer, ScoreComparisonSelector
-from reef.train.cordis_backend.processor import CordisProcessor
+from reef.train.cordis_backend.processor import CordisProcessor, RecordDrivenTraceProcessor
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
 from reef.train.evaluation.contracts import CandidateSelector
 from reef.train.evaluation.evaluators import AlwaysSelect, DefaultCandidateEvaluationPlugin
@@ -136,6 +136,7 @@ class CordisRecipe(Recipe):
     candidate_selector: CandidateSelector = field(default_factory=ScoreComparisonSelector, repr=False)
     batch_size: int = config_field(1)
     max_score: float = config_field(0.0)
+    batch_policy: str = config_field("reports")
     name: str = field(default="harness_evolve", kw_only=True)
 
     @property
@@ -151,6 +152,8 @@ class CordisRecipe(Recipe):
             raise ValueError("harness evolution requires tasks")
         if self.batch_size <= 0:
             raise ValueError("batch_size must be positive")
+        if self.batch_policy not in ("reports", "records"):
+            raise ValueError("batch_policy must be 'reports' or 'records'")
         if self.episode_timeout_s <= 0:
             raise ValueError("episode_timeout_s must be positive")
         if self.episode_repeats < 1:
@@ -272,8 +275,10 @@ class CordisRecipe(Recipe):
         return Trainer.build(
             scenario,
             records,
-            processor_factory=lambda context: CordisProcessor(
-                context.with_config({"batch_size": self.batch_size, "max_score": self.max_score})
+            processor_factory=lambda context: (
+                RecordDrivenTraceProcessor(context.with_config({"batch_size": self.batch_size}))
+                if self.batch_policy == "records"
+                else CordisProcessor(context.with_config({"batch_size": self.batch_size, "max_score": self.max_score}))
             ),
             training_backend=training_backend,
             candidate_evaluator=DefaultCandidateEvaluationPlugin(training_backend, self.candidate_selector),

--- a/reef/train/cordis_backend/strategies.py
+++ b/reef/train/cordis_backend/strategies.py
@@ -57,7 +57,9 @@ class Proposer(ABC):
 
     Implement:
         ``__call__`` — given the current composition (as ``(kind, config)``
-        pairs in tree order), a batch of trace samples, and the
+        pairs in tree order), a batch of trace samples (a sample's ``score``
+        is ``None`` when the deployment batches recorded traffic without
+        reports, so a method must handle unscored samples), and the
         :class:`~reef.harness.model_binding.ModelBindings` the method may
         call, return one :class:`~reef.train.cordis_backend.Mutation`, a
         sequence of them (one composite proposal, applied under one snapshot

--- a/reef/train/types/batches.py
+++ b/reef/train/types/batches.py
@@ -108,12 +108,13 @@ class TraceSample:
     whose ``trajectory`` holds every referenced payload in reference order
     and whose ``payload`` is the last of them, so single-payload consumers
     keep seeing the exchange that carries the full conversation.
-    ``feedback`` is the report's feedback field, verbatim.
+    ``feedback`` is the report's feedback field, verbatim. ``score`` is
+    ``None`` for a sample batched from recorded traffic without a report.
     """
 
     source_agent_record_id: str
     payload: Mapping[str, Any]
-    score: float
+    score: float | None
     feedback: str | Mapping[str, Any] | None = None
     trajectory: tuple[Mapping[str, Any], ...] = ()
 

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -137,6 +137,8 @@ def _dispatcher(
     *,
     bootstrap_files: dict[str, str] | None = None,
     recipe_names: tuple[str, ...] = ("evolve",),
+    batch_policy: str = "reports",
+    batch_size: int = 1,
 ) -> Dispatcher:
     proposals = iter(mutations)
     binary = tmp_path / "fake-pi"
@@ -148,6 +150,8 @@ def _dispatcher(
         ("task one",),
         binary=str(binary),
         runtime=InferenceProxyRuntime(model_path="demo-model", base_url="http://localhost:8000"),
+        batch_policy=batch_policy,
+        batch_size=batch_size,
     )
     bootstrap = tmp_path / "bootstrap"
     bootstrap.mkdir()
@@ -1095,6 +1099,46 @@ def test_install_route_refuses_an_unknown_version_with_a_404_naming_it(tmp_path)
             )
             assert response.status == 404
             assert "no-such-version" in await response.text()
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
+def test_record_only_traffic_fires_a_step_and_publishes(tmp_path) -> None:
+    """The report-free policy end to end through the real service: recorded
+    inference traffic alone fills the batch, one evolve step runs on the
+    unscored samples, and the harness read channel serves the winner. No
+    report is ever posted."""
+
+    async def run() -> None:
+        dispatcher = _dispatcher(tmp_path, MUTATIONS[:1], batch_policy="records", batch_size=2)
+        client = TestClient(TestServer(create_app(dispatcher, inference_backend=_EchoBackend())))
+        await client.start_server()
+        try:
+            for prompt in ("first", "second"):
+                response = await client.post(
+                    "/v1/chat/completions",
+                    headers={"x-reef-scenario": "delivery"},
+                    json={"messages": [{"role": "user", "content": prompt}]},
+                )
+                assert response.status == 200
+                await response.read()
+
+            deadline = asyncio.get_running_loop().time() + _ASYNC_UPDATE_TIMEOUT_S
+            while True:
+                response = await client.get("/reef/harness", headers={"x-reef-scenario": "delivery"})
+                if response.status == 200:
+                    manifest = await response.json()
+                    assert manifest["gate"]["published"] is True
+                    assert "marker rules" in manifest["files"]["pi-agent/AGENTS.md"]
+                    break
+                assert response.status == 404
+                await response.read()
+                if asyncio.get_running_loop().time() >= deadline:
+                    pytest.fail("record-driven step did not publish")
+                await asyncio.sleep(_ASYNC_UPDATE_POLL_S)
         finally:
             await client.close()
 

--- a/tests/reef_service/test_harness_evolve_processor.py
+++ b/tests/reef_service/test_harness_evolve_processor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 
 from reef.core import AgentRecord, RequestType
-from reef.train.cordis_backend.processor import CordisProcessor
+from reef.train.cordis_backend.processor import CordisProcessor, RecordDrivenTraceProcessor
 from reef.train.types import ProcessorContext, TraceBatch
 
 
@@ -139,3 +139,60 @@ def test_trace_processor_refuses_a_non_finite_score() -> None:
         processor.ingest(_report("rep-1", bad, ["inf-1"]))
         assert not processor.ready()
         assert "rep-1" in processor.retention_decision().releasable_agent_record_ids
+
+
+def _record_processor(batch_size: int = 2) -> RecordDrivenTraceProcessor:
+    return RecordDrivenTraceProcessor(ProcessorContext("s", {"batch_size": batch_size}))
+
+
+def test_record_driven_processor_batches_every_n_inferences_unscored() -> None:
+    """The report-free policy: recorded traffic alone forms the batch, in
+    arrival order, with score None on every sample."""
+    processor = _record_processor(batch_size=2)
+    first = {"messages": [{"role": "user", "content": "first"}]}
+    second = {"messages": [{"role": "user", "content": "second"}]}
+    processor.ingest(_inference("inf-1", first))
+    assert not processor.ready()
+    processor.ingest(_inference("inf-2", second))
+    assert processor.ready()
+
+    batch = processor.build_batch()
+    assert isinstance(batch, TraceBatch)
+    assert [s.source_agent_record_id for s in batch.samples] == ["inf-1", "inf-2"]
+    assert [s.payload for s in batch.samples] == [first, second]
+    assert {s.score for s in batch.samples} == {None}
+
+    retention = processor.retention_decision()
+    assert retention.protected_agent_record_ids == frozenset({"inf-1", "inf-2"})
+
+    consumed = processor.acknowledge(batch.batch_id)
+    assert consumed == frozenset({"inf-1", "inf-2"})
+    retention = processor.retention_decision()
+    assert retention.releasable_agent_record_ids == frozenset({"inf-1", "inf-2"})
+    assert not processor.ready()
+
+
+def test_record_driven_processor_releases_reports_untouched() -> None:
+    processor = _record_processor(batch_size=1)
+    processor.ingest(_report("rep-1", 0.0, ["inf-0"], feedback="ignored"))
+    assert not processor.ready()
+    retention = processor.retention_decision()
+    assert retention.releasable_agent_record_ids == frozenset({"rep-1"})
+
+    processor.ingest(_inference("inf-1", {"messages": []}))
+    batch = processor.build_batch()
+    (sample,) = batch.samples
+    assert sample.score is None
+    assert sample.feedback is None
+
+
+def test_record_driven_processor_overflow_stays_pending_for_the_next_batch() -> None:
+    processor = _record_processor(batch_size=2)
+    for index in range(3):
+        processor.ingest(_inference(f"inf-{index}", {"messages": []}))
+    batch = processor.build_batch()
+    assert [s.source_agent_record_id for s in batch.samples] == ["inf-0", "inf-1"]
+    processor.acknowledge(batch.batch_id)
+    retention = processor.retention_decision()
+    assert retention.protected_agent_record_ids == frozenset({"inf-2"})
+    assert not processor.ready()

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -1004,3 +1004,42 @@ def test_backend_rejects_invalid_gate_knobs(tmp_path: Path) -> None:
         build(episode_repeats=0)
     with pytest.raises(ValueError, match="forbid_residue must be a boolean"):
         build(forbid_residue="no")
+
+
+def test_recipe_selects_the_record_driven_processor(tmp_path: Path, monkeypatch) -> None:
+    """data.batch_policy records swaps the processor; the default stays the
+    reported window."""
+    module = tmp_path / "demo_batch_policy.py"
+    module.write_text(
+        "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def config(policy: str | None):
+        data = {} if policy is None else {"batch_policy": policy}
+        return {
+            "data": data,
+            "evolution": {
+                "propose": "demo_batch_policy:propose",
+                "evaluate": "demo_batch_policy:evaluate",
+                "tasks": ["task one"],
+                "binary": str(make_binary(tmp_path)),
+            },
+        }
+
+    records = CordisRecipe.from_environment(
+        {}, config=config("records"), runtime=InferenceProxyRuntime(model_path="m", base_url="http://localhost:8000")
+    )
+    assert records.batch_policy == "records"
+    trainer = records.build("demo", RecordStore())
+    assert type(trainer.processor).__name__ == "RecordDrivenTraceProcessor"
+
+    reported = CordisRecipe.from_environment(
+        {}, config=config(None), runtime=InferenceProxyRuntime(model_path="m", base_url="http://localhost:8000")
+    )
+    assert reported.batch_policy == "reports"
+    trainer = reported.build("demo", RecordStore())
+    assert type(trainer.processor).__name__ == "CordisProcessor"
+
+    with pytest.raises(RecipeConfigError, match="batch_policy must be 'reports' or 'records'"):
+        CordisRecipe.from_environment({}, config=config("sometimes"))


### PR DESCRIPTION
## Motivation

Harness evolution fires only when the deployment's own program posts an outcome signal. A deployment with no outcome signal at all, one that just serves traffic, never batches and gets no evolution. The gate side is already self contained (probe episodes score candidates without outside input); only the trigger and the evidence scores depend on reports. Closes #17.

## Changes

- data.batch_policy selects the batching mode: the default reports keeps today's score window, records batches recorded inference traffic alone, every batch_size requests, in arrival order
- RecordDrivenTraceProcessor implements the record policy over the shared batch cycle: inference records are the units, reports that arrive under it are released untouched, consumed records release for compaction
- Samples batched without reports carry score None; TraceSample.score is now float or None and the Proposer contract documents that a method must handle unscored samples (the SkillClaw night already judge backfills its samples and is the worked instance)
- The method author guide gains a Two batching modes section stating when to use which; the configuration reference and the lane guide document the key

## Compatibility and operational impact

None by default: batch_policy defaults to reports and the reported path is untouched. TraceSample.score widens to float or None; every shipped consumer already tolerates it.

## Verification

A hermetic service test drives record-only traffic through the real HTTP app (two plain inferences, no report ever posted) and sees the step fire and the winner served on the harness read channel. Unit tests cover every-N batching in arrival order with unscored samples, report release under the record policy, overflow staying pending, processor selection by policy, and config validation. The CI-equivalent sweep passes: 1154 tests, 6 skipped. Docs gate clean; pre-commit clean with the CI toolchain.

## AI assistance

Claude Code wrote the change and the tests. I reviewed the diff; the design is the one recorded in #17.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
