### PR TITLE
feat: add evolution budgets, whole-tree credential scan, and client release identity

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -168,6 +168,9 @@ zero.
    evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
    evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own
    evolution.forbid_residue | false | when true, an episode leaving files outside the cleanup whitelist scores as one that could not run
+   evolution.max_steps | 0 | stop after this many evolve steps; 0 disables the limit
+   evolution.max_failure_streak | 0 | stop after this many consecutive rejected steps; 0 disables the limit
+   evolution.max_model_calls_per_step | 0 | cap the proposer's model calls in one step; 0 disables the limit
    evolution.seed | entry options loaded into the tree on first boot; recovered state takes precedence
    evolution.models | auxiliary models for the method: ``url``, ``model``, optional ``api`` (default ``openai``) and ``timeout_s``, with the credential as a literal ``api_key`` or an ``api_key_env`` variable name
    evolution.version_check | appends the adapter's update notice; an interactive pulled tree offers to run the update or skip when behind

--- a/reef/harness/adapters/pi/version_check.ts
+++ b/reef/harness/adapters/pi/version_check.ts
@@ -18,10 +18,13 @@ export default function versionCheck(pi) {
     const serviceUrl = process.env.REEF_SERVICE_URL;
     const scenario = process.env.REEF_SCENARIO;
     if (!agentDir || !serviceUrl || !scenario) return;
+    // The wrapper relocates the agent into a temp copy and exports the true
+    // install root; a directly-run tree falls back to the sidecar beside it.
+    const destDir = process.env.REEF_HARNESS_DEST || join(agentDir, "..");
     let pinned;
     try {
       // harness_pull and the install script write the sidecar at the tree root.
-      pinned = JSON.parse(readFileSync(join(agentDir, "..", ".reef-harness-release"), "utf8")).release_id;
+      pinned = JSON.parse(readFileSync(join(destDir, ".reef-harness-release"), "utf8")).release_id;
     } catch {
       return; // no sidecar: this tree did not come through the channel
     }
@@ -45,7 +48,9 @@ export default function versionCheck(pi) {
     const instruction =
       `curl -fsS -H 'x-reef-scenario: ${scenario}' ` +
       (token ? '-H "Authorization: Bearer $REEF_TOKEN" ' : "") +
-      `'${serviceUrl}/reef/harness/install?adapter=pi' | bash`;
+      // The installer takes the destination as its first argument; without
+      // it a reinstall lands at ./reef-harness relative to the agent's cwd.
+      `'${serviceUrl}/reef/harness/install?adapter=pi' | bash -s -- '${destDir}'`;
     const updateOption = `Update with ${instruction}`;
     const title =
       "Reef harness update available\n\n" +
@@ -69,11 +74,12 @@ export default function versionCheck(pi) {
         "-c",
         'set -o pipefail\nargs=(-fsS -H "x-reef-scenario: $1")\n' +
           'if [[ -n "$3" ]]; then args+=(-H "Authorization: Bearer $3"); fi\n' +
-          'curl "${args[@]}" "$2/reef/harness/install?adapter=pi" | bash',
+          'curl "${args[@]}" "$2/reef/harness/install?adapter=pi" | bash -s -- "$4"',
         "reef-harness-update",
         scenario,
         serviceUrl,
         token || "",
+        destDir,
       ]);
     } catch (error) {
       ctx.ui.notify(`Reef harness update failed: ${error instanceof Error ? error.message : String(error)}`, "error");

--- a/reef/harness/harness_wrapper.py
+++ b/reef/harness/harness_wrapper.py
@@ -48,6 +48,7 @@ import urllib.request
 import uuid
 from http.server import ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 
 from reef_client.serve import CaptureStore, ServeConfig, build_handler
 
@@ -228,6 +229,21 @@ def _wait_for_proxy(port: int, timeout_s: float = 5.0) -> bool:
     return False
 
 
+#: The release sidecar the install script and harness_pull write at the tree
+#: root; version_check.ts reads the same name.
+HARNESS_RELEASE_SIDECAR = ".reef-harness-release"
+
+
+def _installed_release(compose_dir: str) -> str | None:
+    """The release id of the installed tree, from the sidecar beside it."""
+    sidecar = Path(compose_dir).parent / HARNESS_RELEASE_SIDECAR
+    try:
+        release = json.loads(sidecar.read_text(encoding="utf-8")).get("release_id")
+    except (OSError, json.JSONDecodeError):
+        return None
+    return release if isinstance(release, str) and release else None
+
+
 def run_agent(binary: str, compose_dir: str, scenario: str, adapter: str, env_var: str, args: list[str]) -> None:
     reef_url = _extract_reef_url(adapter, Path(compose_dir))
     if reef_url is None:
@@ -236,6 +252,11 @@ def run_agent(binary: str, compose_dir: str, scenario: str, adapter: str, env_va
 
     store = CaptureStore()
     override: dict[str, str] = {"x-reef-scenario": scenario}
+    release = _installed_release(compose_dir)
+    if release:
+        # The opaque tag channel: the record keeps which release answered on
+        # the client, under metadata.tags.release.
+        override["x-reef-tag-release"] = release
     token = os.environ.get("REEF_TOKEN")
     if token:
         override["authorization"] = f"Bearer {token}"
@@ -256,6 +277,11 @@ def run_agent(binary: str, compose_dir: str, scenario: str, adapter: str, env_va
     temp_dir = _create_temp_composition(adapter, compose_dir, proxy_port)
     env = os.environ.copy()
     env[env_var] = temp_dir
+    # The update notice extension needs the service address, the scenario,
+    # and the true install root; the relocated temp copy carries none of them.
+    env["REEF_SERVICE_URL"] = upstream
+    env["REEF_SCENARIO"] = scenario
+    env["REEF_HARNESS_DEST"] = str(Path(compose_dir).resolve().parent)
 
     try:
         result = subprocess.run([binary, *args], env=env)
@@ -296,6 +322,8 @@ def report(scenario: str, adapter: str, score: float, feedback: str, per_receipt
     # One report referencing the whole run batches as one trajectory sample;
     # --per-receipt sends the same score against each receipt on its own.
     reference_lists = [[receipt] for receipt in receipts] if per_receipt else [receipts]
+    release = _installed_release(os.environ.get("REEF_HARNESS_COMPOSE", ""))
+    metadata = {"client_release": release} if release else {}
 
     def restore_unsent(sent: int) -> None:
         # A partial per-receipt failure must not resend what already posted:
@@ -306,7 +334,10 @@ def report(scenario: str, adapter: str, score: float, feedback: str, per_receipt
         os.replace(captures_file, pending_file)
 
     for sent, references in enumerate(reference_lists):
-        payload = json.dumps({"score": score, "feedback": feedback, "references": references}).encode()
+        body: dict[str, Any] = {"score": score, "feedback": feedback, "references": references}
+        if metadata:
+            body["metadata"] = metadata
+        payload = json.dumps(body).encode()
         req = urllib.request.Request(
             f"{reef_url}/reef/report",
             data=payload,
@@ -318,8 +349,8 @@ def report(scenario: str, adapter: str, score: float, feedback: str, per_receipt
                 response.read()
         except urllib.error.HTTPError as exc:
             restore_unsent(sent)
-            body = exc.read().decode(errors="replace")
-            sys.exit(f"reef-{adapter}: report failed ({exc.code}): {body}")
+            detail = exc.read().decode(errors="replace")
+            sys.exit(f"reef-{adapter}: report failed ({exc.code}): {detail}")
         except BaseException:
             restore_unsent(sent)
             raise

--- a/reef/harness/nodes.py
+++ b/reef/harness/nodes.py
@@ -30,6 +30,18 @@ from typing import Any
 
 _NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _SECRET_NAME = re.compile(r"(?i)(api[_-]?keys?([_-]?env)?|tokens?|secrets?|passwords?)$")
+#: Distinctive credential shapes in free text. A tripwire like _SECRET_NAME:
+#: prefixes and key blocks that are never legitimate tree content, chosen so
+#: prose about keys (or the tutorial's sk-local placeholder) cannot trip it.
+_SECRET_TEXT = re.compile(
+    r"(?:sk-[A-Za-z0-9_-]{16,}"
+    r"|ghp_[A-Za-z0-9]{20,}"
+    r"|github_pat_[A-Za-z0-9_]{20,}"
+    r"|gho_[A-Za-z0-9]{20,}"
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"
+    r"|AKIA[0-9A-Z]{16}"
+    r"|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
+)
 
 
 def _holds_literal(value: Any) -> bool:
@@ -106,30 +118,46 @@ def config_node(ctx: Any, config: Any) -> None:
     _reject_inline_secret(data, "data")
 
 
+def _reject_secret_shaped_text(text: str, where: str) -> None:
+    """Refuse a node body carrying a credential-shaped literal.
+
+    The same boundary as :func:`_reject_inline_secret`, for the free-text
+    kinds: tree state persists verbatim, so a pasted key in a rule, skill,
+    command, or extension would outlive rotation in every commit record and
+    published artifact. The message names the field, never the value.
+    """
+    if _SECRET_TEXT.search(text):
+        raise ValueError(
+            f"{where} carries an inline credential; the composition tree never holds secrets: "
+            "set reef.upstream_api_key for the served model or "
+            "evolution.models.<name>.api_key_env for method models"
+        )
+
+
 def rules_node(ctx: Any, config: Any) -> None:
     """Context text for the adapter's rules file (AGENTS.md on both harnesses)."""
-    _require_text(_require_mapping(config), "text")
+    _reject_secret_shaped_text(_require_text(_require_mapping(config), "text"), "rules node 'text'")
 
 
 def agent_command_node(ctx: Any, config: Any) -> None:
     """A named prompt template, rendered as one markdown command file."""
     options = _require_mapping(config)
     _require_name(options)
-    _require_text(options, "text")
+    _reject_secret_shaped_text(_require_text(options, "text"), "agent_command node 'text'")
 
 
 def skill_node(ctx: Any, config: Any) -> None:
     """A named Agent Skill, rendered as ``skills/<name>/SKILL.md``."""
     options = _require_mapping(config)
     _require_name(options)
-    _require_text(options, "text")
+    _reject_secret_shaped_text(_require_text(options, "text"), "skill node 'text'")
 
 
 def code_extension_node(ctx: Any, config: Any) -> None:
     """A named code file the harness loads in-process (extension or plugin)."""
     options = _require_mapping(config)
     _require_name(options)
-    _require_text(options, "code")
+    _reject_secret_shaped_text(_require_text(options, "code"), "code_extension node 'code'")
 
 
 NODE_KINDS: dict[str, Callable[[Any, Any], None]] = {

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -62,6 +62,59 @@ class HarnessCandidate(UpdateCandidate):
         super().__post_init__()
 
 
+class _BudgetedBinding(ModelBinding):
+    """A ModelBinding that delegates ``chat`` to a wrapped binding under a
+    shared per-step call budget.
+
+    A subclass so the proposer still receives ModelBinding values, but it
+    holds the real binding and forwards to its ``chat`` (never the base
+    implementation), so a method's own binding behavior is preserved. The
+    shared counter is a mutable one-element list so every binding in the set
+    decrements the same budget.
+    """
+
+    _inner: ModelBinding
+    _spent: list[int]
+    _cap: int
+
+    def __init__(self, inner: ModelBinding, spent: list[int], cap: int) -> None:
+        super().__init__(
+            base_url=inner.base_url,
+            model=inner.model,
+            api_key=inner.api_key,
+            api=inner.api,
+            timeout_s=inner.timeout_s,
+        )
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_spent", spent)
+        object.__setattr__(self, "_cap", cap)
+
+    def chat(self, *args: Any, **kwargs: Any) -> str:
+        if self._spent[0] >= self._cap:
+            raise RuntimeError(f"model call budget of {self._cap} per evolve step exhausted")
+        self._spent[0] += 1
+        return self._inner.chat(*args, **kwargs)
+
+
+def _budgeted_bindings(models: ModelBindings, cap: int) -> ModelBindings:
+    """The proposer's view: every ``chat`` shares one per-step budget.
+
+    With ``cap`` 0 the bindings pass through unchanged. The counter is per
+    prepare_step call, so a cap bounds one step's model bill, never the
+    campaign's.
+    """
+    if not cap:
+        return models
+    spent: list[int] = [0]
+
+    def wrap(binding: ModelBinding) -> ModelBinding:
+        return _BudgetedBinding(binding, spent, cap)
+
+    return ModelBindings(
+        served=wrap(models.served), named={name: wrap(models[name]) for name in models if name != "served"}
+    )
+
+
 class ScoreComparisonSelector(CandidateSelector):
     """Select a candidate when it wins more task comparisons than it loses."""
 
@@ -136,6 +189,9 @@ class CordisBackend(TrainingBackend):
         episode_timeout_s: float = 600.0,
         episode_repeats: int = 1,
         forbid_residue: bool = False,
+        max_steps: int = 0,
+        max_failure_streak: int = 0,
+        max_model_calls_per_step: int = 0,
         seed: tuple[Mapping[str, Any], ...] = (),
     ) -> None:
         if not tasks:
@@ -168,10 +224,20 @@ class CordisBackend(TrainingBackend):
             raise ValueError("episode_repeats must be an integer of at least 1")
         if not isinstance(forbid_residue, bool):
             raise ValueError("forbid_residue must be a boolean")
+        for label, value in (
+            ("max_steps", max_steps),
+            ("max_failure_streak", max_failure_streak),
+            ("max_model_calls_per_step", max_model_calls_per_step),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{label} must be an integer of at least 0 (0 disables the limit)")
         self._binary = binary
         self._episode_timeout_s = float(episode_timeout_s)
         self._episode_repeats = episode_repeats
         self._forbid_residue = forbid_residue
+        self._max_steps = max_steps
+        self._max_failure_streak = max_failure_streak
+        self._max_model_calls_per_step = max_model_calls_per_step
         self._seed = tuple(dict(entry) for entry in seed)
         self._validate_seed()
 
@@ -234,11 +300,29 @@ class CordisBackend(TrainingBackend):
         carried = {} if previous_manifest is None else {"failure_manifest": previous_manifest}
 
         metrics: dict[str, Any] = {"steps": steps, "traces": len(batch.samples)}
+        # The budgets are circuit breakers, not schedulers: a skipped step
+        # commits its reason and consumes the batch, so a runaway loop stops
+        # burning episodes and model calls instead of queueing forever.
+        if self._max_steps and steps > self._max_steps:
+            return PreparedStep.skipped(
+                state={"steps": steps, "entries": self._entries(), **carried},
+                metrics={**metrics, "skipped": f"step budget of {self._max_steps} exhausted"},
+            )
+        streak = int(state.get("failure_streak", 0))
+        if self._max_failure_streak and streak >= self._max_failure_streak:
+            return PreparedStep.skipped(
+                state={"steps": steps, "entries": self._entries(), **carried},
+                metrics={
+                    **metrics,
+                    "skipped": f"failure streak breaker open after {streak} consecutive rejections",
+                },
+            )
+        models = _budgeted_bindings(self._models, self._max_model_calls_per_step)
         if self._propose_accepts_manifest:
             manifest = None if previous_manifest is None else FailureManifest.from_state(previous_manifest)
-            proposal = self._propose(self._nodes(), batch.samples, self._models, manifest=manifest)
+            proposal = self._propose(self._nodes(), batch.samples, models, manifest=manifest)
         else:
-            proposal = self._propose(self._nodes(), batch.samples, self._models)
+            proposal = self._propose(self._nodes(), batch.samples, models)
         mutations = (proposal,) if isinstance(proposal, Mutation) else tuple(proposal or ())
         if not mutations:
             return PreparedStep.skipped(
@@ -358,7 +442,13 @@ class CordisBackend(TrainingBackend):
             "persisting": len(manifest.persisting),
             "fixed": len(manifest.fixed),
         }
-        state = {**prepared.state, "failure_manifest": manifest.to_state()}
+        streak = 0 if decision.selected else int(prepared.state.get("failure_streak", 0)) + 1
+        metrics["gated_against"] = {
+            "model": self._models.served.model,
+            "adapter": self._descriptor.name,
+            "adapter_version": self._descriptor.install.version if self._descriptor.install else None,
+        }
+        state = {**prepared.state, "failure_manifest": manifest.to_state(), "failure_streak": streak}
 
         metrics.update(
             {

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -130,6 +130,9 @@ class CordisRecipe(Recipe):
     episode_timeout_s: float = 600.0
     episode_repeats: int = 1
     forbid_residue: bool = False
+    max_steps: int = 0
+    max_failure_streak: int = 0
+    max_model_calls_per_step: int = 0
     seed: tuple[Mapping[str, Any], ...] = ()
     model_name: str | None = None
     models: Mapping[str, ModelBinding] = field(default_factory=dict)
@@ -158,6 +161,13 @@ class CordisRecipe(Recipe):
             raise ValueError("episode_timeout_s must be positive")
         if self.episode_repeats < 1:
             raise ValueError("episode_repeats must be at least 1")
+        for label, value in (
+            ("max_steps", self.max_steps),
+            ("max_failure_streak", self.max_failure_streak),
+            ("max_model_calls_per_step", self.max_model_calls_per_step),
+        ):
+            if value < 0:
+                raise ValueError(f"{label} must be at least 0 (0 disables the limit)")
         if not callable(getattr(self.candidate_selector, "decide", None)):
             raise ValueError("candidate_selector must provide decide(candidate, evaluation)")
 
@@ -181,6 +191,12 @@ class CordisRecipe(Recipe):
         forbid_residue = evolution.get("forbid_residue", False)
         if not isinstance(forbid_residue, bool):
             raise RecipeConfigError("evolution.forbid_residue must be a boolean")
+        budgets: dict[str, int] = {}
+        for label in ("max_steps", "max_failure_streak", "max_model_calls_per_step"):
+            value = evolution.get(label, 0)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise RecipeConfigError(f"evolution.{label} must be an integer of at least 0 (0 disables the limit)")
+            budgets[label] = value
         seed = evolution.get("seed")
         if seed is None:
             seed = ()
@@ -227,6 +243,7 @@ class CordisRecipe(Recipe):
             "episode_timeout_s": float(timeout),
             "episode_repeats": repeats,
             "forbid_residue": forbid_residue,
+            **budgets,
             "seed": tuple(seed),
             "model_name": model_name if isinstance(model_name, str) and model_name else None,
             "models": models,
@@ -270,6 +287,9 @@ class CordisRecipe(Recipe):
             episode_timeout_s=self.episode_timeout_s,
             episode_repeats=self.episode_repeats,
             forbid_residue=self.forbid_residue,
+            max_steps=self.max_steps,
+            max_failure_streak=self.max_failure_streak,
+            max_model_calls_per_step=self.max_model_calls_per_step,
             seed=self.seed,
         )
         return Trainer.build(

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -88,6 +88,23 @@ def batch() -> TraceBatch:
 MODEL = ModelBinding(base_url="http://localhost:8000", model="qwen3-8b", api_key="dummy")
 
 
+class _ChatBinding:
+    """A served binding whose chat returns a canned reply; base_url/model/api
+    mirror MODEL so compose_nodes renders."""
+
+    base_url = MODEL.base_url
+    model = MODEL.model
+    api_key = MODEL.api_key
+    api = MODEL.api
+    timeout_s = MODEL.timeout_s
+
+    def chat(self, *args, **kwargs) -> str:
+        return "ok"
+
+    def compose_nodes(self, descriptor):
+        return MODEL.compose_nodes(descriptor)
+
+
 def runtime() -> InferenceProxyRuntime:
     return InferenceProxyRuntime(model_path=MODEL.model, base_url=MODEL.base_url, api_key=MODEL.api_key)
 
@@ -1043,3 +1060,89 @@ def test_recipe_selects_the_record_driven_processor(tmp_path: Path, monkeypatch)
 
     with pytest.raises(RecipeConfigError, match="batch_policy must be 'reports' or 'records'"):
         CordisRecipe.from_environment({}, config=config("sometimes"))
+
+
+def test_step_budget_skips_further_steps(tmp_path: Path) -> None:
+    """max_steps opens after its count: the step commits a skip reason and
+    proposes nothing more, so the loop stops burning episodes."""
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "x"}})),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        max_steps=1,
+    )
+    state = b.initial_state()
+    first = run_backend_step(b, batch(), state)
+    second = run_backend_step(b, batch(), first.state)
+    assert "step budget of 1 exhausted" in second.metrics["skipped"]
+
+
+def test_failure_streak_breaker_opens_after_consecutive_rejections(tmp_path: Path) -> None:
+    """A rejected step increments the streak in its committed state; once the
+    state carries the cap, the next prepare skips before proposing."""
+    # A candidate that scores no better than the empty current tree loses.
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "nothing of note"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        max_failure_streak=1,
+    )
+    first = run_backend_step(b, batch(), b.initial_state())
+    assert first.metrics["selected"] is False
+    assert first.state["failure_streak"] == 1
+    second = run_backend_step(b, batch(), first.state)
+    assert "failure streak breaker open" in second.metrics["skipped"]
+
+
+def test_model_call_budget_caps_the_proposer(tmp_path: Path) -> None:
+    """max_model_calls_per_step bounds one step's chat calls; the cap raises
+    inside propose, which the backend surfaces as the step error."""
+    calls = {"n": 0}
+
+    def greedy(nodes, samples, models):
+        while True:
+            models.served.chat([{"role": "user", "content": "hi"}])
+            calls["n"] += 1
+
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(greedy),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=ModelBindings(served=_ChatBinding()),
+        binary=str(make_binary(tmp_path)),
+        max_model_calls_per_step=3,
+    )
+    with pytest.raises(RuntimeError, match="model call budget of 3"):
+        run_backend_step(b, batch(), b.initial_state())
+    assert calls["n"] == 3
+
+
+def test_settle_records_what_the_gate_ran_against(tmp_path: Path) -> None:
+    b = backend(tmp_path, lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}}))
+    result = run_backend_step(b, batch(), b.initial_state())
+    stamp = result.metrics["gated_against"]
+    assert stamp["model"] == MODEL.model
+    assert stamp["adapter"] == "pi"
+    assert stamp["adapter_version"] == get_adapter("pi").install.version
+
+
+def test_backend_rejects_negative_budgets(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="max_steps must be an integer of at least 0"):
+        CordisBackend(
+            descriptor=get_adapter("pi"),
+            propose=resolve_proposer(lambda n, s, m: None),
+            score_episode=resolve_episode_scorer(evaluate),
+            tasks=("task one",),
+            models=MODEL,
+            binary=str(make_binary(tmp_path)),
+            max_steps=-1,
+        )

--- a/tests/reef_service/test_harness_wrapper.py
+++ b/tests/reef_service/test_harness_wrapper.py
@@ -348,6 +348,51 @@ def test_per_receipt_report_posts_one_report_for_each_capture(tmp_path) -> None:
 
 
 @pytest.mark.unit
+def test_report_carries_the_installed_release_as_metadata(tmp_path) -> None:
+    """report reads the sidecar beside the compose dir and stamps the report
+    with the release the client is running."""
+    compose = tmp_path / "reef-harness" / "pi-agent"
+    compose.mkdir(parents=True)
+    (tmp_path / "reef-harness" / ".reef-harness-release").write_text(
+        json.dumps({"release_id": "rel-42"}), encoding="utf-8"
+    )
+    scenario_key = hashlib.sha256(b"scenario").hexdigest()
+    captures = tmp_path / f"{scenario_key}-{1:020d}-run.pending.json"
+    captures.write_text(json.dumps({"reef_url": "http://reef", "scenario": "scenario", "turns": [{"receipt": "r1"}]}))
+    posted: list[dict] = []
+
+    def record(req, timeout=None):
+        posted.append(json.loads(req.data))
+        return _Response()
+
+    with (
+        patch.dict(
+            os.environ,
+            {"REEF_HARNESS_CAPTURES_DIR": str(tmp_path), "REEF_HARNESS_COMPOSE": str(compose)},
+        ),
+        patch("reef.harness.harness_wrapper.urllib.request.urlopen", record),
+    ):
+        report("scenario", "pi", 0.0, "note")
+
+    assert posted[0]["metadata"] == {"client_release": "rel-42"}
+
+
+@pytest.mark.unit
+def test_run_agent_tags_records_with_the_installed_release(tmp_path) -> None:
+    """run_agent reads the sidecar and sends x-reef-tag-release, so the record
+    keeps which release answered."""
+    from reef.harness import harness_wrapper
+
+    compose = tmp_path / "reef-harness" / "pi-agent"
+    compose.mkdir(parents=True)
+    (tmp_path / "reef-harness" / ".reef-harness-release").write_text(
+        json.dumps({"release_id": "rel-7"}), encoding="utf-8"
+    )
+    assert harness_wrapper._installed_release(str(compose)) == "rel-7"
+    assert harness_wrapper._installed_release(str(tmp_path / "missing")) is None
+
+
+@pytest.mark.unit
 def test_partial_per_receipt_failure_retries_only_the_unsent(tmp_path) -> None:
     """When a later per-receipt post fails, the restored claim holds only the
     receipts that never went out, so a retry cannot duplicate reports."""

--- a/tests/reef_service/test_node_credential_scan.py
+++ b/tests/reef_service/test_node_credential_scan.py
@@ -1,0 +1,41 @@
+"""The credential admission gate over every node body, not only config keys."""
+
+from __future__ import annotations
+
+import pytest
+
+from reef.harness.nodes import NODE_KINDS
+
+
+def _validate(kind: str, config: dict) -> None:
+    NODE_KINDS[kind](None, config)
+
+
+CREDENTIAL_BODIES = [
+    "sk-abcdef1234567890ABCDEFGH",
+    "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345",
+    "AKIAIOSFODNN7EXAMPLE",
+    "-----BEGIN OPENSSH " + "PRIVATE " + "KEY-----\nabc",
+]
+
+
+@pytest.mark.parametrize("secret", CREDENTIAL_BODIES)
+def test_rules_skill_command_extension_bodies_reject_inline_credentials(secret: str) -> None:
+    for kind, config in (
+        ("rules", {"text": f"Use this key {secret} to call the API."}),
+        ("agent_command", {"name": "deploy", "text": f"export TOKEN={secret}"}),
+        ("skill", {"name": "notes", "text": f"# notes\n\n{secret}"}),
+        ("code_extension", {"name": "plugin", "code": f'const key = "{secret}";'}),
+    ):
+        with pytest.raises(ValueError, match="inline credential"):
+            _validate(kind, config)
+
+
+def test_ordinary_text_about_keys_is_not_a_credential() -> None:
+    # Prose that mentions keys, and the tutorial's sk-local placeholder, pass.
+    for kind, config in (
+        ("rules", {"text": "Set your api key in the environment before running."}),
+        ("skill", {"name": "auth", "text": "# auth\n\nUse REEF_TOKEN=sk-local for the demo."}),
+        ("code_extension", {"name": "read", "code": "const key = process.env.API_KEY;"}),
+    ):
+        _validate(kind, config)

--- a/tests/reef_service/test_version_check.py
+++ b/tests/reef_service/test_version_check.py
@@ -166,5 +166,8 @@ console.log(JSON.stringify(events));
         execution = events[2]
         assert execution["command"] == "bash"
         assert "/reef/harness/install?adapter=pi" in execution["args"][1]
-        assert execution["args"][-3:] == ["code-repair", "http://reef:8900", ""]
+        assert "bash -s --" in execution["args"][1]
+        # scenario, serviceUrl, token, destDir: destDir defaults to agentDir/..
+        assert execution["args"][-4:-1] == ["code-repair", "http://reef:8900", ""]
+        assert execution["args"][-1].endswith("pi-agent/..") or "/" in execution["args"][-1]
         assert events[3]["message"] == "Reef harness updated. Restart reef-pi to load it."


### PR DESCRIPTION
## Motivation

The evolution loop has safety and lifecycle defects that need only code, not a new mechanism. Nothing stops a runaway loop: no step budget, no failure-streak breaker, no cap on the proposer's model calls. The credential admission gate scans only config key names, so a pasted key in a rule, skill, command, or extension body persists into every commit record and published artifact. The shipped reef-pi update-notice channel is dead through three breaks. A client never tells the service which release it runs, and a release records neither the model nor the binary it was gated against. Closes #131.

## Changes

- evolution.max_steps, evolution.max_failure_streak, and evolution.max_model_calls_per_step: circuit breakers with a safe default of 0 (disabled). A tripped budget commits a skip reason and consumes the batch instead of queueing; the model-call cap wraps the proposer's bindings for one step
- The credential gate covers every node body, not only config keys: rules, skill, agent_command, and code_extension text is scanned for credential-shaped literals (sk-, ghp_, AKIA, PEM blocks) with the same message and boundary as the config-key gate; prose about keys and the sk-local placeholder do not trip it
- The reef-pi update notice works end to end: run_agent exports REEF_SERVICE_URL, REEF_SCENARIO, and the true install root (the relocated temp copy carried none), and version_check.ts reads the sidecar and reinstalls at that root instead of ./reef-harness
- Inference and report carry the installed release: run_agent sends x-reef-tag-release, report stamps metadata.client_release, both read from the sidecar beside the compose dir
- A published release's metrics record gated_against: the served model, the adapter, and the adapter binary version the gate ran with (the minimal slice of #15)

## Compatibility and operational impact

None by default: every budget defaults to 0 (disabled), and the credential text scan only rejects credential-shaped literals that have no legitimate place in a tree. Full composite version identity stays with #15; episode sandboxing stays with #18.

## Verification

The CI-equivalent sweep passes: 1171 tests, 6 skipped. New tests cover the step budget, the failure-streak breaker, the per-step model-call cap, the gated_against stamp, and negative-budget rejection; the credential text scan across all four node kinds with a false-positive guard; the wrapper release tag and report metadata; and the version-check dest wiring. Docs gate clean; pre-commit clean with the CI toolchain.

## AI assistance

Claude Code wrote the change and the tests. I reviewed the diff; the scope is the one recorded in #131.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
