### PR TITLE
fix(service): relocate the install wrapper by the env entry above the config target

### DIFF
--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -98,21 +98,25 @@ def _write_file_block(target: str, content: str) -> str:
 def _compose_env_var(descriptor: AdapterDescriptor) -> tuple[str, str]:
     """The env var and compose subdirectory that point the binary at the composition.
 
-    The compose directory is the parent of the primary config target's path
-    (e.g. ``pi-agent`` for pi, ``opencode`` for opencode). The env var is the
-    one whose value is ``{root}/<compose_dir>`` — the entry that relocates
-    the binary's whole composition at the episode root, and the only env
+    The compose directory is the deepest directory above the primary config
+    target that an env entry relocates with a ``{root}/<dir>`` value: the
+    target's own parent for pi and opencode, the home two levels up for dsh,
+    whose config file sits inside a profile. That entry relocates the
+    binary's whole composition at the episode root, and it is the only env
     entry the user-facing wrapper needs (session/state dirs use the binary's
     own defaults outside episodes).
     """
-    compose_dir = str(PurePosixPath(descriptor.config_targets["primary"].path).parent)
-    marker = f"{{root}}/{compose_dir}"
-    for key, value in descriptor.env.items():
-        if value == marker:
-            return key, compose_dir
+    primary = PurePosixPath(descriptor.config_targets["primary"].path)
+    for parent in primary.parents:
+        if parent == PurePosixPath("."):
+            break
+        marker = f"{{root}}/{parent}"
+        for key, value in descriptor.env.items():
+            if value == marker:
+                return key, str(parent)
     raise DescriptorError(
-        f"adapter {descriptor.name!r} has no env var pointing at {compose_dir!r} "
-        f"(expected an entry with value {marker!r})"
+        f"adapter {descriptor.name!r} has no env var relocating a directory above {str(primary)!r} "
+        "(expected an entry with a {root}/<dir> value)"
     )
 
 

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -1138,3 +1138,26 @@ def test_record_only_traffic_fires_a_step_and_publishes(tmp_path) -> None:
             await client.close()
 
     asyncio.run(run())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("adapter", "env_var", "compose_dir"),
+    [
+        ("pi", "PI_CODING_AGENT_DIR", "pi-agent"),
+        ("opencode", "OPENCODE_CONFIG_DIR", "opencode"),
+        ("claude", "CLAUDE_CONFIG_DIR", "claude"),
+        # dsh's config file sits inside a profile; the relocated directory is the home two levels up.
+        ("dsh", "DSH_HOME", "dsh"),
+    ],
+)
+def test_install_script_relocates_every_bundled_adapters_compose_directory(
+    adapter: str, env_var: str, compose_dir: str
+) -> None:
+    descriptor = get_adapter(adapter)
+    files = render_composition([("rules", {"text": "hello"})], descriptor)
+    script = render_install_script(
+        descriptor=descriptor, files=files, release_id="v1", content_id="content-v1", scenario="s"
+    )
+    assert f'export REEF_HARNESS_ENV_VAR="{env_var}"' in script
+    assert f'COMPOSE_ABS="$(mkdir -p "$DEST/{compose_dir}" && cd "$DEST/{compose_dir}" && pwd)"' in script


### PR DESCRIPTION
## Motivation

GET /reef/harness/install?adapter=dsh answered 500: the install script generator derives the wrapper's relocation directory as the parent of the primary config target and then looks for an env entry whose value is exactly {root}/<that parent>. dsh's config file sits inside a profile (dsh/profiles/headless/cordis.patch.yml) while its relocation entry is DSH_HOME={root}/dsh, so no entry matched and rendering raised DescriptorError. The three older adapters keep their config file directly under the relocated directory, which is why nothing caught it before #173 merged. Refs #171.

## Changes

- The install script generator walks up from the primary config target and takes the first parent an env entry relocates with a {root}/<dir> value; pi, opencode, and claude resolve to the same directory as before, dsh resolves to DSH_HOME and dsh
- A parametrized test renders the install script for every bundled adapter and checks the wrapper's env var and compose directory

## Compatibility and operational impact

None for the served scripts of pi, opencode, and claude: same env var, same directory, byte identical output. dsh's install route works. The client wrapper still has no dsh branch for the proxy URL rewrite and still runs the binary with -p, so reef-dsh is a follow up; this fix is about the install route not failing.

## Verification

The new parametrized test fails on main with "adapter 'dsh' has no env var pointing at 'dsh/profiles/headless'" and passes here; the install script golden and the wrapper tests are unchanged and pass (test_harness_channel.py and test_harness_render.py, 44 tests). The pre-commit hook set is clean on the two files.

## AI assistance

Claude Code found the failure while mapping the next adapter and wrote the fix and the test.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
