### PR TITLE
refactor: make recipes deployment-scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ modules implement each step.
 ## Using Reef
 
 Reef supports two learning surfaces: model **weights** and agent **harnesses**.
-The recipe bound to a scenario determines which surface it updates.
+The deployment's recipe determines which surface its scenarios update.
 
 ### 1 · Serve
 
@@ -117,9 +117,9 @@ SAO recipe uses each eligible scored rollout to run a training step.
 #### Send an inference request and report feedback
 
 Reef's inference endpoint is OpenAI- and Anthropic-compatible: `/v1/chat/completions`
-and `/v1/messages` take the provider's own request body. The first request for a
-new scenario must include both Reef headers. Reef stores the recipe binding and
-rejects later attempts to change it.
+and `/v1/messages` take the provider's own request body. A request includes the
+`x-reef-scenario` header; a new name creates a scenario using the deployment's
+configured recipe. Requests do not select recipes.
 
 The response body uses the provider's OpenAI-compatible format. Reef adds the
 `x-reef-agent-record-id` response header. Its value is the **receipt** that a

--- a/docs/getting-started/architecture.rst
+++ b/docs/getting-started/architecture.rst
@@ -4,7 +4,8 @@ Architecture
 An agent is a model plus its harness. Reef sits between the harness and the
 runtime that executes the model. It records the release that served
 each response, accepts feedback that refers to those responses, and lets a
-scenario's recipe use eligible records to produce the next release.
+deployment's recipe use each scenario's eligible records to produce the next
+release.
 
 Which package holds which code is `Codebase structure
 <../contributing/codebase-structure.rst>`__.

--- a/docs/getting-started/intro.rst
+++ b/docs/getting-started/intro.rst
@@ -82,8 +82,8 @@ the current and proposed versions on your tasks, and keeps the winner. See `Evol
 What a call looks like
 ----------------------
 
-A deployment names one recipe in its config. Every scenario it creates binds
-to that recipe:
+A deployment names one recipe in its config. Every scenario it creates uses
+that recipe; recipe identity is not part of scenario state:
 
 .. code:: yaml
 

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -27,7 +27,7 @@ Routes
 +-------------------------------------------------+---------------------------------------------------+
 | ``POST /reef/report``                           | submit feedback about one or more receipts        |
 +-------------------------------------------------+---------------------------------------------------+
-| ``GET /reef/scenarios``                         | every known scenario, recipe, and current release |
+| ``GET /reef/scenarios``                         | every known scenario and current release          |
 +-------------------------------------------------+---------------------------------------------------+
 | ``POST /reef/scenarios``                        | create a scenario explicitly                      |
 +-------------------------------------------------+---------------------------------------------------+
@@ -75,7 +75,8 @@ Scenarios
 ---------
 
 The first inference request or report carrying a new ``x-reef-scenario`` creates
-the scenario and binds it to the deployment's recipe.
+the scenario using the deployment's configured recipe. Requests never select a
+recipe.
 
 .. code:: bash
 
@@ -91,15 +92,15 @@ unknown scenario returns HTTP 404 and you create it first:
 +---------------------------------------------+---------------------------------------------+
 | Route                                       | Body and response                           |
 +=============================================+=============================================+
-| ``POST /reef/scenarios``                    | ``{"name", "recipe", "release_id"?}``       |
-|                                             | → ``{scenario, recipe, release_id,          |
+| ``POST /reef/scenarios``                    | ``{"name", "release_id"?}``                 |
+|                                             | → ``{scenario, release_id,                  |
 |                                             | content_id}``; 201 created, 200 already     |
 |                                             | existed                                     |
 +---------------------------------------------+---------------------------------------------+
-| ``GET /reef/scenarios``                     | every known scenario with its recipe and    |
-|                                             | current release once loaded                 |
+| ``GET /reef/scenarios``                     | every known scenario and its current        |
+|                                             | release once loaded                         |
 +---------------------------------------------+---------------------------------------------+
-| ``GET /reef/scenarios/{scenario}/contract`` | ``{scenario, recipe, processor,             |
+| ``GET /reef/scenarios/{scenario}/contract`` | ``{scenario, processor,                     |
 |                                             | required_request_types}``                   |
 +---------------------------------------------+---------------------------------------------+
 
@@ -282,7 +283,7 @@ Status codes
 |        | release, unknown adapter, no configured harness             |
 |        | recipe, or a scenario that serves no files                  |
 +--------+-------------------------------------------------------------+
-| 409    | a recipe or base artifact conflicting with the binding, a   |
+| 409    | a base artifact conflicting with the scenario registration, |
 |        | record id resent with different content, a rollback naming  |
 |        | a release that is not restorable, or an engine that reports |
 |        | no serving runtime load ID                                  |

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -16,7 +16,7 @@ Start with Recipe and add only what the method actually needs.
 +---------------------------------------------+--------------------------------------------------+------------------------------+
 | Need                                        | Component                                        | Required for                 |
 +=============================================+==================================================+==============================+
-| bind a scenario's behavior                  | `Recipe <#recipe>`__                             | every recipe                 |
+| configure deployment behavior               | `Recipe <#recipe>`__                             | every deployment             |
 +---------------------------------------------+--------------------------------------------------+------------------------------+
 | validate feedback at ingress                | `Report <#report>`__                             | methods whose signal arrives |
 |                                             |                                                  | in reports                   |
@@ -51,8 +51,8 @@ Recipe
    from reef.recipe import Recipe, WeightTrainingRecipe, config_field
    from reef.train.cordis_backend import CordisRecipe
 
-A recipe is one frozen dataclass binding a scenario to its serving and evolution
-behavior.
+A recipe is one frozen dataclass configuring the serving and evolution behavior
+for every scenario in a deployment.
 
 .. code:: text
 

--- a/docs/site/app/page.tsx
+++ b/docs/site/app/page.tsx
@@ -135,7 +135,7 @@ curl http://localhost:8900/healthz`}</code></pre>
       <section className="home-section">
         <div className="section-heading-row">
           <h2>Two surfaces</h2>
-          <p>The recipe bound to a scenario decides which one Reef evolves.</p>
+          <p>The deployment's recipe decides which surface its scenarios evolve.</p>
         </div>
         <div className="path-grid path-grid-2">
           {surfaces.map((item) => {

--- a/docs/site/app/page.tsx
+++ b/docs/site/app/page.tsx
@@ -135,7 +135,7 @@ curl http://localhost:8900/healthz`}</code></pre>
       <section className="home-section">
         <div className="section-heading-row">
           <h2>Two surfaces</h2>
-          <p>The deployment's recipe decides which surface its scenarios evolve.</p>
+          <p>The deployment&apos;s recipe decides which surface its scenarios evolve.</p>
         </div>
         <div className="path-grid path-grid-2">
           {surfaces.map((item) => {

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -38,8 +38,10 @@ How a recipe is selected
 ------------------------
 
 A deployment serves exactly one recipe, named by ``reef.recipe`` in its config.
-Every scenario it creates binds to that recipe, permanently. Requests never name
-a recipe. The scenario header is the only routing a caller provides.
+Every scenario it creates uses that recipe. Requests never name a recipe, and
+scenario snapshots do not store one. The scenario header is the only routing a
+caller provides. The artifact repository is therefore deployment-owned: do not
+point deployments configured with different recipes at the same repository.
 
 .. code:: yaml
 

--- a/recipes/AGENTS.md
+++ b/recipes/AGENTS.md
@@ -79,7 +79,6 @@ Connection settings come from environment variables set by `run.sh`:
 
 - `REEF_SERVICE_URL` (required)
 - `REEF_SCENARIO` (required)
-- `REEF_RECIPE`
 - `REEF_TOKEN`
 - `REEF_TIMEOUT_S`
 
@@ -127,7 +126,8 @@ training stack under the same `reef:` section.
 
 ## `run.sh`
 
-1. Set environment variables (port, token, scenario, recipe, work dir).
+1. Set environment variables (port, token, scenario, work dir); select the
+   deployment recipe in YAML.
 2. Start `reef serve -c <yaml>` in the background; wait for `/healthz`.
 3. Run reef-eval with `--with-editable "$PWD"` (installs `harness/`) and
    `--with reef-client` (installs the SDK from PyPI).

--- a/recipes/basic/harness/agent.py
+++ b/recipes/basic/harness/agent.py
@@ -27,9 +27,8 @@ from .report import post_report
 #: The Reef ``run.sh`` starts from ``external-provider.yaml``.
 SERVICE_URL = "http://127.0.0.1:8900"
 TOKEN = "reef-local"
-#: This workload's isolated lane, and the recipe that serves it.
+#: This workload's isolated lane.
 SCENARIO = "basic-arithmetic"
-RECIPE = "recipe"  # the record-only core recipe
 #: Where the basic task's instruction says to put the answer
 #: (see ``harbor/instruction.md``).
 ANSWER_PATH = "/workspace/answer.txt"
@@ -86,7 +85,6 @@ class HarborAgent(BaseAgent):
             SCENARIO,
             "/v1/chat/completions",
             {"model": self.model_name, "messages": [{"role": "user", "content": instruction}]},
-            recipe=RECIPE,
         )
 
     def _report_trial_result(self) -> None:
@@ -95,5 +93,5 @@ class HarborAgent(BaseAgent):
         while not (result_path.exists() and result_path.stat().st_mtime >= self._started):
             time.sleep(1)
         result = json.loads(result_path.read_text(encoding="utf-8"))
-        post_report(result, client=self._client, scenario=SCENARIO, recipe=RECIPE)
+        post_report(result, client=self._client, scenario=SCENARIO)
         self.logger.info("reported verifier reward %s to reef", result["verifier_result"]["rewards"]["reward"])

--- a/recipes/basic/harness/report.py
+++ b/recipes/basic/harness/report.py
@@ -11,7 +11,7 @@ from typing import Any
 from reef_client import ReefClient
 
 
-def post_report(result: dict[str, Any], *, client: ReefClient, scenario: str, recipe: str) -> dict[str, Any]:
+def post_report(result: dict[str, Any], *, client: ReefClient, scenario: str) -> dict[str, Any]:
     trial_id = result["id"]
     task_name = result["task_name"]
     score = result["verifier_result"]["rewards"]["reward"]
@@ -24,4 +24,4 @@ def post_report(result: dict[str, Any], *, client: ReefClient, scenario: str, re
         "references": result["agent_result"]["metadata"]["reef"]["agent_record_ids"],
         "metadata": {"harbor": {"trial_id": trial_id, "task_name": task_name}},
     }
-    return client.report(scenario, payload, recipe=recipe)
+    return client.report(scenario, payload)

--- a/recipes/sao/examples/sao/harness/agent.py
+++ b/recipes/sao/examples/sao/harness/agent.py
@@ -135,7 +135,7 @@ class HarborAgent(BaseAgent):
             completion = response["choices"][0]["message"]["content"]
             predicted = extract_answer(completion)
             score = 1.0 if answers_equal(gold, predicted) else 0.0
-            self._client.report(SCENARIO, {"score": score, "references": [agent_record_id]}, recipe=RECIPE)
+            self._client.report(SCENARIO, {"score": score, "references": [agent_record_id]})
             agent_record_ids.append(agent_record_id)
             print(f"[{RECIPE} {index}] score={score:.1f} predicted={predicted!r}", flush=True)
 
@@ -159,7 +159,6 @@ class HarborAgent(BaseAgent):
                 "temperature": 1.0,
                 "top_p": 1.0,
             },
-            recipe=RECIPE,
         )
 
     def _report_trial_result(self) -> None:
@@ -168,5 +167,5 @@ class HarborAgent(BaseAgent):
         while not (result_path.exists() and result_path.stat().st_mtime >= self._report_watch_from):
             time.sleep(1.0)
         result = json.loads(result_path.read_text(encoding="utf-8"))
-        post_report(result, client=self._client, scenario=SCENARIO, recipe=RECIPE)
+        post_report(result, client=self._client, scenario=SCENARIO)
         self.logger.info("reported verifier reward %s to reef", result["verifier_result"]["rewards"]["reward"])

--- a/recipes/sao/examples/sao/harness/report.py
+++ b/recipes/sao/examples/sao/harness/report.py
@@ -12,7 +12,7 @@ import uuid
 from reef_client import ReefClient
 
 
-def post_report(result: dict, *, client: ReefClient, scenario: str, recipe: str) -> dict:
+def post_report(result: dict, *, client: ReefClient, scenario: str) -> dict:
     trial_id = result["id"]
     task_name = result["task_name"]
     score = result["verifier_result"]["rewards"]["reward"]
@@ -25,4 +25,4 @@ def post_report(result: dict, *, client: ReefClient, scenario: str, recipe: str)
         "references": result["agent_result"]["metadata"]["reef"]["agent_record_ids"],
         "metadata": {"harbor": {"trial_id": trial_id, "task_name": task_name}},
     }
-    return client.report(scenario, payload, recipe=recipe)
+    return client.report(scenario, payload)

--- a/recipes/skillclaw/harness/harbor_agent.py
+++ b/recipes/skillclaw/harness/harbor_agent.py
@@ -10,7 +10,7 @@ report: the smoke proves the task contract - environment up, instruction
 in, exchange recorded, verifier reward out of ``lab.run``.
 
 The connection is passed as agent kwargs by ``run.py solve`` (Harbor's
-``AgentConfig.kwargs``): ``service_url``, ``scenario``, and ``recipe``.
+``AgentConfig.kwargs``): ``service_url`` and ``scenario``.
 """
 
 from __future__ import annotations
@@ -39,12 +39,10 @@ class HarborAgent(BaseAgent):
         *args: Any,
         service_url: str,
         scenario: str,
-        recipe: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self._scenario = scenario
-        self._recipe = recipe
         self._client = ReefClient(
             service_url,
             timeout_s=float(os.environ.get("REEF_TIMEOUT_S", "300")),
@@ -95,5 +93,4 @@ class HarborAgent(BaseAgent):
                 "model": self.model_name or "reef",
                 "messages": [{"role": "user", "content": instruction}],
             },
-            recipe=self._recipe,
         )

--- a/recipes/skillclaw/run.py
+++ b/recipes/skillclaw/run.py
@@ -73,7 +73,7 @@ from reef.core.records_types import AgentRecord, RequestType
 from reef.dispatcher import Dispatcher
 from reef.harness.adapters import get_adapter
 from reef.harness.render import render_composition
-from reef.recipe.registry import RecipeRegistry, build_recipe
+from reef.recipe.registry import build_recipe
 from reef.records import RecordStore
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.runtime.inference import HttpInferenceBackend, provider_request_headers
@@ -93,7 +93,7 @@ class Ledger:
             handle.write(json.dumps(record) + "\n")
 
 
-def load_recipe() -> tuple[str, Any]:
+def load_recipe() -> Any:
     """The recipe skillclaw.yaml declares, built through its explicit implementation.
 
     This driver is the deployment: it owns the upstream binding and hands it
@@ -108,8 +108,7 @@ def load_recipe() -> tuple[str, Any]:
         api_key=read_key(),
         inference_timeout_s=600.0,
     )
-    recipe = build_recipe(str(sections["implementation"]), config=sections, runtime=runtime)
-    return recipe.name, recipe
+    return build_recipe(str(sections["implementation"]), config=sections, runtime=runtime)
 
 
 def _default_headers_middleware(scenario: str) -> Any:
@@ -137,7 +136,6 @@ class RunService:
         self,
         *,
         scenario: str,
-        recipe_name: str,
         recipe: Any,
         bootstrap_pool: Path,
         run_dir: Path,
@@ -147,11 +145,10 @@ class RunService:
         inference_backend: Any | None = None,
     ) -> None:
         self.scenario = scenario
-        self.recipe_name = recipe_name
         self.port = port
         self.base_url = f"http://127.0.0.1:{port}"
         self.dispatcher = Dispatcher(
-            RecipeRegistry({recipe_name: recipe}),
+            recipe,
             InMemoryRepositoryBackend.factory(bootstrap_pool, root=run_dir / "artifacts"),
             local_artifact_dir=run_dir / "staged",
             agent_record_dir=run_dir / "reef-data",
@@ -173,7 +170,7 @@ class RunService:
     def start(self) -> None:
         # Scenario creation (or durable recovery from the commit log) happens
         # before any request lands.
-        self.dispatcher.get_or_create_scenario(self.scenario, self.recipe_name)
+        self.dispatcher.get_or_create_scenario(self.scenario)
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._loop.run_forever, name="reef-embedded", daemon=True)
         self._thread.start()
@@ -210,7 +207,7 @@ class RunService:
         return artifact.local_path
 
     def records(self) -> RecordStore:
-        scenario = self.dispatcher.get_or_create_scenario(self.scenario, self.recipe_name)
+        scenario = self.dispatcher.get_or_create_scenario(self.scenario)
         assert scenario is not None
         return scenario.records
 
@@ -227,7 +224,7 @@ class RunService:
         return len(trained - baseline)
 
     def training_step(self) -> int:
-        current = self.dispatcher.get_or_create_scenario(self.scenario, self.recipe_name)
+        current = self.dispatcher.get_or_create_scenario(self.scenario)
         assert current is not None
         return current.scenario_step
 
@@ -247,7 +244,7 @@ class RunService:
         If the process died after the trigger report but before its commit, no
         further record will re-trigger it, so a resumed run drives one step.
         """
-        current = self.dispatcher.get_or_create_scenario(self.scenario, self.recipe_name)
+        current = self.dispatcher.get_or_create_scenario(self.scenario)
         assert current is not None
         result = current.prepare_training_step()
         if result is None:
@@ -282,7 +279,7 @@ def ensure_task_record(
         payload={"messages": [{"role": "user", "content": composed_prompt}], "response": {}},
         agent_record_id=agent_record_id,
     )
-    service.dispatcher.accept_record(item, recipe=service.recipe_name)
+    service.dispatcher.accept_record(item)
     return item.agent_record_id
 
 
@@ -453,7 +450,7 @@ def report(service: RunService, client: ReefClient, payload: dict[str, Any]) -> 
     checked to determine whether the report landed.
     """
     try:
-        client.report(service.scenario, dict(payload), recipe=service.recipe_name)
+        client.report(service.scenario, dict(payload))
     except ReefClientError as exc:
         if exc.status == 409:
             return  # an already reported task from a replayed day
@@ -557,10 +554,9 @@ def main() -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     ledger = Ledger(run_dir / "ledger.jsonl")
     day.ensure_benchmark()
-    recipe_name, recipe = load_recipe()
+    recipe = load_recipe()
     service = RunService(
         scenario=RUN,
-        recipe_name=recipe_name,
         recipe=recipe,
         # The last durable commit wins over pool-current: a crash between the
         # night's commit and the pool copy must not silently revert the pool.
@@ -639,10 +635,9 @@ def solve() -> None:
 
     run_dir = WORKDIR / "solve"
     run_dir.mkdir(parents=True, exist_ok=True)
-    recipe_name, recipe = load_recipe()
+    recipe = load_recipe()
     service = RunService(
         scenario="solve",
-        recipe_name=recipe_name,
         recipe=recipe,
         bootstrap_pool=_bootstrap_pool(run_dir, "solve", recipe),
         run_dir=run_dir,
@@ -654,7 +649,7 @@ def solve() -> None:
     agent = {
         "name": "harness.harbor_agent:HarborAgent",
         "model_name": AGENT_MODEL,
-        "kwargs": {"service_url": service.base_url, "scenario": "solve", "recipe": recipe_name},
+        "kwargs": {"service_url": service.base_url, "scenario": "solve"},
     }
     try:
         lab = Lab(run_dir / "lab")

--- a/recipes/tttd/examples/guidance_ttt/harness/agent.py
+++ b/recipes/tttd/examples/guidance_ttt/harness/agent.py
@@ -122,7 +122,6 @@ class ReefGuidanceTTTHarness:
         model: str,
         contract: TaskContract,
         scorer: Scorer,
-        recipe: str = "tttd",
         groups_per_step: int = 8,
         rollouts_per_group: int = 16,
         guidance_max_tokens: int = 8_192,
@@ -141,7 +140,6 @@ class ReefGuidanceTTTHarness:
         self.model = model
         self.contract = contract
         self.scorer = scorer
-        self.recipe = recipe
         self.groups_per_step = groups_per_step
         self.rollouts_per_group = rollouts_per_group
         self.guidance_max_tokens = guidance_max_tokens
@@ -213,7 +211,6 @@ class ReefGuidanceTTTHarness:
             self.scenario,
             "/v1/chat/completions",
             payload,
-            recipe=self.recipe,
         )
         guidance_text = openai_action(response)
         guidance, guidance_error = extract_strict_guidance(guidance_text)
@@ -343,7 +340,6 @@ class ReefGuidanceTTTHarness:
                     "library_entry_id": entry.id,
                 },
             },
-            recipe=self.recipe,
         )
         return GuidanceRolloutResult(
             step=step,

--- a/recipes/tttd/examples/tttd/harness/agent.py
+++ b/recipes/tttd/examples/tttd/harness/agent.py
@@ -30,7 +30,6 @@ class ReefTTTDiscoverHarness(_TTTDiscoverHarnessBase):
         *,
         scenario: str,
         model: str,
-        recipe: str = "tttd",
         release_id: str | None = None,
         inference_path: str = "/v1/chat/completions",
         groups_per_step: int = 8,
@@ -53,7 +52,6 @@ class ReefTTTDiscoverHarness(_TTTDiscoverHarnessBase):
         )
         self.client = client
         self.scenario = scenario
-        self.recipe = recipe
         self.release_id = release_id
         self.inference_path = inference_path
 
@@ -70,7 +68,6 @@ class ReefTTTDiscoverHarness(_TTTDiscoverHarnessBase):
             self.scenario,
             self.inference_path,
             self._request_payload(parent),
-            recipe=self.recipe,
             extra_headers=release_headers,
         )
 
@@ -97,7 +94,6 @@ class ReefTTTDiscoverHarness(_TTTDiscoverHarnessBase):
                     "search_value": result.search_value,
                 },
             },
-            recipe=self.recipe,
             extra_headers=release_headers,
         )
         return result

--- a/recipes/tttd/examples/tttd/harness/harbor_agent.py
+++ b/recipes/tttd/examples/tttd/harness/harbor_agent.py
@@ -83,7 +83,6 @@ class HarborAgent(BaseAgent):
             instruction,
             scenario=SCENARIO,
             model=self.model_name,
-            recipe=RECIPE,
             inference_path=inference_path,
             groups_per_step=GROUPS_PER_STEP,
             rollouts_per_group=ROLLOUTS_PER_GROUP,

--- a/reef/__init__.py
+++ b/reef/__init__.py
@@ -42,11 +42,7 @@ from reef.scenario import (
 )
 from reef.recipe import (
     RecipeConfigError,
-    RecipeRegistry,
-    ScenarioRecipeConflict,
-    ScenarioRecipeError,
     Recipe,
-    UnknownScenarioRecipe,
 )
 from reef.dispatcher import Dispatcher, build_default_dispatcher
 from reef.train import DataProcessor, Trainer
@@ -73,7 +69,6 @@ __all__ = [
     "ModelCandidate",
     "Recipe",
     "RecipeConfigError",
-    "RecipeRegistry",
     "RecordStore",
     "ReefError",
     "ReportBase",
@@ -82,12 +77,9 @@ __all__ = [
     "RequestHeaders",
     "RequestType",
     "Scenario",
-    "ScenarioRecipeConflict",
-    "ScenarioRecipeError",
     "SelectionDecision",
     "Trainer",
     "TrainingRuntime",
-    "UnknownScenarioRecipe",
     "UpdateCandidate",
     "build_candidate_evaluation",
     "build_default_dispatcher",

--- a/reef/cli.py
+++ b/reef/cli.py
@@ -8,8 +8,8 @@ process in dependency order, including the internal Reef HTTP service.
 Run `reef serve --help` for config options.
 
 Deployment stacks use the `services` layout documented in the configuration
-reference. Named per-scenario recipe YAML is deployment data, not library
-data: point ``REEF_RECIPE_CONFIG_DIR`` at your own directory.
+reference. Named recipe YAML is deployment data, not library data: point
+``REEF_RECIPE_CONFIG_DIR`` at your own directory.
 """
 
 from __future__ import annotations

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -30,7 +30,6 @@ from reef.observability import (
     TrainingExperimentEvent,
 )
 from reef.recipe.base import Recipe
-from reef.recipe.registry import RecipeRegistry
 from reef.runtime.base import RuntimeContractError, TrainingRuntime
 from reef.scenario.checkpoint_strategy import CheckpointStrategy, EveryNVersions
 from reef.scenario.registry import ScenarioRegistry
@@ -105,14 +104,15 @@ class Dispatcher:
     """Coordinate scenario creation, inference state, training, and model commits.
 
     Invariant: at most one weight-training scenario per process. Its serial
-    thread is bound to the first recipe carrying a ``TrainingRuntime``;
-    resolving a second raises (enforced in :class:`ScenarioRegistry`).
+    thread is bound to the first scenario using the deployment's
+    ``TrainingRuntime``; resolving a second raises (enforced in
+    :class:`ScenarioRegistry`).
     Local training backends are unlimited and drain on per-scenario threads.
     """
 
     def __init__(
         self,
-        recipes: RecipeRegistry,
+        recipe: Recipe,
         backend_factory: RepositoryBackendFactory,
         *,
         local_artifact_dir: Path | None = None,
@@ -120,9 +120,10 @@ class Dispatcher:
         allow_implicit_creation: bool = True,
         experiment_tracker: ExperimentTracker | None = None,
     ) -> None:
+        self._recipe = recipe
         self._experiment_tracker = experiment_tracker if experiment_tracker is not None else NullExperimentTracker()
         self._registry = ScenarioRegistry(
-            recipes,
+            recipe,
             backend_factory,
             local_artifact_dir=local_artifact_dir,
             agent_record_dir=agent_record_dir,
@@ -157,14 +158,12 @@ class Dispatcher:
     def get_or_create_scenario(
         self,
         scenario: str,
-        recipe: str | None = None,
-        release_id: str | None = None,
         *,
+        release_id: str | None = None,
         allow_implicit_creation: bool | None = None,
     ) -> Scenario | None:
         return self._registry.get_or_create(
             scenario,
-            recipe,
             release_id,
             allow_implicit_creation=allow_implicit_creation,
         )
@@ -172,11 +171,8 @@ class Dispatcher:
     def list_scenarios(self) -> tuple[dict[str, Any], ...]:
         return self._registry.list()
 
-    def recipe_has_files(self, recipe: str) -> bool:
-        return self._registry.recipe_has_files(recipe)
-
-    def file_recipe_names(self) -> tuple[str, ...]:
-        return self._registry.file_recipe_names()
+    def recipe_has_files(self) -> bool:
+        return self._registry.recipe_has_files()
 
     def list_releases(self, scenario: str) -> tuple[dict[str, Any], ...]:
         with self._registry.lock_for(scenario):
@@ -188,7 +184,6 @@ class Dispatcher:
             processor = current.trainer.processor
             return {
                 "scenario": scenario,
-                "recipe": current.recipe,
                 "processor": type(processor).__name__,
                 "required_request_types": sorted(rt.value for rt in processor.required_request_types),
             }
@@ -203,7 +198,7 @@ class Dispatcher:
                 return published
             event = RollbackExperimentEvent(
                 scenario=scenario,
-                recipe=current.recipe,
+                recipe=self._recipe.name,
                 step=current.scenario_step,
                 run_segment=context.run_segment,
                 source_artifact_ref=source,
@@ -219,10 +214,10 @@ class Dispatcher:
     def current_artifact(
         self,
         scenario: str,
-        recipe: str | None = None,
+        *,
         release_id: str | None = None,
     ) -> Artifact:
-        current = self.get_or_create_scenario(scenario, recipe, release_id)
+        current = self.get_or_create_scenario(scenario, release_id=release_id)
         if current is None:
             raise UnknownScenario(f"unknown scenario {scenario!r}")
         return Artifact(current.repository.require_current_artifact(), current.repository)
@@ -233,11 +228,10 @@ class Dispatcher:
         self,
         item: AgentRecord,
         *,
-        recipe: str | None = None,
         release_id: str | None = None,
     ) -> AgentRecord:
         with self._registry.lock_for(item.scenario):
-            current = self.get_or_create_scenario(item.scenario, recipe, release_id)
+            current = self.get_or_create_scenario(item.scenario, release_id=release_id)
             if current is None:
                 raise UnknownScenario(f"unknown scenario {item.scenario!r}")
             return self._accept_record(current, item)
@@ -300,8 +294,7 @@ class Dispatcher:
         except Exception:
             logger.exception("experiment tracker failed to record committed training step")
 
-    @staticmethod
-    def _experiment_context(current: Scenario) -> TrainingExperimentContext:
+    def _experiment_context(self, current: Scenario) -> TrainingExperimentContext:
         backend = current.trainer.training_backend
         try:
             backend_config = None if backend is None else dict(backend.experiment_config())
@@ -313,7 +306,7 @@ class Dispatcher:
         run_step = sum(record.operation == "training" and record.step > run_segment for record in records)
         return TrainingExperimentContext(
             scenario=current.name,
-            recipe=current.recipe,
+            recipe=self._recipe.name,
             step=current.scenario_step + 1,
             source_artifact_ref=current.current_artifact_ref(),
             run_segment=run_segment,
@@ -682,19 +675,12 @@ class Dispatcher:
         }
 
     def _serving_status(self) -> dict[str, Any]:
-        """Runtime-wide serving state per recipe (shared adapter residency)."""
-        serving: dict[str, Any] = {}
-        recipes = getattr(self._registry, "recipes", None)
-        if recipes is None:
-            return serving
-        for recipe_name in recipes.names:
-            try:
-                status = recipes.resolve(recipe_name).serving_status()
-            except Exception as exc:
-                status = {"error": self._error_text(exc)}
-            if status is not None:
-                serving[recipe_name] = status
-        return serving
+        """Runtime-wide serving state for the deployment's recipe."""
+        try:
+            status = self._recipe.serving_status()
+        except Exception as exc:
+            status = {"error": self._error_text(exc)}
+        return {} if status is None else {self._recipe.name: status}
 
     # -- Lifecycle -------------------------------------------------------
 
@@ -734,8 +720,8 @@ def build_default_dispatcher(
     """Build a Dispatcher serving the core record-only ``recipe``.
 
     Convenience for tests and service entrypoints that want a working
-    dispatcher without configuring a recipe registry by hand. The recipe is
-    the same base ``Recipe`` a deployment gets from ``reef.recipe: recipe``.
+    dispatcher. The recipe is the same base ``Recipe`` a deployment gets
+    from ``reef.recipe: recipe``.
     Uses an in-memory artifact backend when ``backend_factory`` is not
     provided.
     """
@@ -748,7 +734,7 @@ def build_default_dispatcher(
         checkpoint_strategy=checkpoint_strategy if checkpoint_strategy is not None else EveryNVersions(1),
     )
     return Dispatcher(
-        RecipeRegistry({recipe.name: recipe}),
+        recipe,
         backend_factory,
         local_artifact_dir=local_artifact_dir,
         agent_record_dir=agent_record_dir,

--- a/reef/recipe/__init__.py
+++ b/reef/recipe/__init__.py
@@ -7,9 +7,8 @@ weights or the harness*. This package holds everything a method binds to:
   ``build``, ``build_artifact_validator``, ``build_surface``, the
   ``CheckpointStrategy``) and ``WeightTrainingRecipe`` with its
   ``WeightTrainingSpec`` (step preparer, loss family, data processor).
-- ``registry`` — dotted class resolution (``recipe_class_for``),
-  ``build_named_recipe`` for a deployment preset, and
-  ``RecipeRegistry``, the closed instance table scenarios bind to.
+- ``registry`` — dotted class resolution (``recipe_class_for``) and
+  ``build_named_recipe`` for a deployment preset.
 - ``config_fields`` — one dataclass field as the whole configuration surface
   for one setting (YAML key, env fallback, typed parser).
 - ``config`` — recipe-config YAML loading; ``errors`` — the error family.
@@ -38,16 +37,12 @@ and never ``reef.train.slime_backend`` at module scope.
 from reef.recipe.base import Recipe, WeightTrainingRecipe, WeightTrainingSpec
 from reef.recipe.config import load_recipe_config
 from reef.recipe.config_fields import config_field
-from reef.recipe.errors import RecipeConfigError, ScenarioRecipeConflict, ScenarioRecipeError, UnknownScenarioRecipe
-from reef.recipe.registry import RecipeRegistry, build_named_recipe, build_recipe, recipe_class_for
+from reef.recipe.errors import RecipeConfigError
+from reef.recipe.registry import build_named_recipe, build_recipe, recipe_class_for
 
 __all__ = [
     "Recipe",
     "RecipeConfigError",
-    "RecipeRegistry",
-    "ScenarioRecipeConflict",
-    "ScenarioRecipeError",
-    "UnknownScenarioRecipe",
     "WeightTrainingRecipe",
     "WeightTrainingSpec",
     "build_named_recipe",

--- a/reef/recipe/errors.py
+++ b/reef/recipe/errors.py
@@ -1,19 +1,7 @@
-"""Errors shared by recipe registries, stores, and request handling."""
+"""Errors raised while selecting and configuring a deployment recipe."""
 
 from reef.core.errors import ReefError
 
 
 class RecipeConfigError(ReefError):
     """Raised when a recipe's environment or YAML config is invalid."""
-
-
-class ScenarioRecipeError(ReefError):
-    """Base class for invalid scenario/recipe operations."""
-
-
-class UnknownScenarioRecipe(ScenarioRecipeError):
-    pass
-
-
-class ScenarioRecipeConflict(ScenarioRecipeError):
-    pass

--- a/reef/recipe/registry.py
+++ b/reef/recipe/registry.py
@@ -6,8 +6,6 @@ Two axes live here, deliberately separate:
   record-only recipe or an explicit ``package.module:ClassName`` reference.
 - :func:`build_named_recipe` builds the recipe a deployment names: a YAML
   preset from the recipe config directory, or the core record-only recipe.
-- :class:`RecipeRegistry` is the closed *instance* table mapping the public
-  names scenarios bind to onto built ``Recipe`` objects.
 """
 
 from __future__ import annotations
@@ -21,7 +19,7 @@ from typing import Any
 
 from reef.recipe.base import Recipe
 from reef.recipe.config import load_recipe_config
-from reef.recipe.errors import RecipeConfigError, UnknownScenarioRecipe
+from reef.recipe.errors import RecipeConfigError
 from reef.runtime.base import InferenceRuntime
 from reef.runtime.registry import RuntimeRegistry
 
@@ -96,8 +94,8 @@ def build_named_recipe(
         available = {"recipe"}
         if directory is not None:
             available.update(preset.stem for preset in directory.glob("*.yaml"))
-        raise UnknownScenarioRecipe(
-            f"unknown scenario recipe {name!r}; available recipes: {', '.join(sorted(available))}"
+        raise RecipeConfigError(
+            f"unknown deployment recipe {name!r}; available recipes: {', '.join(sorted(available))}"
         )
 
     settings = load_recipe_config(path)
@@ -114,41 +112,3 @@ def build_named_recipe(
         else default_runtime
     )
     return build_recipe(settings["implementation"], values, config=settings, runtime=runtime)
-
-
-class RecipeRegistry:
-    """The recipes a process serves, by the public name scenarios bind to.
-
-    A closed set: request-time names resolve only to what the operator
-    injected, never materializing another implementation or preset. A reef deployment
-    serves exactly one recipe (see :attr:`served_recipe`); multi-recipe
-    registries exist for tests that exercise scenario bindings across
-    deployments.
-    """
-
-    def __init__(self, recipes: Mapping[str, Recipe]) -> None:
-        self._recipes = dict(recipes)
-
-    @property
-    def names(self) -> tuple[str, ...]:
-        return tuple(sorted(self._recipes))
-
-    @property
-    def served_recipe(self) -> str | None:
-        """The one recipe this registry serves, or ``None`` for a multi-recipe
-        registry.
-
-        A request that names no recipe binds its scenario to the served one;
-        a multi-recipe registry has no served recipe and requests must name one.
-        """
-        if len(self._recipes) != 1:
-            return None
-        return next(iter(self._recipes))
-
-    def resolve(self, recipe: str) -> Recipe:
-        selected = self._recipes.get(recipe)
-        if selected is None:
-            raise UnknownScenarioRecipe(
-                f"unknown scenario recipe {recipe!r}; available recipes: {', '.join(self.names)}"
-            )
-        return selected

--- a/reef/scenario/__init__.py
+++ b/reef/scenario/__init__.py
@@ -4,7 +4,7 @@ A scenario is one durable training aggregate. Its lifecycle, and the module
 responsible for each piece:
 
 - **create** — ``factory`` forks a base artifact and persists a registration
-  snapshot (format in ``snapshot``); ``binding`` freezes the recipe-selected
+  snapshot (format in ``snapshot``); ``binding`` freezes the deployment-selected
   admission, surface, runtime, and inference backend.
 - **train** — ``scenario`` exposes the trainer through lock-guarded methods
   so every mutating path serializes against commit and rollback.
@@ -19,8 +19,9 @@ responsible for each piece:
 - **rollback** — ``commit_protocol`` republishes an older checkpointed
   version as a new fenced commit; history is never rewritten.
 
-The scenario domain does not import recipes: a recipe configures a scenario
-through the factory, and the aggregate never reaches back. Every
+The scenario aggregate does not retain recipe identity: the deployment's
+recipe configures its runtime binding through the factory, and the aggregate
+never reaches back. Every
 step-advancing commit appends exactly one atomic record, and recovery
 re-derives every other store from the log. Checkpoint cadence is the one
 extension point (subclass ``CheckpointStrategy``); the commit ordering itself

--- a/reef/scenario/binding.py
+++ b/reef/scenario/binding.py
@@ -30,7 +30,6 @@ class AcceptAnyArtifact:
 class ScenarioBinding:
     """Runtime-facing capabilities selected by a recipe at construction."""
 
-    name: str
     surface: Surface
     runtime: InferenceRuntime | None
     inference_backend: InferenceBackend | None

--- a/reef/scenario/commit_protocol.py
+++ b/reef/scenario/commit_protocol.py
@@ -194,7 +194,6 @@ class ScenarioCommitProtocol:
             try:
                 snapshot_metadata = snapshot_metadata_for(
                     name=self._name,
-                    recipe=self._binding.name,
                     base_artifact=artifacts.base,
                     scenario_step=next_step,
                     algorithm_state=prepared.algorithm_state,
@@ -306,7 +305,6 @@ class ScenarioCommitProtocol:
             if self._should_checkpoint(result):
                 snapshot_metadata = snapshot_metadata_for(
                     name=self._name,
-                    recipe=self._binding.name,
                     base_artifact=artifacts.base,
                     scenario_step=next_step,
                     algorithm_state=prepared.algorithm_state,

--- a/reef/scenario/factory.py
+++ b/reef/scenario/factory.py
@@ -18,8 +18,6 @@ from reef.artifact.repository import (
 from reef.core.errors import ReefError
 from reef.observability import ExperimentLogger, ExperimentTracker
 from reef.recipe.base import Recipe
-from reef.recipe.errors import ScenarioRecipeConflict
-from reef.recipe.registry import RecipeRegistry
 from reef.records import RecordStore
 from reef.scenario.binding import ScenarioBinding
 from reef.scenario.commit_log import CommitLog, CommitRecord
@@ -101,18 +99,18 @@ def _consumed_by_committed_steps(
 
 
 class ScenarioFactory:
-    """Build a complete scenario from recipe and artifact registries."""
+    """Build a complete scenario from the served recipe and artifact backend."""
 
     def __init__(
         self,
-        recipes: RecipeRegistry,
+        recipe: Recipe,
         backend_factory: RepositoryBackendFactory,
         *,
         local_artifact_dir: Path | None = None,
         agent_record_dir: Path | None = None,
         experiment_tracker: ExperimentTracker,
     ) -> None:
-        self._recipes = recipes
+        self._recipe = recipe
         self._backend_factory = backend_factory
         self._local_artifact_dir = local_artifact_dir
         self._agent_record_dir = None if agent_record_dir is None else Path(agent_record_dir)
@@ -129,23 +127,9 @@ class ScenarioFactory:
     def load_or_create(
         self,
         scenario: str,
-        recipe: str | None = None,
         release_id: str | None = None,
     ) -> Scenario:
-        """Create or recover a scenario.
-
-        Creation binds the scenario to the deployment's served recipe; an
-        in-process caller may name the recipe instead, which a multi-recipe
-        registry (tests) requires.
-        """
-        if recipe is None:
-            recipe = self._recipes.served_recipe
-        if (
-            recipe is None
-            and isinstance(self._backend_factory, RegistrationAwareRepositoryBackendFactory)
-            and not self._backend_factory.has_registration(scenario)
-        ):
-            raise ReefError(f"no served recipe to bind scenario {scenario!r} to")
+        """Create or recover a scenario in this deployment's repository."""
         backend = self._backend_factory(scenario)
         metadata = backend.metadata()
         snapshot_data = None if metadata is None else metadata.get(SCENARIO_SNAPSHOT_METADATA_KEY)
@@ -154,28 +138,23 @@ class ScenarioFactory:
                 scenario,
                 backend,
                 snapshot_data,
-                recipe=recipe,
                 release_id=release_id,
             )
 
-        if recipe is None:
-            raise ReefError(f"no served recipe to bind scenario {scenario!r} to")
-        self._recipes.resolve(recipe)
         selected = backend.resolve_release(release_id)
         backend.fork(
             selected.release_id,
             metadata={
                 SCENARIO_SNAPSHOT_METADATA_KEY: snapshot_metadata_for(
                     name=scenario,
-                    recipe=recipe,
                     base_artifact=selected,
                 )
             },
         )
 
         # fork() is the atomic registration point. Another caller may have
-        # won it, so always rebuild from the durable binding instead of the
-        # recipe this caller proposed.
+        # won it, so always rebuild from the durable registration instead of
+        # assuming this creation attempt won.
         persisted_metadata = backend.metadata()
         persisted_snapshot = (
             None if persisted_metadata is None else persisted_metadata.get(SCENARIO_SNAPSHOT_METADATA_KEY)
@@ -186,7 +165,6 @@ class ScenarioFactory:
             scenario,
             backend,
             persisted_snapshot,
-            recipe=recipe,
             # Freeze moving selectors such as "head" at the release resolved
             # for this create attempt. If another creator won, its persisted
             # base must still match the version this caller observed.
@@ -196,15 +174,12 @@ class ScenarioFactory:
     def validate_existing(
         self,
         current: Scenario,
-        recipe: str | None,
         release_id: str | None,
     ) -> None:
-        self._validate_binding_selectors(
+        self._validate_release_selector(
             current.name,
-            current.recipe,
             current.repository.base_artifact,
             current.repository.backend,
-            recipe,
             release_id,
         )
 
@@ -214,7 +189,6 @@ class ScenarioFactory:
         backend: RepositoryBackend,
         snapshot_data: object,
         *,
-        recipe: str | None,
         release_id: str | None,
     ) -> Scenario:
         if not isinstance(snapshot_data, Mapping):
@@ -223,15 +197,13 @@ class ScenarioFactory:
         if snapshot.scenario != scenario:
             raise ValueError(f"scenario snapshot is for {snapshot.scenario!r}, not {scenario!r}")
         base_artifact = backend.resolve_release(snapshot.base_artifact.release_id)
-        self._validate_binding_selectors(
+        self._validate_release_selector(
             scenario,
-            snapshot.recipe,
             base_artifact,
             backend,
-            recipe,
             release_id,
         )
-        recipe_definition = self._recipes.resolve(snapshot.recipe)
+        recipe_definition = self._recipe
         surface = recipe_definition.build_surface(scenario)
         runtime = recipe_definition.runtime
         checkpoint_head = backend.current()
@@ -273,7 +245,6 @@ class ScenarioFactory:
             surface.loader.activate(Artifact(current_artifact, repository), runtime)
         recovered = self._build(
             scenario,
-            snapshot.recipe,
             recipe_definition,
             surface,
             repository,
@@ -310,7 +281,6 @@ class ScenarioFactory:
     def _build(
         self,
         scenario: str,
-        recipe: str,
         recipe_definition: Recipe,
         surface: Surface,
         repository: Repository,
@@ -326,7 +296,7 @@ class ScenarioFactory:
         records = RecordStore(database)
         experiment_logger = self._experiment_tracker.bind_scenario(
             scenario=scenario,
-            recipe=recipe,
+            recipe=recipe_definition.name,
             source_artifact_ref=repository.require_current_artifact(),
             run_segment=max(
                 (
@@ -347,7 +317,6 @@ class ScenarioFactory:
         return Scenario(
             name=scenario,
             binding=ScenarioBinding(
-                name=recipe,
                 surface=surface,
                 runtime=recipe_definition.runtime,
                 inference_backend=recipe_definition.inference_backend,
@@ -393,26 +362,19 @@ class ScenarioFactory:
         except ArtifactNotFound:
             return False
 
-    def _validate_binding_selectors(
+    def _validate_release_selector(
         self,
         scenario: str,
-        bound_recipe: str,
         base_artifact: ArtifactRef,
         backend: RepositoryBackend,
-        recipe: str | None,
         release_id: str | None,
     ) -> None:
-        """Refuse request selectors that conflict with the existing binding."""
-        if recipe is not None and recipe != bound_recipe:
-            raise ScenarioRecipeConflict(
-                f"scenario {scenario!r} is already bound to recipe {bound_recipe!r}, not {recipe!r}"
-            )
+        """Refuse a release selector that conflicts with the existing binding."""
         if release_id is not None and not self._artifact_selector_matches(
             base_artifact,
             release_id,
             backend,
         ):
             raise ArtifactConflict(
-                f"scenario {scenario!r} is already bound to release "
-                f"{base_artifact.release_id!r}, not {release_id!r}"
+                f"scenario {scenario!r} is already bound to release {base_artifact.release_id!r}, not {release_id!r}"
             )

--- a/reef/scenario/registry.py
+++ b/reef/scenario/registry.py
@@ -17,7 +17,7 @@ from typing import Any
 from reef.artifact.repository import EnumerableRepositoryBackendFactory, RepositoryBackendFactory
 from reef.core.errors import ReefError, UnknownScenario
 from reef.observability import ExperimentTracker, NullExperimentTracker
-from reef.recipe.registry import RecipeRegistry
+from reef.recipe.base import Recipe
 from reef.runtime.base import TrainingRuntime
 from reef.scenario.factory import ScenarioFactory
 from reef.scenario.scenario import Scenario
@@ -35,7 +35,7 @@ class ScenarioRegistry:
 
     def __init__(
         self,
-        recipes: RecipeRegistry,
+        recipe: Recipe,
         backend_factory: RepositoryBackendFactory,
         *,
         local_artifact_dir: Path | None = None,
@@ -44,14 +44,14 @@ class ScenarioRegistry:
         experiment_tracker: ExperimentTracker | None = None,
     ) -> None:
         self._scenario_factory = ScenarioFactory(
-            recipes,
+            recipe,
             backend_factory,
             local_artifact_dir=local_artifact_dir,
             agent_record_dir=agent_record_dir,
             experiment_tracker=(experiment_tracker if experiment_tracker is not None else NullExperimentTracker()),
         )
         self._backend_factory = backend_factory
-        self._recipes = recipes
+        self._recipe = recipe
         self._scenarios: dict[str, Scenario] = {}
         self._scenario_locks: dict[str, RLock] = {}
         self._lock = Lock()
@@ -61,18 +61,10 @@ class ScenarioRegistry:
         self._allow_implicit_creation = allow_implicit_creation
         self._on_training_scenario_resolved: Callable[[Scenario], None] | None = None
 
-    @property
-    def recipes(self) -> RecipeRegistry:
-        return self._recipes
-
-    def recipe_has_files(self, recipe: str) -> bool:
-        """Whether a configured recipe creates a file-serving surface."""
+    def recipe_has_files(self) -> bool:
+        """Whether the served recipe creates a file-serving surface."""
         # Capability probe only: file serving does not depend on the scenario.
-        return self._recipes.resolve(recipe).build_surface("").files is not None
-
-    def file_recipe_names(self) -> tuple[str, ...]:
-        """Materialized recipe names that can back a harness scenario."""
-        return tuple(name for name in self._recipes.names if self.recipe_has_files(name))
+        return self._recipe.build_surface("").files is not None
 
     @property
     def training_scenario_name(self) -> str | None:
@@ -137,7 +129,6 @@ class ScenarioRegistry:
     def get_or_create(
         self,
         scenario: str,
-        recipe: str | None = None,
         release_id: str | None = None,
         *,
         allow_implicit_creation: bool | None = None,
@@ -153,13 +144,13 @@ class ScenarioRegistry:
         with self.lock_for(scenario):
             if not allow_implicit_creation and not self.has(scenario):
                 return None
-            return self._resolve(scenario, recipe, release_id)
+            return self._resolve(scenario, release_id)
 
     def require(self, scenario: str) -> Scenario:
         """Resolve an existing scenario; raise UnknownScenario if not found."""
         if not self.has(scenario):
             raise UnknownScenario(f"unknown scenario {scenario!r}")
-        return self._resolve(scenario, None, None)
+        return self._resolve(scenario, None)
 
     def list(self) -> tuple[dict[str, Any], ...]:
         """Known scenarios: loaded ones with their binding, durable ones by name."""
@@ -173,7 +164,6 @@ class ScenarioRegistry:
             current = loaded.get(name)
             row: dict[str, Any] = {"scenario": name, "loaded": current is not None}
             if current is not None:
-                row["recipe"] = current.recipe
                 ref = current.repository.require_current_artifact()
                 row["release_id"] = ref.release_id
                 row["content_id"] = ref.content_id
@@ -191,7 +181,7 @@ class ScenarioRegistry:
     def reload(self, scenario: str) -> Scenario:
         """Rebuild a scenario from durable state after a training failure."""
         with self.lock_for(scenario):
-            recovered = self._scenario_factory.load_or_create(scenario, None, None)
+            recovered = self._scenario_factory.load_or_create(scenario, None)
             with self._lock:
                 dropped = self._scenarios.get(scenario)
                 self._scenarios[scenario] = recovered
@@ -209,15 +199,14 @@ class ScenarioRegistry:
     def _resolve(
         self,
         scenario: str,
-        recipe: str | None,
         release_id: str | None,
     ) -> Scenario:
         with self._lock:
             current = self._scenarios.get(scenario)
         if current is not None:
-            self._scenario_factory.validate_existing(current, recipe, release_id)
+            self._scenario_factory.validate_existing(current, release_id)
             return current
-        current = self._scenario_factory.load_or_create(scenario, recipe, release_id)
+        current = self._scenario_factory.load_or_create(scenario, release_id)
         training = isinstance(current.runtime, TrainingRuntime)
         with self._lock:
             shared_runtime = training and getattr(current.runtime, "concurrent_training_scenarios", False)

--- a/reef/scenario/scenario.py
+++ b/reef/scenario/scenario.py
@@ -24,7 +24,7 @@ from reef.train.types import TrainingBatch, TrainStepResult
 
 
 class Scenario:
-    """Scenario aggregate owning one immutable recipe binding and release chain."""
+    """Scenario aggregate owning one runtime binding and release chain."""
 
     def __init__(
         self,
@@ -60,10 +60,6 @@ class Scenario:
     @property
     def name(self) -> str:
         return self._name
-
-    @property
-    def recipe(self) -> str:
-        return self._binding.name
 
     @property
     def runtime(self) -> InferenceRuntime | None:
@@ -223,7 +219,6 @@ class Scenario:
     def to_snapshot_metadata(self) -> dict[str, object]:
         return snapshot_metadata_for(
             name=self.name,
-            recipe=self.recipe,
             base_artifact=self.repository.base_artifact,
             scenario_step=self.scenario_step,
         )

--- a/reef/scenario/snapshot.py
+++ b/reef/scenario/snapshot.py
@@ -2,7 +2,7 @@
 
 A scenario registration lives in the artifact backend's metadata under
 ``SCENARIO_SNAPSHOT_METADATA_KEY``. The snapshot pins the durable binding
-(scenario name, recipe, base artifact) plus enough recovery state
+(scenario name and base artifact) plus enough recovery state
 (scenario step, algorithm state, record-consumption progress) for a
 checkpoint to resume training after a crash. This module is the format
 counterpart of ``commit_log.py``: the log journals every commit, the
@@ -69,7 +69,6 @@ class ScenarioSnapshot:
     """Parsed, validated scenario registration metadata."""
 
     scenario: str
-    recipe: str
     base_artifact: ArtifactRef
     scenario_step: int
     algorithm_state: Mapping[str, Any] | None
@@ -83,7 +82,6 @@ class ScenarioSnapshot:
 def snapshot_metadata_for(
     *,
     name: str,
-    recipe: str,
     base_artifact: ArtifactRef,
     scenario_step: int = 0,
     algorithm_state: Mapping[str, Any] | None = None,
@@ -96,7 +94,6 @@ def snapshot_metadata_for(
     metadata: dict[str, object] = {
         "format": SCENARIO_SNAPSHOT_KIND,
         "scenario": name,
-        "recipe": recipe,
         "scenario_step": scenario_step,
         "base_artifact": encode_artifact_ref(base_artifact),
         "operation": operation,
@@ -129,11 +126,8 @@ def parse_snapshot_metadata(value: Mapping[str, Any]) -> ScenarioSnapshot:
     if value.get("format") != SCENARIO_SNAPSHOT_KIND:
         raise ValueError(f"unsupported scenario snapshot format: {value.get('format')!r}")
     scenario = value.get("scenario")
-    recipe = value.get("recipe")
     if not isinstance(scenario, str) or not scenario:
         raise ValueError("scenario snapshot requires scenario")
-    if not isinstance(recipe, str) or not recipe:
-        raise ValueError("scenario snapshot requires recipe")
     raw_base = value.get("base_artifact")
     if not isinstance(raw_base, Mapping):
         raise ValueError("scenario snapshot requires base_artifact")
@@ -176,7 +170,6 @@ def parse_snapshot_metadata(value: Mapping[str, Any]) -> ScenarioSnapshot:
         raise ValueError("non-rollback scenario snapshot cannot carry rollback_target_release_id")
     return ScenarioSnapshot(
         scenario=scenario,
-        recipe=recipe,
         base_artifact=base_artifact,
         scenario_step=scenario_step,
         algorithm_state=algorithm_state,

--- a/reef/service/assembly.py
+++ b/reef/service/assembly.py
@@ -19,7 +19,7 @@ from reef.dispatcher import Dispatcher
 from reef.observability import build_experiment_tracker
 from reef.recipe import Recipe, WeightTrainingRecipe
 from reef.recipe.config_fields import resolve_config_field_values
-from reef.recipe.registry import RecipeRegistry, build_named_recipe, build_recipe, recipe_class_for
+from reef.recipe.registry import build_named_recipe, build_recipe, recipe_class_for
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.runtime.base import InferenceRuntime, TrainingRuntime
 from reef.runtime.inference import InferenceBackendFactory
@@ -203,13 +203,8 @@ def build_dispatcher(
         model=settings.model_path,
         training_config=settings.training_settings,
     )
-    # A deployment serves one recipe, so its registry is closed over that
-    # single entry and request-time names never materialize another. Scenarios
-    # bind to the operator's public name; an implementation reference is not a request name,
-    # so it serves under the recipe's own.
-    name = recipe.name if ":" in selected_recipe else selected_recipe
     return Dispatcher(
-        RecipeRegistry({name: recipe}),
+        recipe,
         backend_factory,
         local_artifact_dir=Path(settings.artifact_cache_dir) / "staged",
         agent_record_dir=Path(settings.agent_record_dir),

--- a/reef/service/errors.py
+++ b/reef/service/errors.py
@@ -15,7 +15,6 @@ from aiohttp import web
 from reef.artifact.artifact import ArtifactConflict, ArtifactError, ArtifactNotFound
 from reef.artifact.release_chain import ReleaseNotRestorable
 from reef.core.errors import ReefError, UnknownScenario
-from reef.recipe.errors import ScenarioRecipeConflict
 from reef.records import RecordConflict
 from reef.runtime.inference import UpstreamStatusError
 from reef.service.request_service import InferenceRetryTimeout
@@ -30,7 +29,6 @@ ERROR_STATUS_TABLE: tuple[tuple[type[Exception], type[web.HTTPError]], ...] = (
     (ArtifactConflict, web.HTTPConflict),
     (ReleaseNotRestorable, web.HTTPConflict),
     (RecordConflict, web.HTTPConflict),
-    (ScenarioRecipeConflict, web.HTTPConflict),
     (RuntimeLoadMismatch, web.HTTPConflict),
     (InferenceRetryTimeout, web.HTTPServiceUnavailable),
     (ArtifactError, web.HTTPServiceUnavailable),

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -427,7 +427,7 @@ class RequestService:
             raise UnknownScenario(f"unknown scenario {parsed.scenario!r}")
         selected_backend = backend if backend is not None else scenario.inference_backend
         if selected_backend is None:
-            raise RecipeConfigError(f"recipe {scenario.recipe!r} has no inference backend")
+            raise RecipeConfigError("the served recipe has no inference backend")
         ref = scenario.current_artifact_ref()
         return PreparedInference(
             parsed=parsed,
@@ -535,18 +535,13 @@ class RequestService:
         """Resolve a file-serving scenario, optionally creating a randomly named one."""
         normalized = {key.lower(): value.strip() for key, value in headers.items()}
         if create_if_missing and not normalized.get(SCENARIO_HEADER):
-            candidates = self._dispatcher.file_recipe_names()
-            if not candidates:
+            if not self._dispatcher.recipe_has_files():
                 raise ArtifactNotFound("no harness recipes are available")
-            if len(candidates) > 1:
-                raise ReefError(f"multiple harness recipes are available ({', '.join(candidates)})")
-            recipe = candidates[0]
 
             scenario_name = _random_harness_scenario_name()
             scenario = self._dispatcher.get_or_create_scenario(
                 scenario_name,
-                recipe,
-                release_id,
+                release_id=release_id,
                 allow_implicit_creation=True,
             )
             if scenario is None:
@@ -556,7 +551,7 @@ class RequestService:
         parsed = self._require_inference(headers)
         if not self._dispatcher.has_scenario(parsed.scenario):
             raise ArtifactNotFound(f"unknown scenario {parsed.scenario!r}")
-        scenario = self._dispatcher.get_or_create_scenario(parsed.scenario, None, parsed.release_id)
+        scenario = self._dispatcher.get_or_create_scenario(parsed.scenario, release_id=parsed.release_id)
         if scenario is None:
             raise ReefError(f"scenario {parsed.scenario!r} disappeared during lookup")
         if scenario.surface.files is None:

--- a/reef/service/routes/scenarios.py
+++ b/reef/service/routes/scenarios.py
@@ -12,21 +12,16 @@ def register_scenario_routes(app: web.Application, *, request_service: RequestSe
     async def create_scenario(request: web.Request) -> web.Response:
         payload = await request.json()
         name = payload.get("name")
-        recipe = payload.get("recipe")
         release_id = payload.get("release_id")
         if not isinstance(name, str) or not name.strip():
             raise web.HTTPBadRequest(text="name must be a non-empty string")
-        if not isinstance(recipe, str) or not recipe.strip():
-            raise web.HTTPBadRequest(text="recipe must be a non-empty string")
         if release_id is not None and not isinstance(release_id, str):
             raise web.HTTPBadRequest(text="release_id must be a string")
         name = name.strip()
-        recipe = recipe.strip()
         created = not request_service.dispatcher.has_scenario(name)
         scenario = request_service.dispatcher.get_or_create_scenario(
             name,
-            recipe,
-            release_id,
+            release_id=release_id,
             allow_implicit_creation=True,
         )
         if scenario is None:
@@ -35,7 +30,6 @@ def register_scenario_routes(app: web.Application, *, request_service: RequestSe
         return web.json_response(
             {
                 "scenario": scenario.name,
-                "recipe": scenario.recipe,
                 "release_id": current.release_id,
                 "content_id": current.content_id,
             },

--- a/tests/reef_service/test_artifact_versions.py
+++ b/tests/reef_service/test_artifact_versions.py
@@ -12,7 +12,6 @@ from reef.artifact import InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
 from reef.dispatcher import Dispatcher
 from reef.observability import NullExperimentLogger
-from reef.recipe import RecipeRegistry
 from reef.runtime import ActivatedModel, ModelCandidate, PreparedTrainingStep, TrainingRuntime
 from reef.runtime.inference import InferenceBackend
 from reef.scenario import ReleaseNotRestorable
@@ -134,12 +133,10 @@ def dispatcher(tmp_path, *, checkpoint_every: int = 1, experiment_tracker=None):
     runtime = RollbackRuntime(tmp_path / "exported")
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     value = Dispatcher(
-        RecipeRegistry(
-            {
-                "test_policy": TestPolicyRecipe(
-                    runtime, batch_size=1, checkpoint_strategy=EveryNVersions(checkpoint_every)
-                )
-            }
+        TestPolicyRecipe(
+            runtime,
+            batch_size=1,
+            checkpoint_strategy=EveryNVersions(checkpoint_every),
         ),
         backend_factory,
         local_artifact_dir=tmp_path / "staged",
@@ -150,8 +147,8 @@ def dispatcher(tmp_path, *, checkpoint_every: int = 1, experiment_tracker=None):
 
 
 def train(dispatcher: Dispatcher, index: int) -> None:
-    dispatcher.accept_record(inference(index), recipe="test_policy")
-    dispatcher.accept_record(report(index), recipe="test_policy")
+    dispatcher.accept_record(inference(index))
+    dispatcher.accept_record(report(index))
     for _ in range(1000):
         if dispatcher.get_or_create_scenario("math").scenario_step >= index:
             return
@@ -162,7 +159,7 @@ def train(dispatcher: Dispatcher, index: int) -> None:
 @pytest.mark.unit
 def test_versions_are_wal_backed_and_rollback_appends_a_new_commit(tmp_path) -> None:
     value, runtime, _ = dispatcher(tmp_path)
-    created = value.get_or_create_scenario("math", "test_policy").releases()[0]["release_id"]
+    created = value.get_or_create_scenario("math").releases()[0]["release_id"]
     train(value, 1)
     train(value, 2)
     train(value, 3)
@@ -229,19 +226,15 @@ def test_recovery_adopts_a_lost_rollback_record_without_treating_it_as_training(
     path.write_text("\n".join(records[:-1]) + "\n", encoding="utf-8")
 
     restarted = Dispatcher(
-        RecipeRegistry(
-            {
-                "test_policy": TestPolicyRecipe(
-                    RollbackRuntime(tmp_path / "restarted-export"),
-                    checkpoint_strategy=EveryNVersions(1),
-                )
-            }
+        TestPolicyRecipe(
+            RollbackRuntime(tmp_path / "restarted-export"),
+            checkpoint_strategy=EveryNVersions(1),
         ),
         backend_factory,
         local_artifact_dir=tmp_path / "restarted-staged",
         agent_record_dir=tmp_path / "agent-record",
     )
-    recovered = restarted.get_or_create_scenario("math", "test_policy")
+    recovered = restarted.get_or_create_scenario("math")
     assert recovered is not None
     adopted = recovered.commit_log.records()[-1]
 
@@ -264,12 +257,12 @@ def test_older_versions_and_version_catalog_survive_restart(tmp_path) -> None:
 
     restarted_runtime = RollbackRuntime(tmp_path / "restarted-export")
     restarted = Dispatcher(
-        RecipeRegistry({"test_policy": TestPolicyRecipe(restarted_runtime, checkpoint_strategy=EveryNVersions(1))}),
+        TestPolicyRecipe(restarted_runtime, checkpoint_strategy=EveryNVersions(1)),
         backend_factory,
         local_artifact_dir=tmp_path / "restarted-staged",
         agent_record_dir=tmp_path / "agent-record",
     )
-    recovered = restarted.get_or_create_scenario("math", "test_policy")
+    recovered = restarted.get_or_create_scenario("math")
     assert [version["operation"] for version in recovered.releases()] == [
         "training",
         "training",

--- a/tests/reef_service/test_async_pipeline_core.py
+++ b/tests/reef_service/test_async_pipeline_core.py
@@ -10,7 +10,6 @@ import pytest
 from reef.artifact import ArtifactPublicationError, InMemoryRepositoryBackend
 from reef.core import AgentRecord, ReefError, RequestType
 from reef.dispatcher import Dispatcher
-from reef.recipe import RecipeRegistry
 from reef.runtime import ActivatedModel, ModelCandidate, PreparedTrainingStep, TrainingJobResult, TrainingRuntime
 from reef.runtime.candidates import CandidateTrainingDeferred, StaleCandidate
 from reef.runtime.inference import InferenceBackend
@@ -179,7 +178,7 @@ def start_dispatcher(tmp_path: Path):
         runtime = DurableRuntime(tmp_path / "checkpoints", **runtime_options)
         factory = (backend_type or InMemoryRepositoryBackend).factory(initial, root=tmp_path / "repository")
         dispatcher = Dispatcher(
-            RecipeRegistry({"test_policy": TestPolicyRecipe(runtime, batch_size=1)}),
+            TestPolicyRecipe(runtime, batch_size=1),
             factory,
             local_artifact_dir=tmp_path / "staged",
             agent_record_dir=tmp_path / "agent-record",
@@ -195,7 +194,7 @@ def start_dispatcher(tmp_path: Path):
 
 
 def _submit_pair(dispatcher: Dispatcher, suffix: str = "1", runtime_load_id: str = "v0") -> None:
-    dispatcher.get_or_create_scenario("math", "test_policy")
+    dispatcher.get_or_create_scenario("math")
     inference_id = f"inference-{suffix}"
     records = (
         AgentRecord.create(
@@ -213,7 +212,7 @@ def _submit_pair(dispatcher: Dispatcher, suffix: str = "1", runtime_load_id: str
         ),
     )
     for record in records:
-        dispatcher.accept_record(record, recipe="test_policy")
+        dispatcher.accept_record(record)
 
 
 def _wait_for_step(dispatcher: Dispatcher, step: int) -> None:
@@ -247,7 +246,7 @@ def test_empty_checkpoint_result_fails_closed() -> None:
 @pytest.mark.unit
 def test_report_returns_and_inference_resolves_while_remote_job_is_blocked(start_dispatcher) -> None:
     runtime, dispatcher = start_dispatcher(fail_once=True, block=True)
-    scenario = dispatcher.get_or_create_scenario("math", "test_policy")
+    scenario = dispatcher.get_or_create_scenario("math")
     expected = scenario.current_artifact_ref()
     _submit_pair(dispatcher)
     assert runtime.started.wait(1)
@@ -299,7 +298,7 @@ def test_inference_resolves_while_lost_ack_publication_blocks(start_dispatcher) 
 @pytest.mark.unit
 def test_weight_inference_does_not_materialize_its_checkpoint(start_dispatcher, monkeypatch) -> None:
     _, dispatcher = start_dispatcher()
-    scenario = dispatcher.get_or_create_scenario("math", "test_policy")
+    scenario = dispatcher.get_or_create_scenario("math")
     monkeypatch.setattr(
         scenario.repository,
         "resolve",
@@ -332,14 +331,14 @@ def test_two_jobs_form_one_deterministic_release_chain(start_dispatcher) -> None
     assert [call["source"] for call in runtime.calls] == ["inference-1", "inference-2"]
     assert scenario.current_artifact_ref().parent_release_id == first.release_id
     with pytest.raises(ReefError, match="already bound"):
-        dispatcher.get_or_create_scenario("other", "test_policy")
+        dispatcher.get_or_create_scenario("other")
 
 
 @pytest.mark.unit
 def test_training_result_metrics_reach_the_durable_commit(start_dispatcher) -> None:
     metrics = {"staleness/samples_fresh": 1, "staleness/samples_admitted_stale": 0}
     _, dispatcher = start_dispatcher(complete_metrics=metrics)
-    dispatcher.get_or_create_scenario("math", "test_policy")
+    dispatcher.get_or_create_scenario("math")
 
     assert dispatcher.training_status["scenarios"]["math"]["last_committed_step"] is None
 

--- a/tests/reef_service/test_commit_log.py
+++ b/tests/reef_service/test_commit_log.py
@@ -22,7 +22,6 @@ from reef.core.errors import ReefError
 from reef.dispatcher import Dispatcher
 from reef.harness.adapters import get_adapter
 from reef.harness.model_binding import ModelBinding
-from reef.recipe import RecipeRegistry
 from reef.recipe.base import Recipe
 from reef.runtime import ActivatedModel, ModelCandidate, PreparedTrainingStep, TrainingRuntime
 from reef.scenario.checkpoint_strategy import CheckpointStrategy, EveryNVersions
@@ -310,16 +309,10 @@ def build_training_dispatcher(
     agent_record_dir=None,
 ):
     return Dispatcher(
-        RecipeRegistry(
-            recipes={
-                "test_policy": TestPolicyRecipe(
-                    runtime,
-                    batch_size=1,
-                    checkpoint_strategy=(
-                        checkpoint_strategy if checkpoint_strategy is not None else EveryNVersions(1000)
-                    ),
-                )
-            }
+        TestPolicyRecipe(
+            runtime,
+            batch_size=1,
+            checkpoint_strategy=(checkpoint_strategy if checkpoint_strategy is not None else EveryNVersions(1000)),
         ),
         backend_factory,
         local_artifact_dir=tmp_path / "staged",
@@ -352,10 +345,10 @@ def test_each_committed_step_appends_one_atomic_record(tmp_path) -> None:
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         agent_record_dir=agent_record_dir,
     )
-    dispatcher.accept_record(sft_inference("i1"), recipe="test_policy")
-    dispatcher.accept_record(sft_report("r1", "i1"), recipe="test_policy")
-    dispatcher.accept_record(sft_inference("i2"), recipe="test_policy")
-    dispatcher.accept_record(sft_report("r2", "i2"), recipe="test_policy")
+    dispatcher.accept_record(sft_inference("i1"))
+    dispatcher.accept_record(sft_report("r1", "i1"))
+    dispatcher.accept_record(sft_inference("i2"))
+    dispatcher.accept_record(sft_report("r2", "i2"))
     wait_for_step(dispatcher, 2)
 
     records = CommitLog(commit_log_path(agent_record_dir)).records()
@@ -389,8 +382,8 @@ def test_training_commit_proves_its_training_job_identity(tmp_path) -> None:
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         agent_record_dir=agent_record_dir,
     )
-    dispatcher.accept_record(sft_inference("i1"), recipe="test_policy")
-    dispatcher.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    dispatcher.accept_record(sft_inference("i1"))
+    dispatcher.accept_record(sft_report("r1", "i1"))
     wait_for_step(dispatcher, 1)
 
     scenario = dispatcher.get_or_create_scenario("math")
@@ -407,10 +400,10 @@ def test_recovery_restores_the_live_head_step_and_state_from_the_log(tmp_path) -
     agent_record_dir = tmp_path / "agent-record"
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     first = build_training_dispatcher(RecordingRuntime(), tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
-    first.accept_record(sft_inference("i2"), recipe="test_policy")
-    first.accept_record(sft_report("r2", "i2"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_report("r1", "i1"))
+    first.accept_record(sft_inference("i2"))
+    first.accept_record(sft_report("r2", "i2"))
     wait_for_step(first, 2)
     committed_head = first.get_or_create_scenario("math").repository.require_current_artifact()
     assert isinstance(committed_head, LiveWeightArtifactRef)
@@ -421,7 +414,7 @@ def test_recovery_restores_the_live_head_step_and_state_from_the_log(tmp_path) -
     second = build_training_dispatcher(
         RecordingRuntime(), tmp_path, backend_factory, agent_record_dir=agent_record_dir
     )
-    recovered = second.get_or_create_scenario("math", "test_policy")
+    recovered = second.get_or_create_scenario("math")
     assert recovered.scenario_step == 2
     # The live head survives the restart: it is the log's head record, even
     # though the release chain only knows the bootstrap checkpoint.
@@ -471,19 +464,17 @@ def test_recovery_resumes_record_progress_without_retraining(tmp_path) -> None:
     initial.mkdir()
     agent_record_dir = tmp_path / "agent-record"
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
-    registry = lambda runtime: RecipeRegistry(  # noqa: E731
-        recipes={
-            "test_policy": ProtectAllPolicyRecipe(
-                runtime,
-                batch_size=1,
-                checkpoint_strategy=EveryNVersions(1000),
-            )
-        }
+    recipe = lambda runtime: (  # noqa: E731
+        ProtectAllPolicyRecipe(
+            runtime,
+            batch_size=1,
+            checkpoint_strategy=EveryNVersions(1000),
+        )
     )
 
     def build(runtime):
         return Dispatcher(
-            registry(runtime),
+            recipe(runtime),
             backend_factory,
             local_artifact_dir=tmp_path / "staged",
             agent_record_dir=agent_record_dir,
@@ -491,8 +482,8 @@ def test_recovery_resumes_record_progress_without_retraining(tmp_path) -> None:
 
     first_runtime = RecordingRuntime()
     first = build(first_runtime)
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
     assert first_runtime.trained_batches == [["i1"]]
     # Nothing was compacted: the consumed pair is still physically present.
@@ -500,11 +491,11 @@ def test_recovery_resumes_record_progress_without_retraining(tmp_path) -> None:
 
     second_runtime = RecordingRuntime()
     second = build(second_runtime)
-    recovered = second.get_or_create_scenario("math", "test_policy")
+    recovered = second.get_or_create_scenario("math")
     assert recovered.trainer.data_offset == 2  # resumed at the committed watermark
 
-    second.accept_record(sft_inference("i2"), recipe="test_policy")
-    second.accept_record(sft_report("r2", "i2"), recipe="test_policy")
+    second.accept_record(sft_inference("i2"))
+    second.accept_record(sft_report("r2", "i2"))
     wait_for_step(second, 2)
     # The only newly trained batch is the genuinely new pair; i1 never retrains.
     assert second_runtime.trained_batches == [["i2"]]
@@ -528,9 +519,9 @@ def test_recovery_reingests_retained_rows_behind_the_watermark(tmp_path) -> None
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     first_runtime = RecordingRuntime()
     first = build_training_dispatcher(first_runtime, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_inference("i2"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_inference("i2"))
+    first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
     assert first_runtime.trained_batches == [["i1"]]
     # The step-2 inference sits below the committed watermark yet survives
@@ -540,10 +531,10 @@ def test_recovery_reingests_retained_rows_behind_the_watermark(tmp_path) -> None
 
     second_runtime = RecordingRuntime()
     second = build_training_dispatcher(second_runtime, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    recovered = second.get_or_create_scenario("math", "test_policy")
+    recovered = second.get_or_create_scenario("math")
     assert recovered.trainer.data_offset == 3  # resumed at the committed watermark
 
-    second.accept_record(sft_report("r2", "i2"), recipe="test_policy")
+    second.accept_record(sft_report("r2", "i2"))
     wait_for_step(second, 2)
     # The reingested inference pairs with the late report; i1 never retrains.
     assert second_runtime.trained_batches == [["i2"]]
@@ -563,7 +554,7 @@ def test_recovery_replays_a_compaction_interrupted_by_a_crash(tmp_path) -> None:
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     first_runtime = RecordingRuntime()
     first = build_training_dispatcher(first_runtime, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    scenario = first.get_or_create_scenario("math", "test_policy")
+    scenario = first.get_or_create_scenario("math")
 
     from reef.train.trainer import Trainer
 
@@ -577,21 +568,21 @@ def test_recovery_replays_a_compaction_interrupted_by_a_crash(tmp_path) -> None:
         original_apply_compaction(self, compacted_ids)
 
     scenario.trainer.apply_compaction = exploding_compaction.__get__(scenario.trainer, Trainer)
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
     assert first_runtime.trained_batches == [["i1"]]
     assert crash["armed"] is False
 
     second_runtime = RecordingRuntime()
     second = build_training_dispatcher(second_runtime, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    recovered = second.get_or_create_scenario("math", "test_policy")
+    recovered = second.get_or_create_scenario("math")
     # Recovery replayed the interrupted compaction and resumed at step 1.
     assert recovered.records.get("math", "i1") is None
     assert recovered.scenario_step == 1
 
-    second.accept_record(sft_inference("i2"), recipe="test_policy")
-    second.accept_record(sft_report("r2", "i2"), recipe="test_policy")
+    second.accept_record(sft_inference("i2"))
+    second.accept_record(sft_report("r2", "i2"))
     wait_for_step(second, 2)
     assert second_runtime.trained_batches == [["i2"]]
     assert recovered.scenario_step == 2
@@ -617,8 +608,8 @@ def test_recovery_adopts_a_checkpoint_whose_record_was_lost(tmp_path) -> None:
         checkpoint_strategy=EveryNVersions(1),
         agent_record_dir=agent_record_dir,
     )
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
     assert first.get_or_create_scenario("math").scenario_step == 1
     committed = first.training_status["scenarios"]["math"]["last_committed_step"]
@@ -634,7 +625,7 @@ def test_recovery_adopts_a_checkpoint_whose_record_was_lost(tmp_path) -> None:
     second = build_training_dispatcher(
         RecordingRuntime(), tmp_path, backend_factory, agent_record_dir=agent_record_dir
     )
-    recovered = second.get_or_create_scenario("math", "test_policy")
+    recovered = second.get_or_create_scenario("math")
     assert recovered.scenario_step == 1
     assert recovered.trainer.state == {"steps": 1}
     # The healed log carries the adopted checkpoint record, with the record
@@ -669,8 +660,8 @@ def test_checkpoint_snapshot_metadata_doubles_as_a_commit_record(tmp_path) -> No
         checkpoint_strategy=EveryNVersions(1),
         agent_record_dir=tmp_path / "agent-record",
     )
-    dispatcher.accept_record(sft_inference("i1"), recipe="test_policy")
-    dispatcher.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    dispatcher.accept_record(sft_inference("i1"))
+    dispatcher.accept_record(sft_report("r1", "i1"))
     wait_for_step(dispatcher, 1)
 
     backend = dispatcher.get_or_create_scenario("math").repository.backend
@@ -693,8 +684,8 @@ def test_recovery_rejects_a_gapped_log(tmp_path) -> None:
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     first = build_training_dispatcher(RecordingRuntime(), tmp_path, backend_factory, agent_record_dir=agent_record_dir)
     for index in (1, 2, 3):
-        first.accept_record(sft_inference(f"i{index}"), recipe="test_policy")
-        first.accept_record(sft_report(f"r{index}", f"i{index}"), recipe="test_policy")
+        first.accept_record(sft_inference(f"i{index}"))
+        first.accept_record(sft_report(f"r{index}", f"i{index}"))
     wait_for_step(first, 3)
 
     path = commit_log_path(agent_record_dir)
@@ -705,7 +696,7 @@ def test_recovery_rejects_a_gapped_log(tmp_path) -> None:
         RecordingRuntime(), tmp_path, backend_factory, agent_record_dir=agent_record_dir
     )
     with pytest.raises(ReefError, match="corrupt"):
-        second.get_or_create_scenario("math", "test_policy")
+        second.get_or_create_scenario("math")
 
 
 @pytest.mark.unit
@@ -715,14 +706,14 @@ def test_recovery_warns_when_the_engine_disagrees_with_the_live_head(tmp_path, c
     agent_record_dir = tmp_path / "agent-record"
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     first = build_training_dispatcher(RecordingRuntime(), tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
 
     disagreeing = RecordingRuntime(served_version="w999")
     second = build_training_dispatcher(disagreeing, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
     with caplog.at_level(logging.WARNING, logger="reef.surface.weights"):
-        recovered = second.get_or_create_scenario("math", "test_policy")
+        recovered = second.get_or_create_scenario("math")
     assert recovered.scenario_step == 1
     assert any("w1" in record.message and "w999" in record.message for record in caplog.records)
 
@@ -730,7 +721,7 @@ def test_recovery_warns_when_the_engine_disagrees_with_the_live_head(tmp_path, c
     third = build_training_dispatcher(agreeing, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="reef.surface.weights"):
-        third.get_or_create_scenario("math", "test_policy")
+        third.get_or_create_scenario("math")
     assert not caplog.records
 
 
@@ -741,8 +732,8 @@ def test_no_commit_log_without_an_agent_record_dir(tmp_path) -> None:
     initial.mkdir()
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     first = build_training_dispatcher(RecordingRuntime(), tmp_path, backend_factory)
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
 
     assert first.get_or_create_scenario("math").commit_log is None
@@ -754,7 +745,7 @@ def test_no_commit_log_without_an_agent_record_dir(tmp_path) -> None:
     # Recovery still works from the release chain: the live head is forgotten, as
     # before the log existed, and the step reverts to the checkpointed 0.
     second = build_training_dispatcher(RecordingRuntime(), tmp_path, backend_factory)
-    recovered = second.get_or_create_scenario("math", "test_policy")
+    recovered = second.get_or_create_scenario("math")
     assert recovered.scenario_step == 0
     assert second.training_status["scenarios"]["math"]["last_committed_step"] is None
     assert not isinstance(recovered.repository.require_current_artifact(), LiveWeightArtifactRef)
@@ -773,8 +764,8 @@ def test_checkpoint_status_metrics_survive_without_a_commit_log(tmp_path) -> Non
         backend_factory,
         checkpoint_strategy=EveryNVersions(1),
     )
-    first.accept_record(sft_inference("i1"), recipe="test_policy")
-    first.accept_record(sft_report("r1", "i1"), recipe="test_policy")
+    first.accept_record(sft_inference("i1"))
+    first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
     committed = first.training_status["scenarios"]["math"]["last_committed_step"]
 
@@ -784,7 +775,7 @@ def test_checkpoint_status_metrics_survive_without_a_commit_log(tmp_path) -> Non
         backend_factory,
         checkpoint_strategy=EveryNVersions(1),
     )
-    recovered = second.get_or_create_scenario("math", "test_policy")
+    recovered = second.get_or_create_scenario("math")
 
     assert recovered.scenario_step == 1
     assert recovered.commit_log is None
@@ -856,7 +847,7 @@ def build_harness_evolve_dispatcher(
 ):
     recipe = _HarnessEvolveTestRecipe(propose=propose, evaluate=evaluate, tasks=tasks, runtime=runtime)
     return Dispatcher(
-        RecipeRegistry(recipes={"harness_evolve": recipe}),
+        recipe,
         backend_factory,
         local_artifact_dir=tmp_path / "staged",
         agent_record_dir=agent_record_dir,
@@ -908,7 +899,7 @@ def test_harness_growth_does_not_block_acceptance_or_other_scenarios(tmp_path) -
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         propose=blocking_proposer,
     )
-    dispatcher.accept_record(trace_inference("a-i1", scenario="skills-a"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_inference("a-i1", scenario="skills-a"))
 
     returned = Event()
     errors: list[Exception] = []
@@ -917,7 +908,6 @@ def test_harness_growth_does_not_block_acceptance_or_other_scenarios(tmp_path) -
         try:
             dispatcher.accept_record(
                 trace_report("a-r1", "a-i1", scenario="skills-a"),
-                recipe="harness_evolve",
             )
         except Exception as exc:
             errors.append(exc)
@@ -946,10 +936,9 @@ def test_harness_growth_does_not_block_acceptance_or_other_scenarios(tmp_path) -
         status = status_values[0]["scenarios"]["skills-a"]
         assert status["scenario_step"] == 0
         assert status["last_committed_step"] is None
-        dispatcher.accept_record(trace_inference("b-i1", scenario="skills-b"), recipe="harness_evolve")
+        dispatcher.accept_record(trace_inference("b-i1", scenario="skills-b"))
         dispatcher.accept_record(
             trace_report("b-r1", "b-i1", scenario="skills-b"),
-            recipe="harness_evolve",
         )
         wait_for_step(dispatcher, 1, scenario="skills-b")
     finally:
@@ -985,8 +974,8 @@ def test_local_backend_failure_reaches_status_and_retries_pending_batch(tmp_path
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         propose=proposer,
     )
-    dispatcher.accept_record(trace_inference("i1"), recipe="harness_evolve")
-    dispatcher.accept_record(trace_report("r1", "i1"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_inference("i1"))
+    dispatcher.accept_record(trace_report("r1", "i1"))
 
     for _ in range(1000):
         if dispatcher.training_status["error"] is not None:
@@ -996,7 +985,7 @@ def test_local_backend_failure_reaches_status_and_retries_pending_batch(tmp_path
 
     failed_attempts = calls
     should_fail = False
-    dispatcher.accept_record(trace_inference("i2"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_inference("i2"))
     wait_for_step(dispatcher, 1, scenario="skills")
     assert calls == failed_attempts + 1
     assert dispatcher.training_status["error"] is None
@@ -1016,7 +1005,7 @@ def test_durable_local_backend_recovers_after_post_commit_compaction_failure(tmp
         backend_factory,
         agent_record_dir=agent_record_dir,
     )
-    original = dispatcher.get_or_create_scenario("skills", "harness_evolve")
+    original = dispatcher.get_or_create_scenario("skills")
     assert original is not None
     rollback_target = original.current_artifact_ref().release_id
     compaction_failed = Event()
@@ -1036,8 +1025,8 @@ def test_durable_local_backend_recovers_after_post_commit_compaction_failure(tmp
 
     original.trainer.apply_compaction = fail_compaction.__get__(original.trainer, Trainer)
     dispatcher._registry.reload = blocking_reload
-    dispatcher.accept_record(trace_inference("i1"), recipe="harness_evolve")
-    dispatcher.accept_record(trace_report("r1", "i1"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_inference("i1"))
+    dispatcher.accept_record(trace_report("r1", "i1"))
 
     assert compaction_failed.wait(1)
     assert reload_started.wait(1)
@@ -1080,8 +1069,8 @@ def test_durable_local_backend_recovers_after_post_commit_compaction_failure(tmp
     assert records[0].metrics is not None
     assert records[0].metrics["skipped"] == "no proposal"
 
-    dispatcher.accept_record(trace_inference("i2"), recipe="harness_evolve")
-    dispatcher.accept_record(trace_report("r2", "i2"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_inference("i2"))
+    dispatcher.accept_record(trace_report("r2", "i2"))
     wait_for_step(dispatcher, 2, scenario="skills")
 
     assert [record.step for record in log.records()] == [1, 2]
@@ -1108,8 +1097,8 @@ def test_no_artifact_commit_appends_a_record_and_advances_the_step(tmp_path) -> 
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     dispatcher = build_harness_evolve_dispatcher(None, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
 
-    dispatcher.accept_record(trace_inference("i1"), recipe="harness_evolve")
-    dispatcher.accept_record(trace_report("r1", "i1"), recipe="harness_evolve")
+    dispatcher.accept_record(trace_inference("i1"))
+    dispatcher.accept_record(trace_report("r1", "i1"))
 
     scenario = dispatcher.get_or_create_scenario("skills")
     wait_for_step(dispatcher, 1, scenario="skills")
@@ -1138,8 +1127,8 @@ def test_no_artifact_commit_survives_a_restart(tmp_path) -> None:
     agent_record_dir = tmp_path / "agent-record"
     backend_factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     first = build_harness_evolve_dispatcher(None, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    first.accept_record(trace_inference("i1"), recipe="harness_evolve")
-    first.accept_record(trace_report("r1", "i1"), recipe="harness_evolve")
+    first.accept_record(trace_inference("i1"))
+    first.accept_record(trace_report("r1", "i1"))
     wait_for_step(first, 1, scenario="skills")
     assert first.get_or_create_scenario("skills").scenario_step == 1
     committed = first.training_status["scenarios"]["skills"]["last_committed_step"]
@@ -1147,7 +1136,7 @@ def test_no_artifact_commit_survives_a_restart(tmp_path) -> None:
     assert committed["metrics"]["skipped"] == "no proposal"
 
     second = build_harness_evolve_dispatcher(None, tmp_path, backend_factory, agent_record_dir=agent_record_dir)
-    recovered = second.get_or_create_scenario("skills", "harness_evolve")
+    recovered = second.get_or_create_scenario("skills")
     assert recovered.scenario_step == 1
     assert recovered.trainer.state["steps"] == 1
     assert second.training_status["scenarios"]["skills"]["last_committed_step"] == committed

--- a/tests/reef_service/test_dependency_boundaries.py
+++ b/tests/reef_service/test_dependency_boundaries.py
@@ -160,7 +160,7 @@ def test_importing_reef_does_not_load_cookbook_or_slime_packages() -> None:
 
 
 def test_scenario_factory_imports_without_a_cycle() -> None:
-    # The factory bridges the scenario domain and the recipe registry; a fresh
+    # The factory bridges the scenario aggregate and the deployment recipe; a fresh
     # interpreter import in either direction must not deadlock on a cycle.
     _assert_isolated_import("from reef.scenario.factory import ScenarioFactory; assert ScenarioFactory")
     _assert_isolated_import("import reef; from reef.scenario.factory import ScenarioFactory")

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -28,7 +28,7 @@ from reef.harness.adapters import get_adapter
 from reef.harness.descriptor import DescriptorError, load_descriptor
 from reef.harness.episode import EpisodeResult
 from reef.harness.render import render_composition
-from reef.recipe import Recipe, RecipeRegistry
+from reef.recipe import Recipe
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.runtime.inference import InferenceBackend
 from reef.service.app import create_app
@@ -136,7 +136,6 @@ def _dispatcher(
     mutations: tuple[Mutation, ...],
     *,
     bootstrap_files: dict[str, str] | None = None,
-    recipe_names: tuple[str, ...] = ("evolve",),
     batch_policy: str = "reports",
     batch_size: int = 1,
 ) -> Dispatcher:
@@ -160,13 +159,13 @@ def _dispatcher(
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(text, encoding="utf-8")
     dispatcher = Dispatcher(
-        RecipeRegistry(dict.fromkeys(recipe_names, recipe)),
+        recipe,
         InMemoryRepositoryBackend.factory(bootstrap, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "local",
         # The commit log is what puts gate metrics on the release catalog.
         agent_record_dir=tmp_path / "agent-record",
     )
-    dispatcher.get_or_create_scenario("delivery", recipe_names[0])
+    dispatcher.get_or_create_scenario("delivery")
     return dispatcher
 
 
@@ -977,34 +976,7 @@ def test_install_route_creates_a_randomly_named_harness_scenario_when_header_is_
             assert response.status == 200
             assert 'export REEF_HARNESS_SCENARIO="harness-0123456789ab"' in await response.text()
             created = dispatcher.get_or_create_scenario("harness-0123456789ab")
-            assert created is not None and created.recipe == "evolve"
-        finally:
-            await client.close()
-
-    asyncio.run(run())
-
-
-@pytest.mark.unit
-def test_install_route_without_scenario_rejects_multiple_harness_recipes(tmp_path, monkeypatch) -> None:
-    dispatcher = _dispatcher(
-        tmp_path,
-        (),
-        bootstrap_files={"pi-agent/AGENTS.md": "starter rules\n"},
-        recipe_names=("code-harness", "support-harness"),
-    )
-    monkeypatch.setattr(
-        "reef.service.request_service._random_harness_scenario_name",
-        lambda: "harness-0123456789ab",
-    )
-
-    async def run() -> None:
-        client = TestClient(TestServer(create_app(dispatcher, inference_backend=_EchoBackend())))
-        await client.start_server()
-        try:
-            response = await client.get("/reef/harness/install", params={"adapter": "pi"})
-            assert response.status == 400
-            assert "multiple harness recipes are available" in await response.text()
-            assert not dispatcher.has_loaded("harness-0123456789ab")
+            assert created is not None
         finally:
             await client.close()
 
@@ -1016,12 +988,12 @@ def test_install_route_without_scenario_returns_404_when_no_harness_recipe_exist
     bootstrap = tmp_path / "bootstrap"
     bootstrap.mkdir()
     dispatcher = Dispatcher(
-        RecipeRegistry({"weights": Recipe()}),
+        Recipe(),
         InMemoryRepositoryBackend.factory(bootstrap, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "local",
         agent_record_dir=None,
     )
-    dispatcher.get_or_create_scenario("weights-only", "weights")
+    dispatcher.get_or_create_scenario("weights-only")
 
     async def run() -> None:
         client = TestClient(TestServer(create_app(dispatcher, inference_backend=_EchoBackend())))

--- a/tests/reef_service/test_harness_read.py
+++ b/tests/reef_service/test_harness_read.py
@@ -4,7 +4,7 @@ import pytest
 
 from reef.artifact import ArtifactNotFound, InMemoryRepositoryBackend
 from reef.dispatcher import Dispatcher
-from reef.recipe import Recipe, RecipeRegistry
+from reef.recipe import Recipe
 from reef.service.app import RequestService
 from reef.surface import Surface, create_harness_surface
 
@@ -23,12 +23,12 @@ def _service(tmp_path, *, recipe, skill_text: str | None) -> RequestService:
         (bootstrap / "skills").mkdir()
         (bootstrap / "skills" / "SKILL.md").write_text(skill_text, encoding="utf-8")
     dispatcher = Dispatcher(
-        RecipeRegistry({"p": recipe}),
+        recipe,
         InMemoryRepositoryBackend.factory(bootstrap, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "local",
         agent_record_dir=None,
     )
-    dispatcher.get_or_create_scenario("delivery", "p")
+    dispatcher.get_or_create_scenario("delivery")
     return RequestService(dispatcher)
 
 

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -19,7 +19,7 @@ from reef.harness.adapters import get_adapter
 from reef.harness.episode import EpisodeResult
 from reef.harness.model_binding import ModelBinding, ModelBindingError, ModelBindings
 from reef.recipe import RecipeConfigError
-from reef.recipe.registry import RecipeRegistry, recipe_class_for
+from reef.recipe.registry import recipe_class_for
 from reef.records import RecordStore
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.train.cordis_backend import CordisBackend, CordisRecipe, Mutation, MutationError, ScoreComparisonSelector
@@ -585,9 +585,9 @@ def test_keyed_proposal_leaves_no_key_material_in_commit_records(tmp_path: Path)
     factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     agent_record_dir = tmp_path / "agent-record"
 
-    dispatcher = Dispatcher(RecipeRegistry({built.name: built}), factory, agent_record_dir=agent_record_dir)
+    dispatcher = Dispatcher(built, factory, agent_record_dir=agent_record_dir)
     try:
-        scenario = dispatcher.get_or_create_scenario("leak-476", built.name)
+        scenario = dispatcher.get_or_create_scenario("leak-476")
         assert scenario is not None
         _report_once(scenario, "leak-476", "1")
         result = scenario.prepare_training_step()
@@ -602,9 +602,9 @@ def test_keyed_proposal_leaves_no_key_material_in_commit_records(tmp_path: Path)
     assert "inline credential" in record["metrics"]["skipped"]
     assert record["algorithm_state"]["entries"] == [SEED_MODELS, SEED_SETTINGS]
 
-    restarted = Dispatcher(RecipeRegistry({built.name: built}), factory, agent_record_dir=agent_record_dir)
+    restarted = Dispatcher(built, factory, agent_record_dir=agent_record_dir)
     try:
-        recovered = restarted.get_or_create_scenario("leak-476", built.name)
+        recovered = restarted.get_or_create_scenario("leak-476")
         assert recovered is not None
         assert recovered.trainer.state["entries"] == [SEED_MODELS, SEED_SETTINGS]
         _report_once(recovered, "leak-476", "2")
@@ -656,9 +656,9 @@ def test_disabled_keyed_proposal_leaves_no_key_material_in_commit_records(tmp_pa
     factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     agent_record_dir = tmp_path / "agent-record"
 
-    dispatcher = Dispatcher(RecipeRegistry({built.name: built}), factory, agent_record_dir=agent_record_dir)
+    dispatcher = Dispatcher(built, factory, agent_record_dir=agent_record_dir)
     try:
-        scenario = dispatcher.get_or_create_scenario("leak-476-disabled", built.name)
+        scenario = dispatcher.get_or_create_scenario("leak-476-disabled")
         assert scenario is not None
         _report_once(scenario, "leak-476-disabled", "1")
         result = scenario.prepare_training_step()
@@ -686,9 +686,9 @@ def test_pregate_recovered_state_refuses_the_step_and_writes_nothing(tmp_path: P
     factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     agent_record_dir = tmp_path / "agent-record"
 
-    dispatcher = Dispatcher(RecipeRegistry({built.name: built}), factory, agent_record_dir=agent_record_dir)
+    dispatcher = Dispatcher(built, factory, agent_record_dir=agent_record_dir)
     try:
-        scenario = dispatcher.get_or_create_scenario("pregate-476", built.name)
+        scenario = dispatcher.get_or_create_scenario("pregate-476")
         assert scenario is not None
         _report_once(scenario, "pregate-476", "1")
         result = scenario.prepare_training_step()
@@ -705,9 +705,9 @@ def test_pregate_recovered_state_refuses_the_step_and_writes_nothing(tmp_path: P
     log_path.write_bytes(json.dumps(record, separators=(",", ":"), sort_keys=True).encode() + b"\n")
     before = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
 
-    restarted = Dispatcher(RecipeRegistry({built.name: built}), factory, agent_record_dir=agent_record_dir)
+    restarted = Dispatcher(built, factory, agent_record_dir=agent_record_dir)
     try:
-        recovered = restarted.get_or_create_scenario("pregate-476", built.name)
+        recovered = restarted.get_or_create_scenario("pregate-476")
         assert recovered is not None
         _report_once(recovered, "pregate-476", "2")
         with pytest.raises(ValueError, match=r"apiKey.*inline credential.*rotate"):

--- a/tests/reef_service/test_multi_scenario_training.py
+++ b/tests/reef_service/test_multi_scenario_training.py
@@ -59,8 +59,8 @@ def _report(scenario: str, agent_record_id: str, reference: str) -> AgentRecord:
 
 
 def _feed(dispatcher, scenario: str, index: int) -> None:
-    dispatcher.accept_record(_inference(scenario, f"{scenario}-i{index}"), recipe="test_policy")
-    dispatcher.accept_record(_report(scenario, f"{scenario}-r{index}", f"{scenario}-i{index}"), recipe="test_policy")
+    dispatcher.accept_record(_inference(scenario, f"{scenario}-i{index}"))
+    dispatcher.accept_record(_report(scenario, f"{scenario}-r{index}", f"{scenario}-i{index}"))
 
 
 @pytest.mark.unit
@@ -119,9 +119,9 @@ def test_a_full_weight_runtime_still_trains_one_scenario_only(tmp_path) -> None:
         RecordingRuntime(), tmp_path, InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
     )
     try:
-        dispatcher.get_or_create_scenario("math", "test_policy")
+        dispatcher.get_or_create_scenario("math")
         with pytest.raises(ReefError, match="already bound"):
-            dispatcher.get_or_create_scenario("code", "test_policy")
+            dispatcher.get_or_create_scenario("code")
     finally:
         dispatcher.close()
 
@@ -147,8 +147,8 @@ def test_one_scenarios_failure_reloads_only_that_scenario(tmp_path) -> None:
         agent_record_dir=tmp_path / "agent-record",
     )
     try:
-        math = dispatcher.get_or_create_scenario("math", "test_policy")
-        code = dispatcher.get_or_create_scenario("code", "test_policy")
+        math = dispatcher.get_or_create_scenario("math")
+        code = dispatcher.get_or_create_scenario("code")
         _feed(dispatcher, "math", 1)
         _feed(dispatcher, "code", 1)
         wait_for_step(dispatcher, 1, scenario="math")

--- a/tests/reef_service/test_reef_concurrency.py
+++ b/tests/reef_service/test_reef_concurrency.py
@@ -22,7 +22,6 @@ from reef.artifact import (
 )
 from reef.core import AgentRecord, RequestType
 from reef.dispatcher import Dispatcher, build_default_dispatcher
-from reef.recipe import RecipeRegistry
 from reef.runtime import ActivatedModel, ModelCandidate, PreparedTrainingStep, TrainingRuntime
 from reef.scenario.checkpoint_strategy import EveryNVersions
 from reef.train.evaluation import SelectionDecision
@@ -150,9 +149,7 @@ def test_concurrent_accepts_train_and_commit_exactly_once_per_batch(tmp_path) ->
     initial.mkdir()
     runtime = CountingRuntime()
     dispatcher = Dispatcher(
-        RecipeRegistry(
-            recipes={"test_policy": TestPolicyRecipe(runtime, batch_size=1, checkpoint_strategy=EveryNVersions(1000))}
-        ),
+        TestPolicyRecipe(runtime, batch_size=1, checkpoint_strategy=EveryNVersions(1000)),
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "staged",
     )
@@ -162,8 +159,8 @@ def test_concurrent_accepts_train_and_commit_exactly_once_per_batch(tmp_path) ->
     def worker(seed: int) -> None:
         for offset in range(pairs_per_thread):
             index = seed * pairs_per_thread + offset
-            dispatcher.accept_record(sft_inference(f"i{index}"), recipe="test_policy")
-            dispatcher.accept_record(sft_report(f"r{index}", f"i{index}"), recipe="test_policy")
+            dispatcher.accept_record(sft_inference(f"i{index}"))
+            dispatcher.accept_record(sft_report(f"r{index}", f"i{index}"))
 
     errors = run_workers(thread_count, worker)
 
@@ -192,13 +189,11 @@ def test_async_worker_serializes_slow_trainer_commits(tmp_path, monkeypatch) -> 
     initial.mkdir()
     runtime = CountingRuntime()
     dispatcher = Dispatcher(
-        RecipeRegistry(
-            recipes={"test_policy": TestPolicyRecipe(runtime, batch_size=1, checkpoint_strategy=EveryNVersions(1000))}
-        ),
+        TestPolicyRecipe(runtime, batch_size=1, checkpoint_strategy=EveryNVersions(1000)),
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "staged",
     )
-    scenario = dispatcher.get_or_create_scenario("math", "test_policy")
+    scenario = dispatcher.get_or_create_scenario("math")
     original_commit = scenario.trainer.commit
 
     def slow_commit():
@@ -208,8 +203,8 @@ def test_async_worker_serializes_slow_trainer_commits(tmp_path, monkeypatch) -> 
     monkeypatch.setattr(scenario.trainer, "commit", slow_commit)
 
     def worker(seed: int) -> None:
-        dispatcher.accept_record(sft_inference(f"i{seed}"), recipe="test_policy")
-        dispatcher.accept_record(sft_report(f"r{seed}", f"i{seed}"), recipe="test_policy")
+        dispatcher.accept_record(sft_inference(f"i{seed}"))
+        dispatcher.accept_record(sft_report(f"r{seed}", f"i{seed}"))
 
     errors = run_workers(4, worker)
 
@@ -228,7 +223,7 @@ def test_concurrent_checkpoint_commits_form_one_linear_chain(tmp_path) -> None:
         checkpoint_strategy=EveryNVersions(1),
         local_artifact_dir=tmp_path / "staged",
     )
-    dispatcher.get_or_create_scenario("chat", "recipe")
+    dispatcher.get_or_create_scenario("chat")
     commits_per_thread = 3
     thread_count = 4
 
@@ -271,7 +266,7 @@ def test_saved_commit_fails_loudly_when_head_moves_mid_commit(tmp_path, monkeypa
         checkpoint_strategy=EveryNVersions(1000),
         local_artifact_dir=tmp_path / "staged",
     )
-    scenario = dispatcher.get_or_create_scenario("chat", "recipe")
+    scenario = dispatcher.get_or_create_scenario("chat")
     repository = scenario.repository
     original_stage = repository.stage
 

--- a/tests/reef_service/test_reef_contracts.py
+++ b/tests/reef_service/test_reef_contracts.py
@@ -17,7 +17,7 @@ from reef.artifact import (
 )
 from reef.core import ReefError, RequestType
 from reef.dispatcher import Dispatcher, build_default_dispatcher
-from reef.recipe import Recipe, RecipeRegistry, ScenarioRecipeConflict, UnknownScenarioRecipe
+from reef.recipe import Recipe
 from reef.runtime.inference import HttpInferenceBackend, InferenceBackend, default_artifact_request_headers
 from reef.scenario.checkpoint_strategy import EveryNVersions
 from reef.service.app import InferenceRetryPolicy, RequestService, create_app
@@ -37,7 +37,7 @@ class ContractInferenceBackend(InferenceBackend):
 def dispatcher_with_checkpoint_strategy(strategy, *, backend_factory, local_artifact_dir):
     recipe = Recipe(checkpoint_strategy=strategy)
     return Dispatcher(
-        RecipeRegistry({"recipe": recipe}),
+        recipe,
         backend_factory,
         local_artifact_dir=local_artifact_dir,
     )
@@ -54,7 +54,7 @@ class WeightRecipe(Recipe):
 
 def weight_dispatcher(tmp_path, initial):
     return Dispatcher(
-        RecipeRegistry({"recipe": WeightRecipe(checkpoint_strategy=EveryNVersions(3))}),
+        WeightRecipe(checkpoint_strategy=EveryNVersions(3)),
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "local",
     )
@@ -132,30 +132,6 @@ def test_dispatcher_isolates_agent_record_and_trainer_state_by_scenario() -> Non
 
 
 @pytest.mark.unit
-def test_scenario_recipe_is_bound_on_first_request_and_cannot_change() -> None:
-    dispatcher = build_default_dispatcher()
-    service = RequestService(dispatcher)
-
-    service.accept({"x-reef-scenario": "math"}, {"score": 1.0}, request_type=RequestType.REPORT)
-
-    assert dispatcher.get_or_create_scenario("math").recipe == "recipe"
-    # The binding is durable: an in-process caller asserting another recipe is refused.
-    with pytest.raises(ScenarioRecipeConflict, match="already bound"):
-        dispatcher.get_or_create_scenario("math", "other")
-
-
-@pytest.mark.unit
-def test_unknown_recipe_does_not_create_scenario_runtime() -> None:
-    dispatcher = build_default_dispatcher()
-
-    # The closed registry never materializes a name it was not given.
-    with pytest.raises(UnknownScenarioRecipe, match="available recipes: recipe"):
-        dispatcher.get_or_create_scenario("math", "tttd")
-
-    assert not dispatcher.has_loaded("math")
-
-
-@pytest.mark.unit
 def test_scenario_release_id_is_bound_on_first_request(tmp_path) -> None:
     initial = tmp_path / "initial"
     initial.mkdir()
@@ -177,7 +153,7 @@ def test_scenario_release_id_is_bound_on_first_request(tmp_path) -> None:
 
 
 @pytest.mark.unit
-def test_dispatcher_selects_backend_registered_recipe_factory(tmp_path) -> None:
+def test_dispatcher_uses_the_served_recipe_factory(tmp_path) -> None:
     initial = tmp_path / "initial"
     initial.mkdir()
     selected: list[str] = []
@@ -194,33 +170,13 @@ def test_dispatcher_selects_backend_registered_recipe_factory(tmp_path) -> None:
             )
 
     dispatcher = Dispatcher(
-        RecipeRegistry(
-            recipes={
-                "default": RecordingRecipe(name="default"),
-                "tttd": RecordingRecipe(name="tttd"),
-            },
-        ),
+        RecordingRecipe(name="tttd"),
         InMemoryRepositoryBackend.factory(initial),
     )
 
-    runtime = dispatcher.get_or_create_scenario("discovery", "tttd")
+    dispatcher.get_or_create_scenario("discovery")
 
-    assert runtime.recipe == "tttd"
     assert selected == ["tttd"]
-
-
-@pytest.mark.unit
-def test_dispatcher_binds_new_scenarios_to_the_served_recipe(tmp_path) -> None:
-    initial = tmp_path / "initial"
-    initial.mkdir()
-
-    dispatcher = Dispatcher(
-        RecipeRegistry({"recipe": Recipe()}),
-        InMemoryRepositoryBackend.factory(initial),
-    )
-
-    assert dispatcher.get_or_create_scenario("math").recipe == "recipe"
-    assert dispatcher.get_or_create_scenario("math", "recipe").recipe == "recipe"
 
 
 @pytest.mark.unit
@@ -246,12 +202,11 @@ def test_new_dispatcher_recovers_scenario_snapshot_from_repository(tmp_path) -> 
     backend = InMemoryRepositoryBackend.factory(initial)
 
     first = build_default_dispatcher(backend_factory=backend)
-    created = first.get_or_create_scenario("math", recipe="recipe")
+    created = first.get_or_create_scenario("math")
     second = build_default_dispatcher(backend_factory=backend)
 
     recovered = second.get_or_create_scenario("math")
 
-    assert recovered.recipe == "recipe"
     assert recovered.repository.base_artifact == created.repository.base_artifact
     assert recovered.repository.current_artifact == created.repository.checkpoint_artifact
     assert recovered.scenario_step == 0
@@ -276,7 +231,7 @@ def test_failed_artifact_fork_does_not_leave_runtime(tmp_path) -> None:
     )
 
     with pytest.raises(ArtifactError, match="cannot fork math"):
-        dispatcher.get_or_create_scenario("math", "recipe")
+        dispatcher.get_or_create_scenario("math")
 
     assert not dispatcher.has_loaded("math")
 
@@ -316,7 +271,7 @@ def test_http_artifact_failure_returns_service_unavailable(tmp_path) -> None:
 
 @pytest.mark.unit
 def test_recipe_pipeline_has_no_update_algorithm() -> None:
-    runtime = build_default_dispatcher().get_or_create_scenario("math", "recipe")
+    runtime = build_default_dispatcher().get_or_create_scenario("math")
 
     assert runtime.trainer.processor.output_schema is PolicyBatch
     assert runtime.trainer.training_backend is None
@@ -635,7 +590,7 @@ def test_published_candidate_is_used_by_next_inference(tmp_path) -> None:
         (initial / "model.txt").write_text("base")
         repository_backend = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
         dispatcher = build_default_dispatcher(backend_factory=repository_backend)
-        old_ref = dispatcher.get_or_create_scenario("chat", "recipe").repository.current_artifact
+        old_ref = dispatcher.get_or_create_scenario("chat").repository.current_artifact
 
         candidate_path = tmp_path / "candidate"
         candidate_path.mkdir()
@@ -686,7 +641,7 @@ def test_every_version_serves_locally_and_only_selected_versions_checkpoint(tmp_
         checkpoint_strategy=EveryNVersions(3),
         local_artifact_dir=tmp_path / "local",
     )
-    original_checkpoint = dispatcher.get_or_create_scenario("chat", "recipe").repository.current_artifact
+    original_checkpoint = dispatcher.get_or_create_scenario("chat").repository.current_artifact
 
     for version in (1, 2, 3):
         candidate = tmp_path / f"candidate-{version}"
@@ -729,7 +684,7 @@ def test_non_checkpointed_version_is_used_by_next_inference(tmp_path) -> None:
         initial.mkdir()
         (initial / "model.txt").write_text("base")
         dispatcher = weight_dispatcher(tmp_path, initial)
-        dispatcher.get_or_create_scenario("chat", "recipe")
+        dispatcher.get_or_create_scenario("chat")
         checkpoint = dispatcher.get_or_create_scenario("chat").repository.checkpoint_artifact
         dispatcher._commit_result("chat", TrainStepResult(state=None, runtime_load_id="sglang-v1"))
         runtime = dispatcher.get_or_create_scenario("chat")
@@ -777,7 +732,7 @@ def test_aborted_inference_restarts_before_recording(tmp_path) -> None:
         initial.mkdir()
         (initial / "model.txt").write_text("base")
         dispatcher = weight_dispatcher(tmp_path, initial)
-        dispatcher.get_or_create_scenario("chat", "recipe")
+        dispatcher.get_or_create_scenario("chat")
         dispatcher._commit_result("chat", TrainStepResult(state=None, runtime_load_id="sglang-v1"))
         head = dispatcher.get_or_create_scenario("chat").repository.current_artifact
         assert isinstance(head, LiveWeightArtifactRef)
@@ -824,7 +779,7 @@ def test_completed_inference_with_mismatched_runtime_load_id_fails_loudly(tmp_pa
         initial.mkdir()
         (initial / "model.txt").write_text("base")
         dispatcher = weight_dispatcher(tmp_path, initial)
-        dispatcher.get_or_create_scenario("chat", "recipe")
+        dispatcher.get_or_create_scenario("chat")
         dispatcher._commit_result("chat", TrainStepResult(state=None, runtime_load_id="sglang-v1"))
 
         client = TestClient(
@@ -908,7 +863,7 @@ def test_inference_fails_loudly_when_the_engine_reports_no_version(tmp_path) -> 
         initial.mkdir()
         (initial / "model.txt").write_text("base")
         dispatcher = weight_dispatcher(tmp_path, initial)
-        dispatcher.get_or_create_scenario("chat", "recipe")
+        dispatcher.get_or_create_scenario("chat")
         dispatcher._commit_result("chat", TrainStepResult(state=None, runtime_load_id="sglang-v1"))
 
         client = TestClient(TestServer(create_app(dispatcher, inference_backend=ContractInferenceBackend(backend))))
@@ -942,7 +897,7 @@ def test_new_dispatcher_falls_back_to_latest_checkpoint(tmp_path) -> None:
         checkpoint_strategy=EveryNVersions(3),
         local_artifact_dir=tmp_path / "first-local",
     )
-    checkpoint = first_dispatcher.get_or_create_scenario("chat", "recipe").repository.checkpoint_artifact
+    checkpoint = first_dispatcher.get_or_create_scenario("chat").repository.checkpoint_artifact
     candidate = tmp_path / "candidate"
     candidate.mkdir()
     (candidate / "model.txt").write_text("v1")
@@ -997,8 +952,8 @@ def test_release_ids_are_independent_and_ignore_results_without_candidates(tmp_p
         local_artifact_dir=tmp_path / "local",
     )
 
-    dispatcher.get_or_create_scenario("math", "recipe")
-    dispatcher.get_or_create_scenario("code", "recipe")
+    dispatcher.get_or_create_scenario("math")
+    dispatcher.get_or_create_scenario("code")
     math_head = dispatcher.get_or_create_scenario("math").repository.require_current_artifact()
     dispatcher._commit_result("math", TrainStepResult(state="no artifact"))
     # A no-artifact commit advances the step (the trainer consumed records and
@@ -1048,7 +1003,7 @@ def test_artifact_publication_failure_leaves_runtime_unchanged(tmp_path, failure
         backend_factory=FailingBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "local",
     )
-    runtime = dispatcher.get_or_create_scenario("chat", "recipe")
+    runtime = dispatcher.get_or_create_scenario("chat")
     previous = (runtime.repository.current_artifact, runtime.repository.checkpoint_artifact, runtime.scenario_step)
     candidate = tmp_path / "candidate"
     candidate.mkdir()
@@ -1120,9 +1075,12 @@ def test_any_accepted_token_authenticates_and_rotation_keeps_scenarios_reachable
             created = await client.post(
                 "/reef/scenarios",
                 headers=current,
-                json={"name": "shared", "recipe": "recipe"},
+                json={"name": "shared"},
             )
             assert created.status == 201
+            created_body = await created.json()
+            assert created_body["scenario"] == "shared"
+            assert "recipe" not in created_body
 
             after_rotation = await client.post(
                 "/reef/report",
@@ -1132,7 +1090,9 @@ def test_any_accepted_token_authenticates_and_rotation_keeps_scenarios_reachable
             assert after_rotation.status == 200
 
             listed = await client.get("/reef/scenarios", headers=rotated)
-            assert [row["scenario"] for row in (await listed.json())["scenarios"]] == ["shared"]
+            listed_rows = (await listed.json())["scenarios"]
+            assert [row["scenario"] for row in listed_rows] == ["shared"]
+            assert all("recipe" not in row for row in listed_rows)
 
             outsider = await client.post(
                 "/reef/report",

--- a/tests/reef_service/test_reef_recipe_requests.py
+++ b/tests/reef_service/test_reef_recipe_requests.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from threading import Barrier, Lock
+from threading import Barrier
 
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
 from reef.artifact import ArtifactRef, GitLFSRepositoryBackend, InMemoryRepositoryBackend
-from reef.artifact.git_client import GitClient
-from reef.core import ReefError, RequestType
-from reef.dispatcher import Dispatcher, build_default_dispatcher
-from reef.recipe import Recipe, RecipeRegistry, ScenarioRecipeConflict
+from reef.core import RequestType
+from reef.dispatcher import build_default_dispatcher
 from reef.runtime.inference import InferenceBackend
 from reef.service.app import RequestService, create_app
 
@@ -33,7 +31,7 @@ def _payload_for(path: str) -> dict:
     "path",
     ["/v1/chat/completions", "/reef/report"],
 )
-def test_new_scenario_binds_the_served_recipe_for_every_request_type(path: str) -> None:
+def test_new_scenario_is_created_for_every_request_type(path: str) -> None:
     async def run() -> None:
         dispatcher = build_default_dispatcher()
         client = TestClient(
@@ -53,7 +51,7 @@ def test_new_scenario_binds_the_served_recipe_for_every_request_type(path: str) 
             )
 
             assert response.status == 200
-            assert dispatcher.get_or_create_scenario("new-scenario").recipe == "recipe"
+            assert dispatcher.has_loaded("new-scenario")
         finally:
             await client.close()
 
@@ -88,7 +86,7 @@ def test_recipe_header_is_not_part_of_the_protocol(path: str) -> None:
             )
 
             assert response.status == 200
-            assert dispatcher.get_or_create_scenario("new-scenario").recipe == "recipe"
+            assert dispatcher.has_loaded("new-scenario")
         finally:
             await client.close()
 
@@ -125,7 +123,7 @@ def test_registered_scenario_keeps_its_binding_for_every_request_type(path: str)
             )
 
             assert response.status == 200
-            assert dispatcher.get_or_create_scenario("registered").recipe == "recipe"
+            assert dispatcher.has_loaded("registered")
         finally:
             await client.close()
 
@@ -133,58 +131,7 @@ def test_registered_scenario_keeps_its_binding_for_every_request_type(path: str)
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "path",
-    ["/v1/chat/completions", "/reef/report"],
-)
-def test_scenario_bound_to_another_recipe_conflicts_for_every_request_type(
-    path: str,
-    tmp_path,
-    fake_git_lfs: None,
-) -> None:
-    """A durable scenario carries its recipe; a deployment serving a different
-    one cannot adopt it."""
-    remote = tmp_path / "artifacts.git"
-    RequestService(
-        build_default_dispatcher(
-            backend_factory=GitLFSRepositoryBackend.factory(
-                remote,
-                work_dir=tmp_path / "first-work",
-                cache_dir=tmp_path / "first-cache",
-            )
-        )
-    ).accept({"x-reef-scenario": "registered"}, {"score": 1.0}, request_type=RequestType.REPORT)
-
-    other = Dispatcher(
-        RecipeRegistry({"other": Recipe(name="other")}),
-        GitLFSRepositoryBackend.factory(
-            remote,
-            work_dir=tmp_path / "other-work",
-            cache_dir=tmp_path / "other-cache",
-        ),
-    )
-
-    async def run() -> None:
-        client = TestClient(TestServer(create_app(other, inference_backend=StubInferenceBackend())))
-        await client.start_server()
-        try:
-            response = await client.post(
-                path,
-                headers={"x-reef-scenario": "registered"},
-                json=_payload_for(path),
-            )
-
-            assert response.status == 409
-            assert "already bound to recipe 'recipe', not 'other'" in await response.text()
-            assert not other.has_loaded("registered")
-        finally:
-            await client.close()
-
-    asyncio.run(run())
-
-
-@pytest.mark.integration
-def test_request_recovers_durable_recipe_without_resubmission(
+def test_request_recovers_durable_scenario_without_resubmission(
     tmp_path,
     fake_git_lfs: None,
 ) -> None:
@@ -211,36 +158,7 @@ def test_request_recovers_durable_recipe_without_resubmission(
         request_type=RequestType.REPORT,
     )
 
-    assert restarted_dispatcher.get_or_create_scenario("durable").recipe == "recipe"
-
-
-@pytest.mark.unit
-def test_rejected_recipeless_creation_leaves_no_scenario_state(tmp_path) -> None:
-    initial = tmp_path / "initial"
-    initial.mkdir()
-    backend = InMemoryRepositoryBackend.factory(
-        initial,
-        root=tmp_path / "repository",
-    )
-    agent_record_dir = tmp_path / "agent-record"
-    # A multi-recipe registry serves no single recipe, so creation must name one.
-    dispatcher = Dispatcher(
-        RecipeRegistry({"recipe": Recipe(), "other": Recipe(name="other")}),
-        backend,
-        agent_record_dir=agent_record_dir,
-    )
-
-    with pytest.raises(ReefError, match="no served recipe"):
-        RequestService(dispatcher).accept(
-            {"x-reef-scenario": "rejected"},
-            {"score": 1.0},
-            request_type=RequestType.REPORT,
-        )
-
-    assert not dispatcher.has_loaded("rejected")
-    assert not backend.has_registration("rejected")
-    assert not (tmp_path / "repository").exists()
-    assert list(agent_record_dir.iterdir()) == []
+    assert restarted_dispatcher.has_loaded("durable")
 
 
 @pytest.mark.unit
@@ -249,16 +167,16 @@ def test_different_scenarios_do_not_share_a_creation_lock(monkeypatch) -> None:
     load_or_create = dispatcher._registry._scenario_factory.load_or_create
     entered = Barrier(2)
 
-    def load_or_create_together(scenario, recipe, release_id):
+    def load_or_create_together(scenario, release_id):
         entered.wait(timeout=2)
-        return load_or_create(scenario, recipe, release_id)
+        return load_or_create(scenario, release_id)
 
     monkeypatch.setattr(dispatcher._registry._scenario_factory, "load_or_create", load_or_create_together)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures = (
-            executor.submit(dispatcher.get_or_create_scenario, "first", "recipe"),
-            executor.submit(dispatcher.get_or_create_scenario, "second", "recipe"),
+            executor.submit(dispatcher.get_or_create_scenario, "first"),
+            executor.submit(dispatcher.get_or_create_scenario, "second"),
         )
         scenarios = [future.result() for future in futures]
 
@@ -291,100 +209,8 @@ def test_create_freezes_head_selector_at_the_resolved_release(monkeypatch, tmp_p
 
     created = dispatcher.get_or_create_scenario(
         "moving-latest",
-        "recipe",
-        "head",
+        release_id="head",
     )
 
     assert created.repository.base_artifact.release_id == initial_release_id
     assert head_calls == 1
-
-
-@pytest.mark.integration
-def test_concurrent_first_requests_bind_exactly_one_recipe(
-    tmp_path,
-    fake_git_lfs: None,
-    monkeypatch,
-) -> None:
-    remote = tmp_path / "artifacts.git"
-    seed_factory = GitLFSRepositoryBackend.factory(
-        remote,
-        work_dir=tmp_path / "seed-work",
-        cache_dir=tmp_path / "seed-cache",
-    )
-    seed_factory("seed")
-    backend_factories = (
-        GitLFSRepositoryBackend.factory(
-            remote,
-            work_dir=tmp_path / "first-work",
-            cache_dir=tmp_path / "first-cache",
-        ),
-        GitLFSRepositoryBackend.factory(
-            remote,
-            work_dir=tmp_path / "second-work",
-            cache_dir=tmp_path / "second-cache",
-        ),
-    )
-
-    def build_dispatcher(index: int) -> Dispatcher:
-        return Dispatcher(
-            RecipeRegistry(
-                {
-                    "recipe-a": Recipe(name="recipe-a"),
-                    "recipe-b": Recipe(name="recipe-b"),
-                },
-            ),
-            backend_factories[index],
-        )
-
-    dispatchers = (build_dispatcher(0), build_dispatcher(1))
-    push_barrier = Barrier(2)
-    registration_push_lock = Lock()
-    git_run = GitClient.run
-
-    def synchronize_registration_push(self, command, *, cwd=None, source_error=False):
-        if command[:3] == ("git", "push", "origin") and any(
-            "refs/reef/scenarios/" in argument for argument in command
-        ):
-            push_barrier.wait(timeout=5)
-            with registration_push_lock:
-                return git_run(self, command, cwd=cwd, source_error=source_error)
-        return git_run(self, command, cwd=cwd, source_error=source_error)
-
-    monkeypatch.setattr(GitClient, "run", synchronize_registration_push)
-
-    def create(index: int, recipe: str):
-        return dispatchers[index].get_or_create_scenario("race", recipe).recipe
-
-    outcomes: list[str] = []
-    errors: list[BaseException] = []
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = (
-            executor.submit(create, 0, "recipe-a"),
-            executor.submit(create, 1, "recipe-b"),
-        )
-        for future in futures:
-            try:
-                outcomes.append(future.result())
-            except BaseException as exc:
-                errors.append(exc)
-
-    assert len(outcomes) == 1
-    assert len(errors) == 1
-    assert isinstance(errors[0], ScenarioRecipeConflict)
-
-    fresh_factory = GitLFSRepositoryBackend.factory(
-        remote,
-        work_dir=tmp_path / "fresh-work",
-        cache_dir=tmp_path / "fresh-cache",
-    )
-    recovered = Dispatcher(
-        RecipeRegistry(
-            {
-                "recipe-a": Recipe(name="recipe-a"),
-                "recipe-b": Recipe(name="recipe-b"),
-            },
-        ),
-        fresh_factory,
-    ).get_or_create_scenario("race")
-    assert recovered.recipe == outcomes[0]
-    assert backend_factories[0]("race").current() == backend_factories[1]("race").current()

--- a/tests/reef_service/test_reef_recipes.py
+++ b/tests/reef_service/test_reef_recipes.py
@@ -13,13 +13,7 @@ from recipes.sao import SAOProcessor, SAORecipe
 from recipes.tttd import TTTDGroupedRolloutReport, TTTDProcessor, TTTDRecipe
 from reef.core import AgentRecord, RequestType
 from reef.core.reports import ScoredRolloutReport
-from reef.recipe import (
-    Recipe,
-    RecipeConfigError,
-    WeightTrainingRecipe,
-    WeightTrainingSpec,
-    load_recipe_config,
-)
+from reef.recipe import Recipe, RecipeConfigError, WeightTrainingRecipe, WeightTrainingSpec, load_recipe_config
 from reef.recipe.registry import build_named_recipe, build_recipe, recipe_class_for
 from reef.records import RecordStore
 from reef.runtime import InferenceProxyRuntime

--- a/tests/reef_service/test_reef_recipes.py
+++ b/tests/reef_service/test_reef_recipes.py
@@ -16,8 +16,6 @@ from reef.core.reports import ScoredRolloutReport
 from reef.recipe import (
     Recipe,
     RecipeConfigError,
-    RecipeRegistry,
-    UnknownScenarioRecipe,
     WeightTrainingRecipe,
     WeightTrainingSpec,
     load_recipe_config,
@@ -81,21 +79,6 @@ def test_dotted_reference_resolves_an_external_recipe_class() -> None:
 def test_dotted_recipe_rejects_bad_references(reference: str, match: str) -> None:
     with pytest.raises(RecipeConfigError, match=match):
         recipe_class_for(reference)
-
-
-def test_recipe_registry_resolves_registered_recipe() -> None:
-    custom_recipe = Recipe()
-    tttd_recipe = Recipe(name="tttd")
-
-    registry = RecipeRegistry(
-        recipes={"custom": custom_recipe, "tttd": tttd_recipe},
-    )
-
-    assert registry.names == ("custom", "tttd")
-    assert registry.resolve("custom") is custom_recipe
-    assert registry.resolve("tttd") is tttd_recipe
-    with pytest.raises(UnknownScenarioRecipe, match="available recipes: custom, tttd"):
-        registry.resolve("missing")
 
 
 @pytest.mark.parametrize(
@@ -348,7 +331,7 @@ model:
 
 def test_named_recipe_without_config_directory_resolves_core_recipe_only() -> None:
     assert isinstance(build_named_recipe("recipe", {}), Recipe)
-    with pytest.raises(UnknownScenarioRecipe, match="unknown scenario recipe 'thorough'"):
+    with pytest.raises(RecipeConfigError, match="unknown deployment recipe 'thorough'"):
         build_named_recipe("thorough", {})
 
 
@@ -358,13 +341,6 @@ def test_named_recipe_reads_the_config_directory_from_the_environment(tmp_path) 
     recipe = build_named_recipe("thorough", {"REEF_RECIPE_CONFIG_DIR": str(tmp_path)})
 
     assert isinstance(recipe, Recipe)
-
-
-def test_instance_registry_is_a_closed_set() -> None:
-    registry = RecipeRegistry({"custom": Recipe()})
-
-    with pytest.raises(UnknownScenarioRecipe):
-        registry.resolve("recipe")
 
 
 def test_named_recipes_never_import_implementation_references() -> None:

--- a/tests/reef_service/test_reef_scenarios.py
+++ b/tests/reef_service/test_reef_scenarios.py
@@ -6,7 +6,7 @@ import inspect
 from reef.artifact import InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
 from reef.dispatcher import Dispatcher, build_default_dispatcher
-from reef.recipe import Recipe, RecipeRegistry
+from reef.recipe import Recipe
 from reef.scenario.checkpoint_strategy import EveryNVersions
 
 
@@ -24,17 +24,17 @@ def test_artifact_state_and_snapshot_are_not_parallel_public_types() -> None:
     assert importlib.util.find_spec("reef.scenarios") is None
 
 
-def test_scenario_owns_recipe_and_base_artifact() -> None:
-    scenario = build_default_dispatcher().get_or_create_scenario("math", "recipe")
+def test_scenario_owns_recipe_derived_policy_and_base_artifact() -> None:
+    scenario = build_default_dispatcher().get_or_create_scenario("math")
 
-    assert scenario.recipe == "recipe"
+    assert not hasattr(scenario, "recipe")
     assert scenario.repository.base_artifact.release_id
     assert scenario._commit_protocol.checkpoint_strategy is not None
     assert scenario.repository.current_artifact == scenario.repository.checkpoint_artifact
 
 
 def test_scenario_step_is_owned_by_scenario() -> None:
-    scenario = build_default_dispatcher().get_or_create_scenario("math", "recipe")
+    scenario = build_default_dispatcher().get_or_create_scenario("math")
 
     assert not hasattr(scenario.repository.base_artifact, "scenario")
     assert scenario.scenario_step == 0
@@ -45,7 +45,7 @@ def test_scenario_step_is_owned_by_scenario() -> None:
 
 
 def test_scenario_owns_scenario_scoped_repository() -> None:
-    scenario = build_default_dispatcher().get_or_create_scenario("math", "recipe")
+    scenario = build_default_dispatcher().get_or_create_scenario("math")
 
     repository = scenario.repository
 
@@ -61,18 +61,18 @@ def test_scenario_owns_scenario_scoped_repository() -> None:
 def test_each_scenario_keeps_recipe_derived_checkpoint_policy(tmp_path) -> None:
     initial = tmp_path / "initial"
     initial.mkdir()
-    dispatcher = Dispatcher(
-        RecipeRegistry(
-            recipes={
-                "fast": Recipe(name="fast", checkpoint_strategy=EveryNVersions(1)),
-                "slow": Recipe(name="slow", checkpoint_strategy=EveryNVersions(3)),
-            },
-        ),
-        InMemoryRepositoryBackend.factory(initial),
+    backend_factory = InMemoryRepositoryBackend.factory(initial)
+    fast_dispatcher = Dispatcher(
+        Recipe(name="fast", checkpoint_strategy=EveryNVersions(1)),
+        backend_factory,
+    )
+    slow_dispatcher = Dispatcher(
+        Recipe(name="slow", checkpoint_strategy=EveryNVersions(3)),
+        backend_factory,
     )
 
-    fast = dispatcher.get_or_create_scenario("fast", "fast")
-    slow = dispatcher.get_or_create_scenario("slow", "slow")
+    fast = fast_dispatcher.get_or_create_scenario("fast")
+    slow = slow_dispatcher.get_or_create_scenario("slow")
 
     assert fast._commit_protocol.checkpoint_strategy.n == 1
     assert slow._commit_protocol.checkpoint_strategy.n == 3
@@ -81,16 +81,16 @@ def test_each_scenario_keeps_recipe_derived_checkpoint_policy(tmp_path) -> None:
 def test_scenario_snapshot_round_trips() -> None:
     from reef.scenario.snapshot import ScenarioSnapshot, parse_snapshot_metadata
 
-    scenario = build_default_dispatcher().get_or_create_scenario("math", "recipe")
+    scenario = build_default_dispatcher().get_or_create_scenario("math")
     metadata = scenario.to_snapshot_metadata()
 
     assert metadata["format"] == "reef-scenario/4"
     assert "scenario" not in metadata["base_artifact"]
     assert metadata["scenario_step"] == 0
     assert metadata["operation"] == "training"
+    assert "recipe" not in metadata
     assert parse_snapshot_metadata(metadata) == ScenarioSnapshot(
         scenario="math",
-        recipe="recipe",
         base_artifact=scenario.repository.base_artifact,
         scenario_step=0,
         algorithm_state=None,
@@ -100,11 +100,15 @@ def test_scenario_snapshot_round_trips() -> None:
         rollback_target_release_id=None,
     )
 
+    # Snapshots written before recipe identity was removed remain readable;
+    # the deployment recipe now supplies those capabilities during recovery.
+    assert parse_snapshot_metadata({**metadata, "recipe": "legacy-name"}) == parse_snapshot_metadata(metadata)
+
 
 def test_rollback_snapshot_preserves_its_operation() -> None:
     from reef.scenario.snapshot import parse_snapshot_metadata
 
-    scenario = build_default_dispatcher().get_or_create_scenario("math", "recipe")
+    scenario = build_default_dispatcher().get_or_create_scenario("math")
     assert scenario is not None
     metadata = scenario.to_snapshot_metadata()
     metadata["operation"] = "rollback"
@@ -129,7 +133,7 @@ def test_dispatcher_restores_agent_record_from_configured_directory(tmp_path) ->
         payload={"score": 1.0},
         created_at=1.0,
     )
-    first.get_or_create_scenario("math", "recipe").records.append(record)
+    first.get_or_create_scenario("math").records.append(record)
 
     second = build_default_dispatcher(backend_factory=backend, agent_record_dir=agent_record_dir)
 
@@ -150,7 +154,6 @@ def test_dispatcher_restores_algorithm_state_from_artifact_metadata(tmp_path) ->
             payload={"score": 1.0},
             created_at=1.0,
         ),
-        recipe="recipe",
     )
     # recipe never trains, so step stays at 0 and records accumulate.
     assert first.get_or_create_scenario("math").trainer.state == {}
@@ -174,7 +177,7 @@ def test_dispatcher_restores_algorithm_state_from_artifact_metadata(tmp_path) ->
 
 
 def test_scenario_close_closes_processor_before_records() -> None:
-    scenario = build_default_dispatcher().get_or_create_scenario("math", "recipe")
+    scenario = build_default_dispatcher().get_or_create_scenario("math")
     calls: list[str] = []
 
     def _spy(name: str, original):
@@ -197,7 +200,7 @@ def test_scenario_close_closes_processor_before_records() -> None:
 
 def test_dispatcher_close_tears_down_scenarios_through_close() -> None:
     dispatcher = build_default_dispatcher()
-    scenario = dispatcher.get_or_create_scenario("math", "recipe")
+    scenario = dispatcher.get_or_create_scenario("math")
     closed: list[str] = []
     original = scenario.close
     scenario.close = lambda: (closed.append("scenario"), original())[-1]
@@ -209,7 +212,7 @@ def test_dispatcher_close_tears_down_scenarios_through_close() -> None:
 
 def test_dispatcher_reload_closes_the_dropped_scenario_instance() -> None:
     dispatcher = build_default_dispatcher()
-    dropped = dispatcher.get_or_create_scenario("math", "recipe")
+    dropped = dispatcher.get_or_create_scenario("math")
     closed: list[str] = []
     original = dropped.close
     dropped.close = lambda: (closed.append("dropped"), original())[-1]

--- a/tests/reef_service/test_reports.py
+++ b/tests/reef_service/test_reports.py
@@ -16,7 +16,6 @@ from reef.core import AgentRecord, RequestType
 from reef.core.reports import ReportBase, ReportValidationError, ScoredRolloutReport
 from reef.dispatcher import Dispatcher
 from reef.recipe.base import Recipe
-from reef.recipe.registry import RecipeRegistry
 from reef.train import ProcessorContext
 
 
@@ -184,7 +183,7 @@ def _dispatcher(recipe: Recipe, name: str) -> Dispatcher:
     initial = root / "initial"
     initial.mkdir()
     return Dispatcher(
-        RecipeRegistry({name: recipe}),
+        recipe,
         InMemoryRepositoryBackend.factory(initial, root=root / "repository"),
     )
 
@@ -206,18 +205,18 @@ def test_declared_schema_is_enforced_at_ingress() -> None:
 
     dispatcher = _dispatcher(_ScoredRecipe(name="scored"), "scored")
     with pytest.raises(ReportValidationError, match="score must be a number"):
-        dispatcher.accept_record(_report_record("bad", {"score": "high"}), recipe="scored")
+        dispatcher.accept_record(_report_record("bad", {"score": "high"}))
     # A compliant report on the same scenario still lands.
-    stored = dispatcher.accept_record(_report_record("good", {"score": 1.0}), recipe="scored")
+    stored = dispatcher.accept_record(_report_record("good", {"score": 1.0}))
     assert stored.agent_record_id == "good"
-    scenario = dispatcher.get_or_create_scenario("workload", "scored")
+    scenario = dispatcher.get_or_create_scenario("workload")
     assert scenario is not None
     assert scenario.trainer.processor.context.report_type is ScoredRolloutReport
 
 
 def test_undeclared_recipe_keeps_open_ingress_via_anyreport() -> None:
     dispatcher = _dispatcher(Recipe(), "recipe")
-    stored = dispatcher.accept_record(_report_record("open", {"feedback": "no score at all"}), recipe="recipe")
+    stored = dispatcher.accept_record(_report_record("open", {"feedback": "no score at all"}))
     assert stored.agent_record_id == "open"
 
 

--- a/tests/reef_service/test_runtime_registry.py
+++ b/tests/reef_service/test_runtime_registry.py
@@ -7,7 +7,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from reef.artifact import Artifact, InMemoryRepositoryBackend, LiveWeightArtifactRef
 from reef.dispatcher import Dispatcher
-from reef.recipe import Recipe, RecipeRegistry
+from reef.recipe import Recipe
 from reef.recipe.registry import build_named_recipe
 from reef.runtime import InferenceProxyRuntime, InferenceRuntime, RuntimeConfigError, RuntimeRegistry
 from reef.runtime.inference import InferenceBackend
@@ -91,13 +91,13 @@ model:
     initial = tmp_path / "initial"
     initial.mkdir()
     dispatcher = Dispatcher(
-        RecipeRegistry({"qwen": build_named_recipe("qwen", config_directory=recipes)}),
+        build_named_recipe("qwen", config_directory=recipes),
         InMemoryRepositoryBackend.factory(initial),
     )
 
-    scenario = dispatcher.get_or_create_scenario("math", "qwen")
+    scenario = dispatcher.get_or_create_scenario("math")
 
-    assert scenario.recipe == "qwen"
+    assert scenario.runtime is not None
 
 
 @pytest.mark.unit
@@ -119,23 +119,21 @@ def test_http_app_routes_scenarios_to_runtime_specific_inference_services(tmp_pa
 
         initial = tmp_path / "initial"
         initial.mkdir()
-        dispatcher = Dispatcher(
-            RecipeRegistry(
-                recipes={
-                    "qwen": Recipe(name="qwen", runtime=RoutingRuntime("qwen")),
-                    "gemma": Recipe(name="gemma", runtime=RoutingRuntime("gemma")),
-                },
-            ),
-            InMemoryRepositoryBackend.factory(initial),
-        )
+        backend_factory = InMemoryRepositoryBackend.factory(initial)
+        dispatchers = {
+            recipe: Dispatcher(
+                Recipe(name=recipe, runtime=RoutingRuntime(recipe)),
+                backend_factory,
+            )
+            for recipe in ("qwen", "gemma")
+        }
 
         for scenario, recipe in (("math", "qwen"), ("code", "gemma")):
-            dispatcher.get_or_create_scenario(scenario, recipe)
-
-        client = TestClient(TestServer(create_app(dispatcher)))
-        await client.start_server()
-        try:
-            for scenario, recipe in (("math", "qwen"), ("code", "gemma")):
+            dispatcher = dispatchers[recipe]
+            dispatcher.get_or_create_scenario(scenario)
+            client = TestClient(TestServer(create_app(dispatcher)))
+            await client.start_server()
+            try:
                 response = await client.post(
                     "/v1/chat/completions",
                     headers={"x-reef-scenario": scenario},
@@ -143,8 +141,8 @@ def test_http_app_routes_scenarios_to_runtime_specific_inference_services(tmp_pa
                 )
                 assert response.status == 200
                 assert await response.json() == {"runtime": recipe}
-        finally:
-            await client.close()
+            finally:
+                await client.close()
 
     asyncio.run(run())
 

--- a/tests/reef_service/test_sao_pipeline.py
+++ b/tests/reef_service/test_sao_pipeline.py
@@ -19,7 +19,6 @@ from reef.artifact import InMemoryRepositoryBackend
 from reef.artifact.artifact import LiveWeightArtifactRef
 from reef.core import AgentRecord, RequestType
 from reef.dispatcher import Dispatcher
-from reef.recipe import RecipeRegistry
 from reef.recipe.registry import build_recipe, recipe_class_for
 from reef.records import RecordStore
 from reef.runtime import ActivatedModel, ModelCandidate, PreparedTrainingStep, TrainingRuntime
@@ -428,13 +427,13 @@ def test_dispatcher_runs_a_full_sao_train_step_per_rollout(tmp_path) -> None:
     initial.mkdir()
 
     dispatcher = Dispatcher(
-        RecipeRegistry(recipes={"sao": SAORecipe(runtime)}),
+        SAORecipe(runtime),
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "staged",
     )
     try:
-        dispatcher.accept_record(_sao_inference("i1"), recipe="sao")
-        dispatcher.accept_record(_sao_report("r1", "i1", 0.9), recipe="sao")
+        dispatcher.accept_record(_sao_inference("i1"))
+        dispatcher.accept_record(_sao_report("r1", "i1", 0.9))
 
         # batch_size 1 => exactly one accepted rollout drives one training step,
         # executed asynchronously on the dispatcher's training worker.
@@ -473,13 +472,13 @@ def test_external_checkpoint_evaluation_rejects_before_serving_activation(tmp_pa
         runtime=runtime,
     )
     dispatcher = Dispatcher(
-        RecipeRegistry(recipes={"sao": recipe}),
+        recipe,
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "staged",
     )
     try:
-        dispatcher.accept_record(_sao_inference("i1"), recipe="sao")
-        dispatcher.accept_record(_sao_report("r1", "i1", 0.9), recipe="sao")
+        dispatcher.accept_record(_sao_inference("i1"))
+        dispatcher.accept_record(_sao_report("r1", "i1", 0.9))
 
         _wait_for_step(dispatcher, 1)
 
@@ -509,16 +508,16 @@ def test_sao_train_step_swaps_the_served_runtime_load_id(tmp_path) -> None:
     runtime = _StubTrainingRuntime(tmp_path / "checkpoints")
 
     dispatcher = Dispatcher(
-        RecipeRegistry(recipes={"sao": SAORecipe(runtime, checkpoint_strategy=EveryNVersions(99))}),
+        SAORecipe(runtime, checkpoint_strategy=EveryNVersions(99)),
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "staged",
     )
     try:
-        pre_head = dispatcher.get_or_create_scenario("math", recipe="sao").repository.require_current_artifact()
+        pre_head = dispatcher.get_or_create_scenario("math").repository.require_current_artifact()
         assert runtime.serving_runtime_load_id() == "slime-v3"
 
-        dispatcher.accept_record(_sao_inference("i1"), recipe="sao")
-        dispatcher.accept_record(_sao_report("r1", "i1", 0.9), recipe="sao")
+        dispatcher.accept_record(_sao_inference("i1"))
+        dispatcher.accept_record(_sao_report("r1", "i1", 0.9))
 
         _wait_for_step(dispatcher, 1)
         head = dispatcher.get_or_create_scenario("math").repository.require_current_artifact()
@@ -547,7 +546,7 @@ def test_sao_recovers_step_from_the_commit_log_after_restart(tmp_path) -> None:
 
     def _make_dispatcher() -> Dispatcher:
         return Dispatcher(
-            RecipeRegistry(recipes={"sao": SAORecipe(runtime)}),
+            SAORecipe(runtime),
             backend,
             local_artifact_dir=tmp_path / "staged",
             agent_record_dir=agent_dir,
@@ -555,8 +554,8 @@ def test_sao_recovers_step_from_the_commit_log_after_restart(tmp_path) -> None:
 
     first = _make_dispatcher()
     try:
-        first.accept_record(_sao_inference("i1"), recipe="sao")
-        first.accept_record(_sao_report("r1", "i1", 0.9), recipe="sao")
+        first.accept_record(_sao_inference("i1"))
+        first.accept_record(_sao_report("r1", "i1", 0.9))
         _wait_for_step(first, 1)
     finally:
         first.close()
@@ -581,8 +580,8 @@ def test_sao_recovers_step_from_the_commit_log_after_restart(tmp_path) -> None:
 
         # Training resumes at the next rollout and advances past the recovered
         # step. The serving version already moved to slime-v4 on the first step.
-        second.accept_record(_sao_inference("i2", runtime_load_id="slime-v4"), recipe="sao")
-        second.accept_record(_sao_report("r2", "i2", 0.5), recipe="sao")
+        second.accept_record(_sao_inference("i2", runtime_load_id="slime-v4"))
+        second.accept_record(_sao_report("r2", "i2", 0.5))
         _wait_for_step(second, 2)
         assert second.get_or_create_scenario("math").trainer.state == {"steps": 2}
     finally:

--- a/tests/reef_service/test_scenario_api.py
+++ b/tests/reef_service/test_scenario_api.py
@@ -5,14 +5,14 @@ import pytest
 from reef.artifact import InMemoryRepositoryBackend
 from reef.core import UnknownScenario
 from reef.dispatcher import Dispatcher
-from reef.recipe import Recipe, RecipeRegistry, ScenarioRecipeConflict
+from reef.recipe import Recipe
 
 
 def _dispatcher(tmp_path, *, allow_implicit_creation: bool = True) -> Dispatcher:
     bootstrap = tmp_path / "bootstrap"
     bootstrap.mkdir(exist_ok=True)
     return Dispatcher(
-        RecipeRegistry({"recipe": Recipe()}),
+        Recipe(),
         InMemoryRepositoryBackend.factory(bootstrap, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "local",
         agent_record_dir=None,
@@ -22,43 +22,37 @@ def _dispatcher(tmp_path, *, allow_implicit_creation: bool = True) -> Dispatcher
 
 def test_get_or_create_scenario_returns_same_instance(tmp_path) -> None:
     dispatcher = _dispatcher(tmp_path)
-    first = dispatcher.get_or_create_scenario("code-repair", "recipe")
-    assert first is not None and first.recipe == "recipe"
-    again = dispatcher.get_or_create_scenario("code-repair", "recipe")
+    first = dispatcher.get_or_create_scenario("code-repair")
+    assert first is not None
+    again = dispatcher.get_or_create_scenario("code-repair")
     assert again is first
-
-
-def test_create_scenario_conflicts_on_a_different_recipe(tmp_path) -> None:
-    dispatcher = _dispatcher(tmp_path)
-    dispatcher.get_or_create_scenario("code-repair", "recipe")
-    with pytest.raises(ScenarioRecipeConflict):
-        dispatcher.get_or_create_scenario("code-repair", "other")
 
 
 def test_implicit_creation_off_returns_none_for_unknown_scenarios(tmp_path) -> None:
     dispatcher = _dispatcher(tmp_path, allow_implicit_creation=False)
-    assert dispatcher.get_or_create_scenario("typo-name", "recipe") is None
+    assert dispatcher.get_or_create_scenario("typo-name") is None
 
 
 def test_implicit_creation_off_still_resolves_created_scenarios(tmp_path) -> None:
     dispatcher = _dispatcher(tmp_path, allow_implicit_creation=False)
-    dispatcher.get_or_create_scenario("code-repair", "recipe", allow_implicit_creation=True)
-    assert dispatcher.get_or_create_scenario("code-repair", "recipe").name == "code-repair"
+    dispatcher.get_or_create_scenario("code-repair", allow_implicit_creation=True)
+    assert dispatcher.get_or_create_scenario("code-repair").name == "code-repair"
 
 
 def test_implicit_creation_on_keeps_current_behavior(tmp_path) -> None:
     dispatcher = _dispatcher(tmp_path)
-    assert dispatcher.get_or_create_scenario("fresh", "recipe").name == "fresh"
+    assert dispatcher.get_or_create_scenario("fresh").name == "fresh"
 
 
 def test_list_scenarios_shows_loaded_bindings(tmp_path) -> None:
     dispatcher = _dispatcher(tmp_path)
-    dispatcher.get_or_create_scenario("a", "recipe")
-    dispatcher.get_or_create_scenario("b", "recipe")
+    dispatcher.get_or_create_scenario("a")
+    dispatcher.get_or_create_scenario("b")
     rows = dispatcher.list_scenarios()
     names = [row["scenario"] for row in rows]
     assert names == ["a", "b"]
-    assert all(row["loaded"] and row["recipe"] == "recipe" and row["release_id"] for row in rows)
+    assert all(row["loaded"] and row["release_id"] for row in rows)
+    assert all("recipe" not in row for row in rows)
 
 
 def test_list_scenarios_empty_when_nothing_exists(tmp_path) -> None:
@@ -67,10 +61,10 @@ def test_list_scenarios_empty_when_nothing_exists(tmp_path) -> None:
 
 def test_scenario_contract_returns_processor_and_request_types(tmp_path) -> None:
     dispatcher = _dispatcher(tmp_path)
-    dispatcher.get_or_create_scenario("math", "recipe")
+    dispatcher.get_or_create_scenario("math")
     contract = dispatcher.scenario_contract("math")
     assert contract["scenario"] == "math"
-    assert contract["recipe"] == "recipe"
+    assert "recipe" not in contract
     assert contract["processor"] == "DataProcessor"
     assert contract["required_request_types"] == ["inference", "report"]
 

--- a/tests/reef_service/test_skillclaw.py
+++ b/tests/reef_service/test_skillclaw.py
@@ -480,7 +480,6 @@ def test_replay_driver_dry_run(driver, skillclaw, example, tmp_path, monkeypatch
     recipe = _dry_recipe(example, tmp_path, batch_size=2)
     service = driver.RunService(
         scenario="dry",
-        recipe_name="skillclaw",
         recipe=recipe,
         bootstrap_pool=driver._bootstrap_pool(run_dir, "dry", recipe),
         run_dir=run_dir,
@@ -578,7 +577,6 @@ def test_poke_night_recovers_a_pending_batch(driver, skillclaw, example, tmp_pat
     recipe = _dry_recipe(example, tmp_path, batch_size=1)
     service = driver.RunService(
         scenario="dry2",
-        recipe_name="skillclaw",
         recipe=recipe,
         bootstrap_pool=driver._bootstrap_pool(run_dir, "dry2", recipe),
         run_dir=run_dir,
@@ -588,7 +586,7 @@ def test_poke_night_recovers_a_pending_batch(driver, skillclaw, example, tmp_pat
         inference_backend=_stub_backend(),
     )
     try:
-        scenario = service.dispatcher.get_or_create_scenario("dry2", "skillclaw")
+        scenario = service.dispatcher.get_or_create_scenario("dry2")
         assert scenario is not None
         # Append straight to the store to simulate a crash before the trigger.
         scenario.records.append_result(

--- a/tests/reef_service/test_surfaces.py
+++ b/tests/reef_service/test_surfaces.py
@@ -374,7 +374,6 @@ def test_inference_injects_and_records_the_post_transform_request(tmp_path) -> N
 
     from reef.artifact import InMemoryRepositoryBackend
     from reef.dispatcher import Dispatcher
-    from reef.recipe import RecipeRegistry
     from reef.runtime.inference import InferenceBackend
     from reef.service.app import RequestService
 
@@ -396,9 +395,8 @@ def test_inference_injects_and_records_the_post_transform_request(tmp_path) -> N
     (bootstrap / "skills" / "SKILL.md").write_text("Always check units.", encoding="utf-8")
 
     recipe = SkillRecipe(name="skill_delivery")
-    registry = RecipeRegistry({"skill_delivery": recipe})
     dispatcher = Dispatcher(
-        registry,
+        recipe,
         InMemoryRepositoryBackend.factory(bootstrap, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "local",
         agent_record_dir=None,
@@ -420,7 +418,7 @@ def test_inference_injects_and_records_the_post_transform_request(tmp_path) -> N
         assert recorded[1] == {"role": "user", "content": "hi"}
 
     asyncio.run(run())
-    scenario = dispatcher.get_or_create_scenario("smoke", None)
+    scenario = dispatcher.get_or_create_scenario("smoke")
     assert scenario.surface is scenario.surface
 
 

--- a/tests/reef_service/test_trainer.py
+++ b/tests/reef_service/test_trainer.py
@@ -10,7 +10,7 @@ from recipes.tttd import TTTDGroupedRolloutReport, TTTDProcessor
 from reef.artifact import InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
 from reef.dispatcher import Dispatcher
-from reef.recipe import RecipeRegistry, WeightTrainingRecipe
+from reef.recipe import WeightTrainingRecipe
 from reef.records import RecordStore
 from reef.runtime import ActivatedModel, ModelCandidate, PreparedTrainingStep, TrainingRuntime
 from reef.train import ProcessorContext, Trainer
@@ -817,13 +817,13 @@ def test_scenario_runtime_executes_grpo_as_one_async_transaction(tmp_path) -> No
             )
 
     dispatcher = Dispatcher(
-        RecipeRegistry(recipes={"grouped_pg": GroupedPgRecipe(training_runtime, name="grouped_pg")}),
+        GroupedPgRecipe(training_runtime, name="grouped_pg"),
         InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
         local_artifact_dir=tmp_path / "staged",
     )
     for rid, score in (("i1", 0.2), ("i2", 0.8)):
-        dispatcher.accept_record(inference(rid), recipe="grouped_pg")
-        dispatcher.accept_record(report("r" + rid, rid, score, comparison_set="set-a"), recipe="grouped_pg")
+        dispatcher.accept_record(inference(rid))
+        dispatcher.accept_record(report("r" + rid, rid, score, comparison_set="set-a"))
 
     runtime = dispatcher.get_or_create_scenario("math")
     for _ in range(1000):

--- a/tests/reef_service/test_training_server.py
+++ b/tests/reef_service/test_training_server.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 from reef_service.runtime_stubs import StubTrainingRuntime as StubRuntime
 
-from reef.recipe import UnknownScenarioRecipe
 from reef.scenario.checkpoint_strategy import EveryNVersions
 from reef.service import deploy
 from reef.service.assembly import _repository_location
@@ -251,7 +250,7 @@ def test_build_dispatcher_connects_runtime_and_injects_selected_recipe(monkeypat
         connector=connector,
     )
 
-    assert dispatcher._registry.recipes.names == ("openclawrl",)
+    assert dispatcher._recipe.name == "openclawrl"
     assert connected == {
         "inference_url": "http://ray-head:30000",
         "actor_name": "reef-train-bridge",
@@ -279,17 +278,11 @@ def test_build_dispatcher_loads_recipe_for_inference_service(monkeypatch, tmp_pa
         )
     )
 
-    registry = dispatcher._registry.recipes
-    assert registry.names == ("recipe",)
-    assert registry.served_recipe == "recipe"
-    # The deployment serves one recipe: a request-time name never materializes
-    # another method, even though a dotted resolver could have built it.
-    with pytest.raises(UnknownScenarioRecipe):
-        registry.resolve("harness_evolve")
+    assert dispatcher._recipe.name == "recipe"
 
 
 @pytest.mark.unit
-def test_build_dispatcher_uses_the_dotted_recipe_name_as_its_registry_key(monkeypatch, tmp_path) -> None:
+def test_build_dispatcher_uses_the_recipe_name_for_a_dotted_reference(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         deploy.GitLFSRepositoryBackend,
         "factory",
@@ -305,8 +298,7 @@ def test_build_dispatcher_uses_the_dotted_recipe_name_as_its_registry_key(monkey
         environ={},
     )
 
-    assert dispatcher._registry.recipes.names == ("recipe",)
-    assert dispatcher._registry.recipes.served_recipe == "recipe"
+    assert dispatcher._recipe.name == "recipe"
 
 
 @pytest.mark.unit
@@ -326,7 +318,7 @@ def test_build_dispatcher_applies_common_recipe_controls(monkeypatch, tmp_path) 
         environ={},
         connector=lambda **kwargs: StubRuntime(),
     )
-    recipe = dispatcher._registry.recipes.resolve("openclawrl")
+    recipe = dispatcher._recipe
     captured["batch_size"] = recipe.batch_size
     captured["checkpoint_strategy"] = recipe.checkpoint_strategy
 
@@ -355,7 +347,7 @@ def test_build_dispatcher_injects_candidate_evaluation_into_weight_recipe(monkey
         connector=lambda **kwargs: StubRuntime(),
     )
 
-    recipe = dispatcher._registry.recipes.resolve("openclawrl")
+    recipe = dispatcher._recipe
     assert recipe.candidate_evaluation is not None
     assert recipe.candidate_evaluation.module == evaluation["module"]
 
@@ -461,11 +453,11 @@ def test_build_dispatcher_treats_sao_as_training_recipe(monkeypatch, tmp_path) -
         connector=connector,
     )
 
-    assert dispatcher._registry.recipes.names == ("sao",)
+    assert dispatcher._recipe.name == "sao"
     # The runtime connector was invoked (inference branch never connects).
     assert connected["actor_name"] == "reef-train-bridge"
     assert connected["max_staleness"] == 2
-    assert dispatcher._registry.recipes.resolve("sao").max_staleness == 2
+    assert dispatcher._recipe.max_staleness == 2
 
 
 @pytest.mark.unit
@@ -493,7 +485,7 @@ def test_build_dispatcher_resolves_max_staleness_environment_for_runtime(
     )
 
     assert connected.get("max_staleness", 0) == max_staleness
-    assert dispatcher._registry.recipes.resolve("openclawrl").max_staleness == max_staleness
+    assert dispatcher._recipe.max_staleness == max_staleness
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_training_wait.py
+++ b/tests/reef_service/test_training_wait.py
@@ -25,7 +25,6 @@ import reef.dispatcher as dispatcher_module
 from reef.artifact.memory import InMemoryRepositoryBackend
 from reef.dispatcher import _DERIVATION_POLL_SECONDS, _STORAGE_RETRY_SECONDS, _UNDRAINED_WARNING_SECONDS, Dispatcher
 from reef.recipe import Recipe
-from reef.recipe.registry import RecipeRegistry
 
 pytestmark = pytest.mark.unit
 
@@ -35,7 +34,7 @@ def _dispatcher() -> Dispatcher:
     initial = root / "initial"
     initial.mkdir()
     return Dispatcher(
-        RecipeRegistry({"recipe": Recipe()}),
+        Recipe(),
         InMemoryRepositoryBackend.factory(initial, root=root / "repository"),
     )
 

--- a/tests/test_example_entrypoints.py
+++ b/tests/test_example_entrypoints.py
@@ -329,10 +329,8 @@ def test_harbor_result_posts_verifier_reward_to_its_exact_receipts(monkeypatch, 
     }
     client = Client()
 
-    assert report_module.post_report(result, client=client, scenario="example-host-test", recipe=example) == {
-        "accepted": True
-    }
+    assert report_module.post_report(result, client=client, scenario="example-host-test") == {"accepted": True}
     scenario, payload, recipe = client.call
-    assert (scenario, recipe) == ("example-host-test", example)
+    assert (scenario, recipe) == ("example-host-test", None)
     assert payload["score"] == 0.75
     assert payload["references"] == ["receipt-7"]

--- a/tests/test_guidance_ttt.py
+++ b/tests/test_guidance_ttt.py
@@ -77,7 +77,7 @@ class _ReefClient:
         assert (scenario, path, recipe, release_id) == (
             "guidance-smoke",
             "/v1/chat/completions",
-            "tttd",
+            None,
             None,
         )
         with self._lock:
@@ -87,7 +87,7 @@ class _ReefClient:
         return {"choices": [{"message": {"content": content}}]}, f"receipt-{index}"
 
     def report(self, scenario, payload, *, recipe=None, release_id=None):
-        assert (scenario, recipe, release_id) == ("guidance-smoke", "tttd", None)
+        assert (scenario, recipe, release_id) == ("guidance-smoke", None, None)
         with self._lock:
             self.reports.append(payload)
         return {}

--- a/tests/test_tttd_harness.py
+++ b/tests/test_tttd_harness.py
@@ -201,7 +201,7 @@ class _Client:
         assert (scenario, path, recipe, extra_headers) == (
             "discovery",
             "/v1/chat/completions",
-            "tttd",
+            None,
             {"x-reef-release-id": "checkpoint-v1"},
         )
         self.index += 1


### PR DESCRIPTION
Closes #38

## Summary

- replace `RecipeRegistry` with a single built `Recipe` passed through `Dispatcher`, `ScenarioRegistry`, and `ScenarioFactory`
- remove recipe identity from scenarios, snapshots, scenario APIs, and first-party request examples
- keep legacy snapshots readable by ignoring their old `recipe` field
- simplify file-surface resolution and delete the impossible multi-recipe serving branches and errors
- document the artifact repository as deployment-owned

## Design note

This intentionally takes the single-recipe invariant further than the issue proposal. A recipe name is deployment configuration and an observability label, not scenario identity. `x-reef-recipe` therefore does not assert or select a scenario recipe, and deployments configured with different recipes must not share an artifact repository.

This removes the second recipe name instead of wrapping `(name, recipe)` in a `ServedRecipe` record.

## Validation

- full repository run: 1622 passed, 2 skipped; the only failure is the real Git LFS integration test because `git lfs` is not installed locally
- focused changed-area run: 180 passed
- Ruff checks and formatting checks pass for all changed Python files
- Python compile checks pass
- documentation link and contract checks pass