### PR TITLE
ci: create releases with GitHub CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,7 @@ jobs:
         with:
           name: python-distributions
           path: dist/
-      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-        with:
-          generate_release_notes: true
-          files: dist/*
-          fail_on_unmatched_files: true
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --verify-tag


### PR DESCRIPTION
## Summary

- replace the disallowed third-party GitHub Release action with the GitHub CLI available on hosted runners
- preserve generated release notes, tag verification, and distribution asset uploads

## Why

The `v0.0.2` release run failed before starting because the organization Actions policy does not allow `softprops/action-gh-release`. PyPI was not published and no GitHub Release was created.

## Validation

- `release.yml` parses as valid YAML
- verified the installed `gh release create` supports `--generate-notes` and `--verify-tag`

This unblocks the `v0.0.2` release.