### PR TITLE
feat: recheck published trees and roll back a regressed publish

### DIFF
--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -27,7 +27,12 @@ binding returns the assistant text. ``propose`` returns one ``Mutation``
 (``create``, ``update``, or
 ``remove`` on one root-level entry), a sequence applied as one composite
 proposal under one verdict, or ``None`` to skip. An optional keyword-only
-``manifest`` argument receives the previous step's ``FailureManifest``.
+``manifest`` argument receives the previous step's ``FailureManifest``, and an
+optional keyword-only ``rejected`` argument receives the recent rejected
+proposals, oldest first, each a mapping of ``step``, ``mutations`` (``op`` and
+``id`` pairs), and the verdict's ``reason``; a method uses it to stop
+re-proposing what the gate already refused. Reef passes each keyword only to
+a signature that names it.
 
 ``evaluate`` grades one finished episode. Reef calls it for both sides of every
 pair. ``result`` carries the exit code, stdout, stderr, and the parsed ``trajectory``. Episodes
@@ -40,7 +45,8 @@ permanent tasks. Reef dedupes, screens for credentials, and caps what it
 returns. Without it every failing trace's user prompt is promoted.
 
 ``selection`` defaults to ``score_comparison``: select when the candidate wins
-more task comparisons than it loses. ``always`` selects every applied mutation.
+more task comparisons than it loses, by more than ``evolution.min_win_margin``
+when that is set. ``always`` selects every applied mutation.
 
 .. warning::
 

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -90,6 +90,19 @@ and ``max_score`` live under ``data:`` in the recipe config, and
 recorded traffic alone batches, unscored, for methods that judge for
 themselves.
 
+A publish passes the gate as the suite stood at the time, so a suite that
+keeps growing can later expose a published tree as a regression on a task the
+gate had not seen yet. ``evolution.recheck_every: N`` (0, off, by default)
+closes that gap: every ``N`` steps, and at once when the served model or the
+adapter version has changed since the publish, the loop re-gates the last
+published tree against the tree it replaced on the current suite instead of
+proposing. If
+the older tree now wins, the loop publishes it, which rolls the deployment
+back; if the published tree still wins, nothing changes. Only the tree from
+the most recent publish is kept as a rollback target, and a rollback consumes
+it, so the recheck reverts one bad publish rather than walking the whole
+history back.
+
 Most of a step's cost is the evaluation. Every task runs on both trees,
 ``episode_repeats`` times each (once by default), which makes
 ``2 x len(tasks) x episode_repeats`` headless episodes, interleaved so both

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -103,6 +103,15 @@ the most recent publish is kept as a rollback target, and a rollback consumes
 it, so the recheck reverts one bad publish rather than walking the whole
 history back.
 
+Two more settings shape the search itself. ``evolution.min_win_margin: M``
+(0 by default) is a noise floor on the verdict: the candidate must win more
+than ``M`` task pairings beyond its losses, so on a stochastic episode a
+single lucky flip does not publish. ``evolution.max_rejected_history: N``
+(25 by default, 0 off) keeps the last ``N`` rejected proposals in the
+scenario state, each with its step, its mutations, and the verdict's reason;
+a ``propose`` whose signature names ``rejected`` receives them and can stop
+re-proposing what the gate already refused.
+
 Most of a step's cost is the evaluation. Every task runs on both trees,
 ``episode_repeats`` times each (once by default), which makes
 ``2 x len(tasks) x episode_repeats`` headless episodes, interleaved so both

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -47,6 +47,7 @@ from reef.train.cordis_backend.strategies import (
     MutationError,
     Promoter,
     Proposer,
+    accepts_keyword,
     accepts_manifest,
 )
 from reef.train.evaluation.contracts import CandidateSelector, EvaluationResult, SelectionDecision, UpdateCandidate
@@ -168,13 +169,21 @@ def _budgeted_bindings(models: ModelBindings, cap: int) -> ModelBindings:
 
 
 class ScoreComparisonSelector(CandidateSelector):
-    """Select a candidate when it wins more task comparisons than it loses."""
+    """Select a candidate when its wins exceed its losses by more than ``min_win_margin`` (0: plain majority)."""
+
+    def __init__(self, min_win_margin: int = 0) -> None:
+        if isinstance(min_win_margin, bool) or not isinstance(min_win_margin, int) or min_win_margin < 0:
+            raise ValueError("min_win_margin must be an integer of at least 0")
+        self._min_win_margin = min_win_margin
 
     def decide(self, candidate: UpdateCandidate, evaluation: EvaluationResult) -> SelectionDecision:
         candidate_scores, current_scores = _score_vectors(evaluation)
         wins, losses = _score_comparison_tally(candidate_scores, current_scores)
         ties = len(candidate_scores) - wins - losses
-        selected = wins > losses
+        selected = wins - losses > self._min_win_margin
+        metrics: dict[str, Any] = {"wins": wins, "losses": losses, "ties": ties}
+        if self._min_win_margin:
+            metrics["min_win_margin"] = self._min_win_margin
         return SelectionDecision(
             outcome="select" if selected else "reject",
             policy="score_comparison",
@@ -185,7 +194,7 @@ class ScoreComparisonSelector(CandidateSelector):
                 else f"candidate did not exceed its {losses} losses with {wins} wins"
             ),
             evaluation=evaluation,
-            metrics={"wins": wins, "losses": losses, "ties": ties},
+            metrics=metrics,
         )
 
 
@@ -249,6 +258,7 @@ class CordisBackend(TrainingBackend):
         max_promoted_tasks: int = 50,
         promote: Promoter | None = None,
         recheck_every: int = 0,
+        max_rejected_history: int = 25,
         seed: tuple[Mapping[str, Any], ...] = (),
     ) -> None:
         if not tasks:
@@ -271,6 +281,7 @@ class CordisBackend(TrainingBackend):
         # Checked once at boot: an out-of-tree Proposer subclass whose
         # ``__call__`` predates the manifest keyword is called without it.
         self._propose_accepts_manifest = accepts_manifest(propose.__call__)
+        self._propose_accepts_rejected = accepts_keyword(propose.__call__, "rejected")
         if (
             isinstance(episode_timeout_s, bool)
             or not isinstance(episode_timeout_s, (int, float))
@@ -286,6 +297,7 @@ class CordisBackend(TrainingBackend):
             ("max_failure_streak", max_failure_streak),
             ("max_model_calls_per_step", max_model_calls_per_step),
             ("recheck_every", recheck_every),
+            ("max_rejected_history", max_rejected_history),
         ):
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise ValueError(f"{label} must be an integer of at least 0 (0 disables the limit)")
@@ -306,6 +318,7 @@ class CordisBackend(TrainingBackend):
         self._promote_task = promote
         self._promote_accepts_manifest = promote is not None and accepts_manifest(promote.__call__)
         self._recheck_every = recheck_every
+        self._max_rejected_history = max_rejected_history
         self._seed = tuple(dict(entry) for entry in seed)
         self._validate_seed()
 
@@ -376,6 +389,9 @@ class CordisBackend(TrainingBackend):
         if rollback_entries is not None:
             carried["rollback_entries"] = rollback_entries
             carried["rollback_gated_against"] = rollback_gated_against
+        rejected = list(state.get("rejected_proposals", ()))
+        if rejected:
+            carried["rejected_proposals"] = rejected
 
         metrics: dict[str, Any] = {"steps": steps, "traces": len(batch.samples)}
         # The budgets are circuit breakers, not schedulers: a skipped step
@@ -434,10 +450,12 @@ class CordisBackend(TrainingBackend):
                 metrics=metrics,
             )
         models = _budgeted_bindings(self._models, self._max_model_calls_per_step)
+        extra: dict[str, Any] = {}
         if self._propose_accepts_manifest:
-            proposal = self._propose(self._nodes(), batch.samples, models, manifest=manifest)
-        else:
-            proposal = self._propose(self._nodes(), batch.samples, models)
+            extra["manifest"] = manifest
+        if self._propose_accepts_rejected:
+            extra["rejected"] = tuple(rejected)
+        proposal = self._propose(self._nodes(), batch.samples, models, **extra)
         mutations = (proposal,) if isinstance(proposal, Mutation) else tuple(proposal or ())
         if not mutations:
             return PreparedStep.skipped(
@@ -584,6 +602,17 @@ class CordisBackend(TrainingBackend):
         if rollback_entries is not None:
             state["rollback_entries"] = rollback_entries
             state["rollback_gated_against"] = rollback_gated_against
+        # A real rejection joins a bounded ledger the proposer can read back.
+        if not candidate.recheck and not decision.selected and self._max_rejected_history:
+            rejected = list(prepared.state.get("rejected_proposals", ()))
+            rejected.append(
+                {
+                    "step": int(prepared.state["steps"]),
+                    "mutations": [{"op": mutation.op, "id": mutation.id} for mutation in candidate.mutations],
+                    "reason": decision.reason,
+                }
+            )
+            state["rejected_proposals"] = rejected[-self._max_rejected_history :]
 
         metrics.update(
             {

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -67,6 +67,8 @@ class HarnessCandidate(UpdateCandidate):
     mutations: tuple[Mutation, ...]
     #: Seed tasks, then promoted traffic prompts; the seed set when promotion is off.
     gate_tasks: tuple[str, ...] = ()
+    #: The candidate is the rollback target, so selecting it rolls back.
+    recheck: bool = False
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -246,6 +248,7 @@ class CordisBackend(TrainingBackend):
         promote_failures: bool = False,
         max_promoted_tasks: int = 50,
         promote: Promoter | None = None,
+        recheck_every: int = 0,
         seed: tuple[Mapping[str, Any], ...] = (),
     ) -> None:
         if not tasks:
@@ -282,6 +285,7 @@ class CordisBackend(TrainingBackend):
             ("max_steps", max_steps),
             ("max_failure_streak", max_failure_streak),
             ("max_model_calls_per_step", max_model_calls_per_step),
+            ("recheck_every", recheck_every),
         ):
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise ValueError(f"{label} must be an integer of at least 0 (0 disables the limit)")
@@ -301,6 +305,7 @@ class CordisBackend(TrainingBackend):
         self._max_promoted_tasks = max_promoted_tasks
         self._promote_task = promote
         self._promote_accepts_manifest = promote is not None and accepts_manifest(promote.__call__)
+        self._recheck_every = recheck_every
         self._seed = tuple(dict(entry) for entry in seed)
         self._validate_seed()
 
@@ -365,6 +370,12 @@ class CordisBackend(TrainingBackend):
         promoted = list(state.get("promoted_tasks", ()))
         if promoted:
             carried["promoted_tasks"] = promoted
+        # Carried through skips so a no-commit step keeps the rollback target.
+        rollback_entries = state.get("rollback_entries")
+        rollback_gated_against = state.get("rollback_gated_against")
+        if rollback_entries is not None:
+            carried["rollback_entries"] = rollback_entries
+            carried["rollback_gated_against"] = rollback_gated_against
 
         metrics: dict[str, Any] = {"steps": steps, "traces": len(batch.samples)}
         # The budgets are circuit breakers, not schedulers: a skipped step
@@ -400,6 +411,28 @@ class CordisBackend(TrainingBackend):
         if self._promote_failures:
             metrics["gate_tasks"] = len(gate_tasks)
             metrics["promoted_tasks"] = len(gate_tasks) - len(self._tasks)
+        # Re-gate the last-good tree against the published one on cadence or when the served model changed.
+        drifted = rollback_gated_against is not None and rollback_gated_against != self._gated_against()
+        due = bool(self._recheck_every) and steps % self._recheck_every == 0
+        if self._recheck_every and rollback_entries is not None and (due or drifted):
+            target = [dict(entry) for entry in rollback_entries]
+            published = [dict(entry) for entry in self._entries()]
+            metrics["recheck"] = True
+            metrics["recheck_reason"] = "drift" if drifted else "cadence"
+            return PreparedStep.with_candidate(
+                HarnessCandidate(
+                    candidate_id=f"{batch.batch_id}:recheck",
+                    candidate_files=render_composition(self._nodes_from(target), self._descriptor),
+                    current_files=render_composition(self._nodes_from(published), self._descriptor),
+                    candidate_entries=tuple(target),
+                    current_entries=tuple(published),
+                    mutations=(),
+                    gate_tasks=gate_tasks,
+                    recheck=True,
+                ),
+                state={"steps": steps, **carried},
+                metrics=metrics,
+            )
         models = _budgeted_bindings(self._models, self._max_model_calls_per_step)
         if self._propose_accepts_manifest:
             proposal = self._propose(self._nodes(), batch.samples, models, manifest=manifest)
@@ -527,13 +560,30 @@ class CordisBackend(TrainingBackend):
             "persisting": len(manifest.persisting),
             "fixed": len(manifest.fixed),
         }
-        streak = 0 if decision.selected else int(prepared.state.get("failure_streak", 0)) + 1
-        metrics["gated_against"] = {
-            "model": self._models.served.model,
-            "adapter": self._descriptor.name,
-            "adapter_version": self._descriptor.install.version if self._descriptor.install else None,
-        }
+        # A recheck is not a proposal, so it leaves the failure streak alone.
+        if candidate.recheck:
+            streak = int(prepared.state.get("failure_streak", 0))
+        else:
+            streak = 0 if decision.selected else int(prepared.state.get("failure_streak", 0)) + 1
+        metrics["gated_against"] = self._gated_against()
+        # A publish stores the replaced tree and its gate stamp as the rollback target; a rollback consumes it.
+        rollback_entries = prepared.state.get("rollback_entries")
+        rollback_gated_against = prepared.state.get("rollback_gated_against")
+        if candidate.recheck and decision.selected:
+            metrics["rolled_back"] = True
+            rollback_entries = None
+            rollback_gated_against = None
+        elif candidate.recheck:
+            metrics["rolled_back"] = False
+        elif decision.selected and self._recheck_every:
+            rollback_entries = list(candidate.current_entries)
+            rollback_gated_against = metrics["gated_against"]
         state = {**prepared.state, "failure_manifest": manifest.to_state(), "failure_streak": streak}
+        state.pop("rollback_entries", None)
+        state.pop("rollback_gated_against", None)
+        if rollback_entries is not None:
+            state["rollback_entries"] = rollback_entries
+            state["rollback_gated_against"] = rollback_gated_against
 
         metrics.update(
             {
@@ -614,6 +664,14 @@ class CordisBackend(TrainingBackend):
             cause = f"exit {result.exit_code}: {stderr_lines[-1] if stderr_lines else ''}".strip()
             return score, FailureObservation(task=task, stage="exit", cause=cause), residue
         return score, None, residue
+
+    def _gated_against(self) -> dict[str, Any]:
+        """The served model and adapter version this step's gate runs against."""
+        return {
+            "model": self._models.served.model,
+            "adapter": self._descriptor.name,
+            "adapter_version": self._descriptor.install.version if self._descriptor.install else None,
+        }
 
     def _render_for_episode(self, entries: Sequence[Mapping[str, Any]]) -> dict[str, str]:
         return render_composition((*self._nodes_from(entries), *self._binding_nodes), self._descriptor)

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -140,6 +140,8 @@ class CordisRecipe(Recipe):
     max_promoted_tasks: int = 50
     promote: Promoter | None = None
     recheck_every: int = 0
+    max_rejected_history: int = 25
+    min_win_margin: int = 0
     seed: tuple[Mapping[str, Any], ...] = ()
     model_name: str | None = None
     models: Mapping[str, ModelBinding] = field(default_factory=dict)
@@ -173,6 +175,8 @@ class CordisRecipe(Recipe):
             ("max_failure_streak", self.max_failure_streak),
             ("max_model_calls_per_step", self.max_model_calls_per_step),
             ("recheck_every", self.recheck_every),
+            ("max_rejected_history", self.max_rejected_history),
+            ("min_win_margin", self.min_win_margin),
         ):
             if value < 0:
                 raise ValueError(f"{label} must be at least 0 (0 disables the limit)")
@@ -203,9 +207,17 @@ class CordisRecipe(Recipe):
             executor = build_executor(evolution)
         except ReefError as exc:
             raise RecipeConfigError(str(exc)) from exc
+        budget_defaults = {
+            "max_steps": 0,
+            "max_failure_streak": 0,
+            "max_model_calls_per_step": 0,
+            "recheck_every": 0,
+            "max_rejected_history": 25,
+            "min_win_margin": 0,
+        }
         budgets: dict[str, int] = {}
-        for label in ("max_steps", "max_failure_streak", "max_model_calls_per_step", "recheck_every"):
-            value = evolution.get(label, 0)
+        for label, default in budget_defaults.items():
+            value = evolution.get(label, default)
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise RecipeConfigError(f"evolution.{label} must be an integer of at least 0 (0 disables the limit)")
             budgets[label] = value
@@ -225,7 +237,12 @@ class CordisRecipe(Recipe):
                 raise RecipeConfigError("evolution.seed entries must be entry option mappings")
         if "acceptance" in evolution:
             raise RecipeConfigError("evolution.acceptance was removed; configure evolution.selection")
-        candidate_selector = _resolve_candidate_selector(evolution.get("selection", "score_comparison"))
+        selection = evolution.get("selection", "score_comparison")
+        candidate_selector = _resolve_candidate_selector(selection)
+        if budgets["min_win_margin"]:
+            if selection != "score_comparison":
+                raise RecipeConfigError("evolution.min_win_margin applies only to the score_comparison selection")
+            candidate_selector = ScoreComparisonSelector(min_win_margin=budgets["min_win_margin"])
         adapter = str(evolution.get("adapter", "pi"))
         version_check = evolution.get("version_check", False)
         if not isinstance(version_check, bool):
@@ -316,6 +333,7 @@ class CordisRecipe(Recipe):
             max_promoted_tasks=self.max_promoted_tasks,
             promote=self.promote,
             recheck_every=self.recheck_every,
+            max_rejected_history=self.max_rejected_history,
             seed=self.seed,
         )
         return Trainer.build(

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -139,6 +139,7 @@ class CordisRecipe(Recipe):
     promote_failures: bool = False
     max_promoted_tasks: int = 50
     promote: Promoter | None = None
+    recheck_every: int = 0
     seed: tuple[Mapping[str, Any], ...] = ()
     model_name: str | None = None
     models: Mapping[str, ModelBinding] = field(default_factory=dict)
@@ -171,6 +172,7 @@ class CordisRecipe(Recipe):
             ("max_steps", self.max_steps),
             ("max_failure_streak", self.max_failure_streak),
             ("max_model_calls_per_step", self.max_model_calls_per_step),
+            ("recheck_every", self.recheck_every),
         ):
             if value < 0:
                 raise ValueError(f"{label} must be at least 0 (0 disables the limit)")
@@ -202,7 +204,7 @@ class CordisRecipe(Recipe):
         except ReefError as exc:
             raise RecipeConfigError(str(exc)) from exc
         budgets: dict[str, int] = {}
-        for label in ("max_steps", "max_failure_streak", "max_model_calls_per_step"):
+        for label in ("max_steps", "max_failure_streak", "max_model_calls_per_step", "recheck_every"):
             value = evolution.get(label, 0)
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise RecipeConfigError(f"evolution.{label} must be an integer of at least 0 (0 disables the limit)")
@@ -313,6 +315,7 @@ class CordisRecipe(Recipe):
             promote_failures=self.promote_failures,
             max_promoted_tasks=self.max_promoted_tasks,
             promote=self.promote,
+            recheck_every=self.recheck_every,
             seed=self.seed,
         )
         return Trainer.build(

--- a/reef/train/cordis_backend/strategies.py
+++ b/reef/train/cordis_backend/strategies.py
@@ -72,8 +72,11 @@ class Proposer(ABC):
 
     ``manifest`` is the previous step's
     :class:`~reef.train.cordis_backend.FailureManifest`, or ``None`` when
-    no step has settled one yet. The keyword is only forwarded to callables
-    whose signature names it, so pre-manifest proposers run unchanged.
+    no step has settled one yet. ``rejected`` is the recent rejected
+    proposals, oldest first, each a mapping of ``step``, ``mutations``
+    (``{"op", "id"}`` pairs) and the selector's ``reason``. Each keyword is
+    only forwarded to callables whose signature names it, so earlier
+    proposers run unchanged.
     """
 
     @abstractmethod
@@ -84,6 +87,7 @@ class Proposer(ABC):
         models: ModelBindings,
         *,
         manifest: FailureManifest | None = None,
+        rejected: Sequence[Mapping[str, Any]] = (),
     ) -> Mutation | Sequence[Mutation] | None:
         """Propose mutations for the current composition and trace batch."""
 
@@ -101,20 +105,18 @@ class EpisodeScorer(ABC):
         """Score one episode result for a task."""
 
 
-def accepts_manifest(fn: Callable[..., Any]) -> bool:
-    """Whether ``fn``'s signature names ``manifest`` or takes ``**kwargs``.
-
-    Signature inspection is the compatibility gate: the manifest keyword is
-    only ever passed to code that declared it, so every three-argument
-    proposer written before the manifest existed runs unchanged.
-    """
+def accepts_keyword(fn: Callable[..., Any], name: str) -> bool:
+    """Whether ``fn`` names ``name`` or takes ``**kwargs``; a keyword is only passed to code that declared it."""
     try:
         parameters = inspect.signature(fn).parameters.values()
     except (TypeError, ValueError):
         return False
-    return any(
-        parameter.name == "manifest" or parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
-    )
+    return any(parameter.name == name or parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters)
+
+
+def accepts_manifest(fn: Callable[..., Any]) -> bool:
+    """Whether ``fn`` declares the ``manifest`` keyword."""
+    return accepts_keyword(fn, "manifest")
 
 
 class _CallableProposer(Proposer):
@@ -126,6 +128,7 @@ class _CallableProposer(Proposer):
     ) -> None:
         self._fn = fn
         self._forward_manifest = accepts_manifest(fn)
+        self._forward_rejected = accepts_keyword(fn, "rejected")
 
     def __call__(
         self,
@@ -134,10 +137,14 @@ class _CallableProposer(Proposer):
         models: ModelBindings,
         *,
         manifest: FailureManifest | None = None,
+        rejected: Sequence[Mapping[str, Any]] = (),
     ) -> Mutation | Sequence[Mutation] | None:
+        extra: dict[str, Any] = {}
         if self._forward_manifest:
-            return self._fn(nodes, samples, models, manifest=manifest)
-        return self._fn(nodes, samples, models)
+            extra["manifest"] = manifest
+        if self._forward_rejected:
+            extra["rejected"] = rejected
+        return self._fn(nodes, samples, models, **extra)
 
 
 class _CallableEpisodeScorer(EpisodeScorer):

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -1395,3 +1395,155 @@ def test_recipe_resolves_promote_by_dotted_reference(tmp_path: Path, monkeypatch
     on = CordisRecipe.from_environment({}, config=config(promote_failures=True, promote="demo_promote_policy:promote"))
     assert isinstance(on.promote, Promoter) and on.promote(()) == []
     assert CordisRecipe.from_environment({}, config=config()).promote is None
+
+
+def test_recheck_stores_the_last_good_tree_on_publish(tmp_path: Path) -> None:
+    """A real publish records the tree it replaced as the rollback target, so
+    a later health recheck has somewhere to revert to."""
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        seed=(SEED_MODELS, SEED_SETTINGS),
+        recheck_every=5,
+    )
+    result = run_backend_step(b, batch(), b.initial_state())
+    assert result.metrics["selected"] is True
+    # The rollback target is the pre-publish tree: the seed, without the rules
+    # node this step added.
+    target_ids = {entry["id"] for entry in result.state["rollback_entries"]}
+    assert target_ids == {"models", "settings"}
+
+
+def test_healthy_recheck_keeps_the_published_tree(tmp_path: Path) -> None:
+    """When the published tree still wins on the suite, the recheck publishes
+    nothing and keeps the rollback target on file for next time."""
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        seed=(SEED_MODELS, SEED_SETTINGS),
+        recheck_every=1,
+    )
+    first = run_backend_step(b, batch(), b.initial_state())
+    assert first.metrics["selected"] is True
+    second = run_backend_step(b, batch(), first.state)
+    assert second.metrics["recheck"] is True
+    assert second.metrics["rolled_back"] is False
+    assert second.metrics["selected"] is False
+    # The marker tree is still live and the target is retained.
+    assert any(entry.get("id") == "r1" for entry in second.state["entries"])
+    assert {entry["id"] for entry in second.state["rollback_entries"]} == {"models", "settings"}
+
+
+def test_recheck_rolls_back_a_regression_the_grown_suite_reveals(tmp_path: Path) -> None:
+    """The publish passes the seed gate but the grown suite exposes it as a
+    regression: the recheck re-gates the last-good tree against the published
+    tree on the union and rolls back when the last-good tree wins."""
+
+    def split(task: str, result: EpisodeResult) -> float:
+        has_marker = "marker" in result.trajectory[-1]["rules"]
+        if task == "task one":
+            return 1.0 if has_marker else 0.0
+        return 0.0 if has_marker else 1.0
+
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(
+            lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}})
+        ),
+        score_episode=resolve_episode_scorer(split),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        seed=(SEED_MODELS, SEED_SETTINGS),
+        promote_failures=True,
+        recheck_every=2,
+    )
+    first = run_backend_step(b, batch(), b.initial_state())
+    assert first.metrics["selected"] is True
+    # Two prompts the marker tree fails join the gate, then the recheck fires.
+    second = run_backend_step(b, _traced_batch("probe alpha", "probe beta"), first.state)
+    assert second.metrics["recheck"] is True
+    assert second.metrics["rolled_back"] is True
+    assert second.metrics["selected"] is True
+    # Rolled back to the pre-publish tree: the rules node is gone.
+    live_ids = {entry["id"] for entry in second.state["entries"]}
+    assert "r1" not in live_ids and {"models", "settings"} <= live_ids
+    # The target is consumed once used.
+    assert "rollback_entries" not in second.state
+
+
+def test_recipe_parses_recheck_config(tmp_path: Path, monkeypatch) -> None:
+    module = tmp_path / "demo_recheck.py"
+    module.write_text(
+        "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def config(**evolution):
+        return {
+            "evolution": {
+                "propose": "demo_recheck:propose",
+                "evaluate": "demo_recheck:evaluate",
+                "tasks": ["t"],
+                "binary": str(make_binary(tmp_path)),
+                **evolution,
+            }
+        }
+
+    on = CordisRecipe.from_environment({}, config=config(recheck_every=5))
+    assert on.recheck_every == 5
+    off = CordisRecipe.from_environment({}, config=config())
+    assert off.recheck_every == 0
+    with pytest.raises(RecipeConfigError, match="recheck_every must be an integer"):
+        CordisRecipe.from_environment({}, config=config(recheck_every=-1))
+
+
+def test_recheck_fires_when_the_served_model_changes(tmp_path: Path) -> None:
+    """A publish is gated against one served model. When the deployment
+    serves a different one the recheck runs at once instead of waiting for
+    the cadence, so the harness is re-gated on the ground it now runs on."""
+    calls = {"n": 0}
+
+    def propose(n, s, m):
+        calls["n"] += 1
+        return Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}}) if calls["n"] == 1 else None
+
+    def build(model: ModelBinding) -> CordisBackend:
+        return CordisBackend(
+            descriptor=get_adapter("pi"),
+            propose=resolve_proposer(propose),
+            score_episode=resolve_episode_scorer(evaluate),
+            tasks=("task one",),
+            models=model,
+            binary=str(make_binary(tmp_path)),
+            seed=(SEED_MODELS, SEED_SETTINGS),
+            recheck_every=100,
+        )
+
+    b = build(MODEL)
+    first = run_backend_step(b, batch(), b.initial_state())
+    assert first.metrics["selected"] is True
+    assert first.state["rollback_gated_against"]["model"] == MODEL.model
+    # Same model, step 2 of a 100 step cadence: no recheck, and the stamp
+    # rides through the skipped step.
+    same = run_backend_step(b, batch(), first.state)
+    assert "recheck" not in same.metrics
+    assert same.state["rollback_gated_against"]["model"] == MODEL.model
+    # A different served model: the stamp differs, so the recheck fires now.
+    moved = ModelBinding(base_url=MODEL.base_url, model="qwen3-32b", api_key=MODEL.api_key)
+    drift = run_backend_step(build(moved), batch(), same.state)
+    assert drift.metrics["recheck"] is True
+    assert drift.metrics["recheck_reason"] == "drift"
+    assert drift.metrics["rolled_back"] is False

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -1547,3 +1547,80 @@ def test_recheck_fires_when_the_served_model_changes(tmp_path: Path) -> None:
     assert drift.metrics["recheck"] is True
     assert drift.metrics["recheck_reason"] == "drift"
     assert drift.metrics["rolled_back"] is False
+
+
+def test_min_win_margin_blocks_a_single_lucky_win(tmp_path: Path) -> None:
+    """One win and no losses clears the plain majority rule but not a margin of 1."""
+    b = backend(tmp_path, lambda n, s, m: Mutation("create", "r1", {"name": "rules", "config": {"text": "marker"}}))
+    prepared = b.prepare_step(batch(), b.initial_state(), 0)
+    candidate = prepared.candidate
+    assert candidate is not None
+    evaluator = DefaultCandidateEvaluationPlugin(b, ScoreComparisonSelector(min_win_margin=1))
+    decision = evaluator.decide(candidate, evaluator.evaluate(candidate))
+    result = b.settle_step(prepared, decision)
+    assert result.metrics["wins"] == 1 and result.metrics["losses"] == 0
+    assert result.metrics["selected"] is False
+    assert result.metrics["min_win_margin"] == 1
+    with pytest.raises(ValueError, match="min_win_margin must be an integer of at least 0"):
+        ScoreComparisonSelector(min_win_margin=-1)
+
+
+def test_rejected_proposals_reach_a_proposer_that_declares_the_keyword(tmp_path: Path) -> None:
+    """A rejection lands in a bounded ledger; the next step hands it to a
+    proposer whose signature names ``rejected``, and a three-argument
+    proposer keeps running without it."""
+    seen: list[tuple] = []
+
+    def propose(n, s, m, rejected=()):
+        seen.append(tuple(rejected))
+        return Mutation("create", f"r{len(seen)}", {"name": "rules", "config": {"text": "no signal here"}})
+
+    b = CordisBackend(
+        descriptor=get_adapter("pi"),
+        propose=resolve_proposer(propose),
+        score_episode=resolve_episode_scorer(evaluate),
+        tasks=("task one",),
+        models=MODEL,
+        binary=str(make_binary(tmp_path)),
+        max_rejected_history=1,
+    )
+    first = run_backend_step(b, batch(), b.initial_state())
+    # A tie is a rejection, and it is recorded with its step, mutation, and reason.
+    assert first.metrics["selected"] is False
+    assert first.state["rejected_proposals"] == [
+        {"step": 1, "mutations": [{"op": "create", "id": "r1"}], "reason": first.metrics["selection"]["reason"]}
+    ]
+    second = run_backend_step(b, batch(), first.state)
+    assert seen[0] == () and seen[1][0]["mutations"] == [{"op": "create", "id": "r1"}]
+    # The cap keeps only the latest rejection.
+    assert [entry["step"] for entry in second.state["rejected_proposals"]] == [2]
+    third = run_backend_step(backend(tmp_path, lambda n, s, m: None), batch(), second.state)
+    assert third.state["rejected_proposals"] == second.state["rejected_proposals"]
+
+
+def test_recipe_parses_search_quality_config(tmp_path: Path, monkeypatch) -> None:
+    module = tmp_path / "demo_search.py"
+    module.write_text(
+        "def propose(nodes, samples, model):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def config(**evolution):
+        return {
+            "evolution": {
+                "propose": "demo_search:propose",
+                "evaluate": "demo_search:evaluate",
+                "tasks": ["t"],
+                "binary": str(make_binary(tmp_path)),
+                **evolution,
+            }
+        }
+
+    on = CordisRecipe.from_environment({}, config=config(min_win_margin=1, max_rejected_history=5))
+    assert on.min_win_margin == 1 and on.max_rejected_history == 5
+    off = CordisRecipe.from_environment({}, config=config())
+    assert off.min_win_margin == 0 and off.max_rejected_history == 25
+    with pytest.raises(RecipeConfigError, match="min_win_margin applies only to the score_comparison selection"):
+        CordisRecipe.from_environment({}, config=config(min_win_margin=1, selection="always"))
+    with pytest.raises(RecipeConfigError, match="max_rejected_history must be an integer"):
+        CordisRecipe.from_environment({}, config=config(max_rejected_history=-1))


### PR DESCRIPTION
## Motivation

A publish clears the gate as the suite stood at that step, so a suite that keeps growing can later expose a published tree as a regression on a task the gate had not seen when it published. This is the second half of #132: the first half (#155, merged) grows the gate from real failures, and this half re-gates a published tree against the tree it replaced on that grown suite and rolls back when the published tree has since lost. The same recheck also fires the moment the served model or adapter version changes, so the harness is re-gated on the ground it now runs on instead of staying gated against a model that is gone. Off by default, so nothing changes for a deployment that does not opt in. Closes #132.

This branch also carries #159 (the verdict noise floor and the rejected proposal ledger): that PR was merged into this branch during review, so it lands on main with this one.

## Changes

- evolution.recheck_every (default 0, off): every N steps the loop runs a health recheck instead of proposing, and only while a rollback target is on file
- A real publish records the tree it replaced as the single rollback target in the scenario algorithm state, together with what the publish was gated against (served model, adapter, adapter version); both thread through skip paths like the promoted ledger and the failure manifest
- A recheck re-gates the last published tree against that target on the current grown suite through the same selector; if the target now wins the loop publishes it, which rolls the deployment back, and if the published tree still wins nothing changes
- The recheck also fires at once, ahead of the cadence, when the current served model or adapter version differs from the stamp stored at publish; the commit records recheck_reason as drift or cadence so the two triggers are distinct in the log
- Only the most recent publish is kept as a target and a rollback consumes it, so a recheck reverts one bad publish rather than unwinding the whole history
- A recheck is orthogonal to the propose and reject loop, so it leaves the failure streak breaker untouched; the commit records recheck and rolled_back so a rollback is distinct from a normal publish in the log
- From #159: evolution.min_win_margin (default 0) as a noise floor on the verdict, and evolution.max_rejected_history (default 25) keeping a bounded ledger of rejected proposals that reaches a propose whose signature names rejected

## Compatibility and operational impact

None by default: recheck_every is 0, so no rollback target is stored and the algorithm state schema is unchanged; a margin of 0 and a proposer that does not name rejected see identical behavior. With the recheck on, a recheck step spends one step's episode budget on the two stored trees instead of a proposal.

## Verification

On the rebased branch the harness recipe, artifact versions, commit log, contracts, and failure manifest suites pass (159 tests) on Python 3.12. The recheck tests cover a publish storing the replaced tree and its gate stamp as the target, a healthy recheck keeping the published tree and retaining the target, an end to end rollback where the grown suite exposes a regression and the loop republishes the last good tree, the recheck firing on a served model change instead of waiting for the cadence while the stamp rides through a skipped step, and the recipe parsing and validating recheck_every. The #159 tests are described on that PR. ruff, ruff format, isort, mypy, and the repository statement and design policy checks are clean.

## AI assistance

Claude Code designed the recheck and rollback mechanism and wrote the tests. I set the scope in #132.

## Checklist

- [x] The change matches the repository code style and comment density.
- [x] The verification section lists commands that actually ran.
- [x] Tests cover the behavior change.
- [x] Public interface changes include contract tests (the recipe config keys are parsed and validated).
- [x] Affected user documentation is updated (the harness evolution lane guide).
- [x] Non-trivial AI assistance is disclosed above.
