### PR TITLE
feat: grow the evolution gate with promoted failing traces

### DIFF
--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -33,6 +33,12 @@ proposal under one verdict, or ``None`` to skip. An optional keyword-only
 pair. ``result`` carries the exit code, stdout, stderr, and the parsed ``trajectory``. Episodes
 that could not run never reach it.
 
+``promote`` is optional and only matters with ``evolution.promote_failures``:
+it receives the step's trace samples, plus the ``FailureManifest`` when its
+signature names ``manifest``, and returns the prompts to add to the gate as
+permanent tasks. Reef dedupes, screens for credentials, and caps what it
+returns. Without it every failing trace's user prompt is promoted.
+
 ``selection`` defaults to ``score_comparison``: select when the candidate wins
 more task comparisons than it loses. ``always`` selects every applied mutation.
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -173,6 +173,9 @@ zero.
    evolution.max_model_calls_per_step | 0 | cap the proposer's model calls in one step; 0 disables the limit
    evolution.executor | local | ``local`` runs episodes as a plain subprocess (development, hermetic tests); ``sandbox`` runs each in a bubblewrap jail for a hosted service and refuses to start without it
    evolution.sandbox | | the sandbox executor's policy: ``egress_hosts`` (allowlisted model endpoints; empty denies network) and ``limits`` (``cpu_seconds``, ``memory_bytes``, ``processes``, ``file_bytes``)
+   evolution.promote_failures | false | when true, a failing trace's prompt becomes a permanent gate task, so no later candidate can win while bringing the failure back; the seed tasks stay the floor
+   evolution.max_promoted_tasks | 50 | the cap on promoted tasks; admission stops there so the suite is bounded
+   evolution.promote | | optional callable or dotted ``module:attribute`` choosing which trace prompts to promote; receives the step's samples (and the failure manifest when its signature names ``manifest``); without it every failing trace's user prompt is promoted, and the cap and credential screen still apply
    evolution.seed | entry options loaded into the tree on first boot; recovered state takes precedence
    evolution.models | auxiliary models for the method: ``url``, ``model``, optional ``api`` (default ``openai``) and ``timeout_s``, with the credential as a literal ``api_key`` or an ``api_key_env`` variable name
    evolution.version_check | appends the adapter's update notice; an interactive pulled tree offers to run the update or skip when behind

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -72,7 +72,19 @@ receipt batches as that exchange; a report over several batches as one
 trajectory sample carrying every referenced exchange in order, which is what
 ``reef-pi report`` sends for a whole run (``--per-receipt`` fans the score
 across the receipts as separate reports instead). When ``batch_size``
-window entries have accumulated, one step runs the loop once. ``batch_size``
+window entries have accumulated, one step runs the loop once. With
+``evolution.promote_failures: true`` a failing trace's prompt is added to the
+gate as a permanent task, so the seed tasks are the floor of a suite that
+grows from real failures and no later candidate can win while bringing one
+back (the method's ``evaluate`` must score an arbitrary prompt). A prompt is
+real traffic, so it meets the tree's own credential tripwire first: a prompt
+carrying a key-shaped literal is never promoted, never persisted, and never
+re-run as a task, and the step goes on without it. Which prompts are
+promoted is the method's call: an optional ``evolution.promote`` callable
+receives the step's trace samples (and the failure manifest when its
+signature names ``manifest``) and returns the prompts to promote; without it
+every failing trace's user prompt is promoted. Reef still dedupes, screens,
+and caps whatever it returns. ``batch_size``
 and ``max_score`` live under ``data:`` in the recipe config, and
 ``data.batch_policy: records`` drops the report requirement entirely:
 recorded traffic alone batches, unscored, for methods that judge for

--- a/reef/harness/nodes.py
+++ b/reef/harness/nodes.py
@@ -118,6 +118,11 @@ def config_node(ctx: Any, config: Any) -> None:
     _reject_inline_secret(data, "data")
 
 
+def secret_shaped(text: str) -> bool:
+    """Whether free text carries a credential-shaped literal; shared by the tree boundary and the task ledger."""
+    return _SECRET_TEXT.search(text) is not None
+
+
 def _reject_secret_shaped_text(text: str, where: str) -> None:
     """Refuse a node body carrying a credential-shaped literal.
 
@@ -126,7 +131,7 @@ def _reject_secret_shaped_text(text: str, where: str) -> None:
     command, or extension would outlive rotation in every commit record and
     published artifact. The message names the field, never the value.
     """
-    if _SECRET_TEXT.search(text):
+    if secret_shaped(text):
         raise ValueError(
             f"{where} carries an inline credential; the composition tree never holds secrets: "
             "set reef.upstream_api_key for the served model or "

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -34,16 +34,23 @@ from reef.harness.descriptor import AdapterDescriptor
 from reef.harness.episode import EpisodeError, run_episode
 from reef.harness.executor import EpisodeExecutor, LocalExecutor
 from reef.harness.model_binding import ModelBinding, ModelBindings
-from reef.harness.nodes import NODE_KINDS
+from reef.harness.nodes import NODE_KINDS, secret_shaped
 from reef.harness.render import RenderError, render_composition
 from reef.harness.trajectory import TrajectoryError
 from reef.train.backend import PreparedStep, TrainingBackend
 from reef.train.cordis_backend.manifest import FailureManifest, FailureObservation
 from reef.train.cordis_backend.manifest import FailureRecord as FailureRecord  # re-export: manifest entry type
 from reef.train.cordis_backend.manifest import advance
-from reef.train.cordis_backend.strategies import EpisodeScorer, Mutation, MutationError, Proposer, accepts_manifest
+from reef.train.cordis_backend.strategies import (
+    EpisodeScorer,
+    Mutation,
+    MutationError,
+    Promoter,
+    Proposer,
+    accepts_manifest,
+)
 from reef.train.evaluation.contracts import CandidateSelector, EvaluationResult, SelectionDecision, UpdateCandidate
-from reef.train.types import TraceBatch, TrainingBatch, TrainStepResult
+from reef.train.types import TraceBatch, TraceSample, TrainingBatch, TrainStepResult
 
 from .compose import Context, FiberState
 from .compose.loader import EntryOptions, Loader
@@ -58,9 +65,51 @@ class HarnessCandidate(UpdateCandidate):
     candidate_entries: tuple[Mapping[str, Any], ...]
     current_entries: tuple[Mapping[str, Any], ...]
     mutations: tuple[Mutation, ...]
+    #: Seed tasks, then promoted traffic prompts; the seed set when promotion is off.
+    gate_tasks: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         super().__post_init__()
+
+
+def _prompt_of(sample: TraceSample) -> str | None:
+    """The trace's last user message, the prompt ``evaluate`` scores; ``None`` for a tool-only turn."""
+    messages = sample.payload.get("messages") if isinstance(sample.payload, Mapping) else None
+    if not isinstance(messages, Sequence):
+        return None
+    for message in reversed(list(messages)):
+        if not isinstance(message, Mapping) or message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+        if isinstance(content, Sequence) and not isinstance(content, str):
+            text = "".join(
+                part.get("text", "") for part in content if isinstance(part, Mapping) and part.get("type") == "text"
+            )
+            if text.strip():
+                return text
+    return None
+
+
+def _default_promote(samples: Sequence[TraceSample]) -> list[str]:
+    """The default policy: every trace's user prompt is a candidate task."""
+    prompts = (_prompt_of(sample) for sample in samples)
+    return [prompt for prompt in prompts if prompt is not None]
+
+
+def _admit_promoted(existing: Sequence[str], candidates: Sequence[str], seed: frozenset[str], cap: int) -> list[str]:
+    """Append new candidate prompts under the cap; a secret-shaped or malformed prompt is skipped, never failed."""
+    promoted = list(existing)
+    seen = set(seed) | set(promoted)
+    for prompt in candidates:
+        if len(promoted) >= cap:
+            break
+        if not isinstance(prompt, str) or not prompt.strip() or prompt in seen or secret_shaped(prompt):
+            continue
+        promoted.append(prompt)
+        seen.add(prompt)
+    return promoted
 
 
 class _BudgetedBinding(ModelBinding):
@@ -194,6 +243,9 @@ class CordisBackend(TrainingBackend):
         max_failure_streak: int = 0,
         max_model_calls_per_step: int = 0,
         executor: EpisodeExecutor | None = None,
+        promote_failures: bool = False,
+        max_promoted_tasks: int = 50,
+        promote: Promoter | None = None,
         seed: tuple[Mapping[str, Any], ...] = (),
     ) -> None:
         if not tasks:
@@ -243,6 +295,12 @@ class CordisBackend(TrainingBackend):
         # Preflighted at build (recipe.build), so a hosted deployment that
         # requires the sandbox fails to start, not at the first episode.
         self._executor = executor or LocalExecutor()
+        if max_promoted_tasks < 0:
+            raise ValueError("max_promoted_tasks must be at least 0")
+        self._promote_failures = promote_failures
+        self._max_promoted_tasks = max_promoted_tasks
+        self._promote_task = promote
+        self._promote_accepts_manifest = promote is not None and accepts_manifest(promote.__call__)
         self._seed = tuple(dict(entry) for entry in seed)
         self._validate_seed()
 
@@ -302,7 +360,11 @@ class CordisBackend(TrainingBackend):
         # can return; the key is written only when present, so its absence
         # stays "unknown", never an empty manifest (the consumed_ids rule).
         previous_manifest = state.get("failure_manifest")
-        carried = {} if previous_manifest is None else {"failure_manifest": previous_manifest}
+        carried: dict[str, Any] = {} if previous_manifest is None else {"failure_manifest": previous_manifest}
+        # Carried through skips so a budget or streak skip keeps the grown suite.
+        promoted = list(state.get("promoted_tasks", ()))
+        if promoted:
+            carried["promoted_tasks"] = promoted
 
         metrics: dict[str, Any] = {"steps": steps, "traces": len(batch.samples)}
         # The budgets are circuit breakers, not schedulers: a skipped step
@@ -322,9 +384,24 @@ class CordisBackend(TrainingBackend):
                     "skipped": f"failure streak breaker open after {streak} consecutive rejections",
                 },
             )
+        manifest = None if previous_manifest is None else FailureManifest.from_state(previous_manifest)
+        # Failing traces become permanent gate tasks; off by default. The method picks which, Reef screens them.
+        if self._promote_failures:
+            if self._promote_task is None:
+                candidates: Sequence[str] = _default_promote(batch.samples)
+            elif self._promote_accepts_manifest:
+                candidates = self._promote_task(batch.samples, manifest=manifest)
+            else:
+                candidates = self._promote_task(batch.samples)
+            promoted = _admit_promoted(promoted, candidates, frozenset(self._tasks), self._max_promoted_tasks)
+            if promoted:
+                carried["promoted_tasks"] = promoted
+        gate_tasks = (*self._tasks, *(task for task in promoted if task not in frozenset(self._tasks)))
+        if self._promote_failures:
+            metrics["gate_tasks"] = len(gate_tasks)
+            metrics["promoted_tasks"] = len(gate_tasks) - len(self._tasks)
         models = _budgeted_bindings(self._models, self._max_model_calls_per_step)
         if self._propose_accepts_manifest:
-            manifest = None if previous_manifest is None else FailureManifest.from_state(previous_manifest)
             proposal = self._propose(self._nodes(), batch.samples, models, manifest=manifest)
         else:
             proposal = self._propose(self._nodes(), batch.samples, models)
@@ -370,6 +447,7 @@ class CordisBackend(TrainingBackend):
                 candidate_entries=tuple(dict(entry) for entry in self._entries()),
                 current_entries=snapshot,
                 mutations=mutations,
+                gate_tasks=gate_tasks,
             ),
             state={"steps": steps, **carried},
             metrics=metrics,
@@ -389,7 +467,9 @@ class CordisBackend(TrainingBackend):
         # vectors positionally, so every pairing tallies on its own.
         candidate_runs: list[tuple[float | None, FailureObservation | None, int]] = []
         current_runs: list[tuple[float | None, FailureObservation | None, int]] = []
-        for task in self._tasks:
+        # An older candidate carries no gate_tasks and falls back to the seed set.
+        gate_tasks = candidate.gate_tasks or self._tasks
+        for task in gate_tasks:
             for _ in range(self._episode_repeats):
                 candidate_runs.append(self._run_and_score(candidate_files, task))
                 current_runs.append(self._run_and_score(current_files, task))

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -30,9 +30,9 @@ from reef.recipe.errors import RecipeConfigError
 from reef.records import RecordStore
 from reef.surface.base import Surface
 from reef.surface.harnesses import create_harness_surface
-from reef.train.cordis_backend import CordisBackend, EpisodeScorer, Proposer, ScoreComparisonSelector
+from reef.train.cordis_backend import CordisBackend, EpisodeScorer, Promoter, Proposer, ScoreComparisonSelector
 from reef.train.cordis_backend.processor import CordisProcessor, RecordDrivenTraceProcessor
-from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
+from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_promoter, resolve_proposer
 from reef.train.evaluation.contracts import CandidateSelector
 from reef.train.evaluation.evaluators import AlwaysSelect, DefaultCandidateEvaluationPlugin
 from reef.train.trainer import Trainer
@@ -136,6 +136,9 @@ class CordisRecipe(Recipe):
     max_failure_streak: int = 0
     max_model_calls_per_step: int = 0
     executor: EpisodeExecutor = field(default_factory=lambda: build_executor(None))
+    promote_failures: bool = False
+    max_promoted_tasks: int = 50
+    promote: Promoter | None = None
     seed: tuple[Mapping[str, Any], ...] = ()
     model_name: str | None = None
     models: Mapping[str, ModelBinding] = field(default_factory=dict)
@@ -204,6 +207,12 @@ class CordisRecipe(Recipe):
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise RecipeConfigError(f"evolution.{label} must be an integer of at least 0 (0 disables the limit)")
             budgets[label] = value
+        promote_failures = evolution.get("promote_failures", False)
+        if not isinstance(promote_failures, bool):
+            raise RecipeConfigError("evolution.promote_failures must be a boolean")
+        max_promoted_tasks = evolution.get("max_promoted_tasks", 50)
+        if isinstance(max_promoted_tasks, bool) or not isinstance(max_promoted_tasks, int) or max_promoted_tasks < 0:
+            raise RecipeConfigError("evolution.max_promoted_tasks must be an integer of at least 0")
         seed = evolution.get("seed")
         if seed is None:
             seed = ()
@@ -243,6 +252,7 @@ class CordisRecipe(Recipe):
             raise RecipeConfigError("evolution.models may not name a model 'served'; that is the model under test")
         return {
             "propose": resolve_proposer(evolution.get("propose")),
+            "promote": resolve_promoter(evolution["promote"]) if "promote" in evolution else None,
             "score_episode": resolve_episode_scorer(evolution.get("evaluate")),
             "tasks": tuple(str(task) for task in tasks),
             "adapter": adapter,
@@ -252,6 +262,8 @@ class CordisRecipe(Recipe):
             "forbid_residue": forbid_residue,
             **budgets,
             "executor": executor,
+            "promote_failures": promote_failures,
+            "max_promoted_tasks": max_promoted_tasks,
             "seed": tuple(seed),
             "model_name": model_name if isinstance(model_name, str) and model_name else None,
             "models": models,
@@ -298,6 +310,9 @@ class CordisRecipe(Recipe):
             max_steps=self.max_steps,
             max_failure_streak=self.max_failure_streak,
             max_model_calls_per_step=self.max_model_calls_per_step,
+            promote_failures=self.promote_failures,
+            max_promoted_tasks=self.max_promoted_tasks,
+            promote=self.promote,
             seed=self.seed,
         )
         return Trainer.build(

--- a/reef/train/cordis_backend/strategies.py
+++ b/reef/train/cordis_backend/strategies.py
@@ -12,7 +12,7 @@ import inspect
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 from reef.core.errors import ReefError
 from reef.harness.episode import EpisodeResult
@@ -200,3 +200,66 @@ def resolve_episode_scorer(value: object) -> EpisodeScorer:
     raise ValueError(
         "evaluate must be an EpisodeScorer instance, a callable, or a dotted 'module:attribute' reference"
     )
+
+
+class Promoter(ABC):
+    """Base class for choosing which trace prompts become permanent gate tasks.
+
+    Implement ``__call__``: given the step's trace samples, return the prompts
+    to promote. Reef still dedupes, screens for credentials, and caps them.
+    ``manifest`` is forwarded only to a signature that names it.
+    """
+
+    @abstractmethod
+    def __call__(
+        self,
+        samples: tuple[TraceSample, ...],
+        *,
+        manifest: FailureManifest | None = None,
+    ) -> Sequence[str]:
+        """Return the prompts this step should promote into the gate."""
+
+
+class PromotePolicy(Protocol):
+    """A plain promote callable, ``(samples, *, manifest=None) -> Sequence[str]``, the keyword optional."""
+
+    def __call__(self, samples: tuple[TraceSample, ...], /, **kwargs: Any) -> Sequence[str]: ...
+
+
+class _CallablePromoter(Promoter):
+    """Adapter wrapping a plain callable as a :class:`Promoter` instance."""
+
+    def __init__(self, policy: PromotePolicy) -> None:
+        self._policy = policy
+        self._forward_manifest = accepts_manifest(policy)
+
+    def __call__(
+        self,
+        samples: tuple[TraceSample, ...],
+        *,
+        manifest: FailureManifest | None = None,
+    ) -> Sequence[str]:
+        if self._forward_manifest:
+            return self._policy(samples, manifest=manifest)
+        return self._policy(samples)
+
+
+def resolve_promoter(value: object) -> Promoter:
+    """Resolve a callable or dotted reference into a :class:`Promoter` instance."""
+    if isinstance(value, Promoter):
+        return value
+    if callable(value):
+        return _CallablePromoter(value)
+    if isinstance(value, str) and ":" in value:
+        import importlib
+
+        module_name, _, attribute = value.partition(":")
+        try:
+            resolved = getattr(importlib.import_module(module_name), attribute)
+        except (ImportError, AttributeError) as exc:
+            raise ValueError(f"cannot import promoter {value!r}: {exc}") from exc
+        if isinstance(resolved, Promoter):
+            return resolved
+        if callable(resolved):
+            return _CallablePromoter(resolved)
+    raise ValueError("promote must be a Promoter instance, a callable, or a dotted 'module:attribute' reference")

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -22,8 +22,16 @@ from reef.recipe import RecipeConfigError
 from reef.recipe.registry import recipe_class_for
 from reef.records import RecordStore
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
-from reef.train.cordis_backend import CordisBackend, CordisRecipe, Mutation, MutationError, ScoreComparisonSelector
-from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
+from reef.train.cordis_backend import (
+    CordisBackend,
+    CordisRecipe,
+    FailureManifest,
+    Mutation,
+    MutationError,
+    Promoter,
+    ScoreComparisonSelector,
+)
+from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_promoter, resolve_proposer
 from reef.train.evaluation import DefaultCandidateEvaluationPlugin
 from reef.train.trainer import Trainer
 from reef.train.types import NoArtifactPublication, SavedArtifactPublication, TraceBatch, TraceSample, TrainStepResult
@@ -1177,3 +1185,213 @@ def test_recipe_selects_the_episode_executor(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: None)
     with pytest.raises(RecipeConfigError, match="bubblewrap"):
         CordisRecipe.from_environment({}, config=config(executor="sandbox"))
+
+
+def _traced_batch(*prompts: str) -> TraceBatch:
+    samples = tuple(
+        TraceSample(f"a{i}", {"messages": [{"role": "user", "content": p}]}, 0.0) for i, p in enumerate(prompts)
+    )
+    return TraceBatch("demo:trace:promote", samples)
+
+
+def test_promote_failures_grows_the_gate_from_traffic(tmp_path: Path) -> None:
+    """With promotion on, a failing trace's prompt becomes a permanent gate
+    task: the seed set is the floor, and evaluate runs the union."""
+    seen: list[str] = []
+
+    def score(task, result):
+        seen.append(task)
+        return evaluate(task, result)
+
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(score),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        promote_failures=True,
+    )
+    result = run_backend_step(b, _traced_batch("real request A"), b.initial_state())
+    # The gate ran the seed task and the promoted prompt, on both sides.
+    assert "task one" in seen and "real request A" in seen
+    assert result.metrics["gate_tasks"] == 2
+    assert result.metrics["promoted_tasks"] == 1
+    # The ledger persists in the committed state.
+    assert result.state["promoted_tasks"] == ["real request A"]
+
+
+def test_promoted_tasks_are_deduped_capped_and_persist(tmp_path: Path) -> None:
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        promote_failures=True,
+        max_promoted_tasks=2,
+    )
+    first = run_backend_step(b, _traced_batch("A", "B", "C"), b.initial_state())
+    # Cap of 2 admits only the first two distinct prompts.
+    assert first.state["promoted_tasks"] == ["A", "B"]
+    # A later batch dedupes against the ledger and the seed; nothing new fits.
+    second = run_backend_step(b, _traced_batch("A", "task one", "B"), first.state)
+    assert second.state["promoted_tasks"] == ["A", "B"]
+
+
+def test_secret_shaped_prompts_are_never_promoted(tmp_path: Path) -> None:
+    """A traffic prompt meets the tree's credential tripwire before it can
+    become a persisted, re-run gate task; the clean prompt beside it still
+    promotes and the step does not fail."""
+    key = "sk-476-PROMOTED-KEY-0123456789abcdef"
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        promote_failures=True,
+    )
+    result = run_backend_step(b, _traced_batch(f"use {key} to call the api", "clean request"), b.initial_state())
+    assert result.state["promoted_tasks"] == ["clean request"]
+    assert key not in json.dumps(result.state)
+
+
+def test_promotion_off_by_default_leaves_the_gate_frozen(tmp_path: Path) -> None:
+    seen: list[str] = []
+
+    def score(task, result):
+        seen.append(task)
+        return evaluate(task, result)
+
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(score),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+    )
+    result = run_backend_step(b, _traced_batch("real request A"), b.initial_state())
+    assert set(seen) == {"task one"}
+    assert "promoted_tasks" not in result.state
+    assert "gate_tasks" not in result.metrics
+
+
+def test_recipe_parses_promotion_config(tmp_path: Path, monkeypatch) -> None:
+    module = tmp_path / "demo_promote.py"
+    module.write_text(
+        "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def config(**evolution):
+        return {
+            "evolution": {
+                "propose": "demo_promote:propose",
+                "evaluate": "demo_promote:evaluate",
+                "tasks": ["t"],
+                "binary": str(make_binary(tmp_path)),
+                **evolution,
+            }
+        }
+
+    on = CordisRecipe.from_environment({}, config=config(promote_failures=True, max_promoted_tasks=10))
+    assert on.promote_failures is True and on.max_promoted_tasks == 10
+    off = CordisRecipe.from_environment({}, config=config())
+    assert off.promote_failures is False and off.max_promoted_tasks == 50
+    with pytest.raises(RecipeConfigError, match="promote_failures must be a boolean"):
+        CordisRecipe.from_environment({}, config=config(promote_failures="yes"))
+    with pytest.raises(RecipeConfigError, match="max_promoted_tasks must be an integer"):
+        CordisRecipe.from_environment({}, config=config(max_promoted_tasks=-1))
+
+
+def test_promote_callback_picks_the_candidates_and_reef_screens_them(tmp_path: Path) -> None:
+    """The method decides which prompts to promote; Reef still dedupes, drops
+    a secret-shaped one, and applies the cap to what it returns."""
+    key = "sk-476-POLICY-KEY-0123456789abcdef"
+
+    def keep_marked(samples):
+        return [
+            prompt
+            for prompt in (reef_cordis_backend._prompt_of(sample) for sample in samples)
+            if prompt and "keep" in prompt
+        ]
+
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        promote_failures=True,
+        promote=resolve_promoter(keep_marked),
+        max_promoted_tasks=2,
+    )
+    first = run_backend_step(
+        b, _traced_batch("keep A", "drop B", f"keep {key}", "keep C", "keep D"), b.initial_state()
+    )
+    assert first.state["promoted_tasks"] == ["keep A", "keep C"]
+    assert key not in json.dumps(first.state)
+
+
+def test_promote_callback_receives_the_manifest_when_it_names_it(tmp_path: Path) -> None:
+    seen: list[object] = []
+
+    def with_manifest(samples, *, manifest=None):
+        seen.append(manifest)
+        return []
+
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        promote_failures=True,
+        promote=resolve_promoter(with_manifest),
+    )
+    first = run_backend_step(b, _traced_batch("A"), b.initial_state())
+    run_backend_step(b, _traced_batch("B"), first.state)
+    assert seen[0] is None and isinstance(seen[1], FailureManifest)
+    assert "promoted_tasks" not in first.state
+
+
+def test_recipe_resolves_promote_by_dotted_reference(tmp_path: Path, monkeypatch) -> None:
+    module = tmp_path / "demo_promote_policy.py"
+    module.write_text(
+        "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n\n"
+        "def promote(samples):\n    return []\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def config(**evolution):
+        return {
+            "evolution": {
+                "propose": "demo_promote_policy:propose",
+                "evaluate": "demo_promote_policy:evaluate",
+                "tasks": ["t"],
+                "binary": str(make_binary(tmp_path)),
+                **evolution,
+            }
+        }
+
+    on = CordisRecipe.from_environment({}, config=config(promote_failures=True, promote="demo_promote_policy:promote"))
+    assert isinstance(on.promote, Promoter) and on.promote(()) == []
+    assert CordisRecipe.from_environment({}, config=config()).promote is None


### PR DESCRIPTION
## Motivation

The evolution gate judges every step against the same hand-written task list frozen at recipe boot, so successive mutations overfit to that probe set, and failures observed in real traffic are fingerprinted for the proposer but never become part of the judgment. This is the first half of #132: the gate task set grows from experience, with the seed tasks as the floor rather than the whole suite. The second half, post-publish evaluation with health-based auto-rollback, is #157.

The feature splits into two layers. The mechanism is infrastructure: where the promoted tasks live, the cap, the credential screen at admission, and the gate running the seed tasks plus the promoted ones. Which traces deserve to become tasks is policy, and that belongs to the method, so it is an optional callable beside propose and evaluate with today's behavior as the default.

## Changes

- evolution.promote_failures (default false): a failing trace's prompt is admitted to an append-only, per-scenario task ledger, so no later candidate can win while reintroducing the failure; the seed tasks stay the floor
- evolution.max_promoted_tasks (default 50): admission stops at the cap so the suite is bounded
- The ledger lives in the scenario's algorithm state, so it persists and is replayed across restarts like the failure manifest; a budget or streak skip keeps the suite earlier steps grew
- evolution.promote: an optional third method callable, resolved like propose and evaluate (a callable or a dotted module:attribute reference). It receives the step's trace samples, plus the failure manifest when its signature names manifest, and returns the prompts to promote. Without it the default policy promotes every failing trace's last user message
- Whatever the policy returns still passes the infrastructure gates: dedupe against the seed set and the ledger, the cap, and the tree's own credential tripwire, so a key-shaped or malformed prompt is skipped, never persisted, never re-run as a task, and never fails the step
- The candidate carries the effective gate task set (seed plus promoted) and evaluate runs the union; a step reports gate_tasks and promoted_tasks counts when promotion is on
- A method that turns promotion on must have an evaluate that scores an arbitrary prompt, since a promoted real-traffic task has no pre-registered answer; documented in the lane guide and the method guide

## Compatibility and operational impact

None by default: promote_failures is off, gate_tasks defaults to the seed set, an older candidate that carries no gate_tasks falls back to the seed set, and a recipe without evolution.promote gets the default policy, so every existing method and recipe is unchanged.

## Verification

On the current commit the harness recipe and failure manifest suites pass (85 tests) on Python 3.12. New tests cover a failing trace growing the gate (the seed task and the promoted prompt both run, the ledger persists in committed state), dedupe against the seed and the ledger with the cap enforced across two batches, a secret-shaped traffic prompt never entering the ledger or the committed state while the clean prompt beside it still promotes, a custom promote policy choosing only some prompts while the cap and the credential screen still apply to its output, a policy whose signature names manifest receiving it, a dotted reference resolving to a Promoter, promotion off leaving the gate frozen and the state clean, and the recipe parsing and validating the keys. ruff, ruff format, isort, mypy, and the repository statement and design policy checks are clean on the changed files.

## AI assistance

Claude Code designed the promotion ledger and the policy split and wrote the tests. I set the scope in #132 and the split came out of review discussion.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
