### PR TITLE
ci: set repository for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,5 +51,6 @@ jobs:
           path: dist/
       - name: Create GitHub release
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --verify-tag


### PR DESCRIPTION
## Summary

Set `GH_REPO` explicitly for the GitHub Release job.

## Why

The job downloads artifacts without checking out the repository, so `gh release create` cannot infer the repository from a `.git` directory. The `v0.0.2` package reached PyPI successfully, but the GitHub Release step failed with `fatal: not a git repository` and was completed manually using the validated workflow artifacts.

## Validation

- `release.yml` parses as valid YAML
- `v0.0.2` GitHub Release was successfully created with `--repo Human-Agent-Society/reef`, equivalent to setting `GH_REPO`