### PR TITLE
feat: run episodes through a pluggable executor with a bubblewrap sandbox

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -171,6 +171,8 @@ zero.
    evolution.max_steps | 0 | stop after this many evolve steps; 0 disables the limit
    evolution.max_failure_streak | 0 | stop after this many consecutive rejected steps; 0 disables the limit
    evolution.max_model_calls_per_step | 0 | cap the proposer's model calls in one step; 0 disables the limit
+   evolution.executor | local | ``local`` runs episodes as a plain subprocess (development, hermetic tests); ``sandbox`` runs each in a bubblewrap jail for a hosted service and refuses to start without it
+   evolution.sandbox | | the sandbox executor's policy: ``egress_hosts`` (allowlisted model endpoints; empty denies network) and ``limits`` (``cpu_seconds``, ``memory_bytes``, ``processes``, ``file_bytes``)
    evolution.seed | entry options loaded into the tree on first boot; recovered state takes precedence
    evolution.models | auxiliary models for the method: ``url``, ``model``, optional ``api`` (default ``openai``) and ``timeout_s``, with the credential as a literal ``api_key`` or an ``api_key_env`` variable name
    evolution.version_check | appends the adapter's update notice; an interactive pulled tree offers to run the update or skip when behind

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -86,6 +86,14 @@ side into a throwaway root, runs the agent binary with the task as its prompt
 under the ``episode_timeout_s`` limit (600 s by default), reads the
 trajectory back, and deletes the root.
 
+Each episode runs through an executor. The default ``local`` executor runs the
+binary as a plain subprocess, which is right for development and the tests. A
+hosted service that evaluates model-proposed trees sets ``evolution.executor:
+sandbox`` so each episode runs in a bubblewrap jail (a fresh non-root
+namespace, a read-only base filesystem, no host credentials, resource limits,
+and no network unless a model endpoint is allowlisted); a deployment that
+requires it refuses to start without the sandbox runtime.
+
 The throwaway root contains nothing except the rendered tree: a fresh working
 directory and a fresh ``HOME``, with no repository and no files from your
 machine. A task must therefore state the whole problem in its prompt. A task

--- a/reef/harness/episode.py
+++ b/reef/harness/episode.py
@@ -20,11 +20,7 @@ finding.
 
 from __future__ import annotations
 
-import contextlib
-import os
 import shutil
-import signal
-import subprocess
 import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -33,6 +29,7 @@ from typing import Any
 
 from reef.core.errors import ReefError
 from reef.harness.descriptor import AdapterDescriptor
+from reef.harness.executor import EpisodeExecutor, EpisodeLaunchError, EpisodeTimeout, LocalExecutor
 from reef.harness.trajectory import reader_for
 
 
@@ -72,14 +69,19 @@ def run_episode(
     *,
     binary: str | None = None,
     timeout: float = 600.0,
+    executor: EpisodeExecutor | None = None,
 ) -> EpisodeResult:
     """Run one headless episode of ``descriptor``'s harness over ``files``.
 
     ``binary`` overrides the descriptor's binary name (the seam hermetic
     tests drive a fake harness through); ``prompt`` substitutes into the
-    descriptor's argv template. The episode root is removed before this
-    returns, success or failure.
+    descriptor's argv template. ``executor`` decides how the process runs
+    (the default local subprocess, or a sandbox); the root preparation,
+    environment, trajectory read, and residue collection are the same for
+    every executor. The episode root is removed before this returns, success
+    or failure.
     """
+    executor = executor or LocalExecutor()
     reader = reader_for(descriptor.trajectory_format)  # fail before any disk work
     root = Path(tempfile.mkdtemp(prefix=f"reef-episode-{descriptor.name}-"))
     try:
@@ -104,28 +106,11 @@ def run_episode(
         env.setdefault("HOME", str(root))
         argv = [binary or descriptor.binary, *(token.replace("{prompt}", prompt) for token in descriptor.argv)]
         try:
-            # Own session so a timeout can kill the binary's whole process
-            # group: coding agents spawn tool children as a matter of course,
-            # and killing only the direct child would orphan them.
-            process = subprocess.Popen(
-                argv,
-                cwd=workspace,
-                env={**_inherited_env(), **env},
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                start_new_session=True,
-            )
-        except FileNotFoundError as exc:
-            raise EpisodeError(f"harness binary {argv[0]!r} not found") from exc
-        try:
-            stdout, stderr = process.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired as exc:
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(process.pid, signal.SIGKILL)
-            process.wait()
-            raise EpisodeError(f"episode timed out after {timeout}s: {argv}") from exc
-        completed = subprocess.CompletedProcess(argv, process.returncode, stdout, stderr)
+            outcome = executor.launch(argv, root=root, workspace=workspace, env=env, timeout=timeout)
+        except EpisodeLaunchError as exc:
+            raise EpisodeError(str(exc)) from exc
+        except EpisodeTimeout as exc:
+            raise EpisodeError(str(exc)) from exc
         trajectory = reader(root / descriptor.trajectory_path)
         residue = tuple(
             sorted(
@@ -137,18 +122,11 @@ def run_episode(
             )
         )
         return EpisodeResult(
-            exit_code=completed.returncode,
-            stdout=completed.stdout,
-            stderr=completed.stderr,
+            exit_code=outcome.exit_code,
+            stdout=outcome.stdout,
+            stderr=outcome.stderr,
             trajectory=trajectory,
             residue=residue,
         )
     finally:
         shutil.rmtree(root, ignore_errors=True)
-
-
-def _inherited_env() -> dict[str, str]:
-    """The minimal parent environment an episode keeps: how to find binaries."""
-    import os
-
-    return {key: value for key, value in os.environ.items() if key in ("PATH", "SYSTEMROOT", "TMPDIR")}

--- a/reef/harness/executor.py
+++ b/reef/harness/executor.py
@@ -1,0 +1,279 @@
+"""How an episode's process runs, behind an interface.
+
+``run_episode`` owns the executor-agnostic work: it prepares the episode root,
+writes the rendered composition, builds the environment, reads the trajectory,
+and collects residue. Only the launch of the harness process differs between a
+development run and a hosted one, so that step is the seam:
+
+* :class:`LocalExecutor` runs the binary as a plain subprocess in its own
+  session, exactly as before. It is the default, used for development and the
+  hermetic tests.
+* :class:`SandboxExecutor` runs the same binary inside a bubblewrap jail: a
+  fresh non-root namespace, a read-only base filesystem with only the episode
+  root exposed (its workspace writable, the rest read-only), no host
+  environment or credentials, resource limits, network disabled unless an
+  egress allowlist is configured, and death with the parent.
+
+A deployment selects the executor by config; a hosted deployment that requires
+the sandbox refuses to start when the sandbox runtime is unavailable, through
+:meth:`EpisodeExecutor.preflight`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import resource
+import shutil
+import signal
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from reef.core.errors import ReefError
+
+
+class SandboxUnavailable(ReefError):
+    """A deployment requires the sandbox executor but it cannot isolate."""
+
+
+@dataclass(frozen=True)
+class ProcessOutcome:
+    """What a launched episode process produced."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class EpisodeTimeout(Exception):
+    """The process exceeded its wall-clock budget; raised for run_episode to map."""
+
+
+class EpisodeLaunchError(Exception):
+    """The process could not be launched; raised for run_episode to map."""
+
+
+class EpisodeExecutor(Protocol):
+    """Launch one episode process and return its outcome.
+
+    ``run_episode`` prepares ``root`` (with ``workspace`` inside it) and the
+    ``env`` overlay; an executor decides how the process sees them. It must
+    kill the whole process tree on timeout and raise :class:`EpisodeTimeout`
+    or :class:`EpisodeLaunchError` so ``run_episode`` maps them to the public
+    ``EpisodeError`` uniformly.
+    """
+
+    def preflight(self) -> None:
+        """Raise if this executor cannot establish its isolation on this host."""
+
+    def launch(
+        self,
+        argv: Sequence[str],
+        *,
+        root: Path,
+        workspace: Path,
+        env: Mapping[str, str],
+        timeout: float,
+    ) -> ProcessOutcome: ...
+
+
+def _run(popen_argv: Sequence[str], *, cwd: Path, env: Mapping[str, str], timeout: float) -> ProcessOutcome:
+    """Start a process in its own session and wait, killing the whole group on
+    timeout. Coding agents spawn tool children, so a timeout kills the session,
+    not just the direct child."""
+    try:
+        process = subprocess.Popen(
+            list(popen_argv),
+            cwd=cwd,
+            env=dict(env),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+    except FileNotFoundError as exc:
+        raise EpisodeLaunchError(f"harness binary {popen_argv[0]!r} not found") from exc
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+        raise EpisodeTimeout(f"episode timed out after {timeout}s: {list(popen_argv)}") from exc
+    return ProcessOutcome(exit_code=process.returncode, stdout=stdout, stderr=stderr)
+
+
+def _inherited_env() -> dict[str, str]:
+    """The minimal parent environment an episode keeps: how to find binaries."""
+    return {key: value for key, value in os.environ.items() if key in ("PATH", "SYSTEMROOT", "TMPDIR")}
+
+
+@dataclass(frozen=True)
+class LocalExecutor:
+    """Run the binary as a plain subprocess, as the engine always has.
+
+    No isolation beyond the episode root, the minimal environment, and the
+    process group. Suitable for development and hermetic tests, not for a
+    hosted service that evaluates untrusted proposals.
+    """
+
+    def preflight(self) -> None:
+        return None
+
+    def launch(
+        self,
+        argv: Sequence[str],
+        *,
+        root: Path,
+        workspace: Path,
+        env: Mapping[str, str],
+        timeout: float,
+    ) -> ProcessOutcome:
+        return _run(argv, cwd=workspace, env={**_inherited_env(), **env}, timeout=timeout)
+
+
+#: Resource limits every sandboxed episode gets unless the config overrides one.
+@dataclass(frozen=True)
+class SandboxLimits:
+    cpu_seconds: int = 0  # 0 disables; else RLIMIT_CPU
+    memory_bytes: int = 0  # 0 disables; else RLIMIT_AS
+    processes: int = 0  # 0 disables; else RLIMIT_NPROC
+    file_bytes: int = 0  # 0 disables; else RLIMIT_FSIZE
+
+
+@dataclass(frozen=True)
+class SandboxExecutor:
+    """Run the binary inside a bubblewrap jail.
+
+    bubblewrap (``bwrap``) is an unprivileged, daemonless sandbox: it builds a
+    new mount/pid/user namespace, binds a read-only base filesystem, exposes
+    only the episode root (workspace writable), clears the environment, and
+    dies with its parent. Network is unshared (no egress) unless
+    ``egress_hosts`` lists the model endpoint the episode must reach, in which
+    case the network namespace is shared so the endpoint is reachable; a
+    single-host firewall is the follow-up (issue #18).
+    """
+
+    egress_hosts: tuple[str, ...] = ()
+    limits: SandboxLimits = field(default_factory=SandboxLimits)
+    #: Base directories bound read-only so the binary and its runtime resolve.
+    base_paths: tuple[str, ...] = ("/usr", "/bin", "/lib", "/lib64", "/etc/alternatives", "/etc/ssl", "/opt")
+
+    def preflight(self) -> None:
+        if shutil.which("bwrap") is None:
+            raise SandboxUnavailable(
+                "the sandbox executor requires bubblewrap (bwrap) on PATH; install it or set "
+                "evolution.executor: local for development"
+            )
+
+    def _bwrap_argv(self, argv: Sequence[str], *, root: Path, workspace: Path, env: Mapping[str, str]) -> list[str]:
+        cmd = [
+            "bwrap",
+            "--unshare-user",
+            "--unshare-ipc",
+            "--unshare-pid",
+            "--unshare-uts",
+            "--unshare-cgroup-try",
+            "--die-with-parent",
+            "--new-session",
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--tmpfs",
+            "/tmp",
+            "--clearenv",
+        ]
+        if not self.egress_hosts:
+            cmd.append("--unshare-net")
+        for base in self.base_paths:
+            if Path(base).exists():
+                cmd += ["--ro-bind", base, base]
+        # The episode root is read-only except its workspace.
+        cmd += ["--ro-bind", str(root), str(root)]
+        cmd += ["--bind", str(workspace), str(workspace)]
+        cmd += ["--chdir", str(workspace)]
+        for key, value in {**_inherited_env(), **env}.items():
+            cmd += ["--setenv", key, value]
+        cmd += ["--", *argv]
+        return cmd
+
+    def launch(
+        self,
+        argv: Sequence[str],
+        *,
+        root: Path,
+        workspace: Path,
+        env: Mapping[str, str],
+        timeout: float,
+    ) -> ProcessOutcome:
+        self.preflight()
+        full = self._bwrap_argv(argv, root=root, workspace=workspace, env=env)
+        # bwrap clears the environment inside the jail; the outer process only
+        # needs PATH to find bwrap itself. Resource limits are set on the child
+        # before exec, so they apply through bwrap to the jailed process tree.
+        try:
+            process = subprocess.Popen(
+                full,
+                env={"PATH": os.environ.get("PATH", "")},
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+                preexec_fn=self._apply_limits,
+            )
+        except FileNotFoundError as exc:
+            raise EpisodeLaunchError("the sandbox runtime (bwrap) is not available") from exc
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+            raise EpisodeTimeout(f"episode timed out after {timeout}s: {list(argv)}") from exc
+        return ProcessOutcome(exit_code=process.returncode, stdout=stdout, stderr=stderr)
+
+    def _apply_limits(self) -> None:
+        if self.limits.cpu_seconds:
+            resource.setrlimit(resource.RLIMIT_CPU, (self.limits.cpu_seconds, self.limits.cpu_seconds))
+        if self.limits.memory_bytes:
+            resource.setrlimit(resource.RLIMIT_AS, (self.limits.memory_bytes, self.limits.memory_bytes))
+        if self.limits.processes:
+            resource.setrlimit(resource.RLIMIT_NPROC, (self.limits.processes, self.limits.processes))
+        if self.limits.file_bytes:
+            resource.setrlimit(resource.RLIMIT_FSIZE, (self.limits.file_bytes, self.limits.file_bytes))
+
+
+def build_executor(config: Mapping[str, object] | None) -> EpisodeExecutor:
+    """Build the executor a deployment selected.
+
+    ``executor`` is ``local`` (default) or ``sandbox``; a sandbox reads its
+    ``egress_hosts`` and ``limits`` from the same section. The executor is
+    preflighted at build so a hosted deployment that requires the sandbox
+    fails to start, not at the first episode.
+    """
+    config = config or {}
+    kind = config.get("executor", "local")
+    if kind == "local":
+        return LocalExecutor()
+    if kind != "sandbox":
+        raise ReefError(f"unknown episode executor {kind!r}; use 'local' or 'sandbox'")
+    sandbox_config = config.get("sandbox") or {}
+    if not isinstance(sandbox_config, Mapping):
+        raise ReefError("evolution.sandbox must be a mapping")
+    egress = tuple(str(host) for host in (sandbox_config.get("egress_hosts") or ()))
+    limits_config = sandbox_config.get("limits") or {}
+    if not isinstance(limits_config, Mapping):
+        raise ReefError("evolution.sandbox.limits must be a mapping")
+    limits = SandboxLimits(
+        cpu_seconds=int(limits_config.get("cpu_seconds", 0)),
+        memory_bytes=int(limits_config.get("memory_bytes", 0)),
+        processes=int(limits_config.get("processes", 0)),
+        file_bytes=int(limits_config.get("file_bytes", 0)),
+    )
+    executor = SandboxExecutor(egress_hosts=egress, limits=limits)
+    executor.preflight()
+    return executor

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -32,6 +32,7 @@ from typing import Any
 from reef.artifact.artifact import Artifact
 from reef.harness.descriptor import AdapterDescriptor
 from reef.harness.episode import EpisodeError, run_episode
+from reef.harness.executor import EpisodeExecutor, LocalExecutor
 from reef.harness.model_binding import ModelBinding, ModelBindings
 from reef.harness.nodes import NODE_KINDS
 from reef.harness.render import RenderError, render_composition
@@ -192,6 +193,7 @@ class CordisBackend(TrainingBackend):
         max_steps: int = 0,
         max_failure_streak: int = 0,
         max_model_calls_per_step: int = 0,
+        executor: EpisodeExecutor | None = None,
         seed: tuple[Mapping[str, Any], ...] = (),
     ) -> None:
         if not tasks:
@@ -238,6 +240,9 @@ class CordisBackend(TrainingBackend):
         self._max_steps = max_steps
         self._max_failure_streak = max_failure_streak
         self._max_model_calls_per_step = max_model_calls_per_step
+        # Preflighted at build (recipe.build), so a hosted deployment that
+        # requires the sandbox fails to start, not at the first episode.
+        self._executor = executor or LocalExecutor()
         self._seed = tuple(dict(entry) for entry in seed)
         self._validate_seed()
 
@@ -505,7 +510,14 @@ class CordisBackend(TrainingBackend):
         whitelist; with ``forbid_residue`` a littering episode scores as one
         that could not run."""
         try:
-            result = run_episode(self._descriptor, files, task, binary=self._binary, timeout=self._episode_timeout_s)
+            result = run_episode(
+                self._descriptor,
+                files,
+                task,
+                binary=self._binary,
+                timeout=self._episode_timeout_s,
+                executor=self._executor,
+            )
         except EpisodeError as error:
             return None, FailureObservation(task=task, stage="launch", cause=str(error)), 0
         except TrajectoryError as error:

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -16,9 +16,11 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from reef.core.errors import ReefError
 from reef.core.reports import ScoredRolloutReport
 from reef.harness.adapters import get_adapter
 from reef.harness.descriptor import DescriptorError
+from reef.harness.executor import EpisodeExecutor, build_executor
 from reef.harness.model_binding import ModelBinding, ModelBindings
 from reef.harness.version_check import version_check_entry
 from reef.observability import ExperimentLogger
@@ -133,6 +135,7 @@ class CordisRecipe(Recipe):
     max_steps: int = 0
     max_failure_streak: int = 0
     max_model_calls_per_step: int = 0
+    executor: EpisodeExecutor = field(default_factory=lambda: build_executor(None))
     seed: tuple[Mapping[str, Any], ...] = ()
     model_name: str | None = None
     models: Mapping[str, ModelBinding] = field(default_factory=dict)
@@ -191,6 +194,10 @@ class CordisRecipe(Recipe):
         forbid_residue = evolution.get("forbid_residue", False)
         if not isinstance(forbid_residue, bool):
             raise RecipeConfigError("evolution.forbid_residue must be a boolean")
+        try:
+            executor = build_executor(evolution)
+        except ReefError as exc:
+            raise RecipeConfigError(str(exc)) from exc
         budgets: dict[str, int] = {}
         for label in ("max_steps", "max_failure_streak", "max_model_calls_per_step"):
             value = evolution.get(label, 0)
@@ -244,6 +251,7 @@ class CordisRecipe(Recipe):
             "episode_repeats": repeats,
             "forbid_residue": forbid_residue,
             **budgets,
+            "executor": executor,
             "seed": tuple(seed),
             "model_name": model_name if isinstance(model_name, str) and model_name else None,
             "models": models,

--- a/tests/reef_service/test_episode_executor.py
+++ b/tests/reef_service/test_episode_executor.py
@@ -1,0 +1,121 @@
+"""The episode executor abstraction: local behavior, sandbox construction,
+and the fail-fast contract when a required sandbox cannot isolate."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from reef.core.errors import ReefError
+from reef.harness.executor import (
+    EpisodeLaunchError,
+    EpisodeTimeout,
+    LocalExecutor,
+    SandboxExecutor,
+    SandboxLimits,
+    SandboxUnavailable,
+    build_executor,
+)
+
+
+def _script(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "prog"
+    path.write_text(f"#!/usr/bin/env python3\n{body}\n")
+    path.chmod(0o755)
+    return path
+
+
+def test_local_executor_runs_in_the_workspace_and_returns_the_outcome(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    prog = _script(tmp_path, "import os; print(os.getcwd()); print('err', file=__import__('sys').stderr)")
+    outcome = LocalExecutor().launch([sys.executable, str(prog)], root=root, workspace=workspace, env={}, timeout=10.0)
+    assert outcome.exit_code == 0
+    assert outcome.stdout.strip() == str(workspace)
+    assert "err" in outcome.stderr
+
+
+def test_local_executor_maps_a_missing_binary(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    (root / "workspace").mkdir(parents=True)
+    with pytest.raises(EpisodeLaunchError):
+        LocalExecutor().launch(
+            [str(tmp_path / "does-not-exist")], root=root, workspace=root / "workspace", env={}, timeout=10.0
+        )
+
+
+def test_local_executor_kills_the_tree_on_timeout(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    (root / "workspace").mkdir(parents=True)
+    prog = _script(tmp_path, "import time; time.sleep(30)")
+    with pytest.raises(EpisodeTimeout):
+        LocalExecutor().launch(
+            [sys.executable, str(prog)], root=root, workspace=root / "workspace", env={}, timeout=0.5
+        )
+
+
+def test_build_executor_defaults_to_local() -> None:
+    assert isinstance(build_executor(None), LocalExecutor)
+    assert isinstance(build_executor({"executor": "local"}), LocalExecutor)
+
+
+def test_build_executor_rejects_an_unknown_kind() -> None:
+    with pytest.raises(ReefError, match="unknown episode executor"):
+        build_executor({"executor": "vm"})
+
+
+def test_sandbox_preflight_fails_fast_without_bubblewrap(monkeypatch) -> None:
+    monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: None)
+    with pytest.raises(SandboxUnavailable, match="bubblewrap"):
+        SandboxExecutor().preflight()
+    with pytest.raises(ReefError, match="bubblewrap"):
+        build_executor({"executor": "sandbox"})
+
+
+def test_sandbox_argv_isolates_the_filesystem_env_and_network(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: "/usr/bin/bwrap")
+    monkeypatch.setattr("reef.harness.executor.os.environ", {"PATH": "/usr/bin"})
+    root = tmp_path / "root"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    sandbox = SandboxExecutor()
+    argv = sandbox._bwrap_argv([sys.executable, "-c", "pass"], root=root, workspace=workspace, env={"A": "b"})
+
+    assert argv[0] == "bwrap"
+    assert "--unshare-net" in argv  # no egress hosts: network is denied
+    assert "--die-with-parent" in argv
+    assert "--clearenv" in argv
+    # The root is read-only, its workspace writable.
+    ro = [argv[i + 2] for i, tok in enumerate(argv) if tok == "--ro-bind" and argv[i + 1] == str(root)]
+    rw = [argv[i + 2] for i, tok in enumerate(argv) if tok == "--bind" and argv[i + 1] == str(workspace)]
+    assert ro == [str(root)]
+    assert rw == [str(workspace)]
+    # The overlay env is passed; host secrets are not (only PATH from inherited).
+    assert "--setenv" in argv
+    joined = " ".join(argv)
+    assert "A b" in joined
+
+
+def test_sandbox_shares_the_network_when_egress_is_allowlisted(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: "/usr/bin/bwrap")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    sandbox = SandboxExecutor(egress_hosts=("127.0.0.1:8000",))
+    argv = sandbox._bwrap_argv(["true"], root=tmp_path, workspace=workspace, env={})
+    assert "--unshare-net" not in argv
+
+
+def test_build_executor_reads_sandbox_limits(monkeypatch) -> None:
+    monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: "/usr/bin/bwrap")
+    executor = build_executor(
+        {
+            "executor": "sandbox",
+            "sandbox": {"egress_hosts": ["127.0.0.1:8000"], "limits": {"cpu_seconds": 30, "memory_bytes": 1 << 30}},
+        }
+    )
+    assert isinstance(executor, SandboxExecutor)
+    assert executor.egress_hosts == ("127.0.0.1:8000",)
+    assert executor.limits == SandboxLimits(cpu_seconds=30, memory_bytes=1 << 30)

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -1146,3 +1146,34 @@ def test_backend_rejects_negative_budgets(tmp_path: Path) -> None:
             binary=str(make_binary(tmp_path)),
             max_steps=-1,
         )
+
+
+def test_recipe_selects_the_episode_executor(tmp_path: Path, monkeypatch) -> None:
+    """evolution.executor selects the executor; local is the default, and a
+    sandbox that cannot isolate refuses at recipe build."""
+    module = tmp_path / "demo_executor.py"
+    module.write_text(
+        "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def config(**evolution):
+        return {
+            "evolution": {
+                "propose": "demo_executor:propose",
+                "evaluate": "demo_executor:evaluate",
+                "tasks": ["task one"],
+                "binary": str(make_binary(tmp_path)),
+                **evolution,
+            }
+        }
+
+    default = CordisRecipe.from_environment({}, config=config())
+    assert type(default.executor).__name__ == "LocalExecutor"
+
+    local = CordisRecipe.from_environment({}, config=config(executor="local"))
+    assert type(local.executor).__name__ == "LocalExecutor"
+
+    monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: None)
+    with pytest.raises(RecipeConfigError, match="bubblewrap"):
+        CordisRecipe.from_environment({}, config=config(executor="sandbox"))


### PR DESCRIPTION
## Motivation

Harness evolution evaluates model-proposed trees, including executable code_extension nodes, by launching the harness binary directly as a child of the Reef service under the operator's user, with a temporary root but no security boundary. A malicious or compromised episode can read service credentials, reach internal services, exhaust host resources, or modify the host. A hosted service must treat every proposal as untrusted. Closes #18.

## Changes

- Introduce an episode executor interface: run_episode owns the executor-agnostic work (root, rendered files, environment, trajectory, residue), and only the process launch is behind the interface
- LocalExecutor preserves the current subprocess behavior and is the default for development and the hermetic tests
- SandboxExecutor runs the binary in a bubblewrap jail: a fresh non-root user/pid/ipc/uts namespace, a read-only base filesystem exposing only the episode root with a writable workspace, a cleared environment carrying no host credentials, resource limits (CPU, memory, PID, file size) applied before exec, network denied unless a model endpoint is allowlisted, die-with-parent, and whole-tree termination on timeout
- evolution.executor selects local or sandbox; evolution.sandbox carries egress_hosts and limits; the executor is preflighted at recipe build, so a deployment that requires the sandbox refuses to start when bubblewrap is unavailable
- CordisBackend depends on the executor interface, not the concrete subprocess

## Compatibility and operational impact

None by default: evolution.executor defaults to local and the local path is byte-for-byte the previous behavior. A single-host egress firewall (restricting the shared network to exactly the allowlisted endpoints) and a container/microVM strong-isolation backend are the next slice of #18; this lands the abstraction, the local executor, and a bubblewrap sandbox with the filesystem, environment, resource, and process-isolation contract.

## Verification

The CI-equivalent sweep passes: 1170 tests, 6 skipped, all existing harness and adapter trajectory tests unchanged through the local executor. New tests cover the local executor's workspace, missing-binary, and timeout paths; build_executor defaulting and rejection; the sandbox fail-fast without bubblewrap; and the bwrap argv establishing the read-only root, writable workspace, cleared env, and network isolation (denied by default, shared when egress is allowlisted). mypy, ruff, and the docs gate are clean.

## AI assistance

Claude Code designed the executor seam and wrote the sandbox and tests. I set the scope in #18.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
