### PR TITLE
feat: add a native harness whose loop lives in the tree and whose tools are nodes

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -4,7 +4,10 @@ Harness adapters
 An adapter maps a harness tree into the files expected by a third-party
 coding-agent CLI and binds that harness to the served model. The harness and
 model together form the running agent. The tree never names a file path; the
-adapter does. Reef bundles five, one per third-party coding-agent CLI.
+adapter does. Reef bundles five, one per third-party coding-agent CLI, and
+one for its own agent, ``native``, whose loop lives in this tree and whose
+tools are ``native_tool`` nodes, so a mutation can add, rewrite, or remove a
+tool.
 
 +--------------+-----------------------------------------------------------+-------------------------------------------+
 | Adapter      | Config targets                                            | Install pin                               |
@@ -21,6 +24,9 @@ adapter does. Reef bundles five, one per third-party coding-agent CLI.
 +--------------+-----------------------------------------------------------+-------------------------------------------+
 | ``hermes``   | ``primary`` → ``hermes/config.yaml``                      | git ``NousResearch/hermes-agent``         |
 |              |                                                           | at ``v2026.8.31`` (0.21.0)                |
++--------------+-----------------------------------------------------------+-------------------------------------------+
+| ``native``   | ``primary`` → ``native/config.json``,                     | none: ``reef-native`` ships with reef     |
+|              | ``models`` → ``native/models.json``                       |                                           |
 +--------------+-----------------------------------------------------------+-------------------------------------------+
 
 The ``dsh`` adapter runs DeepSeek Harness headless (``dsh --profile headless
@@ -70,6 +76,29 @@ binding is a custom provider with a literal key in ``config.yaml``; only the
 ``openai`` dialect is bound. hermes's own default approval policy runs tools
 inside the working directory with no prompt and refuses a command it flags as
 dangerous with a tool error, so no bypass flag is used.
+
+The native adapter also renders the optional ``native_tool`` kind to
+``native/tools/{name}.py``: a module whose ``NAME``, ``DESCRIPTION``, and
+``PARAMETERS`` come from the node config and whose ``code`` defines
+``run(args, workdir) -> str``. ``reef.harness.native.seed.SEED_TOOLS`` holds
+the starting ``read_file``, ``write_file``, and ``run_bash`` tools as entries
+a recipe can seed and the loop can then evolve. An adapter that declares no
+``files.native_tool`` path refuses to render that kind, so the mutation fails
+under it instead of silently dropping the tool.
+
+The native loop writes its trajectory as ``native-jsonl``: one
+``{type, seq, time, data}`` object per line, ``seq`` contiguous from 0. A
+``session`` header line names the task, model, and tools; then ``turn/start``,
+per step ``step/start``, ``request/header`` (the rendered system prompt and
+the tool declarations, logged on the first step so the log holds everything
+the model saw), ``assistant/message`` (``content``, ``tool_calls``,
+``finish``), ``tool/call`` (the raw argument string), ``tool/result``
+(``content``, ``is_error``, and on error a closed ``code``: ``UNKNOWN_TOOL``,
+``INVALID_ARGS``, ``TOOL_FAILED``), ``step/end``, and finally ``turn/end``
+with a ``reason`` of ``completed``, ``max-steps``, or ``error``. Arguments are
+validated against the tool's declared schema before ``run`` sees them, and a
+``user/message`` from the ``loop-guard`` plugin lands when the same call
+repeats three, five, or eight times in a row.
 
 The descriptor
 --------------

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -168,7 +168,7 @@ zero.
    evolution.evaluate | an ``EpisodeScorer``, likewise
    evolution.selection | score_comparison | ``always``, or a dotted reference to an object with ``decide``
    evolution.tasks | non-empty list of episode prompts, scored once per tree per step
-   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), or an entry-point adapter
+   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), ``native`` (Reef's own agent, whose tools are ``native_tool`` nodes), or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
    evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
    evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -21,7 +21,7 @@ called the tree. A tree is a flat list of entries, and each entry has three
 fields: ``id`` is unique within the tree, ``name`` selects one of the node
 kinds below, and ``config`` holds that kind's own fields. For the named kinds
 (``agent_command``, ``skill``, ``code_extension``), ``config.name`` is the
-file name the entry renders to. Five kinds are registered in
+file name the entry renders to. Six kinds are registered in
 `reef/harness/nodes.py <../../reef/harness/nodes.py>`__:
 
 +--------------------+----------------------------------------------------------+
@@ -38,12 +38,17 @@ file name the entry renders to. Five kinds are registered in
 +--------------------+----------------------------------------------------------+
 | ``code_extension`` | a named code file the harness loads in process           |
 +--------------------+----------------------------------------------------------+
+| ``native_tool``    | a named tool the native harness loads (schema and code)  |
++--------------------+----------------------------------------------------------+
 
 The table describes what each kind contains. Where each kind is written is
 decided by an adapter, which maps every kind to a concrete file for one agent.
-Reef bundles five adapters, ``pi``, ``opencode``, ``claude``, ``dsh``
-(DeepSeek Harness), and ``hermes`` (Hermes Agent), each for a third-party
-coding agent CLI. With the ``pi`` adapter, ``GET /reef/harness`` serves:
+Reef bundles adapters for third-party coding agent CLIs (``pi``, ``opencode``,
+``claude``, ``dsh`` (DeepSeek Harness), and ``hermes`` (Hermes Agent)) and
+``native``, its own agent: a loop inside the reef tree whose tools are
+``native_tool`` nodes, so the agent can evolve the tools it runs, not only the
+text around a vendor binary. Only ``native`` renders that kind. With the
+``pi`` adapter, ``GET /reef/harness`` serves:
 
 .. code:: text
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ Homepage = "https://github.com/Human-Agent-Society/reef"
 
 [project.scripts]
 reef = "reef.cli:main"
+reef-native = "reef.harness.native:main"
 
 [project.entry-points."sglang.srt.plugins"]
 reef = "reef.train.slime_backend.reef_adapters.sglang.plugin:install_sglang_plugin"

--- a/reef/harness/adapters/__init__.py
+++ b/reef/harness/adapters/__init__.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from reef.harness.descriptor import AdapterDescriptor, DescriptorError, external_descriptors, load_descriptor
 
-BUILTIN_ADAPTERS = ("claude", "dsh", "hermes", "opencode", "pi")
+BUILTIN_ADAPTERS = ("claude", "dsh", "hermes", "native", "opencode", "pi")
 
 _cache: dict[str, AdapterDescriptor] = {}
 

--- a/reef/harness/adapters/native/__init__.py
+++ b/reef/harness/adapters/native/__init__.py
@@ -1,0 +1,1 @@
+"""The native adapter: Reef's own coding agent (``reef.harness.native``) as a harness."""

--- a/reef/harness/adapters/native/descriptor.yaml
+++ b/reef/harness/adapters/native/descriptor.yaml
@@ -1,0 +1,38 @@
+# Reef's own coding agent: a Python loop inside this tree, driven headless per
+# episode, whose tools are native_tool nodes. REEF_NATIVE_DIR relocates the
+# whole composition root so nothing is read from the working directory.
+name: native
+binary: reef-native
+argv: ["-p", "{prompt}"]
+env:
+  REEF_NATIVE_DIR: "{root}/native"
+  REEF_NATIVE_SESSION_DIR: "{root}/native/sessions"
+files:
+  config:
+    primary:
+      path: "native/config.json"
+      defaults: {}
+    models:
+      path: "native/models.json"
+      defaults: {}
+  rules: "native/RULES.md"
+  agent_command: "native/commands/{name}.md"
+  skill: "native/skills/{name}/SKILL.md"
+  code_extension: "native/extensions/{name}.py"
+  native_tool: "native/tools/{name}.py"
+trajectory:
+  format: native-jsonl
+  path: "native/sessions"
+cleanup_whitelist:
+  - "native/sessions/**"
+  - "native/tools/__pycache__/**"
+# The served model reaches the loop through this file only; the served tree
+# never carries a provider.
+model_binding:
+  openai:
+    - target: models
+      data:
+        api: openai
+        base_url: "{base_url}"
+        api_key: "{api_key}"
+        model: "{model}"

--- a/reef/harness/descriptor.py
+++ b/reef/harness/descriptor.py
@@ -43,6 +43,8 @@ ENTRY_POINT_GROUP = "reef.harness_adapters"
 
 #: Node kinds rendered to one path per named node; templates need ``{name}``.
 NAMED_NODE_KINDS = ("agent_command", "skill", "code_extension")
+#: Named kinds an adapter may leave out; a mutation of that kind then fails to render under it.
+OPTIONAL_NODE_KINDS = ("native_tool",)
 
 
 class DescriptorError(ReefError):
@@ -256,6 +258,13 @@ def _parse_install(raw: Any, where: str) -> InstallSpec | None:
 def _parse_node_paths(files: Mapping[str, Any], where: str) -> dict[str, str]:
     node_paths = {"rules": _require_str(files, "rules", f"{where} files")}
     for kind in NAMED_NODE_KINDS:
+        template = _require_str(files, kind, f"{where} files")
+        if "{name}" not in template:
+            raise DescriptorError(f"{where} files.{kind} template must contain {{name}}")
+        node_paths[kind] = template
+    for kind in OPTIONAL_NODE_KINDS:
+        if kind not in files:
+            continue
         template = _require_str(files, kind, f"{where} files")
         if "{name}" not in template:
             raise DescriptorError(f"{where} files.{kind} template must contain {{name}}")

--- a/reef/harness/native/__init__.py
+++ b/reef/harness/native/__init__.py
@@ -1,0 +1,280 @@
+"""Reef's native coding agent: a headless single prompt loop whose tools are composition nodes.
+
+One episode is one process and one turn. The rendered composition root
+(``REEF_NATIVE_DIR``) holds ``RULES.md``, ``skills/``, ``tools/`` and
+``models.json``; the loop reads them, talks to the served model through the
+rendered binding, dispatches tool calls to the tool modules, and appends one
+JSONL session the ``native-jsonl`` trajectory reader decodes. Everything the
+model saw is in that log: the rendered system prompt, the tool declarations,
+every message, every call, every result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Protocol
+
+from reef.harness.model_binding import ModelBinding, ModelBindingError
+
+#: Step and tool result budgets; an episode also runs under the executor's wall clock.
+MAX_STEPS = 12
+MAX_RESULT_CHARS = 20_000
+#: Consecutive identical calls that earn the model a reminder; the loop never vetoes a call.
+LOOP_GUARD_THRESHOLDS = (3, 5, 8)
+DEFAULT_SYSTEM_PROMPT = "You are a coding agent. Use the tools to complete the task, then answer."
+SESSION_VERSION = 1
+_SCALAR_TYPES: dict[str, type | tuple[type, ...]] = {
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+    "object": dict,
+    "array": list,
+}
+
+
+class ToolRunner(Protocol):
+    """What a tool module's ``run`` looks like: ``run(args, workdir) -> str``."""
+
+    def __call__(self, args: dict[str, Any], workdir: str, /) -> Any: ...
+
+
+class ToolModule:
+    """One rendered ``native_tool`` node: its declaration for the model and its ``run``."""
+
+    def __init__(self, name: str, description: str, parameters: Mapping[str, Any], run: ToolRunner) -> None:
+        self.name = name
+        self.description = description
+        self.parameters = dict(parameters) or {"type": "object", "properties": {}}
+        self.run = run
+
+    def declaration(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {"name": self.name, "description": self.description, "parameters": self.parameters},
+        }
+
+    def validate(self, args: Any) -> str | None:
+        """The first schema violation, checked before ``run``: required keys and top-level scalar types."""
+        if not isinstance(args, dict):
+            return "arguments must be a JSON object"
+        properties = self.parameters.get("properties") or {}
+        for key in self.parameters.get("required") or ():
+            if key not in args:
+                return f"missing required argument {key!r}"
+        for key, value in args.items():
+            expected = _SCALAR_TYPES.get(str((properties.get(key) or {}).get("type", "")))
+            if expected is not None and (
+                not isinstance(value, expected) or (isinstance(value, bool) and expected is not bool)
+            ):
+                return f"argument {key!r} must be {properties[key]['type']}"
+        return None
+
+
+def load_tools(tools_dir: Path) -> dict[str, ToolModule]:
+    """Import every ``tools/*.py``; a module that fails to import is skipped, never fatal."""
+    tools: dict[str, ToolModule] = {}
+    for path in sorted(tools_dir.glob("*.py")):
+        spec = importlib.util.spec_from_file_location(f"reef_native_tool_{path.stem}", path)
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:
+            print(f"[reef-native] tool {path.name} failed to import: {exc}", file=sys.stderr)
+            continue
+        run = getattr(module, "run", None)
+        if not callable(run):
+            print(f"[reef-native] tool {path.name} defines no run(args, workdir)", file=sys.stderr)
+            continue
+        name = str(getattr(module, "NAME", path.stem))
+        parameters = getattr(module, "PARAMETERS", {})
+        tools[name] = ToolModule(name, str(getattr(module, "DESCRIPTION", "")), parameters, run)
+    return tools
+
+
+def system_prompt(root: Path) -> str:
+    """Rules first, then every skill, in path order."""
+    files = [root / "RULES.md", *sorted((root / "skills").glob("*/SKILL.md"))]
+    parts = [path.read_text(encoding="utf-8").strip() for path in files if path.exists()]
+    return "\n\n".join(part for part in parts if part) or DEFAULT_SYSTEM_PROMPT
+
+
+def binding_from(models_path: Path) -> ModelBinding:
+    data = json.loads(models_path.read_text(encoding="utf-8"))
+    return ModelBinding(
+        base_url=str(data["base_url"]),
+        model=str(data["model"]),
+        api_key=str(data.get("api_key") or ""),
+        api=str(data.get("api") or "openai"),
+    )
+
+
+class Session:
+    """The trajectory: ``{type, seq, time, data}`` per line, appended and flushed as the loop goes."""
+
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = path.open("a", encoding="utf-8")
+        self._seq = 0
+
+    def write(self, type_: str, data: Mapping[str, Any]) -> None:
+        event = {"type": type_, "seq": self._seq, "time": int(time.time() * 1000), "data": dict(data)}
+        self._seq += 1
+        self._handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+        self._handle.flush()
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+class _LoopGuard:
+    """Counts consecutive identical calls and says so to the model at the thresholds."""
+
+    def __init__(self) -> None:
+        self._last: str | None = None
+        self._count = 0
+
+    def note(self, name: str, args: Any) -> str | None:
+        key = json.dumps([name, args], sort_keys=True, default=str)
+        self._count = self._count + 1 if key == self._last else 1
+        self._last = key
+        if self._count in LOOP_GUARD_THRESHOLDS:
+            return f"You have called {name} with the same arguments {self._count} times in a row. Change approach or answer."
+        return None
+
+
+def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
+    binding = binding_from(root / "models.json")
+    tools = load_tools(root / "tools")
+    session = Session(session_dir / "session.jsonl")
+    session.write(
+        "session",
+        {
+            "version": SESSION_VERSION,
+            "task": prompt,
+            "model": binding.model,
+            "base_url": binding.base_url,
+            "cwd": str(workdir),
+            "tools": sorted(tools),
+        },
+    )
+    session.write("turn/start", {"turn": 1})
+    system = system_prompt(root)
+    declarations = [tool.declaration() for tool in tools.values()]
+    messages: list[dict[str, Any]] = [{"role": "system", "content": system}, {"role": "user", "content": prompt}]
+    guard = _LoopGuard()
+    try:
+        for step in range(1, MAX_STEPS + 1):
+            session.write("step/start", {"turn": 1, "step": step})
+            if step == 1:
+                session.write("request/header", {"model": binding.model, "system": system, "tools": declarations})
+            body: dict[str, Any] = {"messages": messages}
+            if declarations:
+                body["tools"] = declarations
+            try:
+                response = binding.complete(body)
+                message = dict(response["choices"][0]["message"])
+            except (ModelBindingError, KeyError, IndexError, TypeError) as exc:
+                failure = {"code": "MODEL_ERROR", "message": f"{type(exc).__name__}: {exc}"[:600]}
+                session.write("turn/end", {"turn": 1, "reason": {"kind": "error", "error": failure}})
+                print(f"[reef-native] model call failed: {exc}", file=sys.stderr)
+                return 1
+            calls = list(message.get("tool_calls") or [])
+            messages.append(message)
+            session.write(
+                "assistant/message",
+                {
+                    "step": step,
+                    "content": message.get("content"),
+                    "tool_calls": calls,
+                    "finish": "tool-calls" if calls else "stop",
+                },
+            )
+            if not calls:
+                session.write("step/end", {"turn": 1, "step": step})
+                session.write("turn/end", {"turn": 1, "reason": {"kind": "completed"}})
+                return 0
+            for call in calls:
+                function = call.get("function") or {}
+                name = str(function.get("name", ""))
+                raw = function.get("arguments") or "{}"
+                call_id = str(call.get("id") or name)
+                session.write("tool/call", {"step": step, "call_id": call_id, "name": name, "arguments": raw})
+                result = _invoke(tools, name, raw, workdir)
+                session.write("tool/result", {"step": step, "call_id": call_id, "name": name, **result})
+                messages.append({"role": "tool", "tool_call_id": call_id, "content": result["content"]})
+                reminder = guard.note(name, result.get("arguments"))
+                if reminder is not None:
+                    session.write(
+                        "user/message", {"source": {"kind": "plugin", "plugin": "loop-guard"}, "content": reminder}
+                    )
+                    messages.append({"role": "user", "content": reminder})
+            session.write("step/end", {"turn": 1, "step": step})
+        session.write("turn/end", {"turn": 1, "reason": {"kind": "max-steps", "steps": MAX_STEPS}})
+        return 0
+    finally:
+        session.close()
+
+
+def _invoke(tools: Mapping[str, ToolModule], name: str, raw: str, workdir: Path) -> dict[str, Any]:
+    """One result for one call: content, is_error, and a closed error code; run only sees valid arguments."""
+    try:
+        arguments = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        arguments = raw
+
+    def error(code: str, message: str) -> dict[str, Any]:
+        return {
+            "content": f"Error: {message}",
+            "is_error": True,
+            "error": {"code": code, "message": message},
+            "arguments": arguments,
+        }
+
+    tool = tools.get(name)
+    if tool is None:
+        return error("UNKNOWN_TOOL", f"unknown tool {name!r}; available: {', '.join(sorted(tools)) or 'none'}")
+    if not isinstance(arguments, dict):
+        return error("INVALID_ARGS", "arguments must be a JSON object")
+    violation = tool.validate(arguments)
+    if violation is not None:
+        return error("INVALID_ARGS", violation)
+    started = time.monotonic()
+    try:
+        result = tool.run(arguments, str(workdir))
+    except Exception as exc:
+        return error("TOOL_FAILED", f"{type(exc).__name__}: {exc}")
+    text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False, default=str)
+    truncated = len(text) > MAX_RESULT_CHARS
+    return {
+        "content": text[:MAX_RESULT_CHARS],
+        "is_error": False,
+        "arguments": arguments,
+        "meta": {"duration_ms": int((time.monotonic() - started) * 1000), "truncated": truncated},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="reef-native", description="Reef's native coding agent, one prompt per run.")
+    parser.add_argument("-p", "--prompt", help="the task; the whole problem must be in it")
+    parser.add_argument("-V", "--version", action="store_true", help="print the reef version and exit")
+    args = parser.parse_args(argv)
+    if args.version:
+        from reef import __version__
+
+        print(f"reef-native {__version__}")
+        return 0
+    if not args.prompt:
+        parser.error("-p/--prompt is required")
+    root = Path(os.environ.get("REEF_NATIVE_DIR") or "native")
+    session_dir = Path(os.environ.get("REEF_NATIVE_SESSION_DIR") or root / "sessions")
+    return run_loop(args.prompt, root, session_dir, Path.cwd())

--- a/reef/harness/native/__main__.py
+++ b/reef/harness/native/__main__.py
@@ -1,0 +1,10 @@
+"""``python -m reef.harness.native``: the same entry the ``reef-native`` console script uses."""
+
+from __future__ import annotations
+
+import sys
+
+from reef.harness.native import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reef/harness/native/seed.py
+++ b/reef/harness/native/seed.py
@@ -1,0 +1,88 @@
+"""The native harness's starting tools as ``native_tool`` entries: a seed the evolution loop can mutate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_READ_FILE = """\
+from pathlib import Path
+
+
+def run(args, workdir):
+    root = Path(workdir).resolve()
+    path = (root / str(args.get("path", ""))).resolve()
+    if root not in path.parents and path != root:
+        return "refused: path escapes the workspace"
+    if not path.is_file():
+        return f"no such file: {args.get('path', '')}"
+    return path.read_text(encoding="utf-8", errors="replace")
+"""
+
+_WRITE_FILE = """\
+from pathlib import Path
+
+
+def run(args, workdir):
+    root = Path(workdir).resolve()
+    path = (root / str(args.get("path", ""))).resolve()
+    if root not in path.parents:
+        return "refused: path escapes the workspace"
+    content = str(args.get("content", ""))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return f"wrote {len(content)} characters to {args.get('path', '')}"
+"""
+
+_RUN_BASH = """\
+import subprocess
+
+
+def run(args, workdir):
+    command = str(args.get("command", ""))
+    if not command.strip():
+        return "refused: empty command"
+    try:
+        done = subprocess.run(
+            ["bash", "-lc", command], cwd=workdir, capture_output=True, text=True, timeout=60, check=False
+        )
+    except subprocess.TimeoutExpired:
+        return "timed out after 60s"
+    out = (done.stdout or "") + (("\\n" + done.stderr) if done.stderr else "")
+    return f"exit {done.returncode}\\n{out}"
+"""
+
+
+def _tool(name: str, description: str, parameters: dict[str, Any], code: str) -> dict[str, Any]:
+    return {
+        "id": f"tool-{name.replace('_', '-')}",
+        "name": "native_tool",
+        "config": {"name": name, "description": description, "parameters": parameters, "code": code},
+    }
+
+
+SEED_TOOLS: tuple[dict[str, Any], ...] = (
+    _tool(
+        "read_file",
+        "Read a text file in the workspace.",
+        {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]},
+        _READ_FILE,
+    ),
+    _tool(
+        "write_file",
+        "Write a text file in the workspace, creating parent directories.",
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"],
+        },
+        _WRITE_FILE,
+    ),
+    _tool(
+        "run_bash",
+        "Run a bash command in the workspace and return its exit code and output.",
+        {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]},
+        _RUN_BASH,
+    ),
+)
+
+__all__ = ["SEED_TOOLS"]

--- a/reef/harness/nodes.py
+++ b/reef/harness/nodes.py
@@ -1,11 +1,12 @@
 """Harness composition node kinds: the plugin vocabulary of the Entry tree.
 
 A harness composition is a flat compose Entry tree whose entries name one of
-five node kinds. Each kind's plugin body is its admission gate: it validates
-the entry config at load, so a proposal carrying an invalid node lands as a
-FAILED fiber and never reaches the ledger. The kinds cover what both surveyed
-harnesses compose from files alone - one JSON config tree, markdown resource
-directories, and code-valued extension files:
+the node kinds below. Each kind's plugin body is its admission gate: it
+validates the entry config at load, so a proposal carrying an invalid node
+lands as a FAILED fiber and never reaches the ledger. Five kinds cover what
+both surveyed harnesses compose from files alone - one JSON config tree,
+markdown resource directories, and code-valued extension files - and the
+native harness adds kinds only it renders:
 
 - ``config``: a JSON object merged into one of the adapter's declared config
   targets (``settings.json``/``models.json`` for pi, ``opencode.json``).
@@ -16,6 +17,8 @@ directories, and code-valued extension files:
 - ``skill``: a named Agent Skill, rendered as ``skills/<name>/SKILL.md``.
 - ``code_extension``: a named code file the harness loads in-process (pi
   ``extensions/``, opencode ``plugin/``).
+- ``native_tool``: a named tool of the native harness, a JSON schema plus
+  code defining ``run(args, workdir)`` (``native/tools/``).
 
 The plugins hold no services and register no effects: the Entry tree itself
 is the state, and ``reef.harness.render`` reads it back out per adapter.
@@ -165,11 +168,22 @@ def code_extension_node(ctx: Any, config: Any) -> None:
     _reject_secret_shaped_text(_require_text(options, "code"), "code_extension node 'code'")
 
 
+def native_tool_node(ctx: Any, config: Any) -> None:
+    """A named tool the native harness loads: a description, a JSON schema, and code defining ``run(args, workdir)``."""
+    options = _require_mapping(config)
+    _require_name(options)
+    _require_text(options, "description")
+    if not isinstance(options.get("parameters", {}), Mapping):
+        raise ValueError("native_tool node 'parameters' must be an object")
+    _reject_secret_shaped_text(_require_text(options, "code"), "native_tool node 'code'")
+
+
 NODE_KINDS: dict[str, Callable[[Any, Any], None]] = {
     "config": config_node,
     "rules": rules_node,
     "agent_command": agent_command_node,
     "skill": skill_node,
     "code_extension": code_extension_node,
+    "native_tool": native_tool_node,
 }
 """Entry ``name`` to node plugin; the resolver of the composition loader."""

--- a/reef/harness/render.py
+++ b/reef/harness/render.py
@@ -57,6 +57,20 @@ def render_composition(nodes: Sequence[tuple[str, Any]], descriptor: AdapterDesc
             emit(descriptor.node_paths[kind].format(name=options.get("name")), str(options.get("text", "")))
         elif kind == "code_extension":
             emit(descriptor.node_paths[kind].format(name=options.get("name")), str(options.get("code", "")))
+        elif kind == "native_tool":
+            template = descriptor.node_paths.get(kind)
+            if template is None:
+                raise RenderError(f"adapter {descriptor.name!r} does not render native_tool nodes")
+            # One importable module: the declaration as constants, then the code that defines run(args, workdir).
+            header = "\n".join(
+                f"{key} = {value!r}"
+                for key, value in (
+                    ("NAME", options.get("name")),
+                    ("DESCRIPTION", options.get("description", "")),
+                    ("PARAMETERS", dict(options.get("parameters", {}) or {})),
+                )
+            )
+            emit(template.format(name=options.get("name")), f"{header}\n\n{options.get('code', '')}")
         else:
             raise RenderError(f"unknown node kind {kind!r}")
 

--- a/reef/harness/trajectory.py
+++ b/reef/harness/trajectory.py
@@ -258,3 +258,13 @@ read_claude_session = ClaudeSessionReader()
 read_deepseek_session = DeepseekSessionReader()
 read_hermes_session = HermesSessionReader()
 read_opencode_storage = OpencodeStorageReader()
+
+
+@register_trajectory_reader
+class NativeSessionReader(TrajectoryReader):
+    """Read the native harness session tree: every ``*.jsonl`` under ``path``, in order, like a pi session."""
+
+    format = "native-jsonl"
+
+    def __call__(self, path: Path) -> tuple[dict[str, Any], ...]:
+        return PiSessionReader()(path)

--- a/tests/reef_service/data/harness_goldens/native/native/RULES.md
+++ b/tests/reef_service/data/harness_goldens/native/native/RULES.md
@@ -1,0 +1,3 @@
+Answer briefly.
+
+Prefer the standard library.

--- a/tests/reef_service/data/harness_goldens/native/native/commands/summarize.md
+++ b/tests/reef_service/data/harness_goldens/native/native/commands/summarize.md
@@ -1,0 +1,1 @@
+Summarize $1.

--- a/tests/reef_service/data/harness_goldens/native/native/config.json
+++ b/tests/reef_service/data/harness_goldens/native/native/config.json
@@ -1,0 +1,4 @@
+{
+  "defaultModel": "qwen/qwen3-8b",
+  "defaultProvider": "qwen"
+}

--- a/tests/reef_service/data/harness_goldens/native/native/extensions/tracer.py
+++ b/tests/reef_service/data/harness_goldens/native/native/extensions/tracer.py
@@ -1,0 +1,2 @@
+def tracer():
+    pass

--- a/tests/reef_service/data/harness_goldens/native/native/models.json
+++ b/tests/reef_service/data/harness_goldens/native/native/models.json
@@ -1,0 +1,14 @@
+{
+  "providers": {
+    "qwen": {
+      "api": "openai-completions",
+      "apiKey": "dummy",
+      "baseUrl": "http://localhost:8000/v1",
+      "models": [
+        {
+          "id": "qwen3-8b"
+        }
+      ]
+    }
+  }
+}

--- a/tests/reef_service/data/harness_goldens/native/native/skills/notes/SKILL.md
+++ b/tests/reef_service/data/harness_goldens/native/native/skills/notes/SKILL.md
@@ -1,0 +1,3 @@
+# Notes skill
+
+Keep short notes.

--- a/tests/reef_service/data/harness_goldens/native/native/tools/shout.py
+++ b/tests/reef_service/data/harness_goldens/native/native/tools/shout.py
@@ -1,0 +1,6 @@
+NAME = 'shout'
+DESCRIPTION = 'Upper-case a string.'
+PARAMETERS = {'type': 'object', 'properties': {'text': {'type': 'string'}}, 'required': ['text']}
+
+def run(args, workdir):
+    return str(args.get('text', '')).upper()

--- a/tests/reef_service/test_harness_render.py
+++ b/tests/reef_service/test_harness_render.py
@@ -187,6 +187,24 @@ def test_hermes_quirks_refuse_a_config_that_breaks_the_episode() -> None:
         render_composition([("config", {"data": {"sessions": {"write_json_snapshots": False}}})], descriptor)
 
 
+NATIVE_TOOL = (
+    "native_tool",
+    {
+        "name": "shout",
+        "description": "Upper-case a string.",
+        "parameters": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+        "code": "def run(args, workdir):\n    return str(args.get('text', '')).upper()\n",
+    },
+)
+
+
+def test_native_render_matches_the_golden_tree() -> None:
+    # The native harness loads Python extensions, so its golden carries a Python body.
+    nodes = [node for node in NODES if node[0] != "code_extension"]
+    extension = ("code_extension", {"name": "tracer", "code": "def tracer():\n    pass\n"})
+    assert render_composition([*nodes, extension, NATIVE_TOOL], get_adapter("native")) == golden_tree("native")
+
+
 def test_config_nodes_deep_merge_in_tree_order() -> None:
     files = render_composition(
         [

--- a/tests/reef_service/test_native_harness.py
+++ b/tests/reef_service/test_native_harness.py
@@ -1,0 +1,249 @@
+"""The native adapter: a loop inside the tree whose tools are nodes, driven through the real episode engine.
+
+A stdlib HTTP server plays the served model: it answers by conversation state
+(write a file, then read it back, then answer), so the whole loop, the tool
+modules, and the trajectory run hermetically."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from reef.harness.adapters import available_adapters, get_adapter
+from reef.harness.episode import run_episode
+from reef.harness.model_binding import ModelBinding
+from reef.harness.native import MAX_RESULT_CHARS, ToolModule, _invoke, _LoopGuard
+from reef.harness.native.seed import SEED_TOOLS
+from reef.harness.nodes import NODE_KINDS
+from reef.harness.render import RenderError, render_composition
+from reef.harness.trajectory import reader_for
+from reef.train.cordis_backend import CordisBackend, Mutation, ScoreComparisonSelector
+from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
+from reef.train.evaluation import DefaultCandidateEvaluationPlugin
+from reef.train.types import TraceBatch, TraceSample
+
+TOOL = (
+    "native_tool",
+    {
+        "name": "shout",
+        "description": "Upper-case a string.",
+        "parameters": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+        "code": "def run(args, workdir):\n    return str(args.get('text', '')).upper()\n",
+    },
+)
+
+
+def _reply(content=None, tool_calls=None):
+    message = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return {"id": "fake", "object": "chat.completion", "choices": [{"index": 0, "message": message}]}
+
+
+def _call(name, arguments, call_id):
+    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": json.dumps(arguments)}}
+
+
+class _FakeModel(ThreadingHTTPServer):
+    """Answers /v1/chat/completions by conversation state, so every episode gets the same script."""
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), _Handler)
+        self.requests: list[dict] = []
+        self.thread = threading.Thread(target=self.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.server_address[1]}"
+
+    def script(self, body: dict) -> dict:
+        tool_results = [m for m in body["messages"] if m.get("role") == "tool"]
+        if not tool_results:
+            return _reply(tool_calls=[_call("write_file", {"path": "notes.txt", "content": "hello"}, "c1")])
+        if len(tool_results) == 1:
+            return _reply(tool_calls=[_call("read_file", {"path": "notes.txt"}, "c2")])
+        return _reply(content=f"The file says: {tool_results[-1]['content']}")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
+        self.server.requests.append(body)  # type: ignore[attr-defined]
+        payload = json.dumps(self.server.script(body)).encode()  # type: ignore[attr-defined]
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_model():
+    server = _FakeModel()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _launcher(tmp_path: Path) -> str:
+    """The episode binary: this interpreter running the native loop, like an installed reef-native.
+
+    The child gets no PYTHONPATH from the episode engine, so the source
+    checkout is put on sys.path the way pytest does for this process."""
+    root = Path(__file__).resolve().parents[2]
+    path = tmp_path / "reef-native"
+    path.write_text(
+        f"#!{sys.executable}\nimport sys\nsys.path.insert(0, {str(root)!r})\n"
+        "from reef.harness.native import main\nsys.exit(main())\n"
+    )
+    path.chmod(0o755)
+    return str(path)
+
+
+def _seed_nodes():
+    return [(entry["name"], entry["config"]) for entry in SEED_TOOLS]
+
+
+def _events(trajectory, type_):
+    return [event for event in trajectory if event["type"] == type_]
+
+
+def test_native_adapter_is_bundled_and_renders_tools_as_modules() -> None:
+    assert "native" in available_adapters()
+    descriptor = get_adapter("native")
+    assert descriptor.binary == "reef-native" and descriptor.trajectory_format == "native-jsonl"
+    files = render_composition([("rules", {"text": "Be brief."}), TOOL], descriptor)
+    module = files["native/tools/shout.py"]
+    assert "NAME = 'shout'" in module and "PARAMETERS = {" in module and "def run(args, workdir):" in module
+    assert files["native/RULES.md"] == "Be brief.\n"
+    assert type(reader_for("native-jsonl")).__name__ == "NativeSessionReader"
+
+
+def test_native_tool_is_optional_per_adapter_and_validated() -> None:
+    with pytest.raises(RenderError, match="does not render native_tool"):
+        render_composition([TOOL], get_adapter("pi"))
+    NODE_KINDS["native_tool"](None, TOOL[1])
+    with pytest.raises(ValueError, match="'description'"):
+        NODE_KINDS["native_tool"](None, {"name": "x", "code": "def run(a, w): pass"})
+    with pytest.raises(ValueError, match="'parameters' must be an object"):
+        NODE_KINDS["native_tool"](None, {**TOOL[1], "parameters": ["nope"]})
+    with pytest.raises(ValueError, match="inline credential"):
+        NODE_KINDS["native_tool"](None, {**TOOL[1], "code": "KEY = 'sk-476-TOOL-KEY-0123456789abcdef'"})
+
+
+def test_tool_results_carry_closed_error_codes_and_validate_arguments(tmp_path: Path) -> None:
+    def run(args, workdir):
+        if args.get("text") == "boom":
+            raise RuntimeError("kaboom")
+        return "x" * (MAX_RESULT_CHARS + 5) if args.get("text") == "long" else args["text"].upper()
+
+    tools = {"shout": ToolModule("shout", "Upper-case a string.", TOOL[1]["parameters"], run)}
+    assert _invoke(tools, "nope", "{}", tmp_path)["error"]["code"] == "UNKNOWN_TOOL"
+    assert _invoke(tools, "shout", "{}", tmp_path)["error"] == {
+        "code": "INVALID_ARGS",
+        "message": "missing required argument 'text'",
+    }
+    assert _invoke(tools, "shout", '{"text": 3}', tmp_path)["error"]["code"] == "INVALID_ARGS"
+    assert _invoke(tools, "shout", "not json", tmp_path)["error"]["code"] == "INVALID_ARGS"
+    failed = _invoke(tools, "shout", '{"text": "boom"}', tmp_path)
+    assert failed["is_error"] is True and failed["error"]["code"] == "TOOL_FAILED"
+    assert failed["content"] == "Error: RuntimeError: kaboom"
+    ok = _invoke(tools, "shout", '{"text": "hi"}', tmp_path)
+    assert ok == {"content": "HI", "is_error": False, "arguments": {"text": "hi"}, "meta": ok["meta"]}
+    assert ok["meta"]["truncated"] is False
+    long = _invoke(tools, "shout", '{"text": "long"}', tmp_path)
+    assert len(long["content"]) == MAX_RESULT_CHARS and long["meta"]["truncated"] is True
+
+
+def test_loop_guard_reminds_at_the_thresholds_only() -> None:
+    guard = _LoopGuard()
+    notes = [guard.note("read_file", {"path": "a"}) for _ in range(5)]
+    assert [note is not None for note in notes] == [False, False, True, False, True]
+    assert guard.note("read_file", {"path": "b"}) is None
+
+
+def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path: Path, fake_model) -> None:
+    descriptor = get_adapter("native")
+    binding = ModelBinding(base_url=fake_model.base_url, model="fake", api_key="dummy")
+    files = render_composition(
+        [*_seed_nodes(), ("rules", {"text": "Be brief."}), *binding.compose_nodes(descriptor)], descriptor
+    )
+    result = run_episode(descriptor, files, "put hello in notes.txt and read it back", binary=_launcher(tmp_path))
+    kinds = [event["type"] for event in result.trajectory]
+    assert kinds == [
+        "session",
+        "turn/start",
+        "step/start",
+        "request/header",
+        "assistant/message",
+        "tool/call",
+        "tool/result",
+        "step/end",
+        "step/start",
+        "assistant/message",
+        "tool/call",
+        "tool/result",
+        "step/end",
+        "step/start",
+        "assistant/message",
+        "step/end",
+        "turn/end",
+    ]
+    assert [event["seq"] for event in result.trajectory] == list(range(len(kinds)))
+    header = result.trajectory[0]["data"]
+    assert header["version"] == 1 and header["tools"] == ["read_file", "run_bash", "write_file"]
+    request = _events(result.trajectory, "request/header")[0]["data"]
+    assert request["system"] == "Be brief."
+    assert sorted(tool["function"]["name"] for tool in request["tools"]) == ["read_file", "run_bash", "write_file"]
+    written, read = (event["data"] for event in _events(result.trajectory, "tool/result"))
+    assert written["name"] == "write_file" and written["content"] == "wrote 5 characters to notes.txt"
+    assert written["is_error"] is False and written["arguments"] == {"path": "notes.txt", "content": "hello"}
+    assert read["name"] == "read_file" and read["content"] == "hello"
+    assert _events(result.trajectory, "assistant/message")[-1]["data"]["content"] == "The file says: hello"
+    assert result.trajectory[-1]["data"]["reason"] == {"kind": "completed"}
+    # The first request the fake model saw is the one the log says it saw.
+    first = fake_model.requests[0]
+    assert first["messages"][0] == {"role": "system", "content": "Be brief."}
+    assert sorted(tool["function"]["name"] for tool in first["tools"]) == ["read_file", "run_bash", "write_file"]
+
+
+def test_native_harness_runs_through_the_evolution_gate(tmp_path: Path, fake_model) -> None:
+    """A proposal that adds a tool node is rendered, run on both sides, and scored like any other mutation."""
+
+    def final_answer(task, result):
+        answers = [event for event in result.trajectory if event["type"] == "assistant/message"]
+        return 1.0 if answers and "hello" in (answers[-1]["data"].get("content") or "") else 0.0
+
+    binding = ModelBinding(base_url=fake_model.base_url, model="fake", api_key="dummy")
+    backend = CordisBackend(
+        descriptor=get_adapter("native"),
+        propose=resolve_proposer(
+            lambda nodes, samples, models: Mutation("create", "shout", {"name": "native_tool", "config": TOOL[1]})
+        ),
+        score_episode=resolve_episode_scorer(final_answer),
+        tasks=("put hello in notes.txt and read it back",),
+        models=binding,
+        binary=_launcher(tmp_path),
+        seed=SEED_TOOLS,
+    )
+    batch = TraceBatch("demo:trace:native", (TraceSample("a1", {"messages": []}, 0.0),))
+    prepared = backend.prepare_step(batch, backend.initial_state(), 0)
+    assert prepared.candidate is not None
+    assert "native/tools/shout.py" in prepared.candidate.candidate_files
+    evaluator = DefaultCandidateEvaluationPlugin(backend, ScoreComparisonSelector())
+    decision = evaluator.decide(prepared.candidate, evaluator.evaluate(prepared.candidate))
+    result = backend.settle_step(prepared, decision)
+    # Both trees complete the scripted task, so the verdict is a tie and nothing publishes.
+    assert result.metrics["wins"] == 0 and result.metrics["losses"] == 0 and result.metrics["ties"] == 1
+    assert result.metrics["selected"] is False


### PR DESCRIPTION
## Motivation

The loop we evolve around is a vendor binary pinned in the adapter descriptor, unreachable by any mutation; the evolvable surface is the five file shaped node kinds around it. So the agent decorates someone else's loop but cannot evolve its own software. This is Phase 0 and Phase 1 of #133 in one PR: a native harness owned in this tree, launched per episode like pi, whose loop is Python and whose tools are composition nodes, so a mutation can add, rewrite, or remove a tool. Phase 2 (loop seams as nodes) and the client install path are follow ups listed below. Part of #133.

## Changes

- A native adapter (reef/harness/adapters/native): binary reef-native (a console script this package ships), argv -p {prompt}, env pointing the composition root under the episode root, config targets native/config.json and native/models.json, the existing four kinds mapped under native/, a model_binding for the openai dialect, and trajectory native-jsonl under native/sessions
- The loop (reef/harness/native): reads the rendered root, builds the system prompt from RULES.md and every SKILL.md, loads every tools/*.py module, talks to the served model through ModelBinding.complete with the tool declarations, dispatches tool calls serially, and stops on a plain answer, a step budget, or a model failure
- A native_tool node kind: name, description, a JSON schema parameters object, and code defining run(args, workdir) -> str; it renders to native/tools/{name}.py as a module with NAME, DESCRIPTION, and PARAMETERS constants above the code. The kind is optional per adapter: only a descriptor that declares files.native_tool renders it, and pi, opencode, and claude refuse it with a clear RenderError instead of dropping the tool
- reef.harness.native.seed.SEED_TOOLS: read_file, write_file, and run_bash as native_tool entries, the starting tools a recipe seeds and the loop can then evolve; the seed tools keep paths inside the workspace
- Trajectory design taken from deepseek-harness's session log: one {type, seq, time, data} object per line with a session header, then turn/start, step/start, request/header (the rendered system prompt and tool declarations, so the log holds everything the model saw), assistant/message, tool/call, tool/result, step/end, turn/end; the native-jsonl reader decodes it with the same JSONL rules as the pi reader
- Tool results carry is_error and a closed error code (UNKNOWN_TOOL, INVALID_ARGS, TOOL_FAILED); arguments are validated against the declared schema before run is called; results are tail truncated with a truncated flag; a loop guard appends a logged reminder when the same call repeats three, five, or eight times
- Documented in the harness adapters guide (the adapter, the kind, the trajectory vocabulary), the lane guide (the sixth kind and the native adapter), and the configuration reference

## Compatibility and operational impact

Additive. The three bundled adapters and every existing recipe are unchanged; NAMED_NODE_KINDS is untouched and native_tool sits in a new OPTIONAL_NODE_KINDS tuple, so existing descriptors need no new key. A new console script reef-native is added. The install route answers 400 for adapter=native because the descriptor declares no install section (install kinds are npm only today), and the reef-<adapter> client wrapper has no native branch yet; both are follow ups.

## Follow ups (Phase 2 and beyond, per the #133 RFC)

- Loop seams as nodes: pre_step, request_error, and post_execute, one native_hook kind with a seam field and a waterfall protocol; implemented in #170, stacked on this PR
- A pip install kind so GET /reef/harness/install works for native, and a native branch in the client wrapper
- Result spill to disk beyond the tail cap, and moving rules and skills from the system prompt into logged user messages as deepseek-harness does
- A tutorial variant of harness_evolve on the native adapter

## Verification

New tests drive the real loop through run_episode against a stdlib HTTP server that plays the served model by conversation state (write a file, read it back, answer): the trajectory carries the exact event sequence with contiguous seq, the header lists the seed tools, request/header holds the rendered rules and tool declarations that the fake model actually received, both tool results carry the file contents and is_error false, and turn/end reads completed. A second test runs a proposal that adds a tool node through CordisBackend prepare, evaluate, and settle: the candidate renders native/tools/shout.py, both sides run the scripted task, and the verdict is a tie. Unit tests cover the descriptor loading and rendering tools as modules, native_tool being refused by pi and validated (description, parameters, credential screen), the closed error codes and argument validation in _invoke, truncation, the loop guard thresholds, and the native golden tree in test_harness_render. The whole tests/reef_service directory passes on Python 3.12 (1161 tests). The episode child gets no PYTHONPATH from the engine and the CI test job runs from the checkout without installing the package, so the test launcher puts the checkout on sys.path the way pytest does for the parent. The golden trees are byte exact render output, so the pre-commit exclude now covers tests/reef_service/data. ruff, ruff format, isort, mypy, and the repository statement and design policy checks are clean on the changed files.

## AI assistance

Claude Code mapped the adapter contract and deepseek-harness's loop and wrote the adapter, the loop, and the tests. I set the scope in #133.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [ ] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
