### PR TITLE
harness manifest: distinguish "no surface" from "no artifact" in the 404 message

### DIFF
--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -460,10 +460,18 @@ class RequestService:
         artifact, gate = scenario.artifact_snapshot(release_id)
         tree = scenario.surface.files
         if tree is None:
-            raise ArtifactNotFound(f"scenario {scenario.name!r} serves no files")
+            raise ArtifactNotFound(
+                f"scenario {scenario.name!r} serves no files: the deployment's recipe "
+                "carries no harness surface (record-only or weight-training recipes have "
+                "no file tree). Point 'reef.recipe' at a harness_evolve recipe."
+            )
         files = tree.read_files(artifact)
         if files is None:
-            raise ArtifactNotFound(f"scenario {scenario.name!r} serves no files")
+            raise ArtifactNotFound(
+                f"scenario {scenario.name!r} serves no files: no harness composition has "
+                "been published yet. The scenario's initial artifact carries no files "
+                "until the trainer publishes its first step (see docs/user-guide/evolve-your-harness)."
+            )
         return {
             "release_id": artifact.ref.release_id,
             "parent_release_id": artifact.ref.parent_release_id,
@@ -555,7 +563,11 @@ class RequestService:
         if scenario is None:
             raise ReefError(f"scenario {parsed.scenario!r} disappeared during lookup")
         if scenario.surface.files is None:
-            raise ArtifactNotFound(f"scenario {parsed.scenario!r} serves no files")
+            raise ArtifactNotFound(
+                f"scenario {parsed.scenario!r} serves no files: the deployment's recipe "
+                "carries no harness surface (record-only or weight-training recipes have "
+                "no file tree). Point 'reef.recipe' at a harness_evolve recipe."
+            )
         return scenario
 
     def _accept(

--- a/tests/reef_service/test_harness_read.py
+++ b/tests/reef_service/test_harness_read.py
@@ -48,7 +48,7 @@ def test_current_files_rejects_a_weights_scenario_without_materializing(tmp_path
     monkeypatch.setattr(
         service.dispatcher.get_or_create_scenario("delivery").repository, "materialize", fail_materialize
     )
-    with pytest.raises(ArtifactNotFound):
+    with pytest.raises(ArtifactNotFound, match="the deployment's recipe carries no harness surface"):
         service.harness_manifest({"x-reef-scenario": "delivery"})
 
 
@@ -56,6 +56,15 @@ def test_current_files_never_creates_a_scenario(tmp_path) -> None:
     service = _service(tmp_path, recipe=_HarnessRecipe(), skill_text="x")
     with pytest.raises(ArtifactNotFound):
         service.harness_manifest({"x-reef-scenario": "unknown"})
+
+
+def test_manifest_error_distinguishes_a_scenario_without_a_published_composition(tmp_path) -> None:
+    # A scenario exists and its recipe has a harness surface, but no files
+    # have been published yet. The message must tell the operator that the
+    # trainer has not published, not that the surface is missing.
+    service = _service(tmp_path, recipe=_HarnessRecipe(), skill_text=None)
+    with pytest.raises(ArtifactNotFound, match="no harness composition has been published yet"):
+        service.harness_manifest({"x-reef-scenario": "delivery"})
 
 
 def test_harness_surface_reads_the_file_tree(tmp_path) -> None:


### PR DESCRIPTION
## What changes

`ArtifactNotFound: scenario 'x' serves no files` was raised in two very different situations:

1. The deployment's recipe has no harness surface (record-only Recipe, or a weight-training recipe). Fix: change `reef.recipe`.
2. The surface exists and the scenario is registered, but its artifact carries no files yet. Fix: publish a composition, either through a training step or a driver-owned bootstrap.

Same message, different diagnosis. This PR splits them so the operator gets an actionable line without reading source.

New messages:

- `scenario 'x' serves no files: the deployment's recipe carries no harness surface (record-only or weight-training recipes have no file tree). Point 'reef.recipe' at a harness_evolve recipe.`
- `scenario 'x' serves no files: no harness composition has been published yet. The scenario's initial artifact carries no files until the trainer publishes its first step (see docs/user-guide/evolve-your-harness).`

Applies to both `_harness_manifest_for_scenario` (used by `/reef/harness`, `/reef/harness/install`) and the same-string branch in inference-scenario resolution.

## Related

I filed the underlying "install 404 on a fresh scenario with a seed" gap in #178. That is a design decision that needs a maintainer's take; this PR is the incremental win regardless of how #178 resolves — future readers of the message will still land on the right next step.

## Tests

- Two existing bare-`ArtifactNotFound` assertions in `test_harness_read.py` tightened to match on the specific message they should now emit.
- One new case (`test_manifest_error_distinguishes_a_scenario_without_a_published_composition`) covers the differentiated "no composition published yet" path against a fresh scenario with a harness surface.

```
pytest tests/reef_service/test_harness_read.py tests/reef_service/test_harness_channel.py -k "install_script or harness_manifest or harness_read"
5 passed + 6 passed
```

## AI disclosure

Filed with Claude Code assistance; every claim above is verified against the source at HEAD, tests were run locally.