### PR TITLE
fix: repair docs anchor landing, dialog focus, search, and mobile code blocks

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -41,7 +41,7 @@
   --font-mono: "DM Mono", ui-monospace, monospace;
 }
 
-html { color-scheme: light; scroll-behavior: smooth; scroll-padding-top: 92px; }
+html { color-scheme: light; scroll-padding-top: 92px; } /* auto scroll: smooth raced the late-mounting diagrams and landed deep links hundreds of px off */
 html[data-theme="dark"] {
   color-scheme: dark;
   --background: #100e0c;
@@ -82,6 +82,9 @@ html[data-theme="dark"] {
 
 /* Base */
 * { box-sizing: border-box; }
+.skip-link { position: fixed; z-index: 200; top: -60px; left: 12px; padding: 10px 16px; color: var(--foreground); border: 1px solid var(--border); border-radius: 8px; background: var(--background); transition: top .15s; }
+.skip-link:focus { top: 12px; }
+main.docs-main:focus { outline: none; }
 body { margin: 0; color: var(--text); background: var(--background); font-family: var(--font-sans); font-size: 15px; line-height: 1.7; -webkit-font-smoothing: antialiased; }
 a { color: inherit; text-decoration: none; }
 button, input { color: inherit; font: inherit; }
@@ -126,10 +129,11 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .search-input-row { height: 60px; padding: 0 16px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid var(--border); }
 .search-input-row input { min-width: 0; height: 100%; flex: 1; color: var(--foreground); border: 0; outline: 0; background: transparent; font-size: 16px; }
 .search-input-row button { width: 32px; height: 32px; padding: 0; display: grid; place-items: center; color: var(--muted); border: 0; border-radius: 7px; background: transparent; }
-.search-results { min-height: 250px; max-height: 55vh; padding: 10px; overflow: auto; overscroll-behavior: contain; }
+.search-results { min-height: min(250px, 40vh); max-height: 55vh; padding: 10px; overflow: auto; overscroll-behavior: contain; }
 .search-label { margin: 4px 8px 8px; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
 .search-results > a { padding: 10px; display: flex; align-items: center; gap: 11px; border-radius: 8px; }
 .search-results > a:hover { background: var(--accent); }
+.search-results > a.is-selected { background: var(--accent); }
 .search-results > a > svg { color: var(--muted); }
 .search-results > a > svg:last-child { margin-left: auto; }
 .search-results a span { min-width: 0; display: grid; gap: 3px; }
@@ -259,6 +263,7 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .code-block:hover .code-copy, .code-copy:focus-visible { opacity: 1; }
 .code-copy:hover { color: var(--brand-strong); border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
 .table-scroll { overflow-x: auto; }
+.markdown-body img { max-width: 100%; height: auto; }
 .markdown-body .table-scroll { --scroller-bg: var(--background); margin: 24px 0 32px; border-radius: 10px; box-shadow: var(--shadow-sm); }
 .markdown-body .table-scroll table { margin: 0; }
 .markdown-body table { width: 100%; margin: 24px 0 32px; border-collapse: separate; border-spacing: 0; overflow: hidden; border: 1px solid var(--border); border-radius: 10px; font-size: 14px; line-height: 1.5; }
@@ -447,6 +452,11 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 }
 
 @media (max-width: 600px) {
+  /* Code on a phone: tighter padding buys back the horizontal room the
+     desktop 24px gutter costs, and 12px fits more of each line before a
+     line has to be scrolled sideways. Pad and desktop keep 13px/24px. */
+  .markdown-body pre { padding: 16px 14px; font-size: 12px; }
+  .markdown-body pre code { font-size: 12px; }
   .header-inner { gap: 8px; }
   .header-search { width: 44px; }
   .search-trigger { width: 44px; padding: 0; justify-content: center; border: 0; background: transparent; box-shadow: none; }
@@ -478,6 +488,7 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 @media (pointer: coarse) {
   .icon-button { width: 44px; height: 44px; }
   .code-copy { width: 44px; height: 44px; opacity: 1; top: 8px; right: 8px; }
+  .search-input-row button { width: 44px; height: 44px; }
   .search-trigger { min-width: 44px; min-height: 44px; }
   .logo { min-height: 44px; }
   .markdown-body a.heading-anchor { padding: 10px 15px; margin-left: 0; }

--- a/docs/site/app/layout.tsx
+++ b/docs/site/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Header } from "@/components/header";
+import { RouteFocus } from "@/components/route-focus";
 import { ThemeSync } from "@/components/theme-sync";
 import { getSearchDocuments, navigation } from "@/lib/docs";
 import { siteConfig } from "@/lib/site";
@@ -25,11 +26,13 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
   const searchDocuments = getSearchDocuments();
 
   return (
-    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body>
         {/* Inline so it runs at parse time, before first paint. */}
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <a className="skip-link" href="#main-content">Skip to content</a>
         <ThemeSync />
+        <RouteFocus />
         <Header documents={searchDocuments} navigation={navigation} />
         {children}
       </body>

--- a/docs/site/components/docs-page.tsx
+++ b/docs/site/components/docs-page.tsx
@@ -22,7 +22,7 @@ export function DocsPage({ doc, navigation, previous, next }: { doc: Doc; naviga
   return (
     <div className="docs-layout">
       <Sidebar navigation={navigation} />
-      <main className="docs-main">
+      <main id="main-content" className="docs-main" tabIndex={-1}>
         <div className="doc-context" aria-label="Breadcrumb">
           <Link href="/docs">Docs</Link>
           <ChevronRight size={13} aria-hidden="true" />

--- a/docs/site/components/mermaid-diagram.tsx
+++ b/docs/site/components/mermaid-diagram.tsx
@@ -202,6 +202,14 @@ export function MermaidDiagram({ chart }: { chart: string }) {
     }
 
     draw();
+    // A cold direct load lays the diagram out with fallback-font metrics; when
+    // the site webfont arrives its wider glyphs would otherwise clip the boxes.
+    // Redraw once fonts settle. document.fonts is guarded for older engines.
+    if (typeof document !== "undefined" && "fonts" in document) {
+      void document.fonts.ready.then(() => {
+        if (active) draw();
+      });
+    }
     const observer = new MutationObserver((records) => {
       if (records.some((record) => record.attributeName === "data-theme")) draw();
     });

--- a/docs/site/components/mobile-nav.tsx
+++ b/docs/site/components/mobile-nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { Menu, X } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { NavGroup } from "@/lib/docs";
 
@@ -16,6 +16,8 @@ function isCurrent(pathname: string, href: string) {
 export function MobileNav({ navigation }: { navigation: NavGroup[] }) {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const restoreFocus = useRef<HTMLElement | null>(null);
 
   // Adjust-during-render: a route change (back gesture included) closes the
   // drawer without an effect pass.
@@ -30,14 +32,34 @@ export function MobileNav({ navigation }: { navigation: NavGroup[] }) {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") setOpen(false);
     }
+    function onTrap(event: KeyboardEvent) {
+      if (event.key !== "Tab" || !panelRef.current) return;
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>('a[href], button:not([disabled])');
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
     window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onTrap);
+    // Focus the drawer (its close button) on open; return focus on close.
+    restoreFocus.current = document.activeElement as HTMLElement | null;
+    requestAnimationFrame(() => panelRef.current?.querySelector<HTMLElement>("button, a[href]")?.focus());
     // Scroll lock: without it, scrolling past the end of the nav list chains
     // into the page, and closing the drawer strands the reader mid-document.
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keydown", onTrap);
       document.body.style.overflow = previousOverflow;
+      restoreFocus.current?.focus();
     };
   }, [open]);
 
@@ -51,7 +73,7 @@ export function MobileNav({ navigation }: { navigation: NavGroup[] }) {
           backdrop-filter makes it the containing block for fixed children. */}
       {open && createPortal(
         <div className="mobile-nav-overlay" role="presentation" onMouseDown={() => setOpen(false)}>
-          <div className="mobile-nav-panel" role="dialog" aria-modal="true" aria-label="Site navigation" onMouseDown={(event) => event.stopPropagation()}>
+          <div ref={panelRef} className="mobile-nav-panel" role="dialog" aria-modal="true" aria-label="Site navigation" onMouseDown={(event) => event.stopPropagation()}>
             <div className="mobile-nav-head">
               <span>Documentation</span>
               <button className="icon-button" type="button" aria-label="Close navigation" onClick={() => setOpen(false)}><X size={18} /></button>

--- a/docs/site/components/route-focus.tsx
+++ b/docs/site/components/route-focus.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+// A keyboard user's focus is on a link in the old page when a client-side
+// navigation swaps the content; without this it falls to <body> and the next
+// Tab restarts from the top of the page. Move focus to the main region on
+// every route change after the first, so reading continues where the new
+// page begins. The skip link and heading anchors stay reachable from there.
+export function RouteFocus() {
+  const pathname = usePathname();
+  const first = useRef(true);
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    const main = document.querySelector<HTMLElement>("main.docs-main, main");
+    main?.focus({ preventScroll: true });
+  }, [pathname]);
+  return null;
+}

--- a/docs/site/components/search.tsx
+++ b/docs/site/components/search.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ArrowRight, FileText, Search as SearchIcon, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -13,9 +14,19 @@ type SearchDocument = {
 };
 
 export function Search({ documents }: { documents: SearchDocument[] }) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState(0);
+  // Reset the highlight when the query changes, in render, without an effect.
+  const [lastQuery, setLastQuery] = useState(query);
+  if (query !== lastQuery) {
+    setLastQuery(query);
+    setSelected(0);
+  }
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const restoreFocus = useRef<HTMLElement | null>(null);
 
   const closeSearch = useCallback(() => {
     setOpen(false);
@@ -35,17 +46,17 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
   }, [closeSearch]);
 
   useEffect(() => {
-    if (open) requestAnimationFrame(() => inputRef.current?.focus());
-  }, [open]);
-
-  useEffect(() => {
     if (!open) return;
-    // Same scroll lock as the nav drawer: result-list scrolling must not
-    // chain into the page behind the dialog.
+    // Remember what opened the dialog so focus returns there on close, and
+    // put focus in the input to start.
+    restoreFocus.current = document.activeElement as HTMLElement | null;
+    requestAnimationFrame(() => inputRef.current?.focus());
+    // Scroll lock, so result-list scrolling does not chain into the page.
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       document.body.style.overflow = previousOverflow;
+      restoreFocus.current?.focus();
     };
   }, [open]);
 
@@ -58,19 +69,60 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
         const title = doc.title.toLowerCase();
         const description = doc.description.toLowerCase();
         const text = doc.text.toLowerCase();
+        // Accumulate only positive matches: a page that matches one term is
+        // kept and ranked by its strongest field; an absent term never
+        // subtracts, so a multi-word query cannot cancel a real match out.
         const score = terms.reduce((total, term) => {
           if (title.includes(term)) return total + 12;
           if (description.includes(term)) return total + 5;
           if (text.includes(term)) return total + 1;
-          return total - 20;
+          return total;
         }, 0);
         return { doc, score };
       })
-      .filter(({ score }) => score >= 0)
+      .filter(({ score }) => score > 0)
       .sort((a, b) => b.score - a.score)
       .slice(0, 8)
       .map(({ doc }) => doc);
   }, [documents, query]);
+
+  const hasQuery = query.trim().length > 0;
+
+  function onInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!results.length) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelected((index) => (index + 1) % results.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelected((index) => (index - 1 + results.length) % results.length);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const doc = results[selected];
+      if (doc) {
+        closeSearch();
+        router.push(`/docs/${doc.slug}`);
+      }
+    }
+  }
+
+  function onDialogKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Tab" || !dialogRef.current) return;
+    // Trap Tab inside the dialog so focus cannot fall behind the modal.
+    const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input, [tabindex]:not([tabindex="-1"])',
+    );
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
 
   return (
     <>
@@ -85,13 +137,22 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
           inside it, the backdrop is header-sized and outside clicks miss it. */}
       {open && createPortal(
         <div className="search-overlay" role="presentation" onMouseDown={closeSearch}>
-          <div className="search-dialog" role="dialog" aria-modal="true" aria-label="Search documentation" onMouseDown={(event) => event.stopPropagation()}>
+          <div
+            ref={dialogRef}
+            className="search-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Search documentation"
+            onMouseDown={(event) => event.stopPropagation()}
+            onKeyDown={onDialogKeyDown}
+          >
             <div className="search-input-row">
               <SearchIcon size={19} />
               <input
                 ref={inputRef}
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={onInputKeyDown}
                 placeholder="Search concepts, APIs, and guides…"
                 aria-label="Search query"
               />
@@ -100,10 +161,20 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
               </button>
             </div>
             <div className="search-results">
-              <p className="search-label">{query ? `${results.length} results` : "Suggested pages"}</p>
+              <p className="search-label">
+                {hasQuery
+                  ? `${results.length} ${results.length === 1 ? "result" : "results"}`
+                  : "Suggested pages"}
+              </p>
               {results.length ? (
-                results.map((doc) => (
-                  <Link key={doc.slug} href={`/docs/${doc.slug}`} onClick={closeSearch}>
+                results.map((doc, index) => (
+                  <Link
+                    key={doc.slug}
+                    href={`/docs/${doc.slug}`}
+                    onClick={closeSearch}
+                    aria-selected={index === selected}
+                    className={index === selected ? "is-selected" : undefined}
+                  >
                     <FileText size={18} />
                     <span>
                       <strong>{doc.title}</strong>


### PR DESCRIPTION
## Motivation

A sweep of the docs site with a real browser found fifteen UX defects a normal user would hit, several the same class as the theme-on-client-navigation bug: behavior that worked on a full page load but broke on client-side navigation, focus, scroll, or a small screen. Every one was reproduced with measured before and after.

## Changes

- Anchor landing: drop html scroll-behavior smooth and the App Router smooth opt-in. Smooth turned the initial deep-link scroll into a one-shot animation captured before the Mermaid diagrams mount and grow the document, landing hundreds of pixels off; a mid-flight smooth scroll also threw cross-page fragment links behind the fixed header. Auto lands every anchor exactly, as the reduced-motion path already did
- Dialog focus: the search dialog and the mobile nav drawer now trap Tab, take focus on open, and restore focus to their trigger on close
- Client-navigation focus: a route change moves focus to the main region instead of dropping it to body, and a skip-to-content link is the first tab stop
- Search: Enter opens the highlighted result with arrow-key selection; a multi-word query keeps a page that matches any term instead of a missing term canceling a real match out; the count label reads over a real query only and pluralizes ("1 result")
- Content images are capped at the content width so the recipe pages no longer overflow
- Mobile code blocks tighten to 12px with 16x14 padding, buying back 46px of line width on a phone; pad and desktop keep 13px/24px
- Smaller: the search close button meets the 44px touch target, and the dialog fits a short landscape viewport; Mermaid redraws once the webfont settles

## Compatibility and operational impact

None. Presentation and interaction only; no content or route changes.

## Verification

Built and driven with puppeteer against the static export: the deep link below two diagrams lands the heading at top=92 (was ~830), no content image overflows, search focuses its input on open and Enter navigates, a multi-word query keeps the matching page, the first Tab hits the skip link, a sidebar navigation moves focus to main.docs-main, and a phone code block renders at 12px with the page not overflowing while pad stays 13px. lint and the docs build are clean.

## AI assistance

Claude Code ran the sweep, verified each defect, and wrote the fixes.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
