### PR TITLE
fix(deploy): bind Python service commands explicitly

### DIFF
--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -163,6 +163,11 @@ the one to copy:
      upstream_api_key: ${REEF_UPSTREAM_API_KEY}
      upstream_model: ${REEF_MODEL}
 
+   services:
+     - name: reef
+       command: ["${REEF_PYTHON}", "-m", "reef.service"]
+       ready: curl -sf http://127.0.0.1:${reef.port}/healthz
+
 See `Recipe configuration <../reference/configuration.rst#recipe-configuration>`__.
 ``tutorials/harness_evolve/run.sh`` does exactly this.
 

--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -163,11 +163,6 @@ the one to copy:
      upstream_api_key: ${REEF_UPSTREAM_API_KEY}
      upstream_model: ${REEF_MODEL}
 
-   services:
-     - name: reef
-       command: python3 -m reef.service
-       ready: curl -sf http://127.0.0.1:${reef.port}/healthz
-
 See `Recipe configuration <../reference/configuration.rst#recipe-configuration>`__.
 ``tutorials/harness_evolve/run.sh`` does exactly this.
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1,9 +1,9 @@
 Configuration
 =============
 
-A deployment config is one YAML file. ``reef serve -c <file>`` reads it, starts
-every process in its ``services`` list in dependency order, and hands the
-``reef`` section to the HTTP service.
+A deployment config is one YAML file. ``reef serve -c <file>`` reads it,
+starts any auxiliary processes in its ``services`` list in dependency order,
+then starts the built-in Reef HTTP service from the ``reef`` section.
 
 .. code:: yaml
 
@@ -15,16 +15,17 @@ every process in its ``services`` list in dependency order, and hands the
      upstream_url: ${REEF_UPSTREAM_URL}
      upstream_api_key: ${REEF_UPSTREAM_API_KEY}
 
-   services:
-     - name: reef
-       command: python -m reef.service
-       ready: curl -sf http://127.0.0.1:${reef.port}/healthz
-
 Values interpolate from the environment with ``${VAR}`` and from the config
 itself with ``${dotted.path}``. Any value can be overridden on the command line:
 a bare ``--model_path /models/demo`` targets the ``reef`` section, and a dotted
 ``--training.checkpoint_dir /tmp/ckpt`` targets any other. Each process writes a
 log under ``/tmp/reef-stack/``; set ``run_dir`` to move it.
+
+The Reef HTTP service always uses the interpreter that launched ``reef serve``.
+``REEF_PYTHON`` exposes that interpreter to auxiliary Python services; set it
+before launch to use a different interpreter for those commands. A literal
+``python`` in ``services[].command`` keeps its normal meaning and is resolved
+from that service's ``PATH``.
 
 Start from a cookbook stack
 ---------------------------
@@ -184,10 +185,12 @@ The served model's binding is appended at render time; it never enters the
 published files. The seed defines the baseline the first mutation is measured
 against.
 
-The ``services`` list
----------------------
+The optional ``services`` list
+------------------------------
 
-Each entry is one process.
+Each entry is one auxiliary process. Reef itself is configured by the
+``reef`` section and starts automatically after every auxiliary service is
+ready; ``reef`` is therefore a reserved service name.
 
 .. config::
 
@@ -198,6 +201,9 @@ Each entry is one process.
    services[].depends_on | services that must be ready first
    services[].cuda | the value of ``CUDA_VISIBLE_DEVICES`` for this process
    services[].env | extra environment variables
+
+``reef.process.ready_timeout`` overrides the top-level readiness timeout for
+the built-in Reef process.
 
 The ``training`` section
 ------------------------

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1,9 +1,9 @@
 Configuration
 =============
 
-A deployment config is one YAML file. ``reef serve -c <file>`` reads it,
-starts any auxiliary processes in its ``services`` list in dependency order,
-then starts the built-in Reef HTTP service from the ``reef`` section.
+A deployment config is one YAML file. ``reef serve -c <file>`` reads it, starts
+every process in its ``services`` list in dependency order, and hands the
+``reef`` section to the HTTP service.
 
 .. code:: yaml
 
@@ -15,17 +15,21 @@ then starts the built-in Reef HTTP service from the ``reef`` section.
      upstream_url: ${REEF_UPSTREAM_URL}
      upstream_api_key: ${REEF_UPSTREAM_API_KEY}
 
+   services:
+     - name: reef
+       command: ["${REEF_PYTHON}", "-m", "reef.service"]
+       ready: curl -sf http://127.0.0.1:${reef.port}/healthz
+
 Values interpolate from the environment with ``${VAR}`` and from the config
 itself with ``${dotted.path}``. Any value can be overridden on the command line:
 a bare ``--model_path /models/demo`` targets the ``reef`` section, and a dotted
 ``--training.checkpoint_dir /tmp/ckpt`` targets any other. Each process writes a
 log under ``/tmp/reef-stack/``; set ``run_dir`` to move it.
 
-The Reef HTTP service always uses the interpreter that launched ``reef serve``.
-``REEF_PYTHON`` exposes that interpreter to auxiliary Python services; set it
-before launch to use a different interpreter for those commands. A literal
-``python`` in ``services[].command`` keeps its normal meaning and is resolved
-from that service's ``PATH``.
+``REEF_PYTHON`` defaults to the interpreter that launched ``reef serve`` and
+can be overridden in the environment. Use it when a service must share Reef's
+Python environment. A literal ``python`` keeps its normal meaning and is
+resolved from that service's ``PATH``; Reef never rewrites command names.
 
 Start from a cookbook stack
 ---------------------------
@@ -185,25 +189,22 @@ The served model's binding is appended at render time; it never enters the
 published files. The seed defines the baseline the first mutation is measured
 against.
 
-The optional ``services`` list
-------------------------------
+The ``services`` list
+---------------------
 
-Each entry is one auxiliary process. Reef itself is configured by the
-``reef`` section and starts automatically after every auxiliary service is
-ready; ``reef`` is therefore a reserved service name.
+Each entry is one process. ``command`` can be a command-line string or an argv
+list. Prefer the list form when exact argument boundaries matter; existing
+string commands retain their current ``shlex`` parsing.
 
 .. config::
 
    services[].name | the service's id, used by ``depends_on``; unique within one stack
-   services[].command | the command line to run
+   services[].command | the command line string or argv list to run
    services[].ready | a shell command that succeeds once the service is up
    services[].ready_timeout | seconds to wait for ``ready`` before giving up; the top-level ``ready_timeout`` sets the default
    services[].depends_on | services that must be ready first
    services[].cuda | the value of ``CUDA_VISIBLE_DEVICES`` for this process
    services[].env | extra environment variables
-
-``reef.process.ready_timeout`` overrides the top-level readiness timeout for
-the built-in Reef process.
 
 The ``training`` section
 ------------------------

--- a/recipes/AGENTS.md
+++ b/recipes/AGENTS.md
@@ -113,11 +113,6 @@ reef:
   artifact_repository: ${REEF_WORK}/artifacts.git
   artifact_work_dir: ${REEF_WORK}/artifact-work
   artifact_cache_dir: ${REEF_WORK}/artifact-cache
-
-services:
-  - name: reef
-    command: ${PYTHON} -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
 ```
 
 For a training example (GPU + Ray + Slime/Megatron + SGLang), see

--- a/recipes/AGENTS.md
+++ b/recipes/AGENTS.md
@@ -113,6 +113,11 @@ reef:
   artifact_repository: ${REEF_WORK}/artifacts.git
   artifact_work_dir: ${REEF_WORK}/artifact-work
   artifact_cache_dir: ${REEF_WORK}/artifact-cache
+
+services:
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
 ```
 
 For a training example (GPU + Ray + Slime/Megatron + SGLang), see

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -25,7 +25,10 @@ Each is complete and runnable: a flat `reef:` section (translated into the
 frozen `ServiceSettings` by
 [`reef/service/deploy/settings.py`](../reef/service/deploy/settings.py)) plus
 a `services:` list the orchestrator starts in dependency order, with `${VAR}`
-environment and `${dotted.path}` config interpolation. Copy one and adapt it;
+environment and `${dotted.path}` config interpolation. `${REEF_PYTHON}`
+defaults to the interpreter running `reef serve`, so Python services that use
+it share Reef's environment without changing the meaning of literal `python`
+commands. Copy one and adapt it;
 `reef serve -c <stack> --<key> <value>` overrides any `reef.*` setting. The
 `recipe` they bind is the base contract in
 [`reef/recipe/base.py`](../reef/recipe/base.py); a stack that binds a method

--- a/recipes/basic/external-provider.yaml
+++ b/recipes/basic/external-provider.yaml
@@ -25,3 +25,8 @@ reef:
   artifact_work_dir: .reef/artifact-work
   artifact_cache_dir: .reef/artifact-cache
   agent_record_dir: .reef/agent-record
+
+services:
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz

--- a/recipes/basic/external-provider.yaml
+++ b/recipes/basic/external-provider.yaml
@@ -25,8 +25,3 @@ reef:
   artifact_work_dir: .reef/artifact-work
   artifact_cache_dir: .reef/artifact-cache
   agent_record_dir: .reef/agent-record
-
-services:
-  - name: reef
-    command: python -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz

--- a/recipes/basic/local-sglang.yaml
+++ b/recipes/basic/local-sglang.yaml
@@ -27,13 +27,8 @@ sglang:
 services:
   - name: sglang
     command: >-
-      python -m sglang.launch_server
+      "${REEF_PYTHON}" -m sglang.launch_server
       --model-path=${reef.model_path} --tp 1
       --host 0.0.0.0 --port=${sglang.port}
     ready: curl -sf http://127.0.0.1:${sglang.port}/health
     cuda: ${sglang.cuda_visible_devices}
-
-  - name: reef
-    command: python -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
-    depends_on: [sglang]

--- a/recipes/basic/local-sglang.yaml
+++ b/recipes/basic/local-sglang.yaml
@@ -32,3 +32,8 @@ services:
       --host 0.0.0.0 --port=${sglang.port}
     ready: curl -sf http://127.0.0.1:${sglang.port}/health
     cuda: ${sglang.cuda_visible_devices}
+
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
+    depends_on: [sglang]

--- a/recipes/openclawrl/examples/openclawrl/serve.yaml
+++ b/recipes/openclawrl/examples/openclawrl/serve.yaml
@@ -173,7 +173,7 @@ services:
 
   - name: prm-sglang
     command: >-
-      python -m sglang.launch_server
+      "${REEF_PYTHON}" -m sglang.launch_server
       --model-path=${prm.model_path} --tp ${prm.tp}
       --host 0.0.0.0 --port=${prm.port}
     ready: curl -sf http://127.0.0.1:${prm.port}/health
@@ -182,7 +182,7 @@ services:
 
   - name: user-llm-sglang
     command: >-
-      python -m sglang.launch_server
+      "${REEF_PYTHON}" -m sglang.launch_server
       --model-path=${user_llm.model_path} --tp 1
       --served-model-name=${user_llm.served_name}
       --host 0.0.0.0 --port=${user_llm.port}
@@ -192,7 +192,7 @@ services:
 
   - name: slime-driver
     command: >-
-      python -m reef.train.slime_backend.reef_adapters.driver
+      "${REEF_PYTHON}" -m reef.train.slime_backend.reef_adapters.driver
       --reef-checkpoint-max-storage-fraction=${training.checkpoint_retention.max_storage_fraction}
       --reef-checkpoint-min-free-space-fraction=${training.checkpoint_retention.min_free_space_fraction}
       --reef-checkpoint-policy=${training.checkpoint_retention.policy}
@@ -217,10 +217,3 @@ services:
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]
-
-  - name: reef
-    command: python -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
-    env:
-      RAY_ADDRESS: 127.0.0.1:${training.ray_port}
-    depends_on: [slime-driver, prm-sglang]

--- a/recipes/openclawrl/examples/openclawrl/serve.yaml
+++ b/recipes/openclawrl/examples/openclawrl/serve.yaml
@@ -217,3 +217,10 @@ services:
       CUDA_DEVICE_MAX_CONNECTIONS: "1"
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]
+
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
+    env:
+      RAY_ADDRESS: 127.0.0.1:${training.ray_port}
+    depends_on: [slime-driver, prm-sglang]

--- a/recipes/sao/examples/sao/serve.yaml
+++ b/recipes/sao/examples/sao/serve.yaml
@@ -107,7 +107,7 @@ services:
 
   - name: slime-driver
     command: >-
-      python -m reef.train.slime_backend.reef_adapters.driver
+      "${REEF_PYTHON}" -m reef.train.slime_backend.reef_adapters.driver
       --megatron-to-hf-mode bridge
       --hf-checkpoint=${reef.model_path}
       --load=${training.checkpoint_dir}/megatron
@@ -127,10 +127,3 @@ services:
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
     depends_on: [ray-head]
-
-  - name: reef
-    command: python3 -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
-    env:
-      RAY_ADDRESS: 127.0.0.1:${training.ray_port}
-    depends_on: [slime-driver]

--- a/recipes/sao/examples/sao/serve.yaml
+++ b/recipes/sao/examples/sao/serve.yaml
@@ -127,3 +127,10 @@ services:
       REEF_RAY_NAMESPACE: reef
       REEF_RAY_ACTOR_NAME: reef-train-bridge
     depends_on: [ray-head]
+
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
+    env:
+      RAY_ADDRESS: 127.0.0.1:${training.ray_port}
+    depends_on: [slime-driver]

--- a/recipes/tttd/examples/guidance_ttt/serve.yaml
+++ b/recipes/tttd/examples/guidance_ttt/serve.yaml
@@ -10,6 +10,8 @@ reef:
   host: 127.0.0.1
   model_path: work/model
   port: 8900
+  process:
+    ready_timeout: 120
   recipe: recipes.tttd.recipe:TTTDRecipe
   token: reef-local
   groups_per_step: 2
@@ -61,7 +63,7 @@ services:
 
   - name: slime-driver
     command: >-
-      python -m reef.train.slime_backend.reef_adapters.driver
+      "${REEF_PYTHON}" -m reef.train.slime_backend.reef_adapters.driver
       --hf-checkpoint=${reef.model_path}
       --load=${training.checkpoint_dir}/megatron
       --ref-load=${reef.model_path}
@@ -146,11 +148,3 @@ services:
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]
     cuda: ${training.cuda_visible_devices}
-
-  - name: reef
-    command: python -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
-    ready_timeout: 120
-    env:
-      RAY_ADDRESS: 127.0.0.1:6379
-    depends_on: [slime-driver]

--- a/recipes/tttd/examples/guidance_ttt/serve.yaml
+++ b/recipes/tttd/examples/guidance_ttt/serve.yaml
@@ -10,8 +10,6 @@ reef:
   host: 127.0.0.1
   model_path: work/model
   port: 8900
-  process:
-    ready_timeout: 120
   recipe: recipes.tttd.recipe:TTTDRecipe
   token: reef-local
   groups_per_step: 2
@@ -148,3 +146,11 @@ services:
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]
     cuda: ${training.cuda_visible_devices}
+
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
+    ready_timeout: 120
+    env:
+      RAY_ADDRESS: 127.0.0.1:6379
+    depends_on: [slime-driver]

--- a/recipes/tttd/examples/tttd/serve.yaml
+++ b/recipes/tttd/examples/tttd/serve.yaml
@@ -10,8 +10,6 @@ reef:
   host: 127.0.0.1
   model_path: work/model
   port: 8900
-  process:
-    ready_timeout: 120
   recipe: recipes.tttd.recipe:TTTDRecipe
   token: reef-local
   groups_per_step: 8
@@ -144,3 +142,11 @@ services:
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]
     cuda: ${training.cuda_visible_devices}
+
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
+    ready_timeout: 120
+    env:
+      RAY_ADDRESS: 127.0.0.1:6379
+    depends_on: [slime-driver]

--- a/recipes/tttd/examples/tttd/serve.yaml
+++ b/recipes/tttd/examples/tttd/serve.yaml
@@ -10,6 +10,8 @@ reef:
   host: 127.0.0.1
   model_path: work/model
   port: 8900
+  process:
+    ready_timeout: 120
   recipe: recipes.tttd.recipe:TTTDRecipe
   token: reef-local
   groups_per_step: 8
@@ -56,7 +58,7 @@ services:
 
   - name: slime-driver
     command: >-
-      python -m reef.train.slime_backend.reef_adapters.driver
+      "${REEF_PYTHON}" -m reef.train.slime_backend.reef_adapters.driver
       --hf-checkpoint=${reef.model_path}
       --load=${training.checkpoint_dir}/megatron
       --ref-load=${reef.model_path}
@@ -142,11 +144,3 @@ services:
       NCCL_NVLS_ENABLE: "0"
     depends_on: [ray-head]
     cuda: ${training.cuda_visible_devices}
-
-  - name: reef
-    command: python -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
-    ready_timeout: 120
-    env:
-      RAY_ADDRESS: 127.0.0.1:6379
-    depends_on: [slime-driver]

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -98,12 +98,10 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
 
 
 def validate_services(config: Mapping[str, Any], config_path: str | Path) -> list[dict[str, Any]]:
-    """Optional auxiliary services with unique names, checked before any process starts."""
+    """Services with valid commands and unique names, checked before any process starts."""
     services = config.get("services")
-    if services is None:
-        return []
-    if not isinstance(services, list):
-        raise DeployConfigError(f"config {config_path}: 'services' must be a list, not {type(services).__name__}")
+    if not isinstance(services, list) or not services:
+        raise DeployConfigError(f"config {config_path} must declare a non-empty 'services' list")
     names: list[str] = []
     for index, service in enumerate(services):
         if not isinstance(service, dict):
@@ -113,9 +111,17 @@ def validate_services(config: Mapping[str, Any], config_path: str | Path) -> lis
         name = service.get("name")
         if not isinstance(name, str) or not name.strip():
             raise DeployConfigError(f"config {config_path}: services[{index}] must have a non-empty 'name'")
-        if name == "reef":
+        command = service.get("command")
+        valid_string = isinstance(command, str) and bool(command.strip())
+        valid_list = (
+            isinstance(command, list)
+            and bool(command)
+            and all(isinstance(argument, str) for argument in command)
+            and bool(command[0].strip())
+        )
+        if not valid_string and not valid_list:
             raise DeployConfigError(
-                f"config {config_path}: service name 'reef' is reserved; the reef section starts it automatically"
+                f"config {config_path}: services[{index}] must have a non-empty 'command' string or list of strings"
             )
         names.append(name)
     duplicates = sorted({name for name in names if names.count(name) > 1})

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -1,14 +1,16 @@
 """Config loading and interpolation shared by app assembly and orchestrator.
 
 ``reef serve`` configs are YAML with two interpolation passes: ``${VAR}``
-against the process environment at load time, and ``${dotted.path}`` against
-the config itself when a service command or setting is materialized.
+against the process environment at load time (with ``REEF_PYTHON`` defaulting
+to the current interpreter), and ``${dotted.path}`` against the config itself
+when a service command or setting is materialized.
 """
 
 from __future__ import annotations
 
 import os
 import re
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -90,14 +92,18 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
         config = {}
     if not isinstance(config, dict):
         raise DeployConfigError(f"config {path} must be a YAML object at the root, not {type(config).__name__}")
-    return _deep_interp_env(config, os.environ)
+    environ = dict(os.environ)
+    environ.setdefault("REEF_PYTHON", sys.executable)
+    return _deep_interp_env(config, environ)
 
 
 def validate_services(config: Mapping[str, Any], config_path: str | Path) -> list[dict[str, Any]]:
-    """Services as a non-empty list of objects with unique names, checked before any download, run dir, or process."""
+    """Optional auxiliary services with unique names, checked before any process starts."""
     services = config.get("services")
-    if not isinstance(services, list) or not services:
-        raise DeployConfigError(f"config {config_path} must declare a non-empty 'services' list")
+    if services is None:
+        return []
+    if not isinstance(services, list):
+        raise DeployConfigError(f"config {config_path}: 'services' must be a list, not {type(services).__name__}")
     names: list[str] = []
     for index, service in enumerate(services):
         if not isinstance(service, dict):
@@ -107,6 +113,10 @@ def validate_services(config: Mapping[str, Any], config_path: str | Path) -> lis
         name = service.get("name")
         if not isinstance(name, str) or not name.strip():
             raise DeployConfigError(f"config {config_path}: services[{index}] must have a non-empty 'name'")
+        if name == "reef":
+            raise DeployConfigError(
+                f"config {config_path}: service name 'reef' is reserved; the reef section starts it automatically"
+            )
         names.append(name)
     duplicates = sorted({name for name in names if names.count(name) > 1})
     if duplicates:

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -1,9 +1,10 @@
 """Process orchestrator behind ``reef serve``.
 
-Starts every service a config declares in dependency order, probes readiness,
-mirrors child output, watches for unexpected exits, and tears the stack down
-in reverse order on signal. Assembly of the Reef HTTP application itself
-lives in :mod:`reef.service.deploy.settings` and :mod:`reef.service.assembly`.
+Starts configured auxiliary services in dependency order, then starts the
+built-in Reef HTTP service, probes readiness, mirrors child output, watches
+for unexpected exits, and tears the stack down in reverse order on signal.
+Assembly of the HTTP application itself lives in
+:mod:`reef.service.deploy.settings` and :mod:`reef.service.assembly`.
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -26,16 +27,43 @@ import yaml
 
 from reef.service.deploy.config import (
     PROJECT_ROOT,
+    DeployConfigError,
     config_value,
     interpolate_config,
     load_config,
     resolve_model_paths,
     validate_services,
 )
-from reef.service.deploy.settings import build_parser
+from reef.service.deploy.settings import ServiceSettings, build_parser, service_settings_from_config
 
 _DEFAULT_GRACE_TIMEOUT = 30
 _WATCHDOG_INTERVAL = 5
+
+
+def _builtin_reef_service(
+    config: Mapping[str, Any], auxiliary_services: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    """Build the internal HTTP service managed implicitly by ``reef serve``."""
+    try:
+        settings: ServiceSettings = service_settings_from_config(config)
+    except ValueError as exc:
+        raise DeployConfigError(str(exc)) from exc
+
+    reef = config.get("reef")
+    assert isinstance(reef, Mapping)  # validated by service_settings_from_config
+    process = reef.get("process") or {}
+    if not isinstance(process, Mapping):
+        raise DeployConfigError("reef.process must be an object")
+
+    service: dict[str, Any] = {
+        "name": "reef",
+        "command": shlex.join([sys.executable, "-m", "reef.service"]),
+        "ready": f"curl -sf http://127.0.0.1:{settings.port}/healthz",
+        "depends_on": [str(item["name"]) for item in auxiliary_services],
+    }
+    if "ready_timeout" in process:
+        service["ready_timeout"] = process["ready_timeout"]
+    return service
 
 
 def _log(msg):
@@ -358,7 +386,8 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
     if overrides:
         config = _apply_overrides(config, overrides)
     # Structure first, so a bad stack fails before a model download, a run dir, or a child process.
-    services = validate_services(config, resolved_config_path)
+    auxiliary_services = validate_services(config, resolved_config_path)
+    services = [*auxiliary_services, _builtin_reef_service(config, auxiliary_services)]
     paths_changed = resolve_model_paths(config)
     temp_config_path: Path | None = None
     if overrides or paths_changed:

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -1,10 +1,9 @@
 """Process orchestrator behind ``reef serve``.
 
-Starts configured auxiliary services in dependency order, then starts the
-built-in Reef HTTP service, probes readiness, mirrors child output, watches
-for unexpected exits, and tears the stack down in reverse order on signal.
-Assembly of the HTTP application itself lives in
-:mod:`reef.service.deploy.settings` and :mod:`reef.service.assembly`.
+Starts every service a config declares in dependency order, probes readiness,
+mirrors child output, watches for unexpected exits, and tears the stack down
+in reverse order on signal. Assembly of the Reef HTTP application itself
+lives in :mod:`reef.service.deploy.settings` and :mod:`reef.service.assembly`.
 """
 
 from __future__ import annotations
@@ -27,47 +26,27 @@ import yaml
 
 from reef.service.deploy.config import (
     PROJECT_ROOT,
-    DeployConfigError,
     config_value,
     interpolate_config,
     load_config,
     resolve_model_paths,
     validate_services,
 )
-from reef.service.deploy.settings import ServiceSettings, build_parser, service_settings_from_config
+from reef.service.deploy.settings import build_parser
 
 _DEFAULT_GRACE_TIMEOUT = 30
 _WATCHDOG_INTERVAL = 5
 
 
-def _builtin_reef_service(
-    config: Mapping[str, Any], auxiliary_services: Sequence[Mapping[str, Any]]
-) -> dict[str, Any]:
-    """Build the internal HTTP service managed implicitly by ``reef serve``."""
-    try:
-        settings: ServiceSettings = service_settings_from_config(config)
-    except ValueError as exc:
-        raise DeployConfigError(str(exc)) from exc
-
-    reef = config.get("reef")
-    assert isinstance(reef, Mapping)  # validated by service_settings_from_config
-    process = reef.get("process") or {}
-    if not isinstance(process, Mapping):
-        raise DeployConfigError("reef.process must be an object")
-
-    service: dict[str, Any] = {
-        "name": "reef",
-        "command": shlex.join([sys.executable, "-m", "reef.service"]),
-        "ready": f"curl -sf http://127.0.0.1:{settings.port}/healthz",
-        "depends_on": [str(item["name"]) for item in auxiliary_services],
-    }
-    if "ready_timeout" in process:
-        service["ready_timeout"] = process["ready_timeout"]
-    return service
-
-
 def _log(msg):
     print(f"[reef] {msg}", file=sys.stderr)
+
+
+def _command_argv(config: Mapping[str, Any], command: str | Sequence[str]) -> list[str]:
+    """Materialize a service command without changing its executable semantics."""
+    if isinstance(command, str):
+        return shlex.split(interpolate_config(config, command))
+    return [interpolate_config(config, argument) for argument in command]
 
 
 class InvalidOverrideError(ValueError):
@@ -277,9 +256,9 @@ class _Stack:
             _log(f"{name}: already running (pid {self._procs[name].pid})")
             return
         self._check_deps(svc)
-        command = interpolate_config(self.config, svc["command"])
+        command = _command_argv(self.config, svc["command"])
         env = self._service_env(svc)
-        _log(f"starting {name}: {command}")
+        _log(f"starting {name}: {shlex.join(command)}")
         # The handle outlives this scope (closed in stop()); a context manager
         # would close it under the running service.
         log_fp = open(self._log_file(name), "a")  # noqa: SIM115
@@ -289,7 +268,7 @@ class _Stack:
         tee = _TeeStream(log_fp, sys.stdout)
         self._tees[name] = tee
         proc = subprocess.Popen(
-            shlex.split(command),
+            command,
             env=env,
             cwd=svc.get("cwd"),
             stdout=tee.write_fd,
@@ -386,8 +365,7 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
     if overrides:
         config = _apply_overrides(config, overrides)
     # Structure first, so a bad stack fails before a model download, a run dir, or a child process.
-    auxiliary_services = validate_services(config, resolved_config_path)
-    services = [*auxiliary_services, _builtin_reef_service(config, auxiliary_services)]
+    services = validate_services(config, resolved_config_path)
     paths_changed = resolve_model_paths(config)
     temp_config_path: Path | None = None
     if overrides or paths_changed:

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -162,7 +162,7 @@ def service_owned_keys() -> frozenset[str]:
         settings_field.name
         for settings_field in dataclasses.fields(ServiceSettings)
         if settings_field.name not in non_reef_fields
-    ) | frozenset(SERVICE_CONFIG_ALIASES)
+    ) | frozenset((*SERVICE_CONFIG_ALIASES, "process"))
 
 
 def _service_tokens(config: Mapping[str, Any]) -> tuple[str, ...]:

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -162,7 +162,7 @@ def service_owned_keys() -> frozenset[str]:
         settings_field.name
         for settings_field in dataclasses.fields(ServiceSettings)
         if settings_field.name not in non_reef_fields
-    ) | frozenset((*SERVICE_CONFIG_ALIASES, "process"))
+    ) | frozenset(SERVICE_CONFIG_ALIASES)
 
 
 def _service_tokens(config: Mapping[str, Any]) -> tuple[str, ...]:

--- a/tests/packaging/recipe-wheel.yaml
+++ b/tests/packaging/recipe-wheel.yaml
@@ -7,11 +7,16 @@ reef:
   port: 18900
   recipe: recipe
   token: package-smoke
-  upstream_url: https://example.invalid
-  upstream_model: package-smoke
-  process:
-    ready_timeout: 30
   artifact_repository: .reef/artifacts.git
   artifact_work_dir: .reef/artifact-work
   artifact_cache_dir: .reef/artifact-cache
   agent_record_dir: .reef/agent-record
+
+services:
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:18900/healthz
+    ready_timeout: 30
+    env:
+      REEF_UPSTREAM_URL: https://example.invalid
+      REEF_MODEL_PATH: package-smoke

--- a/tests/packaging/recipe-wheel.yaml
+++ b/tests/packaging/recipe-wheel.yaml
@@ -7,16 +7,11 @@ reef:
   port: 18900
   recipe: recipe
   token: package-smoke
+  upstream_url: https://example.invalid
+  upstream_model: package-smoke
+  process:
+    ready_timeout: 30
   artifact_repository: .reef/artifacts.git
   artifact_work_dir: .reef/artifact-work
   artifact_cache_dir: .reef/artifact-cache
   agent_record_dir: .reef/agent-record
-
-services:
-  - name: reef
-    command: python -m reef.service
-    ready: curl -sf http://127.0.0.1:18900/healthz
-    ready_timeout: 30
-    env:
-      REEF_UPSTREAM_URL: https://example.invalid
-      REEF_MODEL_PATH: package-smoke

--- a/tests/reef_service/test_deploy_config_validation.py
+++ b/tests/reef_service/test_deploy_config_validation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shlex
 import sys
 from pathlib import Path
 
@@ -45,10 +44,10 @@ def test_empty_file_loads_as_an_empty_config(tmp_path: Path) -> None:
 def test_reef_python_defaults_to_the_launching_interpreter(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("REEF_PYTHON", raising=False)
     config = load_config(
-        _write(tmp_path, "services:\n  - name: worker\n    command: '\"${REEF_PYTHON}\" -m worker'\n")
+        _write(tmp_path, 'services:\n  - name: worker\n    command: ["${REEF_PYTHON}", "-m", "worker"]\n')
     )
 
-    assert shlex.split(config["services"][0]["command"])[0] == sys.executable
+    assert config["services"][0]["command"] == [sys.executable, "-m", "worker"]
 
 
 @pytest.mark.unit
@@ -59,63 +58,68 @@ def test_reef_python_can_be_overridden_without_changing_bare_python(tmp_path: Pa
             tmp_path,
             "services:\n"
             "  - name: managed-worker\n"
-            "    command: '\"${REEF_PYTHON}\" -m managed_worker'\n"
+            '    command: ["${REEF_PYTHON}", "-m", "managed_worker"]\n'
             "  - name: path-worker\n"
             "    command: python -m path_worker\n",
         )
     )
 
-    assert shlex.split(config["services"][0]["command"])[0] == "/opt/worker venv/bin/python"
+    assert config["services"][0]["command"][0] == "/opt/worker venv/bin/python"
     assert config["services"][1]["command"] == "python -m path_worker"
 
 
 @pytest.mark.unit
-def test_auxiliary_services_are_optional_but_must_be_a_list_of_named_objects() -> None:
-    assert validate_services({}, "stack.yaml") == []
-    assert validate_services({"services": []}, "stack.yaml") == []
-    with pytest.raises(DeployConfigError, match="'services' must be a list"):
-        validate_services({"services": "worker"}, "stack.yaml")
+def test_services_must_be_a_non_empty_list_of_named_objects() -> None:
+    with pytest.raises(DeployConfigError, match="non-empty 'services' list"):
+        validate_services({}, "stack.yaml")
+    with pytest.raises(DeployConfigError, match="non-empty 'services' list"):
+        validate_services({"services": []}, "stack.yaml")
     with pytest.raises(DeployConfigError, match=r"services\[0\] must be an object, not str"):
         validate_services({"services": ["not-an-object"]}, "stack.yaml")
     with pytest.raises(DeployConfigError, match=r"services\[1\] must have a non-empty 'name'"):
-        validate_services({"services": [{"name": "a"}, {"command": "x"}]}, "stack.yaml")
+        validate_services({"services": [{"name": "a", "command": "a"}, {"command": "x"}]}, "stack.yaml")
 
 
 @pytest.mark.unit
-def test_reef_is_a_reserved_service_name() -> None:
-    with pytest.raises(DeployConfigError, match="service name 'reef' is reserved"):
-        validate_services({"services": [{"name": "reef", "command": "anything"}]}, "stack.yaml")
+@pytest.mark.parametrize("command", [None, "", [], [""], ["python", 3]])
+def test_service_command_must_be_a_string_or_string_list(command) -> None:
+    with pytest.raises(DeployConfigError, match="non-empty 'command' string or list of strings"):
+        validate_services({"services": [{"name": "worker", "command": command}]}, "stack.yaml")
 
 
 @pytest.mark.unit
-def test_builtin_reef_service_uses_the_launcher_and_depends_on_auxiliary_services() -> None:
-    config = {"reef": {"recipe": "recipe", "port": 9123, "process": {"ready_timeout": 45}}}
-    auxiliaries = [{"name": "model"}, {"name": "trainer"}]
+def test_command_argv_supports_exact_lists_and_legacy_strings() -> None:
+    config = {"reef": {"port": 9123}}
 
-    service = orchestrator._builtin_reef_service(config, auxiliaries)
-
-    assert shlex.split(service["command"]) == [sys.executable, "-m", "reef.service"]
-    assert service["ready"] == "curl -sf http://127.0.0.1:9123/healthz"
-    assert service["depends_on"] == ["model", "trainer"]
-    assert service["ready_timeout"] == 45
-
-
-@pytest.mark.unit
-def test_builtin_reef_process_options_must_be_an_object() -> None:
-    with pytest.raises(DeployConfigError, match=r"reef\.process must be an object"):
-        orchestrator._builtin_reef_service({"reef": {"recipe": "recipe", "process": "invalid"}}, [])
+    assert orchestrator._command_argv(
+        config,
+        ["/opt/reef env/bin/python", "-m", "reef.service", "--port=${reef.port}", ""],
+    ) == ["/opt/reef env/bin/python", "-m", "reef.service", "--port=9123", ""]
+    assert orchestrator._command_argv(config, "python -m worker --port=${reef.port}") == [
+        "python",
+        "-m",
+        "worker",
+        "--port=9123",
+    ]
 
 
 @pytest.mark.unit
 def test_duplicate_service_names_are_named() -> None:
-    config = {"services": [{"name": "worker"}, {"name": "api"}, {"name": "worker"}, {"name": "api"}]}
+    config = {
+        "services": [
+            {"name": "worker", "command": "worker"},
+            {"name": "api", "command": "api"},
+            {"name": "worker", "command": "worker"},
+            {"name": "api", "command": "api"},
+        ]
+    }
     with pytest.raises(DeployConfigError, match="service names must be unique; duplicated: api, worker"):
         validate_services(config, "stack.yaml")
 
 
 @pytest.mark.unit
 def test_valid_services_pass_through_in_order() -> None:
-    services = [{"name": "b"}, {"name": "a"}]
+    services = [{"name": "b", "command": "b"}, {"name": "a", "command": ["a", ""]}]
     assert validate_services({"services": services}, "stack.yaml") == services
 
 
@@ -135,7 +139,7 @@ def test_invalid_stack_never_downloads_or_launches(tmp_path: Path, monkeypatch) 
 
 
 @pytest.mark.unit
-def test_orchestrator_appends_the_builtin_reef_service(tmp_path: Path, monkeypatch) -> None:
+def test_orchestrator_uses_exactly_the_declared_services(tmp_path: Path, monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     class StackStub:
@@ -162,14 +166,19 @@ def test_orchestrator_appends_the_builtin_reef_service(tmp_path: Path, monkeypat
         "  recipe: recipe\n"
         "services:\n"
         "  - name: model\n"
-        "    command: model-server\n",
+        "    command: model-server\n"
+        "  - name: reef\n"
+        '    command: ["${REEF_PYTHON}", "-m", "reef.service"]\n'
+        "    depends_on: [model]\n",
     )
 
     assert orchestrator._run_orchestrator(str(path)) == 0
     services = captured["services"]
     assert isinstance(services, list)
-    assert [service["name"] for service in services] == ["model", "reef"]
-    assert services[-1]["depends_on"] == ["model"]
+    assert services == [
+        {"name": "model", "command": "model-server"},
+        {"name": "reef", "command": [sys.executable, "-m", "reef.service"], "depends_on": ["model"]},
+    ]
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_deploy_config_validation.py
+++ b/tests/reef_service/test_deploy_config_validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -40,13 +42,68 @@ def test_empty_file_loads_as_an_empty_config(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_services_must_be_a_non_empty_list_of_objects() -> None:
-    with pytest.raises(DeployConfigError, match="non-empty 'services' list"):
-        validate_services({}, "stack.yaml")
+def test_reef_python_defaults_to_the_launching_interpreter(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("REEF_PYTHON", raising=False)
+    config = load_config(
+        _write(tmp_path, "services:\n  - name: worker\n    command: '\"${REEF_PYTHON}\" -m worker'\n")
+    )
+
+    assert shlex.split(config["services"][0]["command"])[0] == sys.executable
+
+
+@pytest.mark.unit
+def test_reef_python_can_be_overridden_without_changing_bare_python(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("REEF_PYTHON", "/opt/worker venv/bin/python")
+    config = load_config(
+        _write(
+            tmp_path,
+            "services:\n"
+            "  - name: managed-worker\n"
+            "    command: '\"${REEF_PYTHON}\" -m managed_worker'\n"
+            "  - name: path-worker\n"
+            "    command: python -m path_worker\n",
+        )
+    )
+
+    assert shlex.split(config["services"][0]["command"])[0] == "/opt/worker venv/bin/python"
+    assert config["services"][1]["command"] == "python -m path_worker"
+
+
+@pytest.mark.unit
+def test_auxiliary_services_are_optional_but_must_be_a_list_of_named_objects() -> None:
+    assert validate_services({}, "stack.yaml") == []
+    assert validate_services({"services": []}, "stack.yaml") == []
+    with pytest.raises(DeployConfigError, match="'services' must be a list"):
+        validate_services({"services": "worker"}, "stack.yaml")
     with pytest.raises(DeployConfigError, match=r"services\[0\] must be an object, not str"):
         validate_services({"services": ["not-an-object"]}, "stack.yaml")
     with pytest.raises(DeployConfigError, match=r"services\[1\] must have a non-empty 'name'"):
         validate_services({"services": [{"name": "a"}, {"command": "x"}]}, "stack.yaml")
+
+
+@pytest.mark.unit
+def test_reef_is_a_reserved_service_name() -> None:
+    with pytest.raises(DeployConfigError, match="service name 'reef' is reserved"):
+        validate_services({"services": [{"name": "reef", "command": "anything"}]}, "stack.yaml")
+
+
+@pytest.mark.unit
+def test_builtin_reef_service_uses_the_launcher_and_depends_on_auxiliary_services() -> None:
+    config = {"reef": {"recipe": "recipe", "port": 9123, "process": {"ready_timeout": 45}}}
+    auxiliaries = [{"name": "model"}, {"name": "trainer"}]
+
+    service = orchestrator._builtin_reef_service(config, auxiliaries)
+
+    assert shlex.split(service["command"]) == [sys.executable, "-m", "reef.service"]
+    assert service["ready"] == "curl -sf http://127.0.0.1:9123/healthz"
+    assert service["depends_on"] == ["model", "trainer"]
+    assert service["ready_timeout"] == 45
+
+
+@pytest.mark.unit
+def test_builtin_reef_process_options_must_be_an_object() -> None:
+    with pytest.raises(DeployConfigError, match=r"reef\.process must be an object"):
+        orchestrator._builtin_reef_service({"reef": {"recipe": "recipe", "process": "invalid"}}, [])
 
 
 @pytest.mark.unit
@@ -75,6 +132,44 @@ def test_invalid_stack_never_downloads_or_launches(tmp_path: Path, monkeypatch) 
     with pytest.raises(DeployConfigError, match="duplicated: worker"):
         orchestrator._run_orchestrator(str(path))
     assert not (tmp_path / "reef-stack").exists()
+
+
+@pytest.mark.unit
+def test_orchestrator_appends_the_builtin_reef_service(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class StackStub:
+        exit_code = 0
+
+        def __init__(self, config, services, run_dir, ready_timeout_default, config_path):
+            captured["services"] = services
+
+        def start(self):
+            pass
+
+        def block(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr(orchestrator, "_Stack", StackStub)
+    monkeypatch.setattr(orchestrator, "resolve_model_paths", lambda config: False)
+    path = _write(
+        tmp_path,
+        f"run_dir: {tmp_path / 'run'}\n"
+        "reef:\n"
+        "  recipe: recipe\n"
+        "services:\n"
+        "  - name: model\n"
+        "    command: model-server\n",
+    )
+
+    assert orchestrator._run_orchestrator(str(path)) == 0
+    services = captured["services"]
+    assert isinstance(services, list)
+    assert [service["name"] for service in services] == ["model", "reef"]
+    assert services[-1]["depends_on"] == ["model"]
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_sao_configs.py
+++ b/tests/reef_service/test_sao_configs.py
@@ -356,7 +356,13 @@ def test_user_facing_example_deployment_resolves(config_path: Path) -> None:
 
     started: set[str] = set()
     for service in services:
-        assert isinstance(service.get("command"), str) and service["command"].strip()
+        command = service.get("command")
+        assert (isinstance(command, str) and command.strip()) or (
+            isinstance(command, list)
+            and command
+            and all(isinstance(argument, str) for argument in command)
+            and command[0].strip()
+        )
         dependencies = service.get("depends_on") or []
         assert set(dependencies) <= started, f"{service['name']} must follow its dependencies in service order"
         started.add(service["name"])

--- a/tests/reef_service/test_sao_configs.py
+++ b/tests/reef_service/test_sao_configs.py
@@ -340,7 +340,7 @@ def test_user_facing_example_deployment_resolves(config_path: Path) -> None:
     from reef.recipe import load_recipe_config
     from reef.recipe.registry import recipe_class_for
     from reef.service.assembly import _configured_inference_backend_factory, _recipe_owned_settings
-    from reef.service.deploy.config import load_config
+    from reef.service.deploy.config import load_config, validate_services
     from reef.service.deploy.settings import service_settings_from_config
 
     with patch.dict(os.environ, _CONFIG_ENV, clear=False):
@@ -349,8 +349,7 @@ def test_user_facing_example_deployment_resolves(config_path: Path) -> None:
     settings = service_settings_from_config(config)
     if settings.inference_backend_factory is not None:
         assert callable(_configured_inference_backend_factory(settings.inference_backend_factory))
-    services = config.get("services")
-    assert isinstance(services, list) and services
+    services = validate_services(config, config_path)
     names = [service.get("name") for service in services]
     assert all(isinstance(name, str) and name for name in names)
     assert len(names) == len(set(names))

--- a/tests/reef_service/test_training_server.py
+++ b/tests/reef_service/test_training_server.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import shlex
 import signal
+import sys
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,7 @@ from reef.scenario.checkpoint_strategy import EveryNVersions
 from reef.service import deploy
 from reef.service.assembly import _repository_location
 from reef.service.deploy.config import interpolate_config
+from reef.service.deploy.orchestrator import _builtin_reef_service
 from reef.service.deploy.settings import ServiceSettings
 
 OPENCLAWRL_RECIPE = "recipes.openclawrl.recipe:OpenClawRLRecipe"
@@ -173,7 +176,7 @@ def test_service_config_requires_recipe() -> None:
         ("recipes/openclawrl/examples/openclawrl/serve.yaml", OPENCLAWRL_RECIPE),
     ],
 )
-def test_cookbook_configs_launch_internal_service_from_reef_settings(
+def test_cookbook_configs_configure_the_builtin_reef_service(
     config_name: str,
     recipe: str,
     monkeypatch: pytest.MonkeyPatch,
@@ -183,11 +186,13 @@ def test_cookbook_configs_launch_internal_service_from_reef_settings(
         pytest.skip("repo-owned stack: shipped with the repo, not with the package")
     monkeypatch.delenv("REEF_TOKEN", raising=False)
     config = deploy.load_config(config_path)
-    service = next(item for item in config["services"] if item["name"] == "reef")
+    auxiliary_services = config.get("services") or []
+    service = _builtin_reef_service(config, auxiliary_services)
     args = deploy.service_settings_from_config(config)
 
-    assert service["command"] == "python -m reef.service"
-    assert "REEF_TOKEN" not in service.get("env", {})
+    assert all(item["name"] != "reef" for item in auxiliary_services)
+    assert shlex.split(service["command"]) == [sys.executable, "-m", "reef.service"]
+    assert service["depends_on"] == [item["name"] for item in auxiliary_services]
     assert args.tokens == ()
     assert args.recipe == recipe
 
@@ -534,7 +539,15 @@ def test_reef_token_is_service_owned_and_never_reaches_the_recipe() -> None:
     training recipe would reject the cookbook configs as unconsumed settings."""
     from reef.service.assembly import _recipe_owned_settings
 
-    config = {"reef": {"recipe": "openclawrl", "token": "secret", "tokens": ["next"], "batch_size": 2}}
+    config = {
+        "reef": {
+            "recipe": "openclawrl",
+            "token": "secret",
+            "tokens": ["next"],
+            "process": {"ready_timeout": 30},
+            "batch_size": 2,
+        }
+    }
     owned = _recipe_owned_settings(deploy.service_settings_from_config(config))
     assert set(owned) == {"batch_size"}
 

--- a/tests/reef_service/test_training_server.py
+++ b/tests/reef_service/test_training_server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 import signal
 import sys
 from pathlib import Path
@@ -12,7 +11,6 @@ from reef.scenario.checkpoint_strategy import EveryNVersions
 from reef.service import deploy
 from reef.service.assembly import _repository_location
 from reef.service.deploy.config import interpolate_config
-from reef.service.deploy.orchestrator import _builtin_reef_service
 from reef.service.deploy.settings import ServiceSettings
 
 OPENCLAWRL_RECIPE = "recipes.openclawrl.recipe:OpenClawRLRecipe"
@@ -176,7 +174,7 @@ def test_service_config_requires_recipe() -> None:
         ("recipes/openclawrl/examples/openclawrl/serve.yaml", OPENCLAWRL_RECIPE),
     ],
 )
-def test_cookbook_configs_configure_the_builtin_reef_service(
+def test_cookbook_configs_launch_internal_service_from_reef_settings(
     config_name: str,
     recipe: str,
     monkeypatch: pytest.MonkeyPatch,
@@ -186,13 +184,11 @@ def test_cookbook_configs_configure_the_builtin_reef_service(
         pytest.skip("repo-owned stack: shipped with the repo, not with the package")
     monkeypatch.delenv("REEF_TOKEN", raising=False)
     config = deploy.load_config(config_path)
-    auxiliary_services = config.get("services") or []
-    service = _builtin_reef_service(config, auxiliary_services)
+    service = next(item for item in config["services"] if item["name"] == "reef")
     args = deploy.service_settings_from_config(config)
 
-    assert all(item["name"] != "reef" for item in auxiliary_services)
-    assert shlex.split(service["command"]) == [sys.executable, "-m", "reef.service"]
-    assert service["depends_on"] == [item["name"] for item in auxiliary_services]
+    assert service["command"] == [sys.executable, "-m", "reef.service"]
+    assert "REEF_TOKEN" not in service.get("env", {})
     assert args.tokens == ()
     assert args.recipe == recipe
 
@@ -539,15 +535,7 @@ def test_reef_token_is_service_owned_and_never_reaches_the_recipe() -> None:
     training recipe would reject the cookbook configs as unconsumed settings."""
     from reef.service.assembly import _recipe_owned_settings
 
-    config = {
-        "reef": {
-            "recipe": "openclawrl",
-            "token": "secret",
-            "tokens": ["next"],
-            "process": {"ready_timeout": 30},
-            "batch_size": 2,
-        }
-    }
+    config = {"reef": {"recipe": "openclawrl", "token": "secret", "tokens": ["next"], "batch_size": 2}}
     owned = _recipe_owned_settings(deploy.service_settings_from_config(config))
     assert set(owned) == {"batch_size"}
 

--- a/tutorials/harness_evolve/serve.yaml
+++ b/tutorials/harness_evolve/serve.yaml
@@ -81,8 +81,3 @@ reef:
   artifact_cache_dir: work/artifact-cache
 
 run_dir: work/stack
-
-services:
-  - name: reef
-    command: python3 -m reef.service
-    ready: curl -sf http://127.0.0.1:${reef.port}/healthz

--- a/tutorials/harness_evolve/serve.yaml
+++ b/tutorials/harness_evolve/serve.yaml
@@ -81,3 +81,8 @@ reef:
   artifact_cache_dir: work/artifact-cache
 
 run_dir: work/stack
+
+services:
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz


### PR DESCRIPTION
## Motivation

Closes #175. Supersedes the generic command-rewrite approach in #172.

Deployment configs can be launched by one Python interpreter while a bare `python -m ...` service command resolves another from `PATH`. Rewriting all leading Python aliases changes user-owned command semantics, while making the Reef service implicit removes useful process topology from YAML.

## Design

- Keep the Reef HTTP service explicit in `services`, including its `ready`, `depends_on`, `env`, `cwd`, `cuda`, and timeout options.
- Support both the existing command-line string and an exact argv `list[str]` in `services[].command`.
- Make `${REEF_PYTHON}` default to `sys.executable`, with an explicit environment override.
- Use argv form for the shipped Reef service and opt repository-owned Python services into `${REEF_PYTHON}` where they intentionally share the Reef environment.
- Preserve literal command names and service-specific `PATH` behavior. No token rewriting, implicit process, reserved name, or new `reef.process` schema is introduced.

```yaml
services:
  - name: reef
    command: ["${REEF_PYTHON}", "-m", "reef.service"]
    ready: curl -sf http://127.0.0.1:${reef.port}/healthz
    depends_on: [sglang]
```

## Compatibility

This is additive: every existing string command keeps its previous parsing and executable lookup. Existing deployment topology stays visible and configurable. An operator can deliberately use a PATH-resolved `python`, an absolute interpreter, or override `REEF_PYTHON` without Reef guessing intent.

## Verification

- Full GitHub CI tests passed on Python 3.10, 3.11, and 3.12; lint, docs, Docker, and all three package jobs passed.
- Focused local deployment and configuration suite: 52 passed, 1 skipped.
- Ruff, Black, mypy, YAML validation, and `git diff --check` passed for the changed files.
- Documentation link checks, lint, and production build passed locally.
- Real process smoke started Reef with the current virtualenv interpreter, served `/healthz`, and shut down cleanly on SIGTERM.

## AI assistance

OpenAI Codex was used interactively to research established process-launch patterns, implement the user-directed design, update tests and documentation, and run the verification reported above.
