### PR TITLE
feat: add a DeepSeek Harness (dsh) adapter

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -1,9 +1,9 @@
 name: harness-smoke
 
-# Runs the real pinned pi binary through render, run_episode, and the
-# trajectory reader against a stub model server (tests/smoke/test_real_pi.py):
-# the guard against a pi release changing a format the hermetic fakes only
-# imitate. Non-blocking: not in the required check set until stable.
+# Runs the real pinned pi and dsh binaries through render, run_episode, and
+# the trajectory reader against a stub model server (tests/smoke/): the guard
+# against a release changing a format the hermetic fakes only imitate.
+# Non-blocking: not in the required check set until stable.
 
 on:
   pull_request:
@@ -50,3 +50,25 @@ jobs:
           name: real-pi-session
           path: ${{ runner.temp }}/real-pi-session.jsonl
           if-no-files-found: error
+
+  # The same guard for the pinned DeepSeek Harness (tests/smoke/test_real_dsh.py).
+  real-dsh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: git submodule update --init third_party/reef-client
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+      - run: python -m pip install ./third_party/reef-client
+      - run: python -m pip install -e . aiohttp pyyaml huggingface_hub pytest
+      - run: npm install --prefix "$RUNNER_TEMP/dsh" @deepseek-ai/dsh@0.1.2-alpha.5
+      - run: python -m pytest tests/smoke/test_real_dsh.py
+        env:
+          REEF_REAL_DSH_BINARY: ${{ runner.temp }}/dsh/node_modules/.bin/dsh

--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,8 @@ local/
 glm/
 _examples_synced/
 .env
+# The dsh adapter's golden tree renders an (empty) .env: render output, not a secret.
+!tests/reef_service/data/harness_goldens/dsh/dsh/.env
 .DS_Store
 .worktrees/
 .reef/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,17 @@ ci:
 
 # The one list of files no formatter or linter touches. Vendored benchmark
 # content stays byte identical to its upstream pin; saved TTTD result programs
-# are published as produced. CI lints by running pre-commit over all files, so
-# this exclude is the enforced boundary — the tools' pyproject sections carry
-# no copy of it.
+# are published as produced; harness golden trees are byte exact render
+# output. CI lints by running pre-commit over all files, so this exclude is
+# the enforced boundary — the tools' pyproject sections carry no copy of it.
 exclude: |
-  (?x)^recipes/(
-    skillclaw/harbor/(environment/workspace/|tests/grade\.py)
-    |tttd/examples/tttd/harbor/circle_packing_[^/]+/environment/score\.py
-    |tttd/examples/tttd/results/.*/best_solution\.py
+  (?x)^(
+    recipes/(
+      skillclaw/harbor/(environment/workspace/|tests/grade\.py)
+      |tttd/examples/tttd/harbor/circle_packing_[^/]+/environment/score\.py
+      |tttd/examples/tttd/results/.*/best_solution\.py
+    )
+    |tests/reef_service/data/harness_goldens/
   )
 
 repos:

--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -4,16 +4,41 @@ Harness adapters
 An adapter maps a harness tree into the files expected by a third-party
 coding-agent CLI and binds that harness to the served model. The harness and
 model together form the running agent. The tree never names a file path; the
-adapter does. Reef bundles two, one per third-party coding-agent CLI.
+adapter does. Reef bundles four, one per third-party coding-agent CLI.
 
-+--------------+-------------------------------------------+-----------------------------------------+
-| Adapter      | Config targets                            | Install pin                             |
-+==============+===========================================+=========================================+
-| ``pi``       | ``primary`` → ``pi-agent/settings.json``, | npm ``@earendil-works/pi-coding-agent`` |
-|              | ``models`` → ``pi-agent/models.json``     | 0.84.2                                  |
-+--------------+-------------------------------------------+-----------------------------------------+
-| ``opencode`` | ``primary`` → ``opencode/opencode.json``  | npm ``opencode-ai`` 1.18.18             |
-+--------------+-------------------------------------------+-----------------------------------------+
++--------------+-----------------------------------------------------------+-------------------------------------------+
+| Adapter      | Config targets                                            | Install pin                               |
++==============+===========================================================+===========================================+
+| ``pi``       | ``primary`` → ``pi-agent/settings.json``,                 | npm ``@earendil-works/pi-coding-agent``   |
+|              | ``models`` → ``pi-agent/models.json``                     | 0.84.2                                    |
++--------------+-----------------------------------------------------------+-------------------------------------------+
+| ``opencode`` | ``primary`` → ``opencode/opencode.json``                  | npm ``opencode-ai`` 1.18.18               |
++--------------+-----------------------------------------------------------+-------------------------------------------+
+| ``claude``   | ``primary`` → ``claude/settings.json``                    | npm ``@anthropic-ai/claude-code`` 2.1.257 |
++--------------+-----------------------------------------------------------+-------------------------------------------+
+| ``dsh``      | ``primary`` → ``dsh/profiles/headless/cordis.patch.yml``, | npm ``@deepseek-ai/dsh`` 0.1.2-alpha.5    |
+|              | ``env`` → ``dsh/.env``                                    |                                           |
++--------------+-----------------------------------------------------------+-------------------------------------------+
+
+The ``dsh`` adapter runs DeepSeek Harness headless (``dsh --profile headless
+"<task>"``) with its whole home relocated by ``DSH_HOME``. dsh composes its
+plugin tree from bundle layers plus one user patch layer, a YAML list of
+entries addressed by plugin id, so its ``primary`` config target is an
+object keyed by plugin id (``{"agent-loop": {"config": {...}}}``, or
+``{"disabled": true}``) that the adapter's quirks emit as that list. A
+string starting with ``!!js `` becomes a js expression, the form dsh's own
+bundles use. The adapter's defaults keep the session log uncompressed and
+the telemetry and the LLM title call disabled, and a composition that flips
+any of them is refused at render. Rules render to dsh's user global
+``AGENTS.md``; skills to ``skills/<name>/SKILL.md`` (dsh needs YAML
+frontmatter with ``name`` and ``description``, synthesized when the node
+text has none); an ``agent_command`` renders as a user invocable skill
+(``disable-model-invocation: true``, run as ``/name``) under the second
+skill root ``DSH_AGENTS_HOME``, the only command surface dsh has; a
+``code_extension`` renders as a plugin module the patch layer inserts by
+relative path. The model binding declares an ``llm-pi-ai`` route whose key
+is named by ``apiKeyEnv`` and supplied through the ``env`` target, dsh's
+``.env`` launch environment layer.
 
 The descriptor
 --------------
@@ -54,7 +79,7 @@ To connect an agent that has no adapter yet:
       ``pi-agent/auth.json``. A bare directory name matches nothing under it.
 
 `reef/harness/descriptor.py <../../reef/harness/descriptor.py>`__ validates every
-descriptor at load, and the two bundled adapters under `reef/harness/adapters/
+descriptor at load, and the bundled adapters under `reef/harness/adapters/
 <../../reef/harness/adapters>`__ are complete references. A third-party adapter
 registers on the ``reef.harness_adapters`` entry-point group.
 ``evolution.version_check: true`` in the recipe config writes an update

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -163,7 +163,7 @@ zero.
    evolution.evaluate | an ``EpisodeScorer``, likewise
    evolution.selection | score_comparison | ``always``, or a dotted reference to an object with ``decide``
    evolution.tasks | non-empty list of episode prompts, scored once per tree per step
-   evolution.adapter | pi | ``opencode``, or an entry-point adapter
+   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
    evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
    evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -197,7 +197,7 @@ Harness artifacts
 +--------------------------------+---------------------------------------------------------------+
 
 All three are read-only and take ``x-reef-scenario``. Install also requires
-``?adapter=``, whose value may be ``pi``, ``opencode``, or an external
+``?adapter=``, whose value may be ``pi``, ``opencode``, ``claude``, ``dsh``, or an external
 descriptor. If install omits ``x-reef-scenario``, Reef creates a scenario with a
 generated ``harness-`` name and embeds that assignment in the wrapper script;
 when exactly one configured recipe serves harness files, it selects that recipe

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -41,8 +41,9 @@ file name the entry renders to. Five kinds are registered in
 
 The table describes what each kind contains. Where each kind is written is
 decided by an adapter, which maps every kind to a concrete file for one agent.
-Reef bundles two adapters, ``pi`` and ``opencode``, each for a third-party
-coding agent CLI. With the ``pi`` adapter, ``GET /reef/harness`` serves:
+Reef bundles four adapters, ``pi``, ``opencode``, ``claude``, and ``dsh``
+(DeepSeek Harness), each for a third-party coding agent CLI. With the ``pi``
+adapter, ``GET /reef/harness`` serves:
 
 .. code:: text
 

--- a/reef/harness/adapters/__init__.py
+++ b/reef/harness/adapters/__init__.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from reef.harness.descriptor import AdapterDescriptor, DescriptorError, external_descriptors, load_descriptor
 
-BUILTIN_ADAPTERS = ("claude", "opencode", "pi")
+BUILTIN_ADAPTERS = ("claude", "dsh", "opencode", "pi")
 
 _cache: dict[str, AdapterDescriptor] = {}
 

--- a/reef/harness/adapters/dsh/__init__.py
+++ b/reef/harness/adapters/dsh/__init__.py
@@ -1,0 +1,1 @@
+"""The dsh adapter: DeepSeek Harness (https://github.com/deepseek-ai/deepseek-harness) as a harness."""

--- a/reef/harness/adapters/dsh/descriptor.yaml
+++ b/reef/harness/adapters/dsh/descriptor.yaml
@@ -1,0 +1,113 @@
+# DeepSeek Harness (dsh), driven headless per episode.
+#
+# DSH_HOME relocates the whole harness home (the headless profile and its
+# patch layer, sessions, storages, the user AGENTS.md and skills) under the
+# episode root, and DSH_AGENTS_HOME relocates the second skill root, where
+# agent_command nodes render as user invocable skills (dsh has no other
+# command surface). DSH_TELEMETRY_MODE stops the OTLP session telemetry. The
+# default workspace-write permission runs tools inside the working directory
+# with no approval prompt, so no danger mode is needed. The profile patch is
+# a YAML list of plugin entries; config nodes write it as an object keyed by
+# plugin id and the quirks module emits the list.
+name: dsh
+binary: dsh
+# The vendor's install channel at the pinned version; consumed by the
+# GET /reef/harness/install script, never by episode runs. The pin follows
+# the alpha tag: the source line that was mapped and the binary that was
+# measured.
+install:
+  kind: npm
+  package: "@deepseek-ai/dsh"
+  version: "0.1.2-alpha.5"
+  binary_path: "node_modules/.bin/dsh"
+# Two commander layers parse the command line (the launcher, then the
+# headless app); each "--" ends one layer's options, so a task that starts
+# with a dash still reaches the app as its positional.
+argv: ["--profile", "headless", "--", "--", "{prompt}"]
+env:
+  DSH_HOME: "{root}/dsh"
+  DSH_AGENTS_HOME: "{root}/dsh-agents"
+  DSH_TELEMETRY_MODE: "DISABLED"
+files:
+  config:
+    primary:
+      path: "dsh/profiles/headless/cordis.patch.yml"
+      # A patched config replaces the plugin's whole config, so every key
+      # the adapter relies on rides along: the session log stays where the
+      # bundle put it and uncompressed (the reader cannot parse zstd), and
+      # the LLM title call (one extra model request per episode) and the
+      # telemetry stay off.
+      defaults:
+        session-persistence-jsonl:
+          config:
+            root: "!!js dshHomePath('sessions')"
+            compression: none
+        session-title-llm:
+          disabled: true
+        session-telemetry-otel:
+          disabled: true
+    # The lowest trust layer of dsh's launch environment; the model binding
+    # puts the key of its apiKeyEnv route here.
+    env:
+      path: "dsh/.env"
+      defaults: {}
+  rules: "dsh/AGENTS.md"
+  agent_command: "dsh-agents/skills/{name}/SKILL.md"
+  skill: "dsh/skills/{name}/SKILL.md"
+  # A cordis plugin module the patch layer inserts by relative path.
+  code_extension: "dsh/profiles/headless/extensions/{name}.mjs"
+trajectory:
+  # One session per episode under sessions/<cwd slug>/session-<id>/session.jsonl,
+  # the {type, seq, time, data} envelope, read by the deepseek-session-jsonl reader.
+  format: deepseek-session-jsonl
+  path: "dsh/sessions"
+cleanup_whitelist:
+  - "dsh/sessions/**"
+  - "dsh/storages/**"
+quirks: reef.harness.adapters.dsh.quirks
+# How to point dsh at a model endpoint, per API dialect: a hand declared
+# llm-pi-ai route selected by agent-default-model, its key named by
+# apiKeyEnv and supplied through the .env file. Reef renders the set matching
+# its model binding's api into evaluation episodes; the served tree never
+# carries a provider or a key.
+model_binding:
+  openai:
+    - target: primary
+      data:
+        llm-pi-ai:
+          config:
+            providers:
+              reef:
+                displayName: Reef
+                apiKeyEnv: REEF_API_KEY
+                api: openai-completions
+                baseURL: "{base_url}/v1"
+                models:
+                  - id: "{model}"
+        agent-default-model:
+          config:
+            provider: reef
+            model: "{model}"
+    - target: env
+      data:
+        REEF_API_KEY: "{api_key}"
+  anthropic:
+    - target: primary
+      data:
+        llm-pi-ai:
+          config:
+            providers:
+              reef:
+                displayName: Reef
+                apiKeyEnv: REEF_API_KEY
+                api: anthropic-messages
+                baseURL: "{base_url}"
+                models:
+                  - id: "{model}"
+        agent-default-model:
+          config:
+            provider: reef
+            model: "{model}"
+    - target: env
+      data:
+        REEF_API_KEY: "{api_key}"

--- a/reef/harness/adapters/dsh/quirks.py
+++ b/reef/harness/adapters/dsh/quirks.py
@@ -1,0 +1,118 @@
+"""dsh adapter quirks: the patch layer, the credential file, skill frontmatter, and the boot scaffold.
+
+dsh composes its plugin tree from bundle layers plus one user patch layer,
+``profiles/headless/cordis.patch.yml``: a YAML list of entries addressed by
+plugin id. Config nodes write that layer as a JSON object keyed by id, so
+two nodes touching one plugin deep merge, and ``finalize_render`` emits the
+list: one entry per id (a string starting with ``!!js `` becomes a js
+expression, the form dsh's own bundles use), then one ``insert`` entry per
+rendered code extension so the loader boots it from its relative path. The
+``env`` config target becomes ``.env``, the lowest trust layer of dsh's
+launch environment, which is how the model binding's key reaches its
+``apiKeyEnv`` route. dsh ignores a SKILL.md without YAML frontmatter, so a
+skill node whose text has none gets ``name`` and ``description``
+synthesized, and an agent_command renders under the second skill root as a
+user invocable skill (``/name``), the only command surface dsh has.
+
+The traps a mutated patch could reopen: the session log must stay plain
+JSONL (the reader cannot parse zstd), and the session telemetry and the LLM
+title call stay disabled. A composition that flips any of them is rejected
+at render, the same gate that rejects an invalid node.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import yaml
+
+from reef.harness.render import RenderError
+
+_PATCH = "dsh/profiles/headless/cordis.patch.yml"
+_ENV = "dsh/.env"
+_EXTENSIONS = "dsh/profiles/headless/extensions/"
+_SKILLS = "dsh/skills/"
+_COMMANDS = "dsh-agents/skills/"
+_JS = "!!js "
+
+# dsh's boot scaffolds the profile beside the rendered patch: a package
+# manifest, the empty root entry list, the pnpm workspace file, node_modules
+# symlinks into the installation, and the module fallback links. Episode
+# state, not residue.
+cleanup_whitelist = (
+    "dsh/profiles/headless/package.json",
+    "dsh/profiles/headless/cordis.yml",
+    "dsh/profiles/headless/pnpm-workspace.yaml",
+    "dsh/profiles/headless/node_modules/**",
+    "dsh/profiles/headless/.dsh-module-fallback/**",
+    "dsh/profiles/node_modules/**",
+)
+
+
+class _Js(str):
+    """A js expression scalar, dumped with the ``!!js`` tag."""
+
+
+class _Dumper(yaml.SafeDumper):
+    pass
+
+
+_Dumper.add_representer(_Js, lambda dumper, value: dumper.represent_scalar("tag:yaml.org,2002:js", str(value)))
+
+
+def _tagged(value: Any) -> Any:
+    if isinstance(value, str):
+        return _Js(value[len(_JS) :]) if value.startswith(_JS) else value
+    if isinstance(value, dict):
+        return {key: _tagged(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_tagged(item) for item in value]
+    return value
+
+
+def _patch(entries: dict[str, Any], extensions: list[str]) -> str:
+    rows: list[dict[str, Any]] = []
+    for plugin, entry in sorted(entries.items()):
+        if not isinstance(entry, dict):
+            raise RenderError(f"dsh patch entry {plugin!r} must be an object holding config, disabled, or inject")
+        rows.append({"id": plugin, **_tagged(entry)})
+    if extensions:
+        rows.append(
+            {"insert": [{"id": f"extension-{name}", "name": f"./extensions/{name}.mjs"} for name in extensions]}
+        )
+    return yaml.dump(rows, Dumper=_Dumper, sort_keys=True, default_flow_style=False, allow_unicode=True)
+
+
+def _with_frontmatter(path: str, text: str, user_only: bool) -> str:
+    if text.startswith("---\n"):
+        return text
+    first = next((line.strip().lstrip("#").strip() for line in text.splitlines() if line.strip()), "")
+    header: dict[str, Any] = {"name": path.split("/")[-2], "description": first[:200] or path.split("/")[-2]}
+    if user_only:
+        header["disable-model-invocation"] = True
+    return "---\n" + yaml.dump(header, sort_keys=False, default_flow_style=False, allow_unicode=True) + "---\n" + text
+
+
+def finalize_render(files: dict[str, str]) -> dict[str, str]:
+    entries = json.loads(files[_PATCH])
+    log = entries.get("session-persistence-jsonl", {}).get("config", {})
+    if log.get("compression") != "none":
+        raise RenderError(
+            "dsh composition must keep the session log uncompressed (compression: none) so Reef can read it"
+        )
+    for plugin in ("session-telemetry-otel", "session-title-llm"):
+        if entries.get(plugin, {}).get("disabled") is not True:
+            raise RenderError(f"dsh composition must keep {plugin} disabled for benchmark episodes")
+    extensions = sorted(
+        path[len(_EXTENSIONS) : -len(".mjs")]
+        for path in files
+        if path.startswith(_EXTENSIONS) and path.endswith(".mjs") and "/" not in path[len(_EXTENSIONS) :]
+    )
+    files[_PATCH] = _patch(entries, extensions)
+    files[_ENV] = "".join(f"{key}={value}\n" for key, value in sorted(json.loads(files[_ENV]).items()))
+    for path, text in list(files.items()):
+        for root, user_only in ((_SKILLS, False), (_COMMANDS, True)):
+            if path.startswith(root) and path.endswith("/SKILL.md"):
+                files[path] = _with_frontmatter(path, text, user_only)
+    return files

--- a/reef/harness/trajectory.py
+++ b/reef/harness/trajectory.py
@@ -129,6 +129,30 @@ def _resolve_dotted(reference: str) -> TrajectoryReader:
     raise TrajectoryError(f"trajectory reader {reference!r} is not callable")
 
 
+def _read_jsonl_tree(path: Path, label: str) -> tuple[dict[str, Any], ...]:
+    """Every ``*.jsonl`` under ``path`` in path order, one event object per line.
+
+    Each file tolerates one torn final line, the residue a crash mid-write
+    leaves behind; a corrupt line anywhere else is an error naming ``label``.
+    """
+    events: list[dict[str, Any]] = []
+    for file in sorted(Path(path).rglob("*.jsonl")):
+        lines = file.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as exc:
+                if index == len(lines) - 1:
+                    break  # torn tail from a crash mid-write; the event never landed
+                raise TrajectoryError(f"{label} {file} has a corrupt event at line {index + 1}") from exc
+            if not isinstance(event, dict):
+                raise TrajectoryError(f"{label} {file} line {index + 1} is not an event object")
+            events.append(event)
+    return tuple(events)
+
+
 @register_trajectory_reader
 class PiSessionReader(TrajectoryReader):
     """Read pi session JSONL trees: every ``*.jsonl`` under ``path``, in order."""
@@ -136,22 +160,7 @@ class PiSessionReader(TrajectoryReader):
     format = "pi-session-jsonl"
 
     def __call__(self, path: Path) -> tuple[dict[str, Any], ...]:
-        events: list[dict[str, Any]] = []
-        for file in sorted(Path(path).rglob("*.jsonl")):
-            lines = file.read_text(encoding="utf-8").splitlines()
-            for index, line in enumerate(lines):
-                if not line.strip():
-                    continue
-                try:
-                    event = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    if index == len(lines) - 1:
-                        break  # torn tail from a crash mid-write; the event never landed
-                    raise TrajectoryError(f"pi session {file} has a corrupt event at line {index + 1}") from exc
-                if not isinstance(event, dict):
-                    raise TrajectoryError(f"pi session {file} line {index + 1} is not an event object")
-                events.append(event)
-        return tuple(events)
+        return _read_jsonl_tree(path, "pi session")
 
 
 @register_trajectory_reader
@@ -168,22 +177,23 @@ class ClaudeSessionReader(TrajectoryReader):
     format = "claude-session-jsonl"
 
     def __call__(self, path: Path) -> tuple[dict[str, Any], ...]:
-        events: list[dict[str, Any]] = []
-        for file in sorted(Path(path).rglob("*.jsonl")):
-            lines = file.read_text(encoding="utf-8").splitlines()
-            for index, line in enumerate(lines):
-                if not line.strip():
-                    continue
-                try:
-                    event = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    if index == len(lines) - 1:
-                        break  # torn tail from a crash mid-write; the event never landed
-                    raise TrajectoryError(f"claude session {file} has a corrupt event at line {index + 1}") from exc
-                if not isinstance(event, dict):
-                    raise TrajectoryError(f"claude session {file} line {index + 1} is not an event object")
-                events.append(event)
-        return tuple(events)
+        return _read_jsonl_tree(path, "claude session")
+
+
+@register_trajectory_reader
+class DeepseekSessionReader(TrajectoryReader):
+    """Read DeepSeek Harness session JSONL trees: every ``*.jsonl`` under ``path``.
+
+    dsh writes one log per session under
+    ``DSH_HOME/sessions/<cwd-slug>/session-<id>/session.jsonl``: a ``session``
+    header line, then one ``{type, seq, time, data}`` event object per line.
+    The adapter keeps the log uncompressed (dsh's default is zstd framed).
+    """
+
+    format = "deepseek-session-jsonl"
+
+    def __call__(self, path: Path) -> tuple[dict[str, Any], ...]:
+        return _read_jsonl_tree(path, "deepseek session")
 
 
 @register_trajectory_reader
@@ -213,4 +223,5 @@ class OpencodeStorageReader(TrajectoryReader):
 # Module-level instances for backward-compatible call syntax.
 read_pi_session = PiSessionReader()
 read_claude_session = ClaudeSessionReader()
+read_deepseek_session = DeepseekSessionReader()
 read_opencode_storage = OpencodeStorageReader()

--- a/tests/reef_service/data/harness_goldens/dsh/dsh-agents/skills/summarize/SKILL.md
+++ b/tests/reef_service/data/harness_goldens/dsh/dsh-agents/skills/summarize/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: summarize
+description: Summarize $1.
+disable-model-invocation: true
+---
+Summarize $1.

--- a/tests/reef_service/data/harness_goldens/dsh/dsh/AGENTS.md
+++ b/tests/reef_service/data/harness_goldens/dsh/dsh/AGENTS.md
@@ -1,0 +1,3 @@
+Answer briefly.
+
+Prefer the standard library.

--- a/tests/reef_service/data/harness_goldens/dsh/dsh/profiles/headless/cordis.patch.yml
+++ b/tests/reef_service/data/harness_goldens/dsh/dsh/profiles/headless/cordis.patch.yml
@@ -1,0 +1,14 @@
+- config:
+    maxSteps: 40
+  id: agent-loop
+- config:
+    compression: none
+    root: !!js 'dshHomePath(''sessions'')'
+  id: session-persistence-jsonl
+- disabled: true
+  id: session-telemetry-otel
+- disabled: true
+  id: session-title-llm
+- insert:
+  - id: extension-tracer
+    name: ./extensions/tracer.mjs

--- a/tests/reef_service/data/harness_goldens/dsh/dsh/profiles/headless/extensions/tracer.mjs
+++ b/tests/reef_service/data/harness_goldens/dsh/dsh/profiles/headless/extensions/tracer.mjs
@@ -1,0 +1,1 @@
+export default function tracer() {}

--- a/tests/reef_service/data/harness_goldens/dsh/dsh/skills/notes/SKILL.md
+++ b/tests/reef_service/data/harness_goldens/dsh/dsh/skills/notes/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: notes
+description: Notes skill
+---
+# Notes skill
+
+Keep short notes.

--- a/tests/reef_service/test_harness_episode.py
+++ b/tests/reef_service/test_harness_episode.py
@@ -17,6 +17,7 @@ from reef.harness.render import render_composition
 from reef.harness.trajectory import (
     TrajectoryError,
     read_claude_session,
+    read_deepseek_session,
     read_opencode_storage,
     read_pi_session,
     reader_for,
@@ -160,6 +161,21 @@ def test_claude_reader_tolerates_exactly_one_torn_tail(tmp_path: Path) -> None:
 
 def test_claude_format_resolves_through_reader_for() -> None:
     assert reader_for("claude-session-jsonl").format == "claude-session-jsonl"
+
+
+def test_deepseek_reader_reads_nested_sessions_and_tolerates_one_torn_tail(tmp_path: Path) -> None:
+    # dsh lays sessions out as sessions/<cwd-slug>/session-<id>/session.jsonl.
+    first = tmp_path / "slug" / "session-01" / "session.jsonl"
+    second = tmp_path / "slug" / "session-02" / "session.jsonl"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    first.write_text('{"type": "session", "version": 0}\n{"type": "turn/start", "seq": 0}\n')
+    second.write_text('{"type": "session", "version": 0}\n{"type": "turn/end", "seq": 0\n')  # crash mid-write
+    assert [event["type"] for event in read_deepseek_session(tmp_path)] == ["session", "turn/start", "session"]
+    second.write_text('{"type": "session"\n{"type": "turn/end", "seq": 0}\n')  # torn in the middle: corruption
+    with pytest.raises(TrajectoryError, match=r"deepseek session .* corrupt event at line 1"):
+        read_deepseek_session(tmp_path)
+    assert reader_for("deepseek-session-jsonl").format == "deepseek-session-jsonl"
 
 
 def test_missing_trajectory_reads_as_empty(tmp_path: Path) -> None:

--- a/tests/reef_service/test_harness_render.py
+++ b/tests/reef_service/test_harness_render.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from reef.harness.adapters import available_adapters, get_adapter
+from reef.harness.model_binding import ModelBinding
 from reef.harness.render import RenderError, render_composition
 
 GOLDENS = Path(__file__).parent / "data" / "harness_goldens"
@@ -55,6 +57,67 @@ def test_opencode_render_matches_the_golden_tree() -> None:
 def test_claude_render_matches_the_golden_tree() -> None:
     nodes = [node for node in NODES if node[1].get("target") != "models"]
     assert render_composition(nodes, get_adapter("claude")) == golden_tree("claude")
+
+
+DSH_PATCH = "dsh/profiles/headless/cordis.patch.yml"
+
+
+def _dsh_nodes():
+    # dsh's config target is keyed by plugin id, so the pi shaped config nodes are swapped for one of its own.
+    nodes = [node for node in NODES if node[0] != "config"]
+    return [("config", {"data": {"agent-loop": {"config": {"maxSteps": 40}}}}), *nodes]
+
+
+def test_dsh_render_matches_the_golden_tree() -> None:
+    assert render_composition(_dsh_nodes(), get_adapter("dsh")) == golden_tree("dsh")
+
+
+def test_dsh_quirks_emit_the_patch_layer_the_env_file_and_skill_frontmatter() -> None:
+    descriptor = get_adapter("dsh")
+    binding = ModelBinding(base_url="http://127.0.0.1:9", model="m1", api_key="k-1")
+    files = render_composition([*_dsh_nodes(), *binding.compose_nodes(descriptor)], descriptor)
+    patch = yaml.safe_load(files[DSH_PATCH].replace("!!js ", ""))
+    by_id = {row["id"]: row for row in patch if "id" in row}
+    # Every entry in id order, the defaults that keep an episode readable and quiet, the binding, then the inserts.
+    assert [row.get("id", "insert") for row in patch] == [
+        "agent-default-model",
+        "agent-loop",
+        "llm-pi-ai",
+        "session-persistence-jsonl",
+        "session-telemetry-otel",
+        "session-title-llm",
+        "insert",
+    ]
+    assert by_id["session-persistence-jsonl"]["config"] == {"compression": "none", "root": "dshHomePath('sessions')"}
+    assert "root: !!js 'dshHomePath(''sessions'')'" in files[DSH_PATCH]
+    assert by_id["session-telemetry-otel"] == {"id": "session-telemetry-otel", "disabled": True}
+    route = by_id["llm-pi-ai"]["config"]["providers"]["reef"]
+    assert route["baseURL"] == "http://127.0.0.1:9/v1" and route["apiKeyEnv"] == "REEF_API_KEY"
+    assert by_id["agent-default-model"]["config"] == {"provider": "reef", "model": "m1"}
+    assert patch[-1] == {"insert": [{"id": "extension-tracer", "name": "./extensions/tracer.mjs"}]}
+    assert files["dsh/.env"] == "REEF_API_KEY=k-1\n"
+    # A skill without frontmatter gets name and description; a command is a user invocable skill.
+    assert (
+        files["dsh/skills/notes/SKILL.md"]
+        == "---\nname: notes\ndescription: Notes skill\n---\n# Notes skill\n\nKeep short notes.\n"
+    )
+    assert files["dsh-agents/skills/summarize/SKILL.md"] == (
+        "---\nname: summarize\ndescription: Summarize $1.\ndisable-model-invocation: true\n---\nSummarize $1.\n"
+    )
+    own = ("skill", {"name": "own", "text": "---\nname: own\ndescription: mine\n---\nBody.\n"})
+    assert render_composition([own], descriptor)["dsh/skills/own/SKILL.md"] == own[1]["text"]
+
+
+def test_dsh_quirks_refuse_a_patch_that_breaks_the_episode() -> None:
+    descriptor = get_adapter("dsh")
+    with pytest.raises(RenderError, match="uncompressed"):
+        render_composition(
+            [("config", {"data": {"session-persistence-jsonl": {"config": {"compression": "zstd"}}}})], descriptor
+        )
+    with pytest.raises(RenderError, match="session-telemetry-otel disabled"):
+        render_composition([("config", {"data": {"session-telemetry-otel": {"disabled": False}}})], descriptor)
+    with pytest.raises(RenderError, match="must be an object"):
+        render_composition([("config", {"data": {"agent-loop": "nope"}})], descriptor)
 
 
 def test_config_nodes_deep_merge_in_tree_order() -> None:

--- a/tests/smoke/test_real_dsh.py
+++ b/tests/smoke/test_real_dsh.py
@@ -1,0 +1,109 @@
+"""Smoke of the real dsh binary: render, episode, and trajectory against the
+real thing. The hermetic suites drive scripted fakes, so every format and
+environment assumption about the real DeepSeek Harness lives here: a pinned
+dsh runs one episode against a stdlib OpenAI-compatible stub and must read
+our rendered patch layer, reach the stub with the rules text and the bound
+key, write a session our reader parses, and leave no unexplained residue.
+Skipped unless REEF_REAL_DSH_BINARY points at an installed dsh
+(.github/workflows/harness-smoke.yml provides one)."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+
+from reef.harness.adapters import get_adapter
+from reef.harness.episode import run_episode
+from reef.harness.model_binding import ModelBinding
+from reef.harness.render import render_composition
+
+REAL_DSH = os.environ.get("REEF_REAL_DSH_BINARY", "")
+
+pytestmark = pytest.mark.skipif(not REAL_DSH, reason="REEF_REAL_DSH_BINARY does not name a real dsh binary")
+
+MODEL = "smoke-model"
+RULES_SENTENCE = "The reef smoke marker phrase is TIDEPOOL-STONE-41."
+
+
+class StubOpenAI(ThreadingHTTPServer):
+    """A canned /v1 endpoint that records every request it is sent."""
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), StubHandler)
+        self.bodies: list[str] = []
+        self.auth: list[str | None] = []
+
+
+class StubHandler(BaseHTTPRequestHandler):
+    server: StubOpenAI
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass  # keep the harness's stderr out of pytest output
+
+    def do_POST(self) -> None:
+        body = self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode("utf-8")
+        self.server.bodies.append(body)
+        self.server.auth.append(self.headers.get("Authorization"))
+        usage = {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        if json.loads(body).get("stream"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunks = [
+                {"choices": [{"index": 0, "delta": {"role": "assistant", "content": "READY"}}]},
+                {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}], "usage": usage},
+            ]
+            for chunk in chunks:
+                event = {"id": "chatcmpl-smoke", "object": "chat.completion.chunk", "model": MODEL, **chunk}
+                self.wfile.write(b"data: " + json.dumps(event).encode("utf-8") + b"\n\n")
+            self.wfile.write(b"data: [DONE]\n\n")
+        else:
+            message = {"role": "assistant", "content": "READY"}
+            payload = {
+                "id": "chatcmpl-smoke",
+                "object": "chat.completion",
+                "model": MODEL,
+                "choices": [{"index": 0, "message": message, "finish_reason": "stop"}],
+                "usage": usage,
+            }
+            raw = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+
+def test_real_dsh_episode_renders_runs_and_cleans_up() -> None:
+    server = StubOpenAI()
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    descriptor = get_adapter("dsh")
+    try:
+        binding = ModelBinding(
+            base_url=f"http://127.0.0.1:{server.server_address[1]}", model=MODEL, api_key="smoke-key"
+        )
+        nodes = [("rules", {"text": RULES_SENTENCE}), *binding.compose_nodes(descriptor)]
+        files = render_composition(nodes, descriptor)
+        # The task starts with a dash on purpose: it must pass both commander layers as a positional.
+        result = run_episode(descriptor, files, "- Reply with exactly the word READY", binary=REAL_DSH, timeout=180.0)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    # (a) The rendered rules text and the bound key reached the model: the
+    # whole chain (patch layer, .env, relocation env, real binary, request) held.
+    assert any(RULES_SENTENCE in body for body in server.bodies), server.bodies
+    assert any("- Reply with exactly the word READY" in body for body in server.bodies), server.bodies
+    assert server.auth and server.auth[0] == "Bearer smoke-key", server.auth
+    # (b) The session the real binary wrote parses through our reader and
+    # carries the assistant message and the turn end.
+    kinds = [event.get("type") for event in result.trajectory]
+    assert kinds and kinds[0] == "session" and "assistant/message" in kinds and kinds[-1] == "turn/end", kinds
+    # (c) The cleanup audit found nothing outside the declared whitelist.
+    assert result.residue == ()


### PR DESCRIPTION
## Motivation

Reef evolves a harness tree for pi, opencode, and Claude Code, but a team that runs DeepSeek Harness (dsh) cannot point evolution.adapter at it, so the gate cannot score a dsh tree and GET /reef/harness cannot serve one. This adds dsh as the fourth bundled adapter, run headless per episode from a hermetic root like the other three. Every fact the descriptor states was measured on the real pinned binary against a stub model endpoint, and the same run is now a smoke job. Closes #171.

## Changes

- A dsh adapter (reef/harness/adapters/dsh): binary dsh, argv --profile headless with a double -- so a task that starts with a dash still reaches the app as its positional, DSH_HOME and DSH_AGENTS_HOME relocating the whole home and the second skill root under the episode root, DSH_TELEMETRY_MODE=DISABLED, the npm install pin @deepseek-ai/dsh 0.1.2-alpha.5 (the alpha tag: the source that was mapped and the binary that was measured), and a cleanup whitelist for dsh's boot scaffold (profile package.json, cordis.yml, pnpm-workspace.yaml, node_modules symlinks, the module fallback) plus sessions and storages
- The primary config target is dsh's user patch layer, profiles/headless/cordis.patch.yml. dsh wants a YAML list of entries addressed by plugin id, so config nodes write an object keyed by plugin id (nodes touching one plugin deep merge) and the quirks module emits the list; a string starting with !!js becomes a js expression, the form dsh's own bundles use. The defaults keep the session log at dshHomePath('sessions') and uncompressed (a patched config replaces the whole config, and dsh's default zstd framing is unreadable to a JSONL reader), and the LLM session title call and the telemetry disabled; a composition that flips any of them is refused at render
- The env config target renders dsh/.env, the lowest trust layer of dsh's launch environment. The model binding declares an llm-pi-ai route (openai-completions at {base_url}/v1, or anthropic-messages at {base_url}) whose key is named by apiKeyEnv and supplied through that file, and agent-default-model selects the route; the served tree never carries a provider or a key
- Rules render to dsh's user global AGENTS.md. Skills render to skills/{name}/SKILL.md; dsh ignores a SKILL.md without YAML frontmatter carrying name and description, so the quirks synthesize it when the node text has none and leave the author's frontmatter alone. dsh has no user command directory, so an agent_command renders as a user invocable skill (disable-model-invocation: true, run as /name) under DSH_AGENTS_HOME. A code_extension renders as a plugin module under profiles/headless/extensions/{name}.mjs and the patch layer gains one insert entry per extension with a relative specifier
- A deepseek-session-jsonl trajectory reader for sessions/<cwd slug>/session-<id>/session.jsonl; the pi, claude, and deepseek readers now share one JSONL tree helper with the same torn tail rule
- tests/smoke/test_real_dsh.py and a real-dsh job in harness-smoke.yml beside real-pi: the pinned dsh renders, runs, and is read back against a stub endpoint
- The golden trees under tests/reef_service/data/harness_goldens are byte exact render output, so the pre-commit exclude now covers them (check-yaml cannot construct the !!js tag) and .gitignore stops ignoring the dsh golden's .env
- Documented in the harness adapters guide (the table gains the claude row it was missing and the dsh row, plus a dsh paragraph), the lane guide, the configuration reference, and the install route

## Compatibility and operational impact

Additive: a fourth bundled adapter next to pi, opencode, and claude, no existing descriptor, node kind, or recipe changes. The trajectory reader refactor keeps the pi and claude readers' formats, tolerance, and messages. The client wrapper reef-<adapter> gets no dsh branch in this cut, like claude: the proxy URL rewrite it does for pi and opencode is a follow up. dsh needs Node 22.19 or newer on the host that runs episodes; the pin follows a prerelease line and the smoke job is the tripwire for its format drift. dsh is MIT licensed and the adapter carries no dsh code.

## Verification

Measured on the real binary before writing the descriptor (scratch probes, not in the tree): a pre rendered patch survives boot and is applied; a config override replaces the whole entry config; a hand declared llm-pi-ai route with apiKeyEnv resolved from DSH_HOME/.env reached the stub as Authorization: Bearer <key>; the user AGENTS.md text reached the model; a SKILL.md without frontmatter is not listed while one with frontmatter is; a disable-model-invocation skill under DSH_AGENTS_HOME is not listed but /name injects its body; a relative .mjs plugin inserted by the patch loaded at boot; a bash call in the default workspace-write mode wrote a file inside the workspace with no approval prompt; the session log with compression none is plain JSONL with the {type, seq, time, data} envelope; a task starting with a dash is rejected with one -- and accepted with two.

tests/smoke/test_real_dsh.py passes locally against the installed 0.1.2-alpha.5 (exit 0, the rules sentence and the dash leading task in the request body, Bearer smoke-key, a trajectory from session to turn/end, no residue). The render suite covers the dsh golden tree, the patch layer emission (entry order, the !!js scalar, the binding route, the extension insert), the .env file, skill frontmatter synthesis for skills and commands, the author's own frontmatter left alone, and the three render refusals; the episode suite covers the nested session layout, the torn tail rule, and reader_for. tests/reef_service passes on Python 3.12 (1232 tests, the ray and slime bridge modules skipped for lack of those packages locally). The pre-commit hook set, mypy on reef/harness, and the docs link and contract checks are clean.

## AI assistance

Claude Code mapped deepseek-harness's source and probed the real binary, then wrote the descriptor, the quirks, the reader, the tests, and the docs. I set the scope in #171.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
