### PR TITLE
feat: add a code copy button and align the logo with the sidebar

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -254,6 +254,10 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .markdown-body pre { --scroller-bg: var(--code); margin: 24px 0 32px; padding: 22px 24px; overflow-x: auto; color: var(--code-text); border: 1px solid color-mix(in srgb, var(--border) 88%, transparent); border-radius: 10px; box-shadow: inset 0 1px color-mix(in srgb, var(--foreground) 4%, transparent); font: 13px/1.65 var(--font-mono); }
 .markdown-body pre, .markdown-body .table-scroll { background: linear-gradient(90deg, var(--scroller-bg) 45%, transparent) left center / 32px 100% no-repeat local, linear-gradient(270deg, var(--scroller-bg) 45%, transparent) right center / 32px 100% no-repeat local, radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) left center / 14px 100% no-repeat scroll, radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) right center / 14px 100% no-repeat scroll, var(--scroller-bg); }
 .markdown-body pre code { display: block; width: max-content; min-width: 100%; padding: 0; color: inherit; background: transparent; font-size: 13px; }
+.code-block { position: relative; }
+.code-copy { position: absolute; top: 10px; right: 10px; width: 30px; height: 30px; display: grid; place-items: center; color: var(--muted); border: 1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius: 7px; background: color-mix(in srgb, var(--code) 90%, var(--background)); opacity: 0; transition: opacity .12s, color .12s, border-color .12s; }
+.code-block:hover .code-copy, .code-copy:focus-visible { opacity: 1; }
+.code-copy:hover { color: var(--brand-strong); border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
 .table-scroll { overflow-x: auto; }
 .markdown-body .table-scroll { --scroller-bg: var(--background); margin: 24px 0 32px; border-radius: 10px; box-shadow: var(--shadow-sm); }
 .markdown-body .table-scroll table { margin: 0; }
@@ -473,6 +477,7 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 
 @media (pointer: coarse) {
   .icon-button { width: 44px; height: 44px; }
+  .code-copy { width: 44px; height: 44px; opacity: 1; top: 8px; right: 8px; }
   .search-trigger { min-width: 44px; min-height: 44px; }
   .logo { min-height: 44px; }
   .markdown-body a.heading-anchor { padding: 10px 15px; margin-left: 0; }

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -90,7 +90,7 @@ button { cursor: pointer; }
 
 /* Header and navigation */
 .site-header { position: fixed; z-index: 50; top: 0; right: 0; left: 0; height: 68px; border-bottom: 1px solid color-mix(in srgb, var(--border) 76%, transparent); background: color-mix(in srgb, var(--background) 82%, transparent); backdrop-filter: blur(20px) saturate(140%); }
-.header-inner { width: min(1440px, 100%); height: 68px; margin: 0 auto; padding: 0 28px; display: flex; align-items: center; gap: 32px; }
+.header-inner { width: 100%; height: 68px; padding: 0 28px; display: flex; align-items: center; gap: 32px; }
 .logo { display: inline-flex; align-items: center; gap: 11px; color: var(--foreground); font-weight: 600; }
 .logo-mark { color: var(--brand); stroke-width: 2.4; }
 .logo-name { color: var(--foreground); font-size: 15px; font-weight: 700; letter-spacing: .15em; }
@@ -218,7 +218,7 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 
 /* Documentation layout */
 .docs-layout { width: 100%; min-height: 100vh; padding-top: 68px; display: grid; grid-template-columns: 270px minmax(0, 760px) minmax(220px, 1fr); }
-.docs-sidebar { position: fixed; z-index: 20; top: 68px; bottom: 0; left: 0; width: 270px; padding: 38px 22px 48px; overflow-y: auto; border-right: 1px solid color-mix(in srgb, var(--border) 72%, transparent); background: color-mix(in srgb, var(--background) 92%, var(--accent)); }
+.docs-sidebar { position: fixed; z-index: 20; top: 68px; bottom: 0; left: 0; width: 270px; padding: 38px 18px 48px; overflow-y: auto; border-right: 1px solid color-mix(in srgb, var(--border) 72%, transparent); background: color-mix(in srgb, var(--background) 92%, var(--accent)); }
 .sidebar-group { margin-bottom: 30px; }
 .sidebar-group-items { display: grid; gap: 3px; }
 .sidebar-group a { padding: 7px 10px; color: var(--muted); border-radius: 7px; font-size: 13px; line-height: 20px; }

--- a/docs/site/components/code-block.tsx
+++ b/docs/site/components/code-block.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+// A copy button in the top-right of every code block. The rendered <pre> is
+// wrapped so the button positions against it; the text copied is the block's
+// own textContent, which the shiki path stores with real newlines. On a
+// phone the button is always visible (no hover), so it sits out of the way in
+// the padding and grows to a 44px touch target on coarse pointers.
+export function CodeBlock({ className, children }: { className?: string; children: ReactNode }) {
+  const ref = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    const text = ref.current?.textContent ?? "";
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // clipboard unavailable (insecure context, denied): leave the button as is
+    }
+  }
+
+  return (
+    <div className="code-block">
+      <pre ref={ref} className={className}>
+        {children}
+      </pre>
+      <button
+        type="button"
+        className="code-copy"
+        onClick={copy}
+        aria-label={copied ? "Copied" : "Copy code"}
+        title={copied ? "Copied" : "Copy"}
+      >
+        {copied ? <Check size={15} /> : <Copy size={15} />}
+      </button>
+    </div>
+  );
+}

--- a/docs/site/components/markdown.tsx
+++ b/docs/site/components/markdown.tsx
@@ -8,6 +8,7 @@ import parse, {
   type HTMLReactParserOptions,
 } from "html-react-parser";
 import { CircleAlert, ExternalLink, Info, Lightbulb, TriangleAlert } from "lucide-react";
+import { CodeBlock } from "./code-block";
 import { MermaidDiagram } from "@/components/mermaid-diagram";
 import { getDoc } from "@/lib/docs";
 import { siteConfig } from "@/lib/site";
@@ -67,6 +68,10 @@ export function ReStructuredText({ content, sourcePath }: { content: string; sou
 
       if (node.name === "pre" && node.attribs.class?.split(" ").includes("language-mermaid")) {
         return <MermaidDiagram chart={textFromNodes(children).replace(/\n$/, "")} />;
+      }
+
+      if (node.name === "pre") {
+        return <CodeBlock className={node.attribs.class}>{domToReact(children, options)}</CodeBlock>;
       }
 
       if (node.name === "div" && node.attribs.class?.split(" ").includes("admonition")) {


### PR DESCRIPTION
## Motivation

Code blocks had no copy button, so a reader had to select the text by hand. This is a basic docs affordance, and it has to work the same on desktop, phone, and pad.

## Changes

- CodeBlock wraps every rendered code block (the client-side pre handler in markdown.tsx, after the mermaid branch) and adds a copy button in the top-right; the copied text is the block's own textContent, which the shiki path stores with real newlines
- Desktop: the button is revealed on hover or keyboard focus and confirms with a check and a "Copied" label for 1.6s
- Coarse pointers (phone, pad touch): the button is always visible and a 44px touch target, positioned in the padding so it does not sit on the code

## Compatibility and operational impact

None. Presentation only; clipboard failures (an insecure context or a denied permission) leave the button unchanged.

## Verification

Built and driven with puppeteer against the static export across three viewports: on desktop the button is hidden at rest (opacity 0), reveals on hover, and a click writes the block's exact textContent to the clipboard and flips the label to "Copied"; on a 390px phone it is always visible at 44x44; on a 768px pad it renders on-screen. lint and the docs build are clean.


## Logo alignment

The header was a centered 1440px container while the sidebar is fixed at the left edge, so the logo drifted right of the sidebar content on wide screens (76px off at 1600px, 4px off at 1280px). The header is now full width so the logo x is stable, and the sidebar content indent is set so the logo mark, the section titles, and the links all share the same 28px left edge. Verified at 1280/1600/1920 (all aligned to 28px, search on screen) with the landing and phone headers unregressed.

## AI assistance

Claude Code wrote the component and verified it on the three viewports.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.

