### PR TITLE
Add `reef adapters` CLI subcommand

### DIFF
--- a/reef/cli.py
+++ b/reef/cli.py
@@ -2,6 +2,7 @@
 
 Usage:
   reef serve -c path/to/stack.yaml             # start a configured stack
+  reef adapters                                # list bundled + entry-point adapters
 
 `reef serve` reads a config's `services` list and starts every declared
 process in dependency order, including the internal Reef HTTP service.
@@ -14,16 +15,18 @@ reference. Named recipe YAML is deployment data, not library data: point
 
 from __future__ import annotations
 
+import json
 import sys
 
-_COMMANDS = {"serve"}
+_COMMANDS = {"serve", "adapters"}
 
 
 def _help_text():
     return """\
 usage: reef <command> [options]
 
-  serve  Start a stack from a config
+  serve     Start a stack from a config
+  adapters  List available harness adapters
 
   -c CONFIG   Config file (default: reef.yaml or $REEF_CONFIG)
   --version   Print the installed reef version
@@ -31,7 +34,77 @@ usage: reef <command> [options]
 Examples:
   reef serve -c path/to/local-sglang.yaml
   reef serve -c path/to/external-provider.yaml
+  reef adapters
+  reef adapters --format json
 """
+
+
+def _adapters_main(argv):
+    output = "table"
+    it = iter(argv)
+    for arg in it:
+        if arg in ("-h", "--help"):
+            print(
+                "usage: reef adapters [--format table|json]\n"
+                "\n"
+                "List every harness adapter this reef installation resolves.\n"
+            )
+            return 0
+        if arg.startswith("--format="):
+            output = arg.split("=", 1)[1]
+        elif arg == "--format":
+            value = next(it, None)
+            if value is None:
+                print("reef adapters: --format needs a value", file=sys.stderr)
+                return 2
+            output = value
+        else:
+            print(f"reef adapters: unknown argument {arg!r}", file=sys.stderr)
+            return 2
+    # Delay heavy imports until the subcommand actually runs.
+    from reef.harness.adapters import available_adapters, get_adapter
+    from reef.harness.descriptor import DescriptorError
+
+    entries = []
+    for name in available_adapters():
+        try:
+            descriptor = get_adapter(name)
+        except DescriptorError as exc:
+            entries.append({"name": name, "error": str(exc)})
+            continue
+        install = descriptor.install
+        entries.append(
+            {
+                "name": name,
+                "binary": descriptor.binary,
+                "trajectory_format": descriptor.trajectory_format,
+                "model_bindings": sorted(descriptor.model_binding),
+                "install": (
+                    None
+                    if install is None
+                    else {"kind": install.kind, "package": install.package, "version": install.version}
+                ),
+            }
+        )
+    if output == "json":
+        print(json.dumps({"adapters": entries}, indent=2))
+        return 0
+    if output != "table":
+        print(f"reef adapters: unknown --format {output!r}", file=sys.stderr)
+        return 2
+    header = ("name", "binary", "trajectory", "install")
+    rows = [header]
+    for entry in entries:
+        if "error" in entry:
+            rows.append((entry["name"], "-", "-", f"(error: {entry['error']})"))
+            continue
+        install = entry["install"]
+        install_cell = "-" if install is None else f"{install['package']}@{install['version']}"
+        rows.append((entry["name"], entry["binary"], entry["trajectory_format"], install_cell))
+    widths = [max(len(row[column]) for row in rows) for column in range(len(header))]
+    for row in rows:
+        print("  ".join(cell.ljust(widths[column]) for column, cell in enumerate(row)))
+    return 0
 
 
 def main(argv=None):
@@ -54,6 +127,9 @@ def main(argv=None):
         print(f"reef: unknown command '{cmd}'\n", file=sys.stderr)
         print(_help_text(), file=sys.stderr)
         sys.exit(2)
+
+    if cmd == "adapters":
+        sys.exit(_adapters_main(rest))
 
     from reef.service.deploy import DeployConfigError
     from reef.service.deploy import main as _serve_main

--- a/tests/test_cli_adapters.py
+++ b/tests/test_cli_adapters.py
@@ -1,0 +1,46 @@
+"""``reef adapters`` lists every harness adapter this installation resolves."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+
+import pytest
+
+from reef.cli import main
+
+
+def _capture(argv):
+    buf = io.StringIO()
+    with redirect_stdout(buf), pytest.raises(SystemExit) as excinfo:
+        main(argv)
+    return excinfo.value.code, buf.getvalue()
+
+
+def test_adapters_default_table_lists_bundled_names():
+    code, out = _capture(["adapters"])
+    assert code == 0
+    # Header plus one line per bundled adapter, whichever ones are compiled in.
+    lines = out.splitlines()
+    assert lines[0].startswith("name")
+    names = {line.split()[0] for line in lines[1:] if line.strip()}
+    assert {"claude", "opencode", "pi"}.issubset(names)
+
+
+def test_adapters_json_format_carries_install_pins():
+    code, out = _capture(["adapters", "--format", "json"])
+    assert code == 0
+    payload = json.loads(out)
+    by_name = {entry["name"]: entry for entry in payload["adapters"]}
+    pi = by_name["pi"]
+    assert pi["binary"] == "pi"
+    assert pi["trajectory_format"] == "pi-session-jsonl"
+    install = pi["install"]
+    assert install["kind"] == "npm"
+    assert install["package"].startswith("@")
+
+
+def test_adapters_rejects_unknown_format():
+    code, _ = _capture(["adapters", "--format=yaml"])
+    assert code == 2


### PR DESCRIPTION
## What this adds

`reef adapters` on the CLI:

```
$ reef adapters
name      binary    trajectory              install
claude    claude    claude-session-jsonl    @anthropic-ai/claude-code@2.1.257
dsh       dsh       deepseek-session-jsonl  @deepseek-ai/dsh@0.1.2-alpha.5
opencode  opencode  opencode-storage-json   opencode-ai@1.18.18
pi        pi        pi-session-jsonl        @earendil-works/pi-coding-agent@0.84.2

$ reef adapters --format json
{
  "adapters": [
    {"name": "claude", "binary": "claude", "trajectory_format": "claude-session-jsonl",
     "model_bindings": ["anthropic"],
     "install": {"kind": "npm", "package": "@anthropic-ai/claude-code", "version": "2.1.257"}},
    ...
  ]
}
```

The subcommand shares the same source (`available_adapters()` + `get_adapter().descriptor`) as the `GET /reef/adapters` route from #180. Whichever route lands first is fine; the two answer the same question from different clients.

An adapter whose `descriptor.yaml` fails to load raises `DescriptorError` inline and prints `(error: ...)` in place of its columns, so a broken third-party adapter never sinks the whole listing.

## Motivation

Same as #180: adapters were only discoverable through the `?adapter=nosuch` error text or by reading source. A shell command that answers the question is easier to script against and shows up in tab-completion for anyone learning what reef supports.

## Tests

Added `tests/test_cli_adapters.py`:

- `test_adapters_default_table_lists_bundled_names`: default output has the four bundled adapters.
- `test_adapters_json_format_carries_install_pins`: JSON output round-trips through `json.loads` and carries the expected fields.
- `test_adapters_rejects_unknown_format`: `--format=yaml` exits 2.

```
pytest tests/test_cli_adapters.py
3 passed
```

Black/isort/ruff pass on the touched files.

## AI disclosure

Filed with Claude Code assistance; verified locally.