### PR TITLE
fix(deploy): validate the stack config structure and unique service names before startup

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -191,7 +191,7 @@ Each entry is one process.
 
 .. config::
 
-   services[].name | the service's id, used by ``depends_on``
+   services[].name | the service's id, used by ``depends_on``; unique within one stack
    services[].command | the command line to run
    services[].ready | a shell command that succeeds once the service is up
    services[].ready_timeout | seconds to wait for ``ready`` before giving up; the top-level ``ready_timeout`` sets the default

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -81,9 +81,39 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
         path = PROJECT_ROOT / path
     if not path.exists():
         raise DeployConfigError(f"config not found: {path}\n  pass a deployment stack with: reef serve -c <path>")
-    with open(path) as handle:
-        config = yaml.safe_load(handle) or {}
+    try:
+        with open(path) as handle:
+            config = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise DeployConfigError(f"config {path} is not valid YAML: {exc}") from exc
+    if config is None:
+        config = {}
+    if not isinstance(config, dict):
+        raise DeployConfigError(f"config {path} must be a YAML object at the root, not {type(config).__name__}")
     return _deep_interp_env(config, os.environ)
+
+
+def validate_services(config: Mapping[str, Any], config_path: str | Path) -> list[dict[str, Any]]:
+    """Services as a non-empty list of objects with unique names, checked before any download, run dir, or process."""
+    services = config.get("services")
+    if not isinstance(services, list) or not services:
+        raise DeployConfigError(f"config {config_path} must declare a non-empty 'services' list")
+    names: list[str] = []
+    for index, service in enumerate(services):
+        if not isinstance(service, dict):
+            raise DeployConfigError(
+                f"config {config_path}: services[{index}] must be an object, not {type(service).__name__}"
+            )
+        name = service.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise DeployConfigError(f"config {config_path}: services[{index}] must have a non-empty 'name'")
+        names.append(name)
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise DeployConfigError(
+            f"config {config_path}: service names must be unique; duplicated: {', '.join(duplicates)}"
+        )
+    return services
 
 
 def is_local_path(value: str) -> bool:
@@ -158,4 +188,5 @@ __all__ = [
     "load_config",
     "resolve_hf_snapshot",
     "resolve_model_paths",
+    "validate_services",
 ]

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -24,7 +24,14 @@ from typing import Any
 
 import yaml
 
-from reef.service.deploy.config import PROJECT_ROOT, config_value, interpolate_config, load_config, resolve_model_paths
+from reef.service.deploy.config import (
+    PROJECT_ROOT,
+    config_value,
+    interpolate_config,
+    load_config,
+    resolve_model_paths,
+    validate_services,
+)
 from reef.service.deploy.settings import build_parser
 
 _DEFAULT_GRACE_TIMEOUT = 30
@@ -350,17 +357,13 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
     config = load_config(resolved_config_path)
     if overrides:
         config = _apply_overrides(config, overrides)
+    # Structure first, so a bad stack fails before a model download, a run dir, or a child process.
+    services = validate_services(config, resolved_config_path)
     paths_changed = resolve_model_paths(config)
     temp_config_path: Path | None = None
     if overrides or paths_changed:
         temp_config_path = _write_override_config(config)
         resolved_config_path = temp_config_path
-    services = config.get("services") or []
-    if not isinstance(services, list) or not services:
-        sys.exit("[reef] ERROR: config must declare a non-empty 'services' list")
-    names = [svc.get("name") for svc in services]
-    if any(not n for n in names):
-        sys.exit("[reef] ERROR: every service must have a 'name'")
     run_dir = Path(config_value(config, "run_dir", default="/tmp/reef-stack") or "/tmp/reef-stack")
     run_dir.mkdir(parents=True, exist_ok=True)
     ready_timeout_default = int(config_value(config, "ready_timeout", default="3600") or "3600")

--- a/tests/reef_service/test_deploy_config_validation.py
+++ b/tests/reef_service/test_deploy_config_validation.py
@@ -1,0 +1,88 @@
+"""A bad deployment stack fails as a typed config error before anything starts (#141, #143)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import reef.service.deploy.orchestrator as orchestrator
+from reef.cli import main as cli_main
+from reef.service.deploy.config import DeployConfigError, load_config, validate_services
+
+VALID = "services:\n  - name: worker\n    command: python -c 'print(1)'\n"
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "stack.yaml"
+    path.write_text(text)
+    return path
+
+
+@pytest.mark.unit
+def test_malformed_yaml_is_a_config_error_naming_the_path(tmp_path: Path) -> None:
+    path = _write(tmp_path, "services: [unclosed\n")
+    with pytest.raises(DeployConfigError, match="not valid YAML") as caught:
+        load_config(path)
+    assert str(path) in str(caught.value)
+
+
+@pytest.mark.unit
+def test_non_object_root_is_a_config_error(tmp_path: Path) -> None:
+    path = _write(tmp_path, "- not\n- an\n- object\n")
+    with pytest.raises(DeployConfigError, match="must be a YAML object at the root, not list"):
+        load_config(path)
+
+
+@pytest.mark.unit
+def test_empty_file_loads_as_an_empty_config(tmp_path: Path) -> None:
+    assert load_config(_write(tmp_path, "")) == {}
+
+
+@pytest.mark.unit
+def test_services_must_be_a_non_empty_list_of_objects() -> None:
+    with pytest.raises(DeployConfigError, match="non-empty 'services' list"):
+        validate_services({}, "stack.yaml")
+    with pytest.raises(DeployConfigError, match=r"services\[0\] must be an object, not str"):
+        validate_services({"services": ["not-an-object"]}, "stack.yaml")
+    with pytest.raises(DeployConfigError, match=r"services\[1\] must have a non-empty 'name'"):
+        validate_services({"services": [{"name": "a"}, {"command": "x"}]}, "stack.yaml")
+
+
+@pytest.mark.unit
+def test_duplicate_service_names_are_named() -> None:
+    config = {"services": [{"name": "worker"}, {"name": "api"}, {"name": "worker"}, {"name": "api"}]}
+    with pytest.raises(DeployConfigError, match="service names must be unique; duplicated: api, worker"):
+        validate_services(config, "stack.yaml")
+
+
+@pytest.mark.unit
+def test_valid_services_pass_through_in_order() -> None:
+    services = [{"name": "b"}, {"name": "a"}]
+    assert validate_services({"services": services}, "stack.yaml") == services
+
+
+@pytest.mark.unit
+def test_invalid_stack_never_downloads_or_launches(tmp_path: Path, monkeypatch) -> None:
+    def must_not_run(*args, **kwargs):
+        raise RuntimeError("reached a stage that must not run for an invalid stack")
+
+    monkeypatch.setattr(orchestrator, "resolve_model_paths", must_not_run)
+    monkeypatch.setattr(orchestrator, "_Stack", must_not_run)
+    path = _write(
+        tmp_path, "services:\n  - name: worker\n    command: sleep 60\n  - name: worker\n    command: echo 1\n"
+    )
+    with pytest.raises(DeployConfigError, match="duplicated: worker"):
+        orchestrator._run_orchestrator(str(path))
+    assert not (tmp_path / "reef-stack").exists()
+
+
+@pytest.mark.unit
+def test_cli_exits_2_without_a_traceback(tmp_path: Path, capsys) -> None:
+    path = _write(tmp_path, "- not\n- an\n- object\n")
+    with pytest.raises(SystemExit) as exit_info:
+        cli_main(["serve", "-c", str(path)])
+    assert exit_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "[reef] ERROR" in err and "must be a YAML object" in err
+    assert "Traceback" not in err


### PR DESCRIPTION
## Motivation

Two ordinary config mistakes in `reef serve -c` ended in tracebacks or silent misbehavior. Malformed YAML escaped the typed error path, and a valid document whose root is a list, or a service entry that is a scalar, failed later at `config.get` or `svc.get` with an AttributeError. A stack with two services of the same name passed the name check, and at startup the second entry was treated as the already running first one by the alive check and skipped, so the intended process never started. Closes #141. Closes #143.

## Changes

- load_config translates YAML syntax errors into DeployConfigError naming the path, treats an empty file as an empty config, and requires the root to be an object
- validate_services checks that services is a non-empty list of objects with non-empty names and that every name is unique, naming every duplicated id; the orchestrator calls it right after overrides, before any model download, run directory, or child process, and the two old string sys.exit checks are gone
- The CLI already maps DeployConfigError to exit status 2 without a traceback, so these now reach the operator as one clean line
- The configuration reference states that services[].name is unique within one stack

## Compatibility and operational impact

None for valid stacks; their startup order and behavior are unchanged. Invalid stacks that used to traceback or exit 1 now exit 2 with a typed message.

## Verification

New tests cover malformed YAML naming the path, a list root, an empty file, a non-list or empty services key, a scalar service entry, a missing name, duplicated names listed in the error, valid services passing through in order, an invalid stack raising before resolve_model_paths or _Stack run (both patched to fail if reached) with no run dir created, and the CLI exiting 2 with the error line and no traceback. The orchestrator override, training server, SAO config, harness example, SkillClaw, and wandb suites pass alongside them on Python 3.12. ruff, ruff format, isort, mypy, and the repository statement and design policy checks are clean on the changed files.

## AI assistance

Claude Code wrote the fix and the tests from the two issue reports.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above.
