### PR TITLE
Resolve `python` in service commands to the launcher's interpreter

### DIFF
--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -37,6 +37,15 @@ from reef.service.deploy.settings import build_parser
 _DEFAULT_GRACE_TIMEOUT = 30
 _WATCHDOG_INTERVAL = 5
 
+_PYTHON_ALIASES = frozenset({"python", "python3"})
+
+
+def _resolve_python(argv: list[str]) -> list[str]:
+    """Rewrite a leading bare ``python`` / ``python3`` to ``sys.executable``."""
+    if not argv or "/" in argv[0] or argv[0] not in _PYTHON_ALIASES:
+        return argv
+    return [sys.executable, *argv[1:]]
+
 
 def _log(msg):
     print(f"[reef] {msg}", file=sys.stderr)
@@ -260,8 +269,9 @@ class _Stack:
         # operator sees live output without `tail -f`.
         tee = _TeeStream(log_fp, sys.stdout)
         self._tees[name] = tee
+        argv = _resolve_python(shlex.split(command))
         proc = subprocess.Popen(
-            shlex.split(command),
+            argv,
             env=env,
             cwd=svc.get("cwd"),
             stdout=tee.write_fd,

--- a/tests/reef_service/test_orchestrator_python_exec.py
+++ b/tests/reef_service/test_orchestrator_python_exec.py
@@ -1,0 +1,34 @@
+"""Tests for the bare-``python`` swap in the orchestrator."""
+
+from __future__ import annotations
+
+import sys
+
+from reef.service.deploy.orchestrator import _resolve_python
+
+
+def test_bare_python_is_swapped_to_sys_executable() -> None:
+    assert _resolve_python(["python", "-m", "reef.service"]) == [sys.executable, "-m", "reef.service"]
+
+
+def test_bare_python3_is_swapped_to_sys_executable() -> None:
+    assert _resolve_python(["python3", "-m", "reef.service"]) == [sys.executable, "-m", "reef.service"]
+
+
+def test_explicit_absolute_python_is_left_alone() -> None:
+    argv = ["/usr/bin/python3.11", "-m", "reef.service"]
+    assert _resolve_python(argv) == argv
+
+
+def test_versioned_alias_on_path_is_left_alone() -> None:
+    argv = ["python3.12", "-m", "reef.service"]
+    assert _resolve_python(argv) == argv
+
+
+def test_non_python_command_is_left_alone() -> None:
+    argv = ["curl", "-sf", "http://localhost:8900/healthz"]
+    assert _resolve_python(argv) == argv
+
+
+def test_empty_argv_is_left_alone() -> None:
+    assert _resolve_python([]) == []


### PR DESCRIPTION
## The bug

Shipped stack configs invoke child services with a bare `python -m ...` in the yaml `command:` field:

- `recipes/basic/external-provider.yaml`: `command: python -m reef.service`
- `recipes/basic/local-sglang.yaml`: `command: python -m sglang.launch_server ...` and `command: python -m reef.service`

The orchestrator `shlex.split`s that command and `Popen`s the argv, so PATH picks which `python` actually runs. That is not always the interpreter that launched `reef serve`. On a dev box where `/usr/bin/python` is Python 2.7.18 (which happens on RHEL/AL2 and older Debian images that still ship Python 2), the child dies with `No module named metadata` before healthz ever comes up:

```
$ python3.10 -m reef serve -c serve.yaml
[reef] starting reef: python -m reef.service
/usr/bin/python: No module named metadata
[reef] ERROR: 'reef' exited before ready; see /tmp/reef-stack/reef.log
```

Same failure mode with `python3` on any box where `python3` points at 3.7 or older (importlib.metadata is a 3.8+ shim).

## The fix

Rewrite a bare `python` or `python3` at the head of the argv to `sys.executable` (the interpreter that started `reef serve`). Two rules keep it defensive:

- Only the first token is touched.
- Only bare aliases without a directory component. An operator who wrote `/usr/bin/python3.11` or `python3.12` (a versioned alias on PATH) has made a deliberate pin and keeps that choice.

That is enough for the shipped stack configs to work under any launcher without editing yaml.

## Verification

Reproduced locally with `python == /usr/bin/python == Python 2.7.18`. Before the change, `reef serve` exited on the child's `import`; after, healthz returns `{"ok": true}` on the exact same yaml.

Tests added under `tests/reef_service/test_orchestrator_python_exec.py` covering the six cases: bare `python`/`python3` swap, absolute path left alone, versioned alias left alone, non-python command left alone, empty argv, and the existing overrides test still passes.

```
pytest tests/reef_service/test_orchestrator_python_exec.py tests/reef_service/test_orchestrator_overrides.py
18 passed
```

Black/isort/ruff pass on the touched files.

## AI disclosure

Per CONTRIBUTING: written with Claude Code, reviewed every line. Hit this while smoke-testing #118 on a different env. Separate PR because it's an unrelated bug — happy to fold if you'd rather.