### PR TITLE
fix: keep fact-table label columns on one line on phones

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -466,6 +466,12 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .markdown-body h1 { font-size: 31px; }
   .markdown-body td { overflow-wrap: anywhere; }
   .markdown-body th { overflow-wrap: normal; }
+  /* Two-column fact tables (label | value): keep the label column on one line
+     so a phone's auto layout cannot squeeze "Loss family" into a sliver and
+     stack it vertically. Three-column tables (the two-axis recipe grid) are
+     excluded so their wider first column still wraps. */
+  .markdown-body table:not(:has(td:nth-child(3))) td:first-child,
+  .markdown-body table:not(:has(td:nth-child(3))) th:first-child { white-space: nowrap; }
   .markdown-body .page-brief { margin-top: -8px; grid-template-columns: 1fr; gap: 2px 0; }
   .markdown-body .page-brief dd { margin-bottom: 8px; }
   .markdown-body .page-brief dd:last-child { margin-bottom: 0; }


### PR DESCRIPTION
## Motivation

On a phone the two-column fact tables (the recipe pages' Evolves / Signal / Loss family / Processor grid) squeezed the label column to ~53px, so "Loss family" and "Processor" stacked vertically into a sliver while the value column took the rest. Auto table layout allocates by content ratio and starved the short-label column.

## Changes

- On phones, the first column of two-column tables keeps its label on one line, so the column sizes to the label instead of collapsing. Three-column tables (the two-axis recipe grid) are excluded with :not(:has(td:nth-child(3))) so their wider first column still wraps

## Compatibility and operational impact

None. Phone-only presentation; wide screens and three-column tables are untouched.

## Verification

Built and measured on a 390px viewport: the skillclaw fact table's label column went from 53px to 97px with every label on one line, and the three-column two-axis recipe table keeps white-space normal with no page overflow. A screenshot confirms the labels no longer stack.

## AI assistance

Claude Code diagnosed the column ratio and wrote the fix.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
