### PR TITLE
fix(service): reject invalid reef serve arguments instead of ignoring them

### DIFF
--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -35,24 +35,39 @@ def _log(msg):
     print(f"[reef] {msg}", file=sys.stderr)
 
 
+class InvalidOverrideError(ValueError):
+    """A leftover ``reef serve`` argument is not a valid ``--key`` override."""
+
+
 def _parse_overrides(extras: list[str]) -> dict[str, str]:
-    """Parse leftover ``--key value`` / ``--key=value`` pairs from ``parse_known_args``."""
+    """Parse leftover ``--key value`` / ``--key=value`` pairs from ``parse_known_args``.
+
+    Anything that is not a well-formed ``--key`` override — an orphan
+    positional, an unknown short option, or a ``--`` with no name — is
+    rejected instead of silently discarded, so a typo fails fast at the CLI
+    rather than surfacing as an unrelated missing-config error downstream.
+    """
     overrides: dict[str, str] = {}
     i = 0
     while i < len(extras):
         token = extras[i]
         if not token.startswith("--"):
-            i += 1
-            continue
+            raise InvalidOverrideError(f"unrecognized argument: {token!r}")
         key = token[2:]
         if "=" in key:
             key, value = key.split("=", 1)
+            if not key:
+                raise InvalidOverrideError(f"override is missing a name: {token!r}")
             overrides[key] = value
             i += 1
         elif i + 1 < len(extras) and not extras[i + 1].startswith("--"):
+            if not key:
+                raise InvalidOverrideError(f"override is missing a name: {token!r}")
             overrides[key] = extras[i + 1]
             i += 2
         else:
+            if not key:
+                raise InvalidOverrideError(f"override is missing a name: {token!r}")
             overrides[key] = "true"
             i += 1
     return overrides
@@ -373,7 +388,11 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    args, extras = build_parser().parse_known_args(argv)
+    parser = build_parser()
+    args, extras = parser.parse_known_args(argv)
     config_path = args.config or os.environ.get("REEF_CONFIG", "reef.yaml")
-    overrides = _parse_overrides(extras)
+    try:
+        overrides = _parse_overrides(extras)
+    except InvalidOverrideError as exc:
+        parser.error(str(exc))
     sys.exit(_run_orchestrator(config_path, overrides))

--- a/tests/reef_service/test_orchestrator_overrides.py
+++ b/tests/reef_service/test_orchestrator_overrides.py
@@ -1,0 +1,70 @@
+"""``reef serve`` override-parsing tests (issue #142)."""
+
+from __future__ import annotations
+
+import pytest
+
+from reef.service.deploy.orchestrator import InvalidOverrideError, _parse_overrides, main
+
+
+def test_key_value_pair() -> None:
+    assert _parse_overrides(["--port", "9000"]) == {"port": "9000"}
+
+
+def test_key_equals_value() -> None:
+    assert _parse_overrides(["--port=9000"]) == {"port": "9000"}
+
+
+def test_dotted_key() -> None:
+    assert _parse_overrides(["--training.checkpoint_dir", "/tmp/ckpt"]) == {
+        "training.checkpoint_dir": "/tmp/ckpt"
+    }
+
+
+def test_bare_boolean_override() -> None:
+    assert _parse_overrides(["--verbose"]) == {"verbose": "true"}
+
+
+def test_bare_boolean_followed_by_another_flag() -> None:
+    assert _parse_overrides(["--verbose", "--port", "9000"]) == {
+        "verbose": "true",
+        "port": "9000",
+    }
+
+
+def test_orphan_positional_argument_is_rejected() -> None:
+    with pytest.raises(InvalidOverrideError):
+        _parse_overrides(["typo"])
+
+
+def test_unknown_short_option_is_rejected() -> None:
+    with pytest.raises(InvalidOverrideError):
+        _parse_overrides(["-p"])
+
+
+def test_empty_override_name_is_rejected() -> None:
+    with pytest.raises(InvalidOverrideError):
+        _parse_overrides(["--=value"])
+
+
+def test_bare_double_dash_is_rejected() -> None:
+    with pytest.raises(InvalidOverrideError):
+        _parse_overrides(["--"])
+
+
+def test_valid_override_after_an_invalid_one_does_not_mask_the_error() -> None:
+    with pytest.raises(InvalidOverrideError):
+        _parse_overrides(["typo", "--port", "9000"])
+
+
+def test_cli_exits_with_status_2_on_orphan_argument(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["typo"])
+    assert excinfo.value.code == 2
+    assert "typo" in capsys.readouterr().err
+
+
+def test_cli_exits_with_status_2_on_unknown_short_option(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["-p"])
+    assert excinfo.value.code == 2

--- a/tests/reef_service/test_orchestrator_overrides.py
+++ b/tests/reef_service/test_orchestrator_overrides.py
@@ -16,9 +16,7 @@ def test_key_equals_value() -> None:
 
 
 def test_dotted_key() -> None:
-    assert _parse_overrides(["--training.checkpoint_dir", "/tmp/ckpt"]) == {
-        "training.checkpoint_dir": "/tmp/ckpt"
-    }
+    assert _parse_overrides(["--training.checkpoint_dir", "/tmp/ckpt"]) == {"training.checkpoint_dir": "/tmp/ckpt"}
 
 
 def test_bare_boolean_override() -> None:


### PR DESCRIPTION
Closes #142.

`_parse_overrides` in `reef/service/deploy/orchestrator.py` advanced past any leftover token that didn't start with `--`, so `reef serve typo` or `reef serve -p` silently dropped the bad argument instead of failing — the stack would then usually blow up later with an unrelated missing-config or startup error, which is a confusing way to learn you typo'd a flag.

Fix:
- `_parse_overrides` now raises `InvalidOverrideError` for an orphan positional, an unrecognized short option, or an override with no name (`--=value`, bare `--`).
- `main()` catches that and calls `parser.error(...)`, which prints a usage message and exits with status 2 — the standard argparse convention, matching every other CLI usage error in `reef serve`.
- Valid `--key value`, `--key=value`, dotted overrides (`--training.checkpoint_dir`), and bare boolean overrides (`--verbose`) are unchanged, including when a boolean override is immediately followed by another `--flag`.

Tests added in `tests/reef_service/test_orchestrator_overrides.py` covering both the parser function directly and the `main()` exit code/usage-message path.