### PR TITLE
fix(service): answer 400 for non-object request bodies and non-finite report scores

### DIFF
--- a/reef/service/routes/inference.py
+++ b/reef/service/routes/inference.py
@@ -7,6 +7,7 @@ from aiohttp import web
 
 from reef.runtime.inference import InferenceBackend
 from reef.service.request_service import RequestService
+from reef.service.routes.payload import read_object
 from reef.service.streaming import (
     SSEFrameDecoder,
     chat_completion_chunk_identity,
@@ -25,7 +26,7 @@ def register_inference_routes(
     inference_backend: InferenceBackend | None,
 ) -> None:
     async def inference(request: web.Request) -> web.StreamResponse:
-        payload = await request.json()
+        payload = await read_object(request)
         if payload.get("stream") is True:
             upstream, pending = await request_service.start_stream(
                 request.headers,

--- a/reef/service/routes/payload.py
+++ b/reef/service/routes/payload.py
@@ -1,0 +1,15 @@
+"""Shared request body checks for the JSON routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiohttp import web
+
+
+async def read_object(request: web.Request) -> dict[str, Any]:
+    """The decoded JSON body, which must be an object; anything else is a 400, never a traceback."""
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="request body must be an object")
+    return payload

--- a/reef/service/routes/records.py
+++ b/reef/service/routes/records.py
@@ -6,12 +6,13 @@ from aiohttp import web
 
 from reef.core.records_types import RequestType
 from reef.service.request_service import RequestService
+from reef.service.routes.payload import read_object
 
 
 def register_record_routes(app: web.Application, *, request_service: RequestService) -> None:
     def accept_typed(request_type: RequestType):
         async def accept(request: web.Request) -> web.Response:
-            payload = await request.json()
+            payload = await read_object(request)
             agent_record_id = None
             if isinstance(payload, dict) and "agent_record_id" in payload:
                 # Client-supplied id (see reef-protocols.md): lets a

--- a/reef/service/routes/scenarios.py
+++ b/reef/service/routes/scenarios.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from aiohttp import web
 
 from reef.service.request_service import RequestService
+from reef.service.routes.payload import read_object
 
 
 def register_scenario_routes(app: web.Application, *, request_service: RequestService) -> None:
@@ -10,7 +11,7 @@ def register_scenario_routes(app: web.Application, *, request_service: RequestSe
         return web.json_response({"scenarios": list(request_service.dispatcher.list_scenarios())})
 
     async def create_scenario(request: web.Request) -> web.Response:
-        payload = await request.json()
+        payload = await read_object(request)
         name = payload.get("name")
         release_id = payload.get("release_id")
         if not isinstance(name, str) or not name.strip():
@@ -52,9 +53,7 @@ def register_scenario_routes(app: web.Application, *, request_service: RequestSe
 
     async def rollback_scenario(request: web.Request) -> web.Response:
         scenario = request.match_info["scenario"]
-        payload = await request.json()
-        if not isinstance(payload, dict):
-            raise web.HTTPBadRequest(text="request body must be an object")
+        payload = await read_object(request)
         release_id = payload.get("release_id")
         if not isinstance(release_id, str) or not release_id.strip():
             raise ValueError("release_id must be a non-empty string")

--- a/reef/service/wire.py
+++ b/reef/service/wire.py
@@ -7,6 +7,7 @@ aiohttp request and that record.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
@@ -84,6 +85,8 @@ class ReportPayload:
         if score is not None:
             if not isinstance(score, (int, float)) or isinstance(score, bool):
                 raise ValueError("score must be a number")
+            if not math.isfinite(score):
+                raise ValueError("score must be finite")
             score = float(score)
         feedback = payload.get("feedback")
         if feedback is not None and not isinstance(feedback, (str, Mapping)):

--- a/tests/reef_service/test_request_body_validation.py
+++ b/tests/reef_service/test_request_body_validation.py
@@ -1,0 +1,72 @@
+"""Malformed client input is a 400 at the wire, never a traceback (#139, #140)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from reef.dispatcher import build_default_dispatcher
+from reef.service.app import create_app
+from reef.service.wire import ReportPayload
+
+HEADERS = {"x-reef-scenario": "body-validation"}
+NON_OBJECTS = ([], "text", 1, True, None)
+
+
+@pytest.mark.unit
+def test_object_routes_reject_non_object_bodies_with_400() -> None:
+    async def run() -> None:
+        client = TestClient(TestServer(create_app(build_default_dispatcher())))
+        await client.start_server()
+        try:
+            json_headers = {**HEADERS, "Content-Type": "application/json"}
+            for path in ("/reef/scenarios", "/reef/report", "/v1/chat/completions"):
+                for body in NON_OBJECTS:
+                    # data= so JSON null really travels as null; json=None would send no body at all.
+                    response = await client.post(path, data=json.dumps(body), headers=json_headers)
+                    assert response.status == 400, (path, body, response.status)
+                    assert "request body must be an object" in await response.text()
+                empty = await client.post(path, data="", headers=json_headers)
+                assert empty.status == 400, (path, empty.status)
+            created = await client.post("/reef/scenarios", json={"name": "still-works"}, headers=HEADERS)
+            assert created.status in (200, 201)
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("score", [float("nan"), float("inf"), float("-inf")])
+def test_report_payload_rejects_non_finite_scores(score: float) -> None:
+    with pytest.raises(ValueError, match="score must be finite"):
+        ReportPayload.from_dict({"score": score, "feedback": "text"})
+
+
+@pytest.mark.unit
+def test_report_payload_keeps_finite_scores() -> None:
+    assert ReportPayload.from_dict({"score": 3}).score == 3.0
+    assert ReportPayload.from_dict({"score": -0.5}).score == -0.5
+
+
+@pytest.mark.unit
+def test_report_route_answers_400_for_a_non_finite_score() -> None:
+    async def run() -> None:
+        client = TestClient(TestServer(create_app(build_default_dispatcher())))
+        await client.start_server()
+        try:
+            # 1e999 decodes to infinity, so the value reaches the wire contract itself.
+            response = await client.post(
+                "/reef/report",
+                data='{"score": 1e999, "feedback": "x", "references": []}',
+                headers={**HEADERS, "Content-Type": "application/json"},
+            )
+            assert response.status == 400
+            assert "score must be finite" in await response.text()
+        finally:
+            await client.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Motivation

Two ways ordinary bad client input turned into HTTP 500 with a traceback. A JSON body that is valid but not an object (an array, a string, a number, a boolean, null) reached `payload.get(...)` in the inference, report, and scenario creation routes and raised AttributeError, which the error translation table does not know. And the generic report wire contract accepted NaN and infinity as a score, so an untyped recipe could append a non-finite score to the record store. Closes #139. Closes #140.

## Changes

- A shared `read_object` in reef/service/routes/payload.py decodes the body and answers 400 "request body must be an object" for anything that is not an object; the inference, scenario creation, rollback, and report routes all use it, and the rollback route's own inline check is gone
- Invalid or empty JSON keeps its 400 through the existing ValueError translation (JSONDecodeError is a ValueError)
- ReportPayload.from_dict rejects NaN and positive or negative infinity with "score must be finite"; the report route turns that into 400 through the existing table, and finite integers and floats normalize as before

## Compatibility and operational impact

None for valid input. Malformed bodies that were 500 are now 400 with a message; no route or wire shape changes.

## Verification

New tests post an array, a string, a number, a boolean, JSON null, and an empty body to /reef/scenarios, /reef/report, and /v1/chat/completions and get 400 with the message on each, then confirm a valid scenario creation still works; reject NaN, inf, and -inf at the wire contract; keep finite scores; and post `1e999` (which decodes to infinity) to /reef/report and get 400 "score must be finite". The client record id, harness channel, wire, contracts, recipe request, artifact version, and scenario suites pass alongside them on Python 3.12. ruff, ruff format, isort, mypy, and the repository statement and design policy checks are clean on the changed files.

## AI assistance

Claude Code wrote the fix and the tests from the two issue reports.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above.
