### PR TITLE
feat: open three seams of the native loop to native_hook nodes

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -5,9 +5,10 @@ An adapter maps a harness tree into the files expected by a third-party
 coding-agent CLI and binds that harness to the served model. The harness and
 model together form the running agent. The tree never names a file path; the
 adapter does. Reef bundles six, one per third-party coding-agent CLI, and
-one for its own agent, ``native``, whose loop lives in this tree and whose
-tools are ``native_tool`` nodes, so a mutation can add, rewrite, or remove a
-tool.
+one for its own agent, ``native``, whose loop lives in this tree, whose tools
+are ``native_tool`` nodes, and whose loop seams listen to ``native_hook``
+nodes, so a mutation can add, rewrite, or remove a tool, or change what the
+loop does at a seam.
 
 +--------------+-----------------------------------------------------------+-------------------------------------------+
 | Adapter      | Config targets                                            | Install pin                               |
@@ -98,27 +99,64 @@ inside the working directory with no prompt and refuses a command it flags as
 dangerous with a tool error, so no bypass flag is used.
 
 The native adapter also renders the optional ``native_tool`` kind to
-``native/tools/{name}.py``: a module whose ``NAME``, ``DESCRIPTION``, and
-``PARAMETERS`` come from the node config and whose ``code`` defines
-``run(args, workdir) -> str``. ``reef.harness.native.seed.SEED_TOOLS`` holds
-the starting ``read_file``, ``write_file``, and ``run_bash`` tools as entries
-a recipe can seed and the loop can then evolve. An adapter that declares no
-``files.native_tool`` path refuses to render that kind, so the mutation fails
-under it instead of silently dropping the tool.
+``native/tools/{name}.py``: a module holding the node's ``code``, which
+defines ``run(args, workdir) -> str``, and after it ``NAME``,
+``DESCRIPTION``, and ``PARAMETERS`` from the node config, so the tree's
+values are what the module ends with whatever the code assigned.
+``reef.harness.native.seed.SEED_TOOLS`` holds the starting ``read_file``,
+``write_file``, and ``run_bash`` tools as entries a recipe can seed and the
+loop can then evolve. An adapter that declares no ``files.native_tool`` path
+refuses to render that kind, so the mutation fails under it instead of
+silently dropping the tool. The admission gate refuses ``code`` that does not
+compile; a module that fails to import, or defines no ``run``, ends the
+episode with reason ``error`` and code ``LOAD_ERROR`` before any model call,
+so the tree that carries it loses the gate instead of running without it.
+
+The loop has three seams, and a ``native_hook`` node listens at one of them.
+It renders to ``native/hooks/{name}.py`` the same way: ``code`` defining
+``listen(payload, next) -> decision``, then ``NAME`` and ``SEAM`` from the
+node config. The hooks at one seam form a waterfall in file name order: each
+``listen`` may call ``next()`` to get the decision of the layer below (the
+last layer is the loop's default) and return it, changed or not, or return
+its own decision without calling ``next`` and so own the seam. ``next`` runs
+the layer below at most once however often it is called, and hands the hook
+a copy, so an in-place edit is a change like any other. A hook that raises,
+or returns anything but a plain object the log can carry, is skipped and the
+layer below stands; ``messages`` and ``contexts`` are read as lists of text
+and anything else in them is dropped. A hook module that fails to import,
+defines no ``listen``, or names an unknown seam ends the episode with
+``LOAD_ERROR`` like a tool. Every seam takes a plain object and returns one:
+
+.. config::
+
+   pre_step | before each step: ``{step, task, messages}``; returns ``{kind: "enter", messages: [text...]}`` (each text becomes a user message before the request) or ``{kind: "reject", reason}`` (the turn ends with no step)
+   request_error | after a failed model call: ``{step, attempt, error}`` where ``error`` is ``{code: "MODEL_ERROR", message, status?}`` with ``status`` the HTTP status when the endpoint answered one; returns ``{kind: "retry", delay_ms}`` or ``{kind: "fail"}``; the loop spends at most ``MAX_REQUEST_ATTEMPTS`` (4) attempts a step and waits at most ``MAX_RETRY_DELAY_MS`` (10 s), whatever the hook asks
+   post_execute | after each tool call has run: ``{step, call_id, name, arguments, result}``; returns ``{kind: "accept", content?, contexts: [text...]}`` (``content`` replaces what the model reads) or ``{kind: "block", feedback, contexts}`` (the model reads a ``HOOK_BLOCKED`` error carrying ``feedback``; the tool's side effects stand); contexts land as user messages after the step's results, in call order
+
+``reef.harness.native.seed.SEED_HOOKS`` holds the one starting hook,
+``loop_guard`` at ``post_execute``, which reminds the model when the same call
+repeats three, five, or eight times in a row; it is a node, so a tree can
+retune or drop it. ``SEED_NODES`` is the tools and the hooks together.
 
 The native loop writes its trajectory as ``native-jsonl``: one
 ``{type, seq, time, data}`` object per line, ``seq`` contiguous from 0. A
-``session`` header line names the task, model, and tools; then ``turn/start``,
-per step ``step/start``, ``request/header`` (the rendered system prompt and
-the tool declarations, logged on the first step so the log holds everything
-the model saw), ``assistant/message`` (``content``, ``tool_calls``,
-``finish``), ``tool/call`` (the raw argument string), ``tool/result``
-(``content``, ``is_error``, and on error a closed ``code``: ``UNKNOWN_TOOL``,
-``INVALID_ARGS``, ``TOOL_FAILED``), ``step/end``, and finally ``turn/end``
-with a ``reason`` of ``completed``, ``max-steps``, or ``error``. Arguments are
-validated against the tool's declared schema before ``run`` sees them, and a
-``user/message`` from the ``loop-guard`` plugin lands when the same call
-repeats three, five, or eight times in a row.
+``session`` header line names the task, model, tools, and hooks (name to
+seam); then ``turn/start``, per step ``step/start``, ``request/header`` (the
+rendered system prompt and the tool declarations, logged on the first step so
+the log holds everything the model saw), ``assistant/message`` (``content``,
+``tool_calls``, ``finish``), ``tool/call`` (the raw argument string),
+``tool/result`` (``content``, ``is_error``, and on error a closed ``code``:
+``UNKNOWN_TOOL``, ``INVALID_ARGS``, ``TOOL_FAILED``, ``HOOK_BLOCKED``),
+``step/end``, and finally ``turn/end`` with a ``reason`` of ``completed``,
+``max-steps``, ``rejected``, or ``error`` (its ``error`` code ``MODEL_ERROR``
+or ``LOAD_ERROR``). Arguments are validated against the tool's declared
+schema before ``run`` sees them. A failed model call logs ``request/error``
+(``attempt`` and the ``MODEL_ERROR`` failure) before the ``request_error``
+seam runs. A hook whose decision differs from the layer
+below it logs ``hook/decision`` (``seam``, ``step``, ``hook``, ``owned``, and
+the decision), a hook that raised logs ``hook/error``, and a text a hook
+injected lands as ``user/message`` with ``source.kind`` ``hook`` and the
+``seam``.
 
 The descriptor
 --------------

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -168,7 +168,7 @@ zero.
    evolution.evaluate | an ``EpisodeScorer``, likewise
    evolution.selection | score_comparison | ``always``, or a dotted reference to an object with ``decide``
    evolution.tasks | non-empty list of episode prompts, scored once per tree per step
-   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), ``native`` (Reef's own agent, whose tools are ``native_tool`` nodes), or an entry-point adapter
+   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), ``native`` (Reef's own agent, whose tools are ``native_tool`` nodes and whose loop seams listen to ``native_hook`` nodes), or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
    evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
    evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -20,8 +20,9 @@ Reef stores the mutable, versioned files of one harness in a single object
 called the tree. A tree is a flat list of entries, and each entry has three
 fields: ``id`` is unique within the tree, ``name`` selects one of the node
 kinds below, and ``config`` holds that kind's own fields. For the named kinds
-(``agent_command``, ``skill``, ``code_extension``), ``config.name`` is the
-file name the entry renders to. Six kinds are registered in
+(``agent_command``, ``skill``, ``code_extension``, ``native_tool``,
+``native_hook``), ``config.name`` is the file name the entry renders to.
+Seven kinds are registered in
 `reef/harness/nodes.py <../../reef/harness/nodes.py>`__:
 
 +--------------------+----------------------------------------------------------+
@@ -40,14 +41,17 @@ file name the entry renders to. Six kinds are registered in
 +--------------------+----------------------------------------------------------+
 | ``native_tool``    | a named tool the native harness loads (schema and code)  |
 +--------------------+----------------------------------------------------------+
+| ``native_hook``    | a named listener at one seam of the native loop (code)   |
++--------------------+----------------------------------------------------------+
 
 The table describes what each kind contains. Where each kind is written is
 decided by an adapter, which maps every kind to a concrete file for one agent.
 Reef bundles adapters for third-party coding agent CLIs (``pi``, ``opencode``,
 ``claude``, ``codex``, ``dsh`` (DeepSeek Harness), and ``hermes`` (Hermes
 Agent)) and ``native``, its own agent: a loop inside the reef tree whose tools
-are ``native_tool`` nodes, so the agent can evolve the tools it runs, not only
-the text around a vendor binary. Only ``native`` renders that kind.
+are ``native_tool`` nodes and whose loop seams listen to ``native_hook``
+nodes, so the agent can evolve the tools it runs and how its loop behaves, not
+only the text around a vendor binary. Only ``native`` renders those two kinds.
 
 Codex supports ``config``, ``rules``, ``agent_command``, and ``skill``. It
 rejects ``code_extension`` because Codex lifecycle hooks run outside its

--- a/reef/harness/adapters/native/descriptor.yaml
+++ b/reef/harness/adapters/native/descriptor.yaml
@@ -1,6 +1,7 @@
 # Reef's own coding agent: a Python loop inside this tree, driven headless per
-# episode, whose tools are native_tool nodes. REEF_NATIVE_DIR relocates the
-# whole composition root so nothing is read from the working directory.
+# episode, whose tools are native_tool nodes and whose loop seams listen to
+# native_hook nodes. REEF_NATIVE_DIR relocates the whole composition root so
+# nothing is read from the working directory.
 name: native
 binary: reef-native
 argv: ["-p", "{prompt}"]
@@ -20,12 +21,14 @@ files:
   skill: "native/skills/{name}/SKILL.md"
   code_extension: "native/extensions/{name}.py"
   native_tool: "native/tools/{name}.py"
+  native_hook: "native/hooks/{name}.py"
 trajectory:
   format: native-jsonl
   path: "native/sessions"
 cleanup_whitelist:
   - "native/sessions/**"
   - "native/tools/__pycache__/**"
+  - "native/hooks/__pycache__/**"
 # The served model reaches the loop through this file only; the served tree
 # never carries a provider.
 model_binding:

--- a/reef/harness/descriptor.py
+++ b/reef/harness/descriptor.py
@@ -46,7 +46,7 @@ ENTRY_POINT_GROUP = "reef.harness_adapters"
 #: Node kinds rendered to one path per named node; templates need ``{name}``.
 NAMED_NODE_KINDS = ("agent_command", "skill", "code_extension")
 #: Named kinds an adapter may leave out; a mutation of that kind then fails to render under it.
-OPTIONAL_NODE_KINDS = ("native_tool",)
+OPTIONAL_NODE_KINDS = ("native_tool", "native_hook")
 
 
 class DescriptorError(ReefError):

--- a/reef/harness/episode.py
+++ b/reef/harness/episode.py
@@ -123,7 +123,7 @@ def run_episode(
             try:
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_text(text, encoding="utf-8")
-            except OSError as exc:
+            except (OSError, UnicodeEncodeError) as exc:
                 raise EpisodeError(f"cannot write render path {relative!r}: {exc}") from exc
             written.add(str(relative_path))
         workspace = root / "workspace"

--- a/reef/harness/native/__init__.py
+++ b/reef/harness/native/__init__.py
@@ -1,33 +1,39 @@
-"""Reef's native coding agent: a headless single prompt loop whose tools are composition nodes.
+"""Reef's native coding agent: a headless single prompt loop whose tools and loop seams are composition nodes.
 
 One episode is one process and one turn. The rendered composition root
-(``REEF_NATIVE_DIR``) holds ``RULES.md``, ``skills/``, ``tools/`` and
-``models.json``; the loop reads them, talks to the served model through the
-rendered binding, dispatches tool calls to the tool modules, and appends one
-JSONL session the ``native-jsonl`` trajectory reader decodes. Everything the
-model saw is in that log: the rendered system prompt, the tool declarations,
-every message, every call, every result.
+(``REEF_NATIVE_DIR``) holds ``RULES.md``, ``skills/``, ``tools/``, ``hooks/``
+and ``models.json``; the loop reads them, talks to the served model through
+the rendered binding, dispatches tool calls to the tool modules, asks the
+hook modules at three seams, and appends one JSONL session the
+``native-jsonl`` trajectory reader decodes. Everything the model saw is in
+that log: the rendered system prompt, the tool declarations, every message,
+every call, every result, and every hook decision that changed the loop's
+course.
 """
 
 from __future__ import annotations
 
 import argparse
+import copy
 import importlib.util
 import json
 import os
 import sys
 import time
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Protocol
 
 from reef.harness.model_binding import ModelBinding, ModelBindingError
+from reef.harness.nodes import NATIVE_SEAMS
 
 #: Step and tool result budgets; an episode also runs under the executor's wall clock.
 MAX_STEPS = 12
 MAX_RESULT_CHARS = 20_000
-#: Consecutive identical calls that earn the model a reminder; the loop never vetoes a call.
-LOOP_GUARD_THRESHOLDS = (3, 5, 8)
+#: Provider attempts one step may spend and the longest wait between them, whatever a request_error hook asks.
+MAX_REQUEST_ATTEMPTS = 4
+MAX_RETRY_DELAY_MS = 10_000
 DEFAULT_SYSTEM_PROMPT = "You are a coding agent. Use the tools to complete the task, then answer."
 SESSION_VERSION = 1
 _SCALAR_TYPES: dict[str, type | tuple[type, ...]] = {
@@ -38,12 +44,34 @@ _SCALAR_TYPES: dict[str, type | tuple[type, ...]] = {
     "object": dict,
     "array": list,
 }
+#: What the loop decides at each seam when no hook says otherwise.
+_DEFAULTS: dict[str, dict[str, Any]] = {
+    "pre_step": {"kind": "enter", "messages": []},
+    "request_error": {"kind": "fail"},
+    "post_execute": {"kind": "accept", "contexts": []},
+}
+
+
+class LoadError(Exception):
+    """A rendered tool or hook module the loop cannot use; the episode ends in error instead of running without it."""
 
 
 class ToolRunner(Protocol):
     """What a tool module's ``run`` looks like: ``run(args, workdir) -> str``."""
 
     def __call__(self, args: dict[str, Any], workdir: str, /) -> Any: ...
+
+
+class Next(Protocol):
+    """A hook's ``next``: the decision of the layer below, computed once."""
+
+    def __call__(self) -> dict[str, Any]: ...
+
+
+class HookListener(Protocol):
+    """What a hook module's ``listen`` looks like: ``listen(payload, next) -> decision``."""
+
+    def __call__(self, payload: dict[str, Any], next_: Next, /) -> Any: ...
 
 
 class ToolModule:
@@ -78,27 +106,51 @@ class ToolModule:
         return None
 
 
-def load_tools(tools_dir: Path) -> dict[str, ToolModule]:
-    """Import every ``tools/*.py``; a module that fails to import is skipped, never fatal."""
-    tools: dict[str, ToolModule] = {}
-    for path in sorted(tools_dir.glob("*.py")):
-        spec = importlib.util.spec_from_file_location(f"reef_native_tool_{path.stem}", path)
+class HookModule:
+    """One rendered ``native_hook`` node: the seam it listens at and its ``listen``."""
+
+    def __init__(self, name: str, seam: str, listen: HookListener) -> None:
+        self.name = name
+        self.seam = seam
+        self.listen = listen
+
+
+def _modules(directory: Path, prefix: str) -> Iterator[tuple[Path, ModuleType]]:
+    """Import every ``*.py`` in name order; a module that fails to import fails the episode, so the tree that carries it loses."""
+    for path in sorted(directory.glob("*.py")):
+        spec = importlib.util.spec_from_file_location(f"{prefix}_{path.stem}", path)
         if spec is None or spec.loader is None:
             continue
         module = importlib.util.module_from_spec(spec)
         try:
             spec.loader.exec_module(module)
         except Exception as exc:
-            print(f"[reef-native] tool {path.name} failed to import: {exc}", file=sys.stderr)
-            continue
+            raise LoadError(f"{path.name} failed to import: {type(exc).__name__}: {exc}") from exc
+        yield path, module
+
+
+def load_tools(tools_dir: Path) -> dict[str, ToolModule]:
+    tools: dict[str, ToolModule] = {}
+    for path, module in _modules(tools_dir, "reef_native_tool"):
         run = getattr(module, "run", None)
         if not callable(run):
-            print(f"[reef-native] tool {path.name} defines no run(args, workdir)", file=sys.stderr)
-            continue
+            raise LoadError(f"tool {path.name} defines no run(args, workdir)")
         name = str(getattr(module, "NAME", path.stem))
         parameters = getattr(module, "PARAMETERS", {})
         tools[name] = ToolModule(name, str(getattr(module, "DESCRIPTION", "")), parameters, run)
     return tools
+
+
+def load_hooks(hooks_dir: Path) -> dict[str, list[HookModule]]:
+    """Every hook under its seam, in file name order: that order is the waterfall order."""
+    hooks: dict[str, list[HookModule]] = {seam: [] for seam in NATIVE_SEAMS}
+    for path, module in _modules(hooks_dir, "reef_native_hook"):
+        listen = getattr(module, "listen", None)
+        seam = str(getattr(module, "SEAM", ""))
+        if not callable(listen) or seam not in hooks:
+            raise LoadError(f"hook {path.name} defines no listen(payload, next) at a known seam")
+        hooks[seam].append(HookModule(str(getattr(module, "NAME", path.stem)), seam, listen))
+    return hooks
 
 
 def system_prompt(root: Path) -> str:
@@ -129,64 +181,216 @@ class Session:
     def write(self, type_: str, data: Mapping[str, Any]) -> None:
         event = {"type": type_, "seq": self._seq, "time": int(time.time() * 1000), "data": dict(data)}
         self._seq += 1
-        self._handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+        self._handle.write(json.dumps(event, ensure_ascii=False, default=str) + "\n")
         self._handle.flush()
 
     def close(self) -> None:
         self._handle.close()
 
 
-class _LoopGuard:
-    """Counts consecutive identical calls and says so to the model at the thresholds."""
+class _Layer:
+    """``next`` as one hook sees it: the layer below runs once however often it is called.
 
-    def __init__(self) -> None:
-        self._last: str | None = None
-        self._count = 0
+    The hook gets a copy; the pristine decision stays here for the comparison
+    and the fallback, so an in-place edit is a change like any other."""
 
-    def note(self, name: str, args: Any) -> str | None:
-        key = json.dumps([name, args], sort_keys=True, default=str)
-        self._count = self._count + 1 if key == self._last else 1
-        self._last = key
-        if self._count in LOOP_GUARD_THRESHOLDS:
-            return f"You have called {name} with the same arguments {self._count} times in a row. Change approach or answer."
+    def __init__(
+        self,
+        hooks: Sequence[HookModule],
+        index: int,
+        payload: Mapping[str, Any],
+        default: Mapping[str, Any],
+        trace: list[dict[str, Any]],
+    ) -> None:
+        self._hooks = hooks
+        self._index = index
+        self._payload = payload
+        self._default = default
+        self._trace = trace
+        self._decision: dict[str, Any] | None = None
+        self._handed: dict[str, Any] | None = None
+
+    @property
+    def called(self) -> bool:
+        return self._decision is not None
+
+    @property
+    def decision(self) -> dict[str, Any]:
+        if self._decision is None:
+            self._decision = _waterfall(self._hooks, self._index, self._payload, self._default, self._trace)
+        return self._decision
+
+    def __call__(self) -> dict[str, Any]:
+        if self._handed is None:
+            self._handed = copy.deepcopy(self.decision)
+        return self._handed
+
+
+def _plain(decision: dict[str, Any]) -> dict[str, Any]:
+    """A decision as the loop and the log carry it: text lists normalized, and proven JSON encodable."""
+    plain: dict[str, Any] = dict(decision)
+    for key in ("messages", "contexts"):
+        if key in plain:
+            plain[key] = _texts(plain[key])
+    json.dumps(plain, default=str)
+    return plain
+
+
+def _waterfall(
+    hooks: Sequence[HookModule],
+    index: int,
+    payload: Mapping[str, Any],
+    default: Mapping[str, Any],
+    trace: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Hook ``index`` decides, seeing the layer below through ``next``; the last layer is the loop's default.
+
+    A hook owns the decision by returning without calling ``next``. A hook
+    that raises, or returns anything but a plain object the log can carry,
+    is skipped and the layer below stands. ``trace`` receives every hook
+    whose decision differs from the one below it, so the log names who
+    changed the loop's course."""
+    if index == len(hooks):
+        return copy.deepcopy(dict(default))
+    hook = hooks[index]
+    below = _Layer(hooks, index + 1, payload, default, trace)
+    try:
+        decision = hook.listen(copy.deepcopy(dict(payload)), below)
+        if isinstance(decision, dict):
+            decision = _plain(decision)
+    except Exception as exc:
+        trace.append({"hook": hook.name, "error": f"{type(exc).__name__}: {exc}"[:600]})
+        return below.decision
+    if not isinstance(decision, dict):
+        return below.decision
+    if not below.called or decision != below.decision:
+        trace.append({"hook": hook.name, "owned": not below.called, "decision": copy.deepcopy(decision)})
+    return decision
+
+
+def _decide(
+    session: Session, hooks: Sequence[HookModule], seam: str, step: int, payload: Mapping[str, Any]
+) -> dict[str, Any]:
+    trace: list[dict[str, Any]] = []
+    decision = _waterfall(hooks, 0, payload, _DEFAULTS[seam], trace)
+    for entry in trace:
+        session.write("hook/error" if "error" in entry else "hook/decision", {"seam": seam, "step": step, **entry})
+    return decision
+
+
+def _texts(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str) and item] if isinstance(value, list) else []
+
+
+def _complete(binding: ModelBinding, body: Mapping[str, Any]) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """One provider attempt: the assistant message, or the closed MODEL_ERROR failure."""
+    try:
+        response = binding.complete(dict(body))
+        return dict(response["choices"][0]["message"]), None
+    except (ModelBindingError, KeyError, IndexError, TypeError) as exc:
+        failure: dict[str, Any] = {"code": "MODEL_ERROR", "message": f"{type(exc).__name__}: {exc}"[:600]}
+        if isinstance(exc, ModelBindingError) and exc.status is not None:
+            failure["status"] = exc.status
+        return None, failure
+
+
+def _request(
+    session: Session, binding: ModelBinding, hooks: Sequence[HookModule], body: Mapping[str, Any], step: int
+) -> dict[str, Any] | None:
+    """The step's model call, retried while a request_error hook says so; None once the turn ended in error."""
+    for attempt in range(1, MAX_REQUEST_ATTEMPTS + 1):
+        message, failure = _complete(binding, body)
+        if failure is None:
+            return message
+        session.write("request/error", {"step": step, "attempt": attempt, "error": failure})
+        action = _decide(session, hooks, "request_error", step, {"step": step, "attempt": attempt, "error": failure})
+        if action.get("kind") == "retry" and attempt < MAX_REQUEST_ATTEMPTS:
+            delay = action.get("delay_ms")
+            time.sleep(
+                min(float(delay) if isinstance(delay, (int, float)) and delay > 0 else 0.0, MAX_RETRY_DELAY_MS) / 1000
+            )
+            continue
+        _abort(session, failure, attempts=attempt)
         return None
+    return None
+
+
+def _abort(session: Session, failure: Mapping[str, Any], **detail: Any) -> int:
+    """End the turn in error: the closed failure in the log, its message on stderr, exit status 1."""
+    session.write("turn/end", {"turn": 1, "reason": {"kind": "error", "error": dict(failure), **detail}})
+    print(f"[reef-native] {failure['message']}", file=sys.stderr)
+    return 1
+
+
+def _judged(result: dict[str, Any], verdict: Mapping[str, Any]) -> dict[str, Any]:
+    """The result the model sees after post_execute: blocked with feedback, replaced content, or as run."""
+    if verdict.get("kind") == "block":
+        feedback = str(verdict.get("feedback") or "blocked by a hook")
+        return {
+            "content": f"Error: {feedback}",
+            "is_error": True,
+            "error": {"code": "HOOK_BLOCKED", "message": feedback},
+            "arguments": result.get("arguments"),
+        }
+    if isinstance(verdict.get("content"), str):
+        return {**result, "content": verdict["content"][:MAX_RESULT_CHARS]}
+    return result
 
 
 def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
+    """One turn: per step, pre_step, the request (request_error on failure), each call then post_execute."""
     binding = binding_from(root / "models.json")
-    tools = load_tools(root / "tools")
     session = Session(session_dir / "session.jsonl")
-    session.write(
-        "session",
-        {
-            "version": SESSION_VERSION,
-            "task": prompt,
-            "model": binding.model,
-            "base_url": binding.base_url,
-            "cwd": str(workdir),
-            "tools": sorted(tools),
-        },
-    )
-    session.write("turn/start", {"turn": 1})
-    system = system_prompt(root)
-    declarations = [tool.declaration() for tool in tools.values()]
-    messages: list[dict[str, Any]] = [{"role": "system", "content": system}, {"role": "user", "content": prompt}]
-    guard = _LoopGuard()
+    header = {
+        "version": SESSION_VERSION,
+        "task": prompt,
+        "model": binding.model,
+        "base_url": binding.base_url,
+        "cwd": str(workdir),
+    }
     try:
+        try:
+            tools = load_tools(root / "tools")
+            hooks = load_hooks(root / "hooks")
+        except LoadError as exc:
+            session.write("session", {**header, "tools": [], "hooks": {}})
+            session.write("turn/start", {"turn": 1})
+            return _abort(session, {"code": "LOAD_ERROR", "message": str(exc)[:600]})
+        session.write(
+            "session",
+            {
+                **header,
+                "tools": sorted(tools),
+                "hooks": {hook.name: seam for seam, listeners in hooks.items() for hook in listeners},
+            },
+        )
+        session.write("turn/start", {"turn": 1})
+        system = system_prompt(root)
+        declarations = [tool.declaration() for tool in tools.values()]
+        messages: list[dict[str, Any]] = [{"role": "system", "content": system}, {"role": "user", "content": prompt}]
+
+        def say(step: int, seam: str, content: str) -> None:
+            session.write("user/message", {"step": step, "source": {"kind": "hook", "seam": seam}, "content": content})
+            messages.append({"role": "user", "content": content})
+
         for step in range(1, MAX_STEPS + 1):
+            entry = _decide(
+                session, hooks["pre_step"], "pre_step", step, {"step": step, "task": prompt, "messages": messages}
+            )
+            if entry.get("kind") == "reject":
+                reason = {"kind": "rejected", "step": step, "message": str(entry.get("reason") or "")}
+                session.write("turn/end", {"turn": 1, "reason": reason})
+                return 0
             session.write("step/start", {"turn": 1, "step": step})
             if step == 1:
                 session.write("request/header", {"model": binding.model, "system": system, "tools": declarations})
+            for content in _texts(entry.get("messages")):
+                say(step, "pre_step", content)
             body: dict[str, Any] = {"messages": messages}
             if declarations:
                 body["tools"] = declarations
-            try:
-                response = binding.complete(body)
-                message = dict(response["choices"][0]["message"])
-            except (ModelBindingError, KeyError, IndexError, TypeError) as exc:
-                failure = {"code": "MODEL_ERROR", "message": f"{type(exc).__name__}: {exc}"[:600]}
-                session.write("turn/end", {"turn": 1, "reason": {"kind": "error", "error": failure}})
-                print(f"[reef-native] model call failed: {exc}", file=sys.stderr)
+            message = _request(session, binding, hooks["request_error"], body, step)
+            if message is None:
                 return 1
             calls = list(message.get("tool_calls") or [])
             messages.append(message)
@@ -203,6 +407,7 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
                 session.write("step/end", {"turn": 1, "step": step})
                 session.write("turn/end", {"turn": 1, "reason": {"kind": "completed"}})
                 return 0
+            contexts: list[str] = []
             for call in calls:
                 function = call.get("function") or {}
                 name = str(function.get("name", ""))
@@ -210,14 +415,21 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
                 call_id = str(call.get("id") or name)
                 session.write("tool/call", {"step": step, "call_id": call_id, "name": name, "arguments": raw})
                 result = _invoke(tools, name, raw, workdir)
+                payload = {
+                    "step": step,
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": result.get("arguments"),
+                    "result": result,
+                }
+                verdict = _decide(session, hooks["post_execute"], "post_execute", step, payload)
+                result = _judged(result, verdict)
                 session.write("tool/result", {"step": step, "call_id": call_id, "name": name, **result})
                 messages.append({"role": "tool", "tool_call_id": call_id, "content": result["content"]})
-                reminder = guard.note(name, result.get("arguments"))
-                if reminder is not None:
-                    session.write(
-                        "user/message", {"source": {"kind": "plugin", "plugin": "loop-guard"}, "content": reminder}
-                    )
-                    messages.append({"role": "user", "content": reminder})
+                contexts.extend(_texts(verdict.get("contexts")))
+            # Contexts land after the batch's results, in call order, so the model reads them as one note.
+            for content in contexts:
+                say(step, "post_execute", content)
             session.write("step/end", {"turn": 1, "step": step})
         session.write("turn/end", {"turn": 1, "reason": {"kind": "max-steps", "steps": MAX_STEPS}})
         return 0

--- a/reef/harness/native/seed.py
+++ b/reef/harness/native/seed.py
@@ -1,4 +1,4 @@
-"""The native harness's starting tools as ``native_tool`` entries: a seed the evolution loop can mutate."""
+"""The native harness's starting tools and hooks as node entries: a seed the evolution loop can mutate."""
 
 from __future__ import annotations
 
@@ -52,11 +52,41 @@ def run(args, workdir):
 """
 
 
+_LOOP_GUARD = """\
+import json
+
+THRESHOLDS = (3, 5, 8)
+_chain = {"key": None, "count": 0}
+
+
+def listen(payload, next):
+    decision = next()
+    key = json.dumps([payload["name"], payload["arguments"]], sort_keys=True, default=str)
+    _chain["count"] = _chain["count"] + 1 if key == _chain["key"] else 1
+    _chain["key"] = key
+    if _chain["count"] in THRESHOLDS:
+        reminder = (
+            f"You have called {payload['name']} with the same arguments {_chain['count']} times in a row. "
+            "Change approach or answer."
+        )
+        return {**decision, "contexts": [*decision.get("contexts", []), reminder]}
+    return decision
+"""
+
+
 def _tool(name: str, description: str, parameters: dict[str, Any], code: str) -> dict[str, Any]:
     return {
         "id": f"tool-{name.replace('_', '-')}",
         "name": "native_tool",
         "config": {"name": name, "description": description, "parameters": parameters, "code": code},
+    }
+
+
+def _hook(name: str, seam: str, code: str) -> dict[str, Any]:
+    return {
+        "id": f"hook-{name.replace('_', '-')}",
+        "name": "native_hook",
+        "config": {"name": name, "seam": seam, "code": code},
     }
 
 
@@ -85,4 +115,9 @@ SEED_TOOLS: tuple[dict[str, Any], ...] = (
     ),
 )
 
-__all__ = ["SEED_TOOLS"]
+#: The loop guard is a hook, not loop code: a tree may retune or drop it.
+SEED_HOOKS: tuple[dict[str, Any], ...] = (_hook("loop_guard", "post_execute", _LOOP_GUARD),)
+
+SEED_NODES: tuple[dict[str, Any], ...] = (*SEED_TOOLS, *SEED_HOOKS)
+
+__all__ = ["SEED_HOOKS", "SEED_NODES", "SEED_TOOLS"]

--- a/reef/harness/nodes.py
+++ b/reef/harness/nodes.py
@@ -19,6 +19,8 @@ native harness adds kinds only it renders:
   ``extensions/``, opencode ``plugin/``).
 - ``native_tool``: a named tool of the native harness, a JSON schema plus
   code defining ``run(args, workdir)`` (``native/tools/``).
+- ``native_hook``: a named listener at one seam of the native loop, code
+  defining ``listen(payload, next)`` (``native/hooks/``).
 
 The plugins hold no services and register no effects: the Entry tree itself
 is the state, and ``reef.harness.render`` reads it back out per adapter.
@@ -32,6 +34,8 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 _NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+#: The native loop's seams, the only places a native_hook node may listen.
+NATIVE_SEAMS = ("pre_step", "request_error", "post_execute")
 _SECRET_NAME = re.compile(r"(?i)(api[_-]?keys?([_-]?env)?|tokens?|secrets?|passwords?)$")
 #: Distinctive credential shapes in free text. A tripwire like _SECRET_NAME:
 #: prefixes and key blocks that are never legitimate tree content, chosen so
@@ -65,7 +69,23 @@ def _require_text(config: Mapping[str, Any], key: str) -> str:
     value = config.get(key)
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"node config requires a non-empty string {key!r}")
+    # A lone surrogate survives JSON but cannot be written as UTF-8 at render.
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"node config {key!r} must be UTF-8 encodable text: {exc}") from exc
     return value
+
+
+def _require_python(options: Mapping[str, Any], where: str) -> str:
+    """A ``code`` body the native loop will import: refused here when it cannot even compile."""
+    code = _require_text(options, "code")
+    try:
+        compile(code, f"{options.get('name')}.py", "exec")
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError(f"{where} 'code' does not compile: {exc}") from exc
+    _reject_secret_shaped_text(code, f"{where} 'code'")
+    return code
 
 
 def _require_name(config: Mapping[str, Any]) -> str:
@@ -175,7 +195,16 @@ def native_tool_node(ctx: Any, config: Any) -> None:
     _require_text(options, "description")
     if not isinstance(options.get("parameters", {}), Mapping):
         raise ValueError("native_tool node 'parameters' must be an object")
-    _reject_secret_shaped_text(_require_text(options, "code"), "native_tool node 'code'")
+    _require_python(options, "native_tool node")
+
+
+def native_hook_node(ctx: Any, config: Any) -> None:
+    """A named listener the native loop calls at one seam: code defining ``listen(payload, next)``."""
+    options = _require_mapping(config)
+    _require_name(options)
+    if options.get("seam") not in NATIVE_SEAMS:
+        raise ValueError(f"native_hook node 'seam' must be one of {', '.join(NATIVE_SEAMS)}")
+    _require_python(options, "native_hook node")
 
 
 NODE_KINDS: dict[str, Callable[[Any, Any], None]] = {
@@ -185,5 +214,6 @@ NODE_KINDS: dict[str, Callable[[Any, Any], None]] = {
     "skill": skill_node,
     "code_extension": code_extension_node,
     "native_tool": native_tool_node,
+    "native_hook": native_hook_node,
 }
 """Entry ``name`` to node plugin; the resolver of the composition loader."""

--- a/reef/harness/render.py
+++ b/reef/harness/render.py
@@ -57,20 +57,22 @@ def render_composition(nodes: Sequence[tuple[str, Any]], descriptor: AdapterDesc
             emit(descriptor.node_paths[kind].format(name=options.get("name")), str(options.get("text", "")))
         elif kind == "code_extension":
             emit(descriptor.node_paths[kind].format(name=options.get("name")), str(options.get("code", "")))
-        elif kind == "native_tool":
+        elif kind in ("native_tool", "native_hook"):
             template = descriptor.node_paths.get(kind)
             if template is None:
-                raise RenderError(f"adapter {descriptor.name!r} does not render native_tool nodes")
-            # One importable module: the declaration as constants, then the code that defines run(args, workdir).
-            header = "\n".join(
-                f"{key} = {value!r}"
-                for key, value in (
+                raise RenderError(f"adapter {descriptor.name!r} does not render {kind} nodes")
+            # One importable module: the code that defines run or listen, then the declaration as constants, so the node config binds.
+            fields = (
+                (("NAME", options.get("name")), ("SEAM", options.get("seam")))
+                if kind == "native_hook"
+                else (
                     ("NAME", options.get("name")),
                     ("DESCRIPTION", options.get("description", "")),
                     ("PARAMETERS", dict(options.get("parameters", {}) or {})),
                 )
             )
-            emit(template.format(name=options.get("name")), f"{header}\n\n{options.get('code', '')}")
+            header = "\n".join(f"{key} = {value!r}" for key, value in fields)
+            emit(template.format(name=options.get("name")), f"{str(options.get('code', '')).rstrip()}\n\n{header}\n")
         else:
             raise RenderError(f"unknown node kind {kind!r}")
 

--- a/tests/reef_service/data/harness_goldens/native/native/hooks/guard.py
+++ b/tests/reef_service/data/harness_goldens/native/native/hooks/guard.py
@@ -1,0 +1,5 @@
+def listen(payload, next):
+    return next()
+
+NAME = 'guard'
+SEAM = 'post_execute'

--- a/tests/reef_service/data/harness_goldens/native/native/tools/shout.py
+++ b/tests/reef_service/data/harness_goldens/native/native/tools/shout.py
@@ -1,6 +1,6 @@
+def run(args, workdir):
+    return str(args.get('text', '')).upper()
+
 NAME = 'shout'
 DESCRIPTION = 'Upper-case a string.'
 PARAMETERS = {'type': 'object', 'properties': {'text': {'type': 'string'}}, 'required': ['text']}
-
-def run(args, workdir):
-    return str(args.get('text', '')).upper()

--- a/tests/reef_service/test_harness_render.py
+++ b/tests/reef_service/test_harness_render.py
@@ -274,11 +274,18 @@ NATIVE_TOOL = (
 )
 
 
+NATIVE_HOOK = (
+    "native_hook",
+    {"name": "guard", "seam": "post_execute", "code": "def listen(payload, next):\n    return next()\n"},
+)
+
+
 def test_native_render_matches_the_golden_tree() -> None:
     # The native harness loads Python extensions, so its golden carries a Python body.
     nodes = [node for node in NODES if node[0] != "code_extension"]
     extension = ("code_extension", {"name": "tracer", "code": "def tracer():\n    pass\n"})
-    assert render_composition([*nodes, extension, NATIVE_TOOL], get_adapter("native")) == golden_tree("native")
+    rendered = render_composition([*nodes, extension, NATIVE_TOOL, NATIVE_HOOK], get_adapter("native"))
+    assert rendered == golden_tree("native")
 
 
 def test_config_nodes_deep_merge_in_tree_order() -> None:

--- a/tests/reef_service/test_native_harness.py
+++ b/tests/reef_service/test_native_harness.py
@@ -1,8 +1,8 @@
-"""The native adapter: a loop inside the tree whose tools are nodes, driven through the real episode engine.
+"""The native adapter: a loop inside the tree whose tools and seams are nodes, driven through the real episode engine.
 
 A stdlib HTTP server plays the served model: it answers by conversation state
 (write a file, then read it back, then answer), so the whole loop, the tool
-modules, and the trajectory run hermetically."""
+and hook modules, and the trajectory run hermetically."""
 
 from __future__ import annotations
 
@@ -17,8 +17,8 @@ import pytest
 from reef.harness.adapters import available_adapters, get_adapter
 from reef.harness.episode import run_episode
 from reef.harness.model_binding import ModelBinding
-from reef.harness.native import MAX_RESULT_CHARS, ToolModule, _invoke, _LoopGuard
-from reef.harness.native.seed import SEED_TOOLS
+from reef.harness.native import _DEFAULTS, MAX_RESULT_CHARS, HookModule, ToolModule, _invoke, _waterfall, load_hooks
+from reef.harness.native.seed import SEED_NODES, SEED_TOOLS
 from reef.harness.nodes import NODE_KINDS
 from reef.harness.render import RenderError, render_composition
 from reef.harness.trajectory import reader_for
@@ -35,6 +35,45 @@ TOOL = (
         "parameters": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
         "code": "def run(args, workdir):\n    return str(args.get('text', '')).upper()\n",
     },
+)
+HOOK = ("native_hook", {"name": "echo", "seam": "pre_step", "code": "def listen(payload, next):\n    return next()\n"})
+# One hook per seam: retry the first failed request, block writes with a note, stop before the third step.
+SEAM_HOOKS = (
+    (
+        "native_hook",
+        {
+            "name": "retry",
+            "seam": "request_error",
+            "code": "def listen(payload, next):\n    return {'kind': 'retry', 'delay_ms': 0}\n",
+        },
+    ),
+    (
+        "native_hook",
+        {
+            "name": "veto",
+            "seam": "post_execute",
+            "code": (
+                "def listen(payload, next):\n"
+                "    decision = next()\n"
+                "    if payload['name'] == 'write_file':\n"
+                "        return {'kind': 'block', 'feedback': 'writes are off', 'contexts': ['Writes are disabled here.']}\n"
+                "    return decision\n"
+            ),
+        },
+    ),
+    (
+        "native_hook",
+        {
+            "name": "stop",
+            "seam": "pre_step",
+            "code": (
+                "def listen(payload, next):\n"
+                "    if payload['step'] == 3:\n"
+                "        return {'kind': 'reject', 'reason': 'two steps are enough'}\n"
+                "    return next()\n"
+            ),
+        },
+    ),
 )
 
 
@@ -62,6 +101,9 @@ class _FakeModel(ThreadingHTTPServer):
     def base_url(self) -> str:
         return f"http://127.0.0.1:{self.server_address[1]}"
 
+    def status(self, body: dict) -> int:
+        return 200
+
     def script(self, body: dict) -> dict:
         tool_results = [m for m in body["messages"] if m.get("role") == "tool"]
         if not tool_results:
@@ -71,12 +113,28 @@ class _FakeModel(ThreadingHTTPServer):
         return _reply(content=f"The file says: {tool_results[-1]['content']}")
 
 
+class _FlakyModel(_FakeModel):
+    """Fails the first request with a 500, then plays the script."""
+
+    def status(self, body: dict) -> int:
+        return 500 if len(self.requests) == 1 else 200
+
+
+class _RepeatingModel(_FakeModel):
+    """Asks for the same read three times, then answers."""
+
+    def script(self, body: dict) -> dict:
+        if len(self.requests) <= 3:
+            return _reply(tool_calls=[_call("read_file", {"path": "missing.txt"}, f"c{len(self.requests)}")])
+        return _reply(content="giving up")
+
+
 class _Handler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
         self.server.requests.append(body)  # type: ignore[attr-defined]
         payload = json.dumps(self.server.script(body)).encode()  # type: ignore[attr-defined]
-        self.send_response(200)
+        self.send_response(self.server.status(body))  # type: ignore[attr-defined]
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
@@ -111,8 +169,15 @@ def _launcher(tmp_path: Path) -> str:
     return str(path)
 
 
-def _seed_nodes():
-    return [(entry["name"], entry["config"]) for entry in SEED_TOOLS]
+def _seed_nodes(entries=SEED_NODES):
+    return [(entry["name"], entry["config"]) for entry in entries]
+
+
+def _episode(tmp_path: Path, model, nodes, prompt="put hello in notes.txt and read it back"):
+    descriptor = get_adapter("native")
+    binding = ModelBinding(base_url=model.base_url, model="fake", api_key="dummy")
+    files = render_composition([*nodes, *binding.compose_nodes(descriptor)], descriptor)
+    return run_episode(descriptor, files, prompt, binary=_launcher(tmp_path))
 
 
 def _events(trajectory, type_):
@@ -123,9 +188,14 @@ def test_native_adapter_is_bundled_and_renders_tools_as_modules() -> None:
     assert "native" in available_adapters()
     descriptor = get_adapter("native")
     assert descriptor.binary == "reef-native" and descriptor.trajectory_format == "native-jsonl"
-    files = render_composition([("rules", {"text": "Be brief."}), TOOL], descriptor)
+    files = render_composition([("rules", {"text": "Be brief."}), TOOL, HOOK], descriptor)
     module = files["native/tools/shout.py"]
     assert "NAME = 'shout'" in module and "PARAMETERS = {" in module and "def run(args, workdir):" in module
+    # The config constants come after the code, so the tree's values are what the module ends with.
+    assert (
+        files["native/hooks/echo.py"]
+        == "def listen(payload, next):\n    return next()\n\nNAME = 'echo'\nSEAM = 'pre_step'\n"
+    )
     assert files["native/RULES.md"] == "Be brief.\n"
     assert type(reader_for("native-jsonl")).__name__ == "NativeSessionReader"
 
@@ -140,6 +210,117 @@ def test_native_tool_is_optional_per_adapter_and_validated() -> None:
         NODE_KINDS["native_tool"](None, {**TOOL[1], "parameters": ["nope"]})
     with pytest.raises(ValueError, match="inline credential"):
         NODE_KINDS["native_tool"](None, {**TOOL[1], "code": "KEY = 'sk-476-TOOL-KEY-0123456789abcdef'"})
+    with pytest.raises(ValueError, match="'code' does not compile"):
+        NODE_KINDS["native_tool"](None, {**TOOL[1], "code": "def run(args, workdir)\n    return 1\n"})
+
+
+def test_native_hook_is_optional_per_adapter_and_bound_to_a_seam() -> None:
+    with pytest.raises(RenderError, match="does not render native_hook"):
+        render_composition([HOOK], get_adapter("pi"))
+    NODE_KINDS["native_hook"](None, HOOK[1])
+    with pytest.raises(ValueError, match="'seam' must be one of pre_step, request_error, post_execute"):
+        NODE_KINDS["native_hook"](None, {**HOOK[1], "seam": "tool_router"})
+    with pytest.raises(ValueError, match="'code'"):
+        NODE_KINDS["native_hook"](None, {"name": "x", "seam": "pre_step"})
+    with pytest.raises(ValueError, match="'code' does not compile"):
+        NODE_KINDS["native_hook"](None, {**HOOK[1], "code": "def listen(:\n"})
+    # A lone surrogate survives JSON but cannot be written as UTF-8 at render.
+    with pytest.raises(ValueError, match="must be UTF-8 encodable"):
+        NODE_KINDS["native_hook"](
+            None, {**HOOK[1], "code": "X = '\udc80'\ndef listen(payload, next):\n    return next()\n"}
+        )
+
+
+def test_rendered_constants_bind_over_what_the_code_assigns(tmp_path: Path) -> None:
+    sneaky = {
+        "name": "sneaky",
+        "seam": "pre_step",
+        "code": "SEAM = 'post_execute'\nNAME = 'loop_guard'\ndef listen(payload, next):\n    return next()\n",
+    }
+    files = render_composition([("native_hook", sneaky)], get_adapter("native"))
+    for relative, text in files.items():
+        (tmp_path / relative).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / relative).write_text(text)
+    hooks = load_hooks(tmp_path / "native" / "hooks")
+    assert [(hook.name, hook.seam) for hook in hooks["pre_step"]] == [("sneaky", "pre_step")]
+    assert hooks["post_execute"] == []
+
+
+def test_hooks_form_a_waterfall_where_next_runs_once_and_a_raising_hook_is_skipped() -> None:
+    calls: list[str] = []
+
+    def a(payload, next_):
+        calls.append("a")
+        below = next_()
+        assert next_() is below
+        return {**below, "messages": [*below["messages"], "from a"]}
+
+    def b(payload, next_):
+        calls.append("b")
+        raise RuntimeError("boom")
+
+    def c(payload, next_):
+        calls.append("c")
+        return {"kind": "enter", "messages": ["from c"]}
+
+    def d(payload, next_):
+        calls.append("d")
+        return next_()
+
+    hooks = [HookModule(name, "pre_step", listen) for name, listen in (("a", a), ("b", b), ("c", c), ("d", d))]
+    trace: list[dict] = []
+    decision = _waterfall(hooks, 0, {"step": 1}, _DEFAULTS["pre_step"], trace)
+    assert decision == {"kind": "enter", "messages": ["from c", "from a"]}
+    # c owned the seam, so d never ran; b's error fell through to c.
+    assert calls == ["a", "b", "c"]
+    assert trace == [
+        {"hook": "b", "error": "RuntimeError: boom"},
+        {"hook": "c", "owned": True, "decision": {"kind": "enter", "messages": ["from c"]}},
+        {"hook": "a", "owned": False, "decision": {"kind": "enter", "messages": ["from c", "from a"]}},
+    ]
+    # No hooks: the loop's default, as a fresh copy.
+    assert _waterfall([], 0, {}, _DEFAULTS["post_execute"], trace) == {"kind": "accept", "contexts": []}
+    assert _waterfall([], 0, {}, _DEFAULTS["post_execute"], trace) is not _DEFAULTS["post_execute"]
+
+
+def test_hooks_get_a_copy_so_in_place_edits_are_traced_and_bad_decisions_are_skipped() -> None:
+    def in_place(payload, next_):
+        decision = next_()
+        decision["contexts"].append("from in_place")
+        return decision
+
+    def forgetful(payload, next_):
+        next_()["contexts"].append("lost")
+
+    def cyclic(payload, next_):
+        decision = dict(next_())
+        decision["self"] = decision
+        return decision
+
+    def odd_keys(payload, next_):
+        return {**next_(), (1, 2): "x"}
+
+    def fresh(payload, next_):
+        return {"kind": "accept", "contexts": "not a list"}
+
+    names = (
+        ("in_place", in_place),
+        ("forgetful", forgetful),
+        ("cyclic", cyclic),
+        ("odd_keys", odd_keys),
+        ("fresh", fresh),
+    )
+    hooks = [HookModule(name, "post_execute", listen) for name, listen in names]
+    trace: list[dict] = []
+    decision = _waterfall(hooks, 0, {"step": 1}, _DEFAULTS["post_execute"], trace)
+    # fresh's non-list contexts read as empty; every hook above edited a copy, so only in_place changed the decision.
+    assert decision == {"kind": "accept", "contexts": ["from in_place"]}
+    assert trace == [
+        {"hook": "fresh", "owned": True, "decision": {"kind": "accept", "contexts": []}},
+        {"hook": "odd_keys", "error": "TypeError: keys must be str, int, float, bool or None, not tuple"},
+        {"hook": "cyclic", "error": "ValueError: Circular reference detected"},
+        {"hook": "in_place", "owned": False, "decision": {"kind": "accept", "contexts": ["from in_place"]}},
+    ]
 
 
 def test_tool_results_carry_closed_error_codes_and_validate_arguments(tmp_path: Path) -> None:
@@ -166,20 +347,8 @@ def test_tool_results_carry_closed_error_codes_and_validate_arguments(tmp_path: 
     assert len(long["content"]) == MAX_RESULT_CHARS and long["meta"]["truncated"] is True
 
 
-def test_loop_guard_reminds_at_the_thresholds_only() -> None:
-    guard = _LoopGuard()
-    notes = [guard.note("read_file", {"path": "a"}) for _ in range(5)]
-    assert [note is not None for note in notes] == [False, False, True, False, True]
-    assert guard.note("read_file", {"path": "b"}) is None
-
-
 def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path: Path, fake_model) -> None:
-    descriptor = get_adapter("native")
-    binding = ModelBinding(base_url=fake_model.base_url, model="fake", api_key="dummy")
-    files = render_composition(
-        [*_seed_nodes(), ("rules", {"text": "Be brief."}), *binding.compose_nodes(descriptor)], descriptor
-    )
-    result = run_episode(descriptor, files, "put hello in notes.txt and read it back", binary=_launcher(tmp_path))
+    result = _episode(tmp_path, fake_model, [*_seed_nodes(), ("rules", {"text": "Be brief."})])
     kinds = [event["type"] for event in result.trajectory]
     assert kinds == [
         "session",
@@ -203,6 +372,7 @@ def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path:
     assert [event["seq"] for event in result.trajectory] == list(range(len(kinds)))
     header = result.trajectory[0]["data"]
     assert header["version"] == 1 and header["tools"] == ["read_file", "run_bash", "write_file"]
+    assert header["hooks"] == {"loop_guard": "post_execute"}
     request = _events(result.trajectory, "request/header")[0]["data"]
     assert request["system"] == "Be brief."
     assert sorted(tool["function"]["name"] for tool in request["tools"]) == ["read_file", "run_bash", "write_file"]
@@ -216,6 +386,99 @@ def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path:
     first = fake_model.requests[0]
     assert first["messages"][0] == {"role": "system", "content": "Be brief."}
     assert sorted(tool["function"]["name"] for tool in first["tools"]) == ["read_file", "run_bash", "write_file"]
+
+
+def test_hooks_decide_at_the_three_seams(tmp_path: Path) -> None:
+    model = _FlakyModel()
+    try:
+        result = _episode(tmp_path, model, [*_seed_nodes(SEED_TOOLS), *SEAM_HOOKS])
+    finally:
+        model.shutdown()
+        model.server_close()
+    kinds = [event["type"] for event in result.trajectory]
+    assert kinds == [
+        "session",
+        "turn/start",
+        "step/start",
+        "request/header",
+        "request/error",
+        "hook/decision",
+        "assistant/message",
+        "tool/call",
+        "hook/decision",
+        "tool/result",
+        "user/message",
+        "step/end",
+        "step/start",
+        "assistant/message",
+        "tool/call",
+        "tool/result",
+        "step/end",
+        "hook/decision",
+        "turn/end",
+    ]
+    failed = _events(result.trajectory, "request/error")[0]["data"]
+    assert failed["attempt"] == 1 and failed["error"]["code"] == "MODEL_ERROR" and failed["error"]["status"] == 500
+    retry, block, reject = (event["data"] for event in _events(result.trajectory, "hook/decision"))
+    assert retry == {
+        "seam": "request_error",
+        "step": 1,
+        "hook": "retry",
+        "owned": True,
+        "decision": {"kind": "retry", "delay_ms": 0},
+    }
+    assert block["hook"] == "veto" and block["owned"] is False and block["decision"]["kind"] == "block"
+    assert reject == {
+        "seam": "pre_step",
+        "step": 3,
+        "hook": "stop",
+        "owned": True,
+        "decision": {"kind": "reject", "reason": "two steps are enough"},
+    }
+    blocked, read = (event["data"] for event in _events(result.trajectory, "tool/result"))
+    assert blocked["is_error"] is True and blocked["error"] == {"code": "HOOK_BLOCKED", "message": "writes are off"}
+    # post_execute rewrites what the model reads; the tool has already run, so the read still finds the file.
+    assert blocked["content"] == "Error: writes are off" and read["content"] == "hello"
+    note = _events(result.trajectory, "user/message")[0]["data"]
+    assert note == {
+        "step": 1,
+        "source": {"kind": "hook", "seam": "post_execute"},
+        "content": "Writes are disabled here.",
+    }
+    assert result.trajectory[-1]["data"]["reason"] == {
+        "kind": "rejected",
+        "step": 3,
+        "message": "two steps are enough",
+    }
+    # The blocked result and the note are what the model read on its next request.
+    step_two = model.requests[2]["messages"]
+    assert step_two[-2] == {"role": "tool", "tool_call_id": "c1", "content": "Error: writes are off"}
+    assert step_two[-1] == {"role": "user", "content": "Writes are disabled here."}
+
+
+def test_a_module_that_cannot_load_ends_the_episode_in_error(tmp_path: Path, fake_model) -> None:
+    broken = ("native_hook", {"name": "broken", "seam": "pre_step", "code": "raise RuntimeError('no')\n"})
+    result = _episode(tmp_path, fake_model, [*_seed_nodes(SEED_TOOLS), broken])
+    assert result.exit_code == 1 and fake_model.requests == []
+    assert [event["type"] for event in result.trajectory] == ["session", "turn/start", "turn/end"]
+    reason = result.trajectory[-1]["data"]["reason"]
+    assert reason["kind"] == "error" and reason["error"]["code"] == "LOAD_ERROR"
+    assert reason["error"]["message"] == "broken.py failed to import: RuntimeError: no"
+
+
+def test_seed_loop_guard_reminds_the_model_at_the_third_repeat(tmp_path: Path) -> None:
+    model = _RepeatingModel()
+    try:
+        result = _episode(tmp_path, model, _seed_nodes())
+    finally:
+        model.shutdown()
+        model.server_close()
+    decisions = _events(result.trajectory, "hook/decision")
+    assert [event["data"]["hook"] for event in decisions] == ["loop_guard"] and decisions[0]["data"]["step"] == 3
+    reminder = _events(result.trajectory, "user/message")[0]["data"]["content"]
+    assert reminder.startswith("You have called read_file with the same arguments 3 times in a row.")
+    assert model.requests[3]["messages"][-1] == {"role": "user", "content": reminder}
+    assert result.trajectory[-1]["data"]["reason"] == {"kind": "completed"}
 
 
 def test_native_harness_runs_through_the_evolution_gate(tmp_path: Path, fake_model) -> None:
@@ -235,12 +498,13 @@ def test_native_harness_runs_through_the_evolution_gate(tmp_path: Path, fake_mod
         tasks=("put hello in notes.txt and read it back",),
         models=binding,
         binary=_launcher(tmp_path),
-        seed=SEED_TOOLS,
+        seed=SEED_NODES,
     )
     batch = TraceBatch("demo:trace:native", (TraceSample("a1", {"messages": []}, 0.0),))
     prepared = backend.prepare_step(batch, backend.initial_state(), 0)
     assert prepared.candidate is not None
     assert "native/tools/shout.py" in prepared.candidate.candidate_files
+    assert "native/hooks/loop_guard.py" in prepared.candidate.candidate_files
     evaluator = DefaultCandidateEvaluationPlugin(backend, ScoreComparisonSelector())
     decision = evaluator.decide(prepared.candidate, evaluator.evaluate(prepared.candidate))
     result = backend.settle_step(prepared, decision)


### PR DESCRIPTION
## Motivation

After #169 the native harness can evolve its tools, but the loop around them is still fixed code: when to inject context, what to do when a model call fails, and what the model reads back from a tool are decided in reef.harness.native and no mutation can reach them. This is Phase 2 of #133: three seams of the loop are opened to native_hook nodes, so a mutation can change loop behavior at a fixed extension point without exposing the whole loop. The seam set and the waterfall protocol follow deepseek-harness, whose agent/pre-step, agent/request-error, and tools/post-execute waterfalls carry almost every behavior its plugins add. The loop guard that #169 hardcoded is now the one seed hook, so the first evolvable loop behavior exists on day one. Part of #133.

## Changes

- A native_hook node kind: name, seam (pre_step, request_error, or post_execute), and code defining listen(payload, next) -> decision; it renders to native/hooks/{name}.py as the code followed by NAME and SEAM constants, only under an adapter that declares files.native_hook, and the admission gate refuses an unknown seam
- The waterfall: hooks at one seam run in file name order; listen may call next() for the decision of the layer below (the loop's default is the last layer) and return it changed or not, or return its own decision without calling next and own the seam; next runs the layer below at most once; a hook that raises, or returns anything but a plain object the log can carry, is skipped and the layer below stands
- pre_step, before each step, returns enter with texts that become user messages before the request, or reject, which ends the turn with no step; request_error, after a failed model call, returns retry with delay_ms or fail, under a loop cap of four attempts a step and ten seconds a wait whatever the hook asks; post_execute, after a tool call has run, returns accept (optionally replacing the content the model reads) or block (the model reads a HOOK_BLOCKED error carrying the feedback), either with contexts that land as user messages after the step's results in call order
- The rendered tool and hook modules put the node's code first and the config constants (NAME, SEAM, DESCRIPTION, PARAMETERS) after it, so the tree's values are what the module ends with whatever the code assigns; the admission gate refuses code that does not compile and text that is not UTF-8 encodable; a module that fails to import, defines no run or listen, or names an unknown seam ends the episode with LOAD_ERROR before any model call, so the tree that carries it loses the gate instead of running without it
- next hands each hook a copy and keeps the pristine decision for the comparison and the fallback, so an in-place edit is traced like any other change; a decision the log cannot carry (a cycle, a non string key) is skipped like a raise; messages and contexts are read as lists of text; the request_error payload carries the HTTP status when the endpoint answered one
- The trajectory logs request/error before the request_error seam runs, hook/decision for every hook whose decision differs from the layer below (seam, step, hook, owned, the decision), hook/error for a hook that raised, the hooks in the session header (name to seam), a user/message with source kind hook and its seam for every injected text, and turn/end reason rejected
- reef.harness.native.seed.SEED_HOOKS holds loop_guard at post_execute, the reminder at three, five, and eight identical calls that #169 kept in loop code; SEED_NODES is the tools and hooks together. The _LoopGuard class and LOOP_GUARD_THRESHOLDS are gone
- Documented in the harness adapters guide (the kind, the protocol, the seam table, the event vocabulary), the lane guide (the seventh kind), and the configuration reference

## Compatibility and operational impact

Additive. native_hook joins native_tool in OPTIONAL_NODE_KINDS, so the pi, opencode, and claude descriptors need no new key and refuse the kind with a clear RenderError. A native tree without hooks runs as under #169 with two differences: the loop guard reminder now needs the loop_guard node in the tree (a recipe that seeds SEED_TOOLS alone gets no reminder, one that seeds SEED_NODES gets it as before), and a tool module that cannot load now fails the episode with LOAD_ERROR instead of being skipped, so a broken tool mutation loses the gate rather than tying it. The rendered module layout changes (code first, constants after), which only matters to a reader of the served tree. The session header gains hooks; the event vocabulary gains request/error, hook/decision, and hook/error; the error codes gain HOOK_BLOCKED.

## Follow ups (per the #133 RFC)

- A pip install kind so GET /reef/harness/install works for native, and a native branch in the client wrapper
- Result spill to disk beyond the tail cap, and moving rules and skills from the system prompt into logged user messages as deepseek-harness does
- Widening the seam set (a pre_execute gate with allow, deny, ask) only once these three hold up under evolution
- A tutorial variant of harness_evolve on the native adapter

## Verification

A waterfall unit test drives four hooks at one seam: a hook that calls next twice, gets the same object both times, and returns it changed, a raising hook whose error falls through, an owning hook that never calls next so the hook below it never runs, and the trace naming each decision that differed. An episode test runs the real loop through run_episode against a fake model that answers 500 once, with one hook per seam: the trajectory carries request/error then the retry decision, the blocked write_file result with HOOK_BLOCKED and the injected note, the reject at step three closing the turn, and the fake model's next request shows the blocked result and the note exactly as the model read them. A second episode test drives the seed loop_guard hook with a model that repeats the same read three times and checks the reminder reaches the model's fourth request. A second waterfall test stacks five hooks: an in-place edit is traced with the right owner, a hook that edits the copy and returns nothing changes nothing, a cyclic decision and a tuple keyed decision each land as hook/error with the layer below standing, and a non list contexts reads as empty. A hook whose code assigns SEAM and NAME loads at the config's seam under the config's name; a hook that raises at import ends the episode with LOAD_ERROR, zero model requests, and a three event trajectory; the admission gate refuses code that does not compile and a lone surrogate. The evolution gate test seeds SEED_NODES and sees native/hooks/loop_guard.py in the candidate tree, the render golden gains a hook module, and the node validation covers the seam check. The whole tests/reef_service directory passes on Python 3.12 (1231 tests, the ray and slime bridge modules skipped for lack of those packages locally). ruff, ruff format, mypy, and the repository statement and design policy checks are clean on the changed files; the docs link and contract checks pass.

## AI assistance

Claude Code mapped the seams in deepseek-harness and wrote the waterfall, the seed hook, and the tests. I set the scope in #133.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [ ] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
