### PR TITLE
fix: preserve orchestrator shutdown cause

### DIFF
--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -162,6 +162,7 @@ class _Stack:
         self._tees: dict[str, _TeeStream] = {}
         self._names = [svc["name"] for svc in services]
         self._stopping = threading.Event()
+        self._unexpected_exit = threading.Event()
 
     def _pid_file(self, name):
         return self.run_dir / f"{name}.pid"
@@ -264,8 +265,14 @@ class _Stack:
         while not self._stopping.is_set():
             for name, proc in list(self._procs.items()):
                 if proc.poll() is not None:
+                    # A signal may arrive while this polling pass is already
+                    # in progress. Child exits after that stop request belong
+                    # to deliberate teardown, not to the watchdog.
+                    if self._stopping.is_set():
+                        return
                     code = proc.returncode
                     _log(f"{name}: exited (code {code}); bringing down the stack")
+                    self._unexpected_exit.set()
                     self._stopping.set()
                     return
             self._stopping.wait(_WATCHDOG_INTERVAL)
@@ -273,8 +280,6 @@ class _Stack:
     def block(self):
         """Run the watchdog thread and block until a signal arrives or a
         service exits."""
-        watcher = threading.Thread(target=self._watchdog, daemon=True)
-        watcher.start()
 
         def _request_stop(signum, frame):
             _log("received signal, shutting down")
@@ -282,6 +287,8 @@ class _Stack:
 
         signal.signal(signal.SIGTERM, _request_stop)
         signal.signal(signal.SIGINT, _request_stop)
+        watcher = threading.Thread(target=self._watchdog, daemon=True)
+        watcher.start()
         self._stopping.wait()
 
     def shutdown(self, grace=_DEFAULT_GRACE_TIMEOUT):
@@ -314,14 +321,11 @@ class _Stack:
 
     @property
     def exit_code(self) -> int:
-        """1 when any service exited with a failure code, else 0.
+        """1 when a service exited unexpectedly, else 0.
 
         If we got here via a signal, exit 0; if a service died, exit 1.
         """
-        for proc in self._procs.values():
-            if proc.poll() is not None and proc.returncode != 0:
-                return 1
-        return 0
+        return int(self._unexpected_exit.is_set())
 
 
 def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None) -> int:
@@ -360,7 +364,7 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
         # SIGINT during startup (before block() registers its handler) still
         # triggers the default KeyboardInterrupt; shutdown ran via finally.
         # Swallow it so the operator sees a clean exit, not a traceback.
-        pass
+        stack._stopping.set()
     finally:
         stack.shutdown()
         if temp_config_path is not None:

--- a/tests/reef_service/test_training_server.py
+++ b/tests/reef_service/test_training_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import signal
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,27 @@ from reef.service.deploy.settings import ServiceSettings
 
 OPENCLAWRL_RECIPE = "recipes.openclawrl.recipe:OpenClawRLRecipe"
 SAO_RECIPE = "recipes.sao.recipe:SAORecipe"
+
+
+class _Process:
+    """Small Popen stand-in for orchestrator lifecycle tests."""
+
+    pid = 123
+
+    def __init__(self, returncode=None, stop_on_poll=None):
+        self.returncode = returncode
+        self._stop_on_poll = stop_on_poll
+
+    def poll(self):
+        if self._stop_on_poll is not None:
+            self._stop_on_poll.set()
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = -signal.SIGTERM
+
+    def wait(self, timeout=None):
+        return self.returncode
 
 
 def _example_owned(relative_path: str):
@@ -538,3 +560,67 @@ def test_stack_places_the_bridge_ready_marker_under_run_dir(tmp_path: Path, monk
     assert env["REEF_BRIDGE_READY_FILE"] == str(tmp_path / "stack" / "bridge.ready")
     assert env["RAY_ADDRESS"] == "127.0.0.1:8900"
     assert env["REEF_CONFIG"] == str(tmp_path / "serve.yaml")
+
+
+@pytest.mark.unit
+def test_stack_graceful_shutdown_ignores_deliberate_child_termination(tmp_path: Path) -> None:
+    from reef.service.deploy.orchestrator import _Stack
+
+    stack = _Stack({}, [{"name": "service"}], tmp_path, 60, tmp_path / "serve.yaml")
+    process = _Process()
+    stack._procs["service"] = process
+
+    stack.shutdown(grace=0)
+
+    assert process.returncode == -signal.SIGTERM
+    assert stack.exit_code == 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("returncode", [0, 1])
+def test_stack_treats_any_unexpected_child_exit_as_failure(tmp_path: Path, returncode: int) -> None:
+    from reef.service.deploy.orchestrator import _Stack
+
+    stack = _Stack({}, [{"name": "service"}], tmp_path, 60, tmp_path / "serve.yaml")
+    stack._procs["service"] = _Process(returncode)
+
+    stack._watchdog()
+
+    assert stack.exit_code == 1
+
+
+@pytest.mark.unit
+def test_watchdog_does_not_reclassify_a_signal_driven_child_exit(tmp_path: Path) -> None:
+    from reef.service.deploy.orchestrator import _Stack
+
+    stack = _Stack({}, [{"name": "service"}], tmp_path, 60, tmp_path / "serve.yaml")
+    # Simulate a signal arriving after the watchdog began its polling pass but
+    # before shutdown made the child exit.
+    stack._procs["service"] = _Process(-signal.SIGTERM, stop_on_poll=stack._stopping)
+
+    stack._watchdog()
+
+    assert stack.exit_code == 0
+
+
+@pytest.mark.unit
+def test_stack_installs_signal_handlers_before_starting_watchdog(tmp_path: Path, monkeypatch) -> None:
+    from reef.service.deploy import orchestrator
+
+    stack = orchestrator._Stack({}, [], tmp_path, 60, tmp_path / "serve.yaml")
+    handlers = {}
+    started = []
+
+    monkeypatch.setattr(orchestrator.signal, "signal", lambda signum, handler: handlers.setdefault(signum, handler))
+
+    class Watcher:
+        def start(self):
+            assert signal.SIGINT in handlers and signal.SIGTERM in handlers
+            started.append(True)
+            stack._stopping.set()
+
+    monkeypatch.setattr(orchestrator.threading, "Thread", lambda **kwargs: Watcher())
+
+    stack.block()
+
+    assert started == [True]


### PR DESCRIPTION
## Motivation

`reef serve` currently derives its final status from child return codes after teardown. That loses who initiated shutdown: children deliberately terminated after Ctrl-C normally return `-15`, so graceful operator shutdown exits `1`; meanwhile, a long-running child that exits unexpectedly with code `0` brings down the stack but leaves Reef exiting `0`.

Closes #137.

## Changes

- Track unexpected child exit as a separate, thread-safe stack outcome.
- Set that outcome only when the watchdog observes a child exit.
- Guard the signal/watchdog interleavings by checking stop state after polling, installing handlers before starting the watcher, and marking startup Ctrl-C before teardown.
- Derive the orchestrator exit code from the preserved shutdown cause instead of post-teardown child codes.
- Add focused regression coverage for both status directions and the signal races.

## Compatibility and operational impact

No API, configuration, persisted-data, or dependency changes. The CLI status now matches the existing contract: signal-driven shutdown exits `0`, while any unexpected service exit makes the supervisor exit `1`.

No documentation update is required because the existing `_Stack.exit_code` contract already describes this behavior.

## Verification

- `PYTHONPATH=. uv run python -m pytest tests/reef_service/test_training_server.py -q` — 35 passed.
- `uv run pre-commit run --files reef/service/deploy/orchestrator.py tests/reef_service/test_training_server.py` — all hooks passed.
- `PYTHONPATH=. uv run mypy` — success, 176 source files checked.
- Manual sleeper-stack smoke — Ctrl-C terminated the child with `-15` and Reef exited `0`.

## AI assistance

OpenAI Codex assisted with repository triage, independent reproduction, the focused implementation, and regression tests.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
