### PR TITLE
fix: reapply the theme on client-side navigation, not only full loads

### DIFF
--- a/docs/site/app/layout.tsx
+++ b/docs/site/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Header } from "@/components/header";
+import { ThemeSync } from "@/components/theme-sync";
 import { getSearchDocuments, navigation } from "@/lib/docs";
 import { siteConfig } from "@/lib/site";
 import "./globals.css";
@@ -28,6 +29,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       <body>
         {/* Inline so it runs at parse time, before first paint. */}
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <ThemeSync />
         <Header documents={searchDocuments} navigation={navigation} />
         {children}
       </body>

--- a/docs/site/components/theme-sync.tsx
+++ b/docs/site/components/theme-sync.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { apply, storedMode } from "@/lib/theme";
+
+// The inline boot script stamps the theme on a full page load, but a
+// client-side navigation (the /docs redirect, a sidebar link) never re-runs
+// it, so a page reached that way would keep the server-rendered default.
+// Re-apply the stored choice on mount and on every path change.
+export function ThemeSync() {
+  const pathname = usePathname();
+  useEffect(() => apply(storedMode()), [pathname]);
+  return null;
+}

--- a/docs/site/components/theme-toggle.tsx
+++ b/docs/site/components/theme-toggle.tsx
@@ -2,37 +2,16 @@
 
 import { Moon, Sun, SunMoon } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef } from "react";
+import { MODES, Mode, THEME_KEY, apply, storedMode } from "@/lib/theme";
 
 // Click order matches the founder's personal-site toggle: an explicit dark,
 // then light, then back to following the OS. On a light-OS machine the first
 // click must visibly change the page; auto -> light would not.
-const MODES = ["auto", "dark", "light"] as const;
-type Mode = (typeof MODES)[number];
-
 const LABELS: Record<Mode, string> = {
   auto: "Color theme: system. Switch to dark.",
   dark: "Color theme: dark. Switch to light.",
   light: "Color theme: light. Switch to system.",
 };
-
-function storedMode(): Mode {
-  try {
-    const value = localStorage.getItem("reef-theme");
-    return value === "light" || value === "dark" ? value : "auto";
-  } catch {
-    return "auto";
-  }
-}
-
-function resolve(mode: Mode): "light" | "dark" {
-  if (mode !== "auto") return mode;
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
-function apply(mode: Mode) {
-  document.documentElement.dataset.theme = resolve(mode);
-  document.documentElement.dataset.themeMode = mode;
-}
 
 export function ThemeToggle() {
   const button = useRef<HTMLButtonElement>(null);
@@ -60,9 +39,9 @@ export function ThemeToggle() {
     const next = MODES[(MODES.indexOf(storedMode()) + 1) % MODES.length];
     try {
       if (next === "auto") {
-        localStorage.removeItem("reef-theme");
+        localStorage.removeItem(THEME_KEY);
       } else {
-        localStorage.setItem("reef-theme", next);
+        localStorage.setItem(THEME_KEY, next);
       }
     } catch {
       /* private browsing: the theme still applies for this page view */

--- a/docs/site/lib/theme.ts
+++ b/docs/site/lib/theme.ts
@@ -1,0 +1,26 @@
+// Theme helpers shared by the boot script's client-side counterpart. The
+// inline script in the layout stamps data-theme on a full page load; these
+// re-apply the same choice after a client-side navigation, where the inline
+// script never re-runs (the /docs redirect and every sidebar link).
+export const THEME_KEY = "reef-theme";
+export const MODES = ["auto", "dark", "light"] as const;
+export type Mode = (typeof MODES)[number];
+
+export function storedMode(): Mode {
+  try {
+    const value = localStorage.getItem(THEME_KEY);
+    return value === "light" || value === "dark" ? value : "auto";
+  } catch {
+    return "auto";
+  }
+}
+
+export function resolve(mode: Mode): "light" | "dark" {
+  if (mode !== "auto") return mode;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function apply(mode: Mode) {
+  document.documentElement.dataset.theme = resolve(mode);
+  document.documentElement.dataset.themeMode = mode;
+}


### PR DESCRIPTION
## Motivation

A docs page reached by client-side navigation kept the server-rendered light default even when the stored choice was dark. The inline boot script stamps data-theme only on a full page load; the /docs redirect and every sidebar link are client-side navigations, which never re-run it, so the stored theme was applied on a direct URL load but lost on any in-app navigation. On reefinfra.ai this showed as /docs not remembering a choice the landing page kept.

## Changes

- Extract the theme helpers (storedMode, resolve, apply, the key and mode list) into lib/theme.ts, shared by the toggle and the new sync component
- Add ThemeSync, a client component in the root layout that re-applies the stored theme on mount and on every path change, so a page reached by redirect or link is stamped the same as a full load
- theme-toggle reuses the shared helpers instead of its own copies

## Compatibility and operational impact

None. The boot script still runs first on a full load; ThemeSync only covers the client-navigation gap.

## Verification

Built and driven with puppeteer against the static export: with dark stored, reaching a page through the /docs redirect and through a sidebar link both keep data-theme=dark, where before both showed light. lint and the docs build are clean.

## AI assistance

Claude Code found the client-navigation gap and wrote the fix.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
