### PR TITLE
fix: center the code copy button in one-line blocks on phones

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -493,7 +493,9 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 
 @media (pointer: coarse) {
   .icon-button { width: 44px; height: 44px; }
-  .code-copy { width: 44px; height: 44px; opacity: 1; top: 8px; right: 8px; }
+  /* the button centers in a one-line block; the band fades scrolled text out beside and beneath it */
+  .code-block::before { content: ""; position: absolute; top: 1px; right: 1px; width: 72px; height: 58px; max-height: calc(100% - 2px); pointer-events: none; border-radius: 0 9px 9px 0; background: linear-gradient(90deg, transparent, var(--code) 38%); }
+  .code-copy { width: 44px; height: 44px; opacity: 1; top: min(8px, calc(50% - 22px)); right: 8px; }
   .search-input-row button { width: 44px; height: 44px; }
   .search-trigger { min-width: 44px; min-height: 44px; }
   .logo { min-height: 44px; }


### PR DESCRIPTION
## Motivation

On a phone the copy button in a one-line code block sits 8px from the top and almost touches the bottom border, so it reads as crooked, and the code text runs under the button and shows through the gap beside it. The 44px touch target is taller than the content of a short block, and a fixed top offset cannot center it. I spotted this on the CLI reference page on my phone.

## Changes

- In the coarse-pointer rule, top becomes min(8px, calc(50% - 22px)), which centers the button in a block shorter than 60px and keeps it 8px from the top in a taller one
- A code-block::before band behind the button fades scrolled text out beside and beneath it: it spans the button's row only, so the lines below stay fully readable, and it uses the code background variable so both themes match
- The desktop rules are untouched

## Compatibility and operational impact

None. CSS only, coarse pointer only.

## Verification

Measured on the live CLI reference page in Chrome iPhone emulation (390px wide, coarse pointer) before and after injecting the rules, in dark and light. The one-line block went from an 8px top and about 1px bottom inset to 5px and 5px; the 93px and 113px blocks stay at 8px from the top. Screenshots of the one-line and the four-line block in both themes show the text fading before the button, no characters beside it, and the lower lines untouched. eslint is clean.

## AI assistance

Claude Code measured the layout and wrote the rules. I spotted the bug on my phone.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above.
