### PR TITLE
fix(service): parse Bearer auth scheme case-insensitively

### DIFF
--- a/reef/service/auth.py
+++ b/reef/service/auth.py
@@ -48,9 +48,14 @@ def create_authentication_middleware(tokens: str | Iterable[str] | None):
 
     def _authorized(headers) -> bool:
         authorization = headers.get("Authorization")
-        if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
+        if not isinstance(authorization, str):
             return False
-        presented = _digest(authorization.removeprefix("Bearer "))
+        # The auth-scheme is case-insensitive per RFC 9110 §11.1; only the
+        # credential itself stays case-sensitive.
+        scheme, separator, credential = authorization.partition(" ")
+        if not separator or scheme.lower() != "bearer" or not credential:
+            return False
+        presented = _digest(credential)
         matched = False
         for digest in accepted:
             matched |= secrets.compare_digest(presented, digest)

--- a/tests/reef_service/test_auth.py
+++ b/tests/reef_service/test_auth.py
@@ -1,0 +1,88 @@
+"""Bearer authentication middleware tests (issue #145)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+
+def _make_client(tokens) -> TestClient:
+    from reef.service.auth import create_authentication_middleware
+
+    app = web.Application(middlewares=[create_authentication_middleware(tokens)])
+
+    async def _ok(request: web.Request) -> web.Response:
+        del request
+        return web.Response(text="ok")
+
+    app.router.add_get("/protected", _ok)
+    app.router.add_get("/healthz", _ok)
+    return TestClient(TestServer(app))
+
+
+def test_scheme_is_case_insensitive() -> None:
+    async def run() -> None:
+        client = _make_client("secret")
+        async with client:
+            for scheme in ("Bearer", "bearer", "BEARER", "BeArEr"):
+                resp = await client.get("/protected", headers={"Authorization": f"{scheme} secret"})
+                assert resp.status == 200, scheme
+
+    asyncio.run(run())
+
+
+def test_credential_stays_case_sensitive() -> None:
+    async def run() -> None:
+        client = _make_client("secret")
+        async with client:
+            resp = await client.get("/protected", headers={"Authorization": "Bearer SECRET"})
+            assert resp.status == 401
+
+    asyncio.run(run())
+
+
+def test_malformed_or_wrong_scheme_is_rejected() -> None:
+    async def run() -> None:
+        client = _make_client("secret")
+        async with client:
+            for header in ("", "Bearer", "Bearer ", "Basic secret", "BearerSecret secret"):
+                resp = await client.get("/protected", headers={"Authorization": header})
+                assert resp.status == 401, header
+            resp = await client.get("/protected")
+            assert resp.status == 401
+
+    asyncio.run(run())
+
+
+def test_wrong_token_is_rejected() -> None:
+    async def run() -> None:
+        client = _make_client("secret")
+        async with client:
+            resp = await client.get("/protected", headers={"Authorization": "Bearer nope"})
+            assert resp.status == 401
+
+    asyncio.run(run())
+
+
+def test_multiple_accepted_tokens_all_match_any_case() -> None:
+    async def run() -> None:
+        client = _make_client(["one", "two"])
+        async with client:
+            first = await client.get("/protected", headers={"Authorization": "bearer one"})
+            second = await client.get("/protected", headers={"Authorization": "BEARER two"})
+            assert first.status == 200
+            assert second.status == 200
+
+    asyncio.run(run())
+
+
+def test_healthz_reachable_without_credentials() -> None:
+    async def run() -> None:
+        client = _make_client("secret")
+        async with client:
+            resp = await client.get("/healthz")
+            assert resp.status == 200
+
+    asyncio.run(run())


### PR DESCRIPTION
Closes #145.

`reef/service/auth.py::_authorized` used `authorization.startswith("Bearer ")`, which is case-sensitive. Per RFC 9110 §11.1 the HTTP auth-scheme token is case-insensitive, so a standards-compliant client sending `bearer`/`BEARER` was rejected with 401 before the token was even compared.

Fix: split the header once on the first space, compare only the scheme lowercased, and pass the credential through unchanged to the existing SHA-256 + `secrets.compare_digest` comparison loop over every configured token. No change to token case-sensitivity, the comparison loop, or the `/healthz` bypass.

Tests added in `tests/reef_service/test_auth.py`: canonical/lower/upper/mixed-case scheme, case-sensitive credential, missing/empty/malformed header, wrong scheme, wrong token, multiple accepted tokens, and the `/healthz` bypass.