### PR TITLE
feat: add a Hermes Agent (hermes) adapter and a git install kind

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -1,8 +1,9 @@
 name: harness-smoke
 
-# Runs the real pinned pi and dsh binaries through render, run_episode, and
-# the trajectory reader against a stub model server (tests/smoke/): the guard
-# against a release changing a format the hermetic fakes only imitate.
+# Runs the real pinned pi, dsh, and hermes binaries through render,
+# run_episode, and the trajectory reader against a stub model server
+# (tests/smoke/): the guard against a release changing a format the hermetic
+# fakes only imitate.
 # Non-blocking: not in the required check set until stable.
 
 on:
@@ -72,3 +73,27 @@ jobs:
       - run: python -m pytest tests/smoke/test_real_dsh.py
         env:
           REEF_REAL_DSH_BINARY: ${{ runner.temp }}/dsh/node_modules/.bin/dsh
+
+  # The same guard for the pinned Hermes Agent (tests/smoke/test_real_hermes.py):
+  # the vendor's channel is a git checkout installed editable into a venv.
+  real-hermes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: git submodule update --init third_party/reef-client
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - run: python -m pip install ./third_party/reef-client
+      - run: python -m pip install -e . aiohttp pyyaml huggingface_hub pytest
+      - run: |
+          git clone --quiet --depth 1 --branch v2026.8.31 https://github.com/NousResearch/hermes-agent "$RUNNER_TEMP/hermes/src"
+          rm -rf "$RUNNER_TEMP/hermes/src/.git"
+          python3 -m venv "$RUNNER_TEMP/hermes/venv"
+          "$RUNNER_TEMP/hermes/venv/bin/python" -m pip install --quiet -e "$RUNNER_TEMP/hermes/src"
+      - run: python -m pytest tests/smoke/test_real_hermes.py
+        env:
+          REEF_REAL_HERMES_BINARY: ${{ runner.temp }}/hermes/venv/bin/hermes

--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -4,7 +4,7 @@ Harness adapters
 An adapter maps a harness tree into the files expected by a third-party
 coding-agent CLI and binds that harness to the served model. The harness and
 model together form the running agent. The tree never names a file path; the
-adapter does. Reef bundles four, one per third-party coding-agent CLI.
+adapter does. Reef bundles five, one per third-party coding-agent CLI.
 
 +--------------+-----------------------------------------------------------+-------------------------------------------+
 | Adapter      | Config targets                                            | Install pin                               |
@@ -18,6 +18,9 @@ adapter does. Reef bundles four, one per third-party coding-agent CLI.
 +--------------+-----------------------------------------------------------+-------------------------------------------+
 | ``dsh``      | ``primary`` → ``dsh/profiles/headless/cordis.patch.yml``, | npm ``@deepseek-ai/dsh`` 0.1.2-alpha.5    |
 |              | ``env`` → ``dsh/.env``                                    |                                           |
++--------------+-----------------------------------------------------------+-------------------------------------------+
+| ``hermes``   | ``primary`` → ``hermes/config.yaml``                      | git ``NousResearch/hermes-agent``         |
+|              |                                                           | at ``v2026.8.31`` (0.21.0)                |
 +--------------+-----------------------------------------------------------+-------------------------------------------+
 
 The ``dsh`` adapter runs DeepSeek Harness headless (``dsh --profile headless
@@ -40,6 +43,34 @@ relative path. The model binding declares an ``llm-pi-ai`` route whose key
 is named by ``apiKeyEnv`` and supplied through the ``env`` target, dsh's
 ``.env`` launch environment layer.
 
+The ``hermes`` adapter runs Hermes Agent headless (``hermes chat -Q --oneshot
+-q "<task>"``) with its whole home relocated by ``HERMES_HOME``. Its
+``primary`` config target is ``config.yaml``, which the quirks emit as YAML
+from the merged JSON object; the defaults keep an episode hermetic and single
+request: the terminal scanner download off (``approval.tirith_enabled``), the
+session title call off (``auxiliary.title_generation.enabled``), the memory
+nudge that spawns a background review off (``memory.nudge_interval: 0``), and
+the per session JSON snapshot on (``sessions.write_json_snapshots``), which is
+the trajectory the ``hermes-session-json`` reader parses. A composition that
+flips any of them is refused at render. The quirks also write the
+``.no-bundled-skills`` marker, so an episode carries the tree's skills and not
+hermes's bundled catalog. Rules render to ``SOUL.md``, the one home level
+rules file hermes reads (``AGENTS.md`` is project scoped, read from the
+working directory chain); skills to ``skills/<name>/SKILL.md`` with the
+``name`` and ``description`` frontmatter hermes requires synthesized when the
+node text has none; an ``agent_command`` to a second skill root,
+``hermes-commands``, that ``skills.external_dirs`` lists, since every hermes
+skill is also a ``/name`` slash command in the interactive CLI and hermes has
+no other command surface; a ``code_extension`` to a plugin package
+(``plugins/<name>/__init__.py`` defining ``register(ctx)``) whose manifest,
+``plugins.enabled`` entry, and ``tools.override`` grant the quirks write,
+because hermes loads no plugin without that consent; a plugin tool then sits
+behind hermes's ``tool_search`` and ``tool_call`` discovery surface. The model
+binding is a custom provider with a literal key in ``config.yaml``; only the
+``openai`` dialect is bound. hermes's own default approval policy runs tools
+inside the working directory with no prompt and refuses a command it flags as
+dangerous with a tool error, so no bypass flag is used.
+
 The descriptor
 --------------
 
@@ -54,7 +85,7 @@ agent.
    files | where each node kind renders, like ``skills/{name}/SKILL.md``
    trajectory | the format and path of the session log Reef reads back
    env | variables pointing the agent's state under the episode root; ``{root}`` is substituted
-   install | the one-command install pin: ``kind`` (``npm`` only), ``package``, ``version``, and ``binary_path`` under the install prefix
+   install | the one-command install pin: ``kind`` (``npm``, or ``git`` for a checkout installed editable into a venv, which adds ``repository`` and ``ref``), ``package``, ``version`` (what ``--version`` must report), and ``binary_path`` under the install prefix
    model_binding | per API dialect (``openai``, ``anthropic``), the config nodes Reef appends at evaluation time; ``{base_url}``, ``{api_key}``, and ``{model}`` substitute into string values
    cleanup_whitelist | files the agent itself writes at boot or during the run, tolerated instead of read as drift
    quirks | an optional module for adapter-specific render checks and boot mutations

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -168,7 +168,7 @@ zero.
    evolution.evaluate | an ``EpisodeScorer``, likewise
    evolution.selection | score_comparison | ``always``, or a dotted reference to an object with ``decide``
    evolution.tasks | non-empty list of episode prompts, scored once per tree per step
-   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), or an entry-point adapter
+   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
    evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
    evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -203,7 +203,7 @@ Harness artifacts
 +--------------------------------+---------------------------------------------------------------+
 
 The first three are read-only and take ``x-reef-scenario``. Install also requires
-``?adapter=``, whose value may be ``pi``, ``opencode``, ``claude``, ``dsh``, or an external
+``?adapter=``, whose value may be ``pi``, ``opencode``, ``claude``, ``dsh``, ``hermes``, or an external
 descriptor. If install omits ``x-reef-scenario``, Reef creates a scenario with a
 generated ``harness-`` name and embeds that assignment in the wrapper script;
 when exactly one configured recipe serves harness files, it selects that recipe

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -41,9 +41,9 @@ file name the entry renders to. Five kinds are registered in
 
 The table describes what each kind contains. Where each kind is written is
 decided by an adapter, which maps every kind to a concrete file for one agent.
-Reef bundles four adapters, ``pi``, ``opencode``, ``claude``, and ``dsh``
-(DeepSeek Harness), each for a third-party coding agent CLI. With the ``pi``
-adapter, ``GET /reef/harness`` serves:
+Reef bundles five adapters, ``pi``, ``opencode``, ``claude``, ``dsh``
+(DeepSeek Harness), and ``hermes`` (Hermes Agent), each for a third-party
+coding agent CLI. With the ``pi`` adapter, ``GET /reef/harness`` serves:
 
 .. code:: text
 

--- a/reef/harness/adapters/__init__.py
+++ b/reef/harness/adapters/__init__.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from reef.harness.descriptor import AdapterDescriptor, DescriptorError, external_descriptors, load_descriptor
 
-BUILTIN_ADAPTERS = ("claude", "dsh", "opencode", "pi")
+BUILTIN_ADAPTERS = ("claude", "dsh", "hermes", "opencode", "pi")
 
 _cache: dict[str, AdapterDescriptor] = {}
 

--- a/reef/harness/adapters/hermes/__init__.py
+++ b/reef/harness/adapters/hermes/__init__.py
@@ -1,0 +1,1 @@
+"""The hermes adapter: Hermes Agent (https://github.com/NousResearch/hermes-agent) as a harness."""

--- a/reef/harness/adapters/hermes/descriptor.yaml
+++ b/reef/harness/adapters/hermes/descriptor.yaml
@@ -1,0 +1,97 @@
+# Hermes Agent, driven headless per episode.
+#
+# HERMES_HOME relocates the whole home (config.yaml, the session snapshots,
+# SOUL.md, skills, plugins, the state store, logs and caches) under the
+# episode root. `chat -Q --oneshot -q` answers one task on a non TTY and
+# exits; hermes's own approval policy runs file and terminal tools inside
+# the working directory with no prompt and refuses a command it flags as
+# dangerous with a tool error, so no bypass flag is used (the top level -z
+# one shot would bypass those approvals). The config defaults keep an
+# episode hermetic and single request: no scanner download, no session
+# title call, no background review, and a plain file session snapshot the
+# reader can parse.
+name: hermes
+binary: hermes
+# The vendor's channel is a git checkout installed editable into a venv:
+# PyPI is stale and upstream refuses wheel builds. Consumed by the
+# GET /reef/harness/install script, never by episode runs.
+install:
+  kind: git
+  package: hermes-agent
+  version: "0.21.0"
+  repository: "https://github.com/NousResearch/hermes-agent"
+  ref: "v2026.8.31"
+  binary_path: "venv/bin/hermes"
+argv: ["chat", "-Q", "--oneshot", "-q", "{prompt}"]
+env:
+  HERMES_HOME: "{root}/hermes"
+files:
+  config:
+    primary:
+      path: "hermes/config.yaml"
+      defaults:
+        # tirith_enabled downloads a scanner binary from GitHub at boot;
+        # title_generation is one extra model call per episode; the memory
+        # nudge spawns a background review agent; the snapshot is the
+        # trajectory the reader parses.
+        approval:
+          tirith_enabled: false
+        auxiliary:
+          title_generation:
+            enabled: false
+        memory:
+          nudge_interval: 0
+        sessions:
+          write_json_snapshots: true
+        skills:
+          external_dirs:
+            - "${HERMES_HOME}/../hermes-commands"
+  # hermes reads one home level rules file, SOUL.md; AGENTS.md is project
+  # scoped and read from the working directory chain, never from the home.
+  rules: "hermes/SOUL.md"
+  # Every skill is also a /name slash command in the interactive CLI, and
+  # hermes has no other command surface, so a command is a skill under the
+  # second root skills.external_dirs lists.
+  agent_command: "hermes-commands/{name}/SKILL.md"
+  skill: "hermes/skills/{name}/SKILL.md"
+  # A hermes plugin: register(ctx) in the package init, the manifest and
+  # the config grants come from the quirks module.
+  code_extension: "hermes/plugins/{name}/__init__.py"
+trajectory:
+  # One JSON snapshot per session under sessions/, rewritten after every
+  # persistence point, read by the hermes-session-json reader.
+  format: hermes-session-json
+  path: "hermes/sessions"
+cleanup_whitelist:
+  - "hermes/state.db"
+  - "hermes/state.db*"
+  - "hermes/auth.lock"
+  - "hermes/skills/.bundled_manifest"
+  - "hermes/logs/**"
+  - "hermes/cache/**"
+  - "hermes/runtime/**"
+  - "hermes/memories/**"
+  - "hermes/skills/autonomous-ai-agents/**"
+  - "hermes/.skills_prompt_snapshot.json"
+  - "hermes/.update_check"
+  # The first boot of a fresh venv repairs its dependencies through uv or pip
+  # under HOME, which Reef points at the root; on a host with rustup (the CI
+  # runner) its settings file appeared there after a run as well.
+  - ".cache/uv/**"
+  - ".cache/pip/**"
+  - ".local/**"
+  - ".rustup/**"
+quirks: reef.harness.adapters.hermes.quirks
+# How to point hermes at a model endpoint: a custom provider with a literal
+# key in config.yaml. Reef renders this set into evaluation episodes; the
+# served tree never carries a provider or a key. Only the openai dialect is
+# bound; hermes's anthropic_messages api mode was not measured.
+model_binding:
+  openai:
+    - target: primary
+      data:
+        model:
+          provider: custom
+          default: "{model}"
+          base_url: "{base_url}/v1"
+          api_key: "{api_key}"

--- a/reef/harness/adapters/hermes/quirks.py
+++ b/reef/harness/adapters/hermes/quirks.py
@@ -1,0 +1,97 @@
+"""hermes adapter quirks: the config file, skill frontmatter, plugin manifests, and the boot scaffold.
+
+Config nodes write ``config.yaml`` as a JSON object and ``finalize_render``
+emits it as YAML. It also writes the ``.no-bundled-skills`` marker, so an
+episode carries only the tree's skills instead of hermes's bundled catalog;
+synthesizes the ``name`` and ``description`` frontmatter hermes requires on a
+SKILL.md the node text left bare, under both skill roots; and, for every
+rendered plugin, writes the ``plugin.yaml`` manifest and grants the plugin
+in ``config.yaml`` (``plugins.enabled`` and the ``tools.override``
+capability), since hermes discovers plugins but loads none without consent.
+
+The traps a mutated config could reopen: the scanner download, the session
+title call, and the snapshot the reader parses. A composition that flips any
+of them is rejected at render, the same gate that rejects an invalid node.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import yaml
+
+from reef.harness.render import RenderError
+
+_CONFIG = "hermes/config.yaml"
+_MARKER = "hermes/.no-bundled-skills"
+_PLUGINS = "hermes/plugins/"
+_SKILL_ROOTS = ("hermes/skills/", "hermes-commands/")
+
+# hermes's boot scaffolds the home on every start: state directories, the
+# runtime and cache files, lock files beside the state store, and the seed
+# skill it always writes. Episode state, not residue.
+cleanup_whitelist = (
+    "hermes/cron/**",
+    "hermes/sessions/**",
+    "hermes/pairing/**",
+    "hermes/hooks/**",
+    "hermes/image_cache/**",
+    "hermes/audio_cache/**",
+    "hermes/sandboxes/**",
+    "hermes/terminal-sessions/**",
+    "hermes/bin/**",
+    "hermes/models_dev_cache.json*",
+)
+
+
+def _with_frontmatter(path: str, text: str) -> str:
+    if text.startswith("---\n"):
+        return text
+    name = path.split("/")[-2]
+    first = next((line.strip().lstrip("#").strip() for line in text.splitlines() if line.strip()), "")
+    header = {"name": name, "description": first[:200] or name}
+    return "---\n" + yaml.dump(header, sort_keys=False, default_flow_style=False, allow_unicode=True) + "---\n" + text
+
+
+def _granted(config: dict[str, Any], plugins: list[str]) -> dict[str, Any]:
+    section = dict(config.get("plugins") or {})
+    enabled = [name for name in section.get("enabled") or [] if isinstance(name, str)]
+    section["enabled"] = enabled + [name for name in plugins if name not in enabled]
+    entries = dict(section.get("entries") or {})
+    for name in plugins:
+        entry = dict(entries.get(name) or {})
+        granted = [item for item in entry.get("granted_capabilities") or [] if isinstance(item, str)]
+        entry["granted_capabilities"] = granted + ["tools.override"] * ("tools.override" not in granted)
+        entries[name] = entry
+    section["entries"] = entries
+    return {**config, "plugins": section}
+
+
+def finalize_render(files: dict[str, str]) -> dict[str, str]:
+    config = json.loads(files[_CONFIG])
+    if (config.get("approval") or {}).get("tirith_enabled") is not False:
+        raise RenderError("hermes composition must keep approval.tirith_enabled false for benchmark episodes")
+    if ((config.get("auxiliary") or {}).get("title_generation") or {}).get("enabled") is not False:
+        raise RenderError(
+            "hermes composition must keep auxiliary.title_generation.enabled false for benchmark episodes"
+        )
+    if (config.get("sessions") or {}).get("write_json_snapshots") is not True:
+        raise RenderError(
+            "hermes composition must keep sessions.write_json_snapshots true so Reef can read the trajectory"
+        )
+    plugins = sorted(
+        path[len(_PLUGINS) :].split("/")[0]
+        for path in files
+        if path.startswith(_PLUGINS) and path.endswith("/__init__.py") and path.count("/") == 3
+    )
+    for name in plugins:
+        files.setdefault(f"{_PLUGINS}{name}/plugin.yaml", f"name: {name}\nversion: '0.1'\ndescription: {name}\n")
+    if plugins:
+        config = _granted(config, plugins)
+    files[_CONFIG] = yaml.dump(config, sort_keys=True, default_flow_style=False, allow_unicode=True)
+    files[_MARKER] = ""
+    for path, text in list(files.items()):
+        if any(path.startswith(root) for root in _SKILL_ROOTS) and path.endswith("/SKILL.md"):
+            files[path] = _with_frontmatter(path, text)
+    return files

--- a/reef/harness/descriptor.py
+++ b/reef/harness/descriptor.py
@@ -57,14 +57,18 @@ class ConfigTarget:
     defaults: Mapping[str, Any] = field(default_factory=dict)
 
 
-#: Vendor install kinds the install-script generator can render.
-INSTALL_KINDS = ("npm",)
+#: Vendor install kinds the install-script generator can render: an npm
+#: package at a version, or a git checkout at a ref installed editable into
+#: a venv (the channel of a Python agent that publishes no wheel).
+INSTALL_KINDS = ("npm", "git")
 
 #: Install fields land inside generated shell text, so their charsets are
 #: pinned to what package registries actually use: names may add ``@`` and
-#: ``/`` for scopes, versions stay to dotted identifiers.
+#: ``/`` for scopes, versions and refs stay to dotted identifiers, and a
+#: repository is an https URL.
 _INSTALL_PACKAGE_PATTERN = re.compile(r"^[@A-Za-z0-9._/-]+$")
 _INSTALL_VERSION_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+_INSTALL_REPOSITORY_PATTERN = re.compile(r"^https://[A-Za-z0-9._/-]+$")
 
 
 @dataclass(frozen=True)
@@ -73,14 +77,18 @@ class InstallSpec:
 
     Reef never hosts or proxies binaries; this section only names the
     vendor's own install path (``kind``), the package it installs, the
-    pinned ``version``, and where the installed binary lands relative to
-    the install prefix (``binary_path``).
+    pinned ``version`` (what ``--version`` must report), and where the
+    installed binary lands relative to the install prefix (``binary_path``).
+    The ``git`` kind adds the ``repository`` to clone and the ``ref`` to
+    check out.
     """
 
     kind: str
     package: str
     version: str
     binary_path: str
+    repository: str = ""
+    ref: str = ""
 
 
 @dataclass(frozen=True)
@@ -225,11 +233,23 @@ def _parse_install(raw: Any, where: str) -> InstallSpec | None:
     version = _require_str(raw, "version", f"{where} install")
     if not _INSTALL_VERSION_PATTERN.fullmatch(version):
         raise DescriptorError(f"{where} install 'version' {version!r} must match {_INSTALL_VERSION_PATTERN.pattern}")
+    repository = ref = ""
+    if kind == "git":
+        repository = _require_str(raw, "repository", f"{where} install")
+        if not _INSTALL_REPOSITORY_PATTERN.fullmatch(repository):
+            raise DescriptorError(
+                f"{where} install 'repository' {repository!r} must match {_INSTALL_REPOSITORY_PATTERN.pattern}"
+            )
+        ref = _require_str(raw, "ref", f"{where} install")
+        if not _INSTALL_VERSION_PATTERN.fullmatch(ref):
+            raise DescriptorError(f"{where} install 'ref' {ref!r} must match {_INSTALL_VERSION_PATTERN.pattern}")
     return InstallSpec(
         kind=kind,
         package=package,
         version=version,
         binary_path=_require_str(raw, "binary_path", f"{where} install"),
+        repository=repository,
+        ref=ref,
     )
 
 

--- a/reef/harness/trajectory.py
+++ b/reef/harness/trajectory.py
@@ -197,6 +197,38 @@ class DeepseekSessionReader(TrajectoryReader):
 
 
 @register_trajectory_reader
+class HermesSessionReader(TrajectoryReader):
+    """Read Hermes Agent session snapshots: every ``*.json`` under ``path``, in path order.
+
+    With ``sessions.write_json_snapshots`` on, hermes rewrites
+    ``HERMES_HOME/sessions/session_<id>.json`` after every persistence point:
+    one object holding the session facts and a ``messages`` list. Each
+    snapshot becomes a ``session`` event carrying the facts, then one
+    ``message`` event per message (``role``, ``content``, and for the
+    assistant ``tool_calls`` and ``finish_reason``, for tool rows
+    ``tool_name`` and ``tool_call_id``).
+    """
+
+    format = "hermes-session-json"
+
+    def __call__(self, path: Path) -> tuple[dict[str, Any], ...]:
+        events: list[dict[str, Any]] = []
+        for file in sorted(Path(path).rglob("*.json")):
+            try:
+                snapshot = json.loads(file.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                raise TrajectoryError(f"hermes session {file} is not valid JSON") from exc
+            if not isinstance(snapshot, dict) or not isinstance(snapshot.get("messages"), list):
+                raise TrajectoryError(f"hermes session {file} is not a session snapshot with a messages list")
+            events.append({"type": "session", **{key: value for key, value in snapshot.items() if key != "messages"}})
+            for message in snapshot["messages"]:
+                if not isinstance(message, dict):
+                    raise TrajectoryError(f"hermes session {file} holds a message that is not an object")
+                events.append({"type": "message", **message})
+        return tuple(events)
+
+
+@register_trajectory_reader
 class OpencodeStorageReader(TrajectoryReader):
     """Read opencode storage JSON trees: every ``*.json`` under ``path``.
 
@@ -224,4 +256,5 @@ class OpencodeStorageReader(TrajectoryReader):
 read_pi_session = PiSessionReader()
 read_claude_session = ClaudeSessionReader()
 read_deepseek_session = DeepseekSessionReader()
+read_hermes_session = HermesSessionReader()
 read_opencode_storage = OpencodeStorageReader()

--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -166,16 +166,37 @@ def _wrapper_lines(
 
 def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) -> list[str]:
     """The vendor-delegating install step: check the pin, else install through the vendor's channel."""
+    prelude: list[str] = []
+    # Extra condition the "already installed" gate ands onto the binary check.
+    gate = ""
     if install.kind == "git":
         # A checkout installed editable into a venv; the checkout's .git goes so
         # the agent's own startup update check has nothing to fetch.
         pin = f"{install.repository} at {install.ref}"
+        # ``--version`` reports the package version, which a git ref moves
+        # independently of (hermes pins date tags but reports 0.21.0), so the
+        # version match alone would leave a ref-only bump on the old checkout.
+        # The installed ref is recorded beside the prefix and gates too, and is
+        # cleared before installing so an interrupted install never reads back
+        # as current.
+        prelude = [
+            f"PIN={_single_quoted(f'{install.repository}@{install.ref}')}",
+            'PIN_FILE="$PREFIX/.reef-install-pin"',
+        ]
+        gate = ' && [ "$(cat "$PIN_FILE" 2>/dev/null || true)" = "$PIN" ]'
         steps = [
+            '        rm -f "$PIN_FILE"',
+            # git clone refuses a non-empty target, so the checkout (and the
+            # venv installed editable off it) is cleared first: without this a
+            # failed install or a pin bump wedges every rerun on "destination
+            # path already exists". The npm branch is idempotent the same way.
+            '        rm -rf "$PREFIX/src" "$PREFIX/venv"',
             f"        git clone --quiet --depth 1 --branch {_single_quoted(install.ref)} "
             f'{_single_quoted(install.repository)} "$PREFIX/src"',
             '        rm -rf "$PREFIX/src/.git"',
             '        python3 -m venv "$PREFIX/venv"',
             '        "$PREFIX/venv/bin/python" -m pip install --quiet -e "$PREFIX/src"',
+            '        printf \'%s\\n\' "$PIN" > "$PIN_FILE"',
         ]
         # A Python CLI prints its version inside a label ("Hermes Agent v0.21.0"), so the match is a substring.
         pattern = f"    *{install.version}*)"
@@ -185,8 +206,9 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
         pattern = f'    *" {install.version} "*)'
     return [
         f"# Ensure the pinned binary ({pin}) via the vendor's channel.",
+        *prelude,
         'installed=""',
-        'if [ -x "$BINARY" ]; then',
+        f'if [ -x "$BINARY" ]{gate}; then',
         '    installed="$("$BINARY" --version 2>/dev/null || true)"',
         "fi",
         'case " $installed " in',

--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -165,21 +165,37 @@ def _wrapper_lines(
 
 
 def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) -> list[str]:
-    """The vendor-delegating install step: check the pin, else npm install."""
-    pin = _single_quoted(f"{install.package}@{install.version}")
+    """The vendor-delegating install step: check the pin, else install through the vendor's channel."""
+    if install.kind == "git":
+        # A checkout installed editable into a venv; the checkout's .git goes so
+        # the agent's own startup update check has nothing to fetch.
+        pin = f"{install.repository} at {install.ref}"
+        steps = [
+            f"        git clone --quiet --depth 1 --branch {_single_quoted(install.ref)} "
+            f'{_single_quoted(install.repository)} "$PREFIX/src"',
+            '        rm -rf "$PREFIX/src/.git"',
+            '        python3 -m venv "$PREFIX/venv"',
+            '        "$PREFIX/venv/bin/python" -m pip install --quiet -e "$PREFIX/src"',
+        ]
+        # A Python CLI prints its version inside a label ("Hermes Agent v0.21.0"), so the match is a substring.
+        pattern = f"    *{install.version}*)"
+    else:
+        pin = f"{install.package}@{install.version}"
+        steps = [f'        npm install --prefix "$PREFIX" {_single_quoted(pin)}']
+        pattern = f'    *" {install.version} "*)'
     return [
-        f"# Ensure the pinned binary ({install.package}@{install.version}) via the vendor's channel.",
+        f"# Ensure the pinned binary ({pin}) via the vendor's channel.",
         'installed=""',
         'if [ -x "$BINARY" ]; then',
         '    installed="$("$BINARY" --version 2>/dev/null || true)"',
         "fi",
         'case " $installed " in',
-        f'    *" {install.version} "*)',
+        pattern,
         f'        echo "reef: {descriptor.binary} {install.version} already installed"',
         "        ;;",
         "    *)",
         '        mkdir -p "$PREFIX"',
-        f'        npm install --prefix "$PREFIX" {pin}',
+        *steps,
         "        ;;",
         "esac",
         "",

--- a/tests/reef_service/data/harness_goldens/hermes/hermes-commands/summarize/SKILL.md
+++ b/tests/reef_service/data/harness_goldens/hermes/hermes-commands/summarize/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: summarize
+description: Summarize $1.
+---
+Summarize $1.

--- a/tests/reef_service/data/harness_goldens/hermes/hermes/SOUL.md
+++ b/tests/reef_service/data/harness_goldens/hermes/hermes/SOUL.md
@@ -1,0 +1,3 @@
+Answer briefly.
+
+Prefer the standard library.

--- a/tests/reef_service/data/harness_goldens/hermes/hermes/config.yaml
+++ b/tests/reef_service/data/harness_goldens/hermes/hermes/config.yaml
@@ -1,0 +1,21 @@
+agent:
+  max_turns: 40
+approval:
+  tirith_enabled: false
+auxiliary:
+  title_generation:
+    enabled: false
+memory:
+  nudge_interval: 0
+plugins:
+  enabled:
+  - tracer
+  entries:
+    tracer:
+      granted_capabilities:
+      - tools.override
+sessions:
+  write_json_snapshots: true
+skills:
+  external_dirs:
+  - ${HERMES_HOME}/../hermes-commands

--- a/tests/reef_service/data/harness_goldens/hermes/hermes/plugins/tracer/__init__.py
+++ b/tests/reef_service/data/harness_goldens/hermes/hermes/plugins/tracer/__init__.py
@@ -1,0 +1,2 @@
+def register(ctx):
+    pass

--- a/tests/reef_service/data/harness_goldens/hermes/hermes/plugins/tracer/plugin.yaml
+++ b/tests/reef_service/data/harness_goldens/hermes/hermes/plugins/tracer/plugin.yaml
@@ -1,0 +1,3 @@
+name: tracer
+version: '0.1'
+description: tracer

--- a/tests/reef_service/data/harness_goldens/hermes/hermes/skills/notes/SKILL.md
+++ b/tests/reef_service/data/harness_goldens/hermes/hermes/skills/notes/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: notes
+description: Notes skill
+---
+# Notes skill
+
+Keep short notes.

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -9,6 +9,7 @@ generated script under ``sh`` with the vendor tools shimmed on PATH."""
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import hashlib
 import json
 import os
@@ -1179,12 +1180,25 @@ def test_git_install_fields_constrain_their_charset(tmp_path, field: str, value:
         load_descriptor(target)
 
 
-def _git_install_fixture(tmp_path: Path, *, binary_version: str | None) -> tuple[Path, Path, Path, dict, Path]:
-    """A rendered hermes script with git and python3 shims that log their calls and fake the venv."""
+#: The ref the bundled hermes descriptor pins, as the install script records it.
+HERMES_PIN = "https://github.com/NousResearch/hermes-agent@v2026.8.31"
+
+
+def _git_install_fixture(
+    tmp_path: Path, *, binary_version: str | None, pin: str | None = HERMES_PIN, ref: str | None = None
+) -> tuple[Path, Path, Path, dict, Path]:
+    """A rendered hermes script with git and python3 shims that log their calls and fake the venv.
+
+    ``pin`` is the ref recorded beside an already-installed binary (``None``
+    plants none); ``ref`` re-pins the descriptor, standing in for a pin bump.
+    """
+    descriptor = get_adapter("hermes")
+    if ref is not None:
+        descriptor = dataclasses.replace(descriptor, install=dataclasses.replace(descriptor.install, ref=ref))
     script = tmp_path / "install.sh"
     script.write_text(
         render_install_script(
-            descriptor=get_adapter("hermes"),
+            descriptor=descriptor,
             files={"hermes/SOUL.md": "hello\n"},
             release_id="v-test",
             content_id="content-test",
@@ -1195,12 +1209,22 @@ def _git_install_fixture(tmp_path: Path, *, binary_version: str | None) -> tuple
         _write_executable(
             prefix / "venv/bin/hermes", f"#!/bin/sh\necho 'Hermes Agent v{binary_version} (2026.8.31)'\n"
         )
+        if pin is not None:
+            (prefix / ".reef-install-pin").write_text(f"{pin}\n")
     shim = tmp_path / "shim"
     log = tmp_path / "vendor.log"
     # POSIX sh (dash on CI): the clone target is the last argument, found by iterating.
     _write_executable(
         shim / "git",
-        f'#!/bin/sh\nprintf \'git %s\\n\' "$*" >> "{log}"\nfor arg in "$@"; do last="$arg"; done\nmkdir -p "$last/.git"\n',
+        f'#!/bin/sh\nprintf \'git %s\\n\' "$*" >> "{log}"\n'
+        'prev=""\nfor arg in "$@"; do\n'
+        '    [ "$prev" = "--branch" ] && ref="$arg"\n'
+        '    prev="$arg"\n    last="$arg"\ndone\n'
+        'if [ -d "$last" ] && [ -n "$(ls -A "$last")" ]; then\n'
+        "    echo \"fatal: destination path '$last' already exists and is not an empty directory.\" >&2\n"
+        "    exit 128\n"
+        "fi\n"
+        'mkdir -p "$last/.git"\nprintf \'%s\\n\' "$ref" > "$last/REF"\n',
     )
     # python3 -m venv DIR makes DIR/bin/python, whose -m pip install then drops the binary the pin expects.
     _write_executable(
@@ -1241,3 +1265,45 @@ def test_git_install_kind_skips_the_clone_when_the_version_label_matches(tmp_pat
     # The version answered, so the vendor step never ran (the reef-client step still calls python3).
     assert "git clone" not in (log.read_text() if log.exists() else "")
     assert "hermes 0.21.0 already installed" in result.stdout
+
+
+@pytest.mark.unit
+def test_git_install_kind_reinstalls_when_only_the_ref_moved(tmp_path) -> None:
+    """A date-tagged ref bump the package version does not follow still reinstalls.
+
+    hermes pins ``v2026.8.31`` but reports 0.21.0, so gating on the version
+    label alone would leave every existing install on the old checkout.
+    """
+    script, dest, prefix, env, _ = _git_install_fixture(tmp_path, binary_version="0.21.0", ref="v2026.9.2")
+    result = _run_install(script, dest, prefix, env)
+    assert result.returncode == 0, result.stderr
+    assert "already installed" not in result.stdout
+    assert (prefix / "src/REF").read_text() == "v2026.9.2\n"
+    assert (prefix / ".reef-install-pin").read_text() == "https://github.com/NousResearch/hermes-agent@v2026.9.2\n"
+
+
+@pytest.mark.unit
+def test_git_install_kind_reinstalls_over_a_checkout_a_failed_install_left_behind(tmp_path) -> None:
+    """git clone refuses a non-empty target, so the rerun clears it first.
+
+    Without that the first failure (or any pin bump) wedges every later run
+    on "destination path already exists" before a single file is written.
+    """
+    script, dest, prefix, env, _ = _git_install_fixture(tmp_path, binary_version=None)
+    (prefix / "src").mkdir(parents=True)
+    (prefix / "src/leftover").write_text("half a clone\n")
+    result = _run_install(script, dest, prefix, env)
+    assert result.returncode == 0, result.stderr
+    assert "already exists" not in result.stderr
+    assert not (prefix / "src/leftover").exists()
+    assert (dest / "hermes/SOUL.md").read_text() == "hello\n"
+
+
+@pytest.mark.unit
+def test_git_install_kind_reinstalls_when_the_binary_carries_no_recorded_pin(tmp_path) -> None:
+    """A binary of unknown provenance is not evidence the pinned ref is checked out."""
+    script, dest, prefix, env, log = _git_install_fixture(tmp_path, binary_version="0.21.0", pin=None)
+    result = _run_install(script, dest, prefix, env)
+    assert result.returncode == 0, result.stderr
+    assert "already installed" not in result.stdout
+    assert "git clone" in log.read_text()

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -1149,6 +1149,7 @@ def test_record_only_traffic_fires_a_step_and_publishes(tmp_path) -> None:
         ("claude", "CLAUDE_CONFIG_DIR", "claude"),
         # dsh's config file sits inside a profile; the relocated directory is the home two levels up.
         ("dsh", "DSH_HOME", "dsh"),
+        ("hermes", "HERMES_HOME", "hermes"),
     ],
 )
 def test_install_script_relocates_every_bundled_adapters_compose_directory(
@@ -1161,3 +1162,82 @@ def test_install_script_relocates_every_bundled_adapters_compose_directory(
     )
     assert f'export REEF_HARNESS_ENV_VAR="{env_var}"' in script
     assert f'COMPOSE_ABS="$(mkdir -p "$DEST/{compose_dir}" && cd "$DEST/{compose_dir}" && pwd)"' in script
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("repository", "git@github.com:acme/agent.git"), ("ref", "v1$(touch pwned)")],
+)
+def test_git_install_fields_constrain_their_charset(tmp_path, field: str, value: str) -> None:
+    source = Path(reef.harness.adapters.__file__).parent / "hermes" / "descriptor.yaml"
+    data = yaml.safe_load(source.read_text(encoding="utf-8"))
+    data["install"][field] = value
+    target = tmp_path / "descriptor.yaml"
+    target.write_text(yaml.safe_dump(data), encoding="utf-8")
+    with pytest.raises(DescriptorError, match=f"install '{field}'"):
+        load_descriptor(target)
+
+
+def _git_install_fixture(tmp_path: Path, *, binary_version: str | None) -> tuple[Path, Path, Path, dict, Path]:
+    """A rendered hermes script with git and python3 shims that log their calls and fake the venv."""
+    script = tmp_path / "install.sh"
+    script.write_text(
+        render_install_script(
+            descriptor=get_adapter("hermes"),
+            files={"hermes/SOUL.md": "hello\n"},
+            release_id="v-test",
+            content_id="content-test",
+        )
+    )
+    prefix = tmp_path / "prefix"
+    if binary_version is not None:
+        _write_executable(
+            prefix / "venv/bin/hermes", f"#!/bin/sh\necho 'Hermes Agent v{binary_version} (2026.8.31)'\n"
+        )
+    shim = tmp_path / "shim"
+    log = tmp_path / "vendor.log"
+    # POSIX sh (dash on CI): the clone target is the last argument, found by iterating.
+    _write_executable(
+        shim / "git",
+        f'#!/bin/sh\nprintf \'git %s\\n\' "$*" >> "{log}"\nfor arg in "$@"; do last="$arg"; done\nmkdir -p "$last/.git"\n',
+    )
+    # python3 -m venv DIR makes DIR/bin/python, whose -m pip install then drops the binary the pin expects.
+    _write_executable(
+        shim / "python3",
+        "#!/bin/sh\n"
+        f'printf \'python3 %s\\n\' "$*" >> "{log}"\n'
+        'if [ "$1" = "-m" ] && [ "$2" = "venv" ]; then\n'
+        '    mkdir -p "$3/bin"\n'
+        f'    printf \'#!/bin/sh\\nprintf "python %%s\\\\n" "$*" >> "{log}"\\nmkdir -p "$(dirname "$0")"\\n'
+        'printf "#!/bin/sh\\\\necho Hermes Agent v0.21.0\\\\n" > "$(dirname "$0")/hermes"\\nchmod +x "$(dirname "$0")/hermes"\\n\' > "$3/bin/python"\n'
+        '    chmod +x "$3/bin/python"\n'
+        "fi\n",
+    )
+    env = {**os.environ, "PATH": f"{shim}:{os.environ['PATH']}"}
+    return script, tmp_path / "dest", prefix, env, log
+
+
+@pytest.mark.unit
+def test_git_install_kind_clones_the_pinned_ref_into_a_venv_when_the_binary_is_absent(tmp_path) -> None:
+    script, dest, prefix, env, log = _git_install_fixture(tmp_path, binary_version=None)
+    result = _run_install(script, dest, prefix, env)
+    assert result.returncode == 0, result.stderr
+    calls = log.read_text().splitlines()
+    assert calls[0] == (
+        f"git clone --quiet --depth 1 --branch v2026.8.31 https://github.com/NousResearch/hermes-agent {prefix}/src"
+    )
+    assert calls[1] == f"python3 -m venv {prefix}/venv"
+    assert calls[2] == f"python -m pip install --quiet -e {prefix}/src"
+    assert not (prefix / "src" / ".git").exists()  # the checkout's .git goes: nothing for a startup update check
+    assert (dest / "hermes/SOUL.md").read_text() == "hello\n"
+
+
+@pytest.mark.unit
+def test_git_install_kind_skips_the_clone_when_the_version_label_matches(tmp_path) -> None:
+    script, dest, prefix, env, log = _git_install_fixture(tmp_path, binary_version="0.21.0")
+    result = _run_install(script, dest, prefix, env)
+    assert result.returncode == 0, result.stderr
+    # The version answered, so the vendor step never ran (the reef-client step still calls python3).
+    assert "git clone" not in (log.read_text() if log.exists() else "")
+    assert "hermes 0.21.0 already installed" in result.stdout

--- a/tests/reef_service/test_harness_episode.py
+++ b/tests/reef_service/test_harness_episode.py
@@ -18,6 +18,7 @@ from reef.harness.trajectory import (
     TrajectoryError,
     read_claude_session,
     read_deepseek_session,
+    read_hermes_session,
     read_opencode_storage,
     read_pi_session,
     reader_for,
@@ -176,6 +177,30 @@ def test_deepseek_reader_reads_nested_sessions_and_tolerates_one_torn_tail(tmp_p
     with pytest.raises(TrajectoryError, match=r"deepseek session .* corrupt event at line 1"):
         read_deepseek_session(tmp_path)
     assert reader_for("deepseek-session-jsonl").format == "deepseek-session-jsonl"
+
+
+def test_hermes_reader_emits_a_session_event_then_one_event_per_message(tmp_path: Path) -> None:
+    snapshot = {
+        "session_id": "s1",
+        "model": "m",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}], "finish_reason": "tool_calls"},
+            {"role": "tool", "tool_name": "terminal", "tool_call_id": "c1", "content": "ok"},
+        ],
+    }
+    (tmp_path / "session_s1.json").write_text(json.dumps(snapshot))
+    events = read_hermes_session(tmp_path)
+    assert [event["type"] for event in events] == ["session", "message", "message", "message"]
+    assert events[0] == {"type": "session", "session_id": "s1", "model": "m"}
+    assert events[2]["tool_calls"] == [{"id": "c1"}] and events[3]["tool_name"] == "terminal"
+    (tmp_path / "session_s2.json").write_text("{not json")
+    with pytest.raises(TrajectoryError, match="not valid JSON"):
+        read_hermes_session(tmp_path)
+    (tmp_path / "session_s2.json").write_text(json.dumps({"session_id": "s2"}))
+    with pytest.raises(TrajectoryError, match="messages list"):
+        read_hermes_session(tmp_path)
+    assert reader_for("hermes-session-json").format == "hermes-session-json"
 
 
 def test_missing_trajectory_reads_as_empty(tmp_path: Path) -> None:

--- a/tests/reef_service/test_harness_render.py
+++ b/tests/reef_service/test_harness_render.py
@@ -120,6 +120,73 @@ def test_dsh_quirks_refuse_a_patch_that_breaks_the_episode() -> None:
         render_composition([("config", {"data": {"agent-loop": "nope"}})], descriptor)
 
 
+HERMES_CONFIG = "hermes/config.yaml"
+
+
+def _hermes_nodes():
+    # hermes's config target is its config.yaml, so the pi shaped config nodes are swapped for one of its own.
+    nodes = [node for node in NODES if node[0] != "config"]
+    extension = ("code_extension", {"name": "tracer", "code": "def register(ctx):\n    pass\n"})
+    return [
+        ("config", {"data": {"agent": {"max_turns": 40}}}),
+        *[n for n in nodes if n[0] != "code_extension"],
+        extension,
+    ]
+
+
+def test_hermes_render_matches_the_golden_tree() -> None:
+    assert render_composition(_hermes_nodes(), get_adapter("hermes")) == golden_tree("hermes")
+
+
+def test_hermes_quirks_emit_the_config_the_plugin_grants_and_skill_frontmatter() -> None:
+    descriptor = get_adapter("hermes")
+    binding = ModelBinding(base_url="http://127.0.0.1:9", model="m1", api_key="k-1")
+    files = render_composition([*_hermes_nodes(), *binding.compose_nodes(descriptor)], descriptor)
+    config = yaml.safe_load(files[HERMES_CONFIG])
+    assert config["model"] == {
+        "provider": "custom",
+        "default": "m1",
+        "base_url": "http://127.0.0.1:9/v1",
+        "api_key": "k-1",
+    }
+    assert config["agent"] == {"max_turns": 40}
+    # The defaults that keep an episode hermetic and single request, and the second skill root.
+    assert config["approval"] == {"tirith_enabled": False}
+    assert config["auxiliary"] == {"title_generation": {"enabled": False}}
+    assert config["memory"] == {"nudge_interval": 0} and config["sessions"] == {"write_json_snapshots": True}
+    assert config["skills"] == {"external_dirs": ["${HERMES_HOME}/../hermes-commands"]}
+    # A rendered plugin is enabled and granted, and gets its manifest.
+    assert config["plugins"] == {
+        "enabled": ["tracer"],
+        "entries": {"tracer": {"granted_capabilities": ["tools.override"]}},
+    }
+    assert files["hermes/plugins/tracer/plugin.yaml"] == "name: tracer\nversion: '0.1'\ndescription: tracer\n"
+    assert files["hermes/plugins/tracer/__init__.py"] == "def register(ctx):\n    pass\n"
+    assert files["hermes/.no-bundled-skills"] == ""
+    # A skill without frontmatter gets name and description under both roots; the author's frontmatter is left alone.
+    assert (
+        files["hermes/skills/notes/SKILL.md"]
+        == "---\nname: notes\ndescription: Notes skill\n---\n# Notes skill\n\nKeep short notes.\n"
+    )
+    assert (
+        files["hermes-commands/summarize/SKILL.md"]
+        == "---\nname: summarize\ndescription: Summarize $1.\n---\nSummarize $1.\n"
+    )
+    own = ("skill", {"name": "own", "text": "---\nname: own\ndescription: mine\n---\nBody.\n"})
+    assert render_composition([own], descriptor)["hermes/skills/own/SKILL.md"] == own[1]["text"]
+    assert files["hermes/SOUL.md"] == "Answer briefly.\n\nPrefer the standard library.\n"
+
+
+def test_hermes_quirks_refuse_a_config_that_breaks_the_episode() -> None:
+    descriptor = get_adapter("hermes")
+    with pytest.raises(RenderError, match="tirith_enabled false"):
+        render_composition([("config", {"data": {"approval": {"tirith_enabled": True}}})], descriptor)
+    with pytest.raises(RenderError, match=r"title_generation\.enabled false"):
+        render_composition([("config", {"data": {"auxiliary": {"title_generation": {"enabled": True}}}})], descriptor)
+    with pytest.raises(RenderError, match="write_json_snapshots true"):
+        render_composition([("config", {"data": {"sessions": {"write_json_snapshots": False}}})], descriptor)
+
+
 def test_config_nodes_deep_merge_in_tree_order() -> None:
     files = render_composition(
         [

--- a/tests/smoke/test_real_hermes.py
+++ b/tests/smoke/test_real_hermes.py
@@ -1,0 +1,116 @@
+"""Smoke of the real hermes binary: render, episode, and trajectory against the
+real thing. The hermetic suites drive scripted fakes, so every format and
+environment assumption about the real Hermes Agent lives here: a pinned
+hermes runs one episode against a stdlib OpenAI-compatible stub and must read
+our rendered config.yaml, reach the stub with the SOUL.md text and the bound
+key, write a session snapshot our reader parses, make no extra model call,
+and leave no unexplained residue. Skipped unless REEF_REAL_HERMES_BINARY
+points at an installed hermes (.github/workflows/harness-smoke.yml provides
+one)."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+
+from reef.harness.adapters import get_adapter
+from reef.harness.episode import run_episode
+from reef.harness.model_binding import ModelBinding
+from reef.harness.render import render_composition
+
+REAL_HERMES = os.environ.get("REEF_REAL_HERMES_BINARY", "")
+
+pytestmark = pytest.mark.skipif(not REAL_HERMES, reason="REEF_REAL_HERMES_BINARY does not name a real hermes binary")
+
+MODEL = "smoke-model"
+RULES_SENTENCE = "The reef smoke marker phrase is TIDEPOOL-STONE-41."
+
+
+class StubOpenAI(ThreadingHTTPServer):
+    """A canned /v1 endpoint that records every request it is sent."""
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), StubHandler)
+        self.requests: list[tuple[str, str | None, str]] = []
+
+
+class StubHandler(BaseHTTPRequestHandler):
+    server: StubOpenAI
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass  # keep the harness's stderr out of pytest output
+
+    def do_POST(self) -> None:
+        body = self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode("utf-8")
+        self.server.requests.append((self.path, self.headers.get("Authorization"), body))
+        if not self.path.endswith("/chat/completions"):
+            self.send_response(404)  # hermes probes the base URL as a local endpoint first
+            self.end_headers()
+            return
+        usage = {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        if json.loads(body).get("stream"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunks = [
+                {"choices": [{"index": 0, "delta": {"role": "assistant", "content": "READY"}}]},
+                {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}], "usage": usage},
+            ]
+            for chunk in chunks:
+                event = {"id": "chatcmpl-smoke", "object": "chat.completion.chunk", "model": MODEL, **chunk}
+                self.wfile.write(b"data: " + json.dumps(event).encode("utf-8") + b"\n\n")
+            self.wfile.write(b"data: [DONE]\n\n")
+        else:
+            payload = {
+                "id": "chatcmpl-smoke",
+                "object": "chat.completion",
+                "model": MODEL,
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": "READY"}, "finish_reason": "stop"}
+                ],
+                "usage": usage,
+            }
+            raw = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+
+def test_real_hermes_episode_renders_runs_and_cleans_up() -> None:
+    server = StubOpenAI()
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    descriptor = get_adapter("hermes")
+    try:
+        binding = ModelBinding(
+            base_url=f"http://127.0.0.1:{server.server_address[1]}", model=MODEL, api_key="smoke-key-1234"
+        )
+        nodes = [("rules", {"text": RULES_SENTENCE}), *binding.compose_nodes(descriptor)]
+        files = render_composition(nodes, descriptor)
+        # The task starts with a dash on purpose: it must pass through -q as the query.
+        result = run_episode(
+            descriptor, files, "- Reply with exactly the word READY", binary=REAL_HERMES, timeout=300.0
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    completions = [(auth, body) for path, auth, body in server.requests if path.endswith("/chat/completions")]
+    # (a) Exactly one model call: the title call is off. It carried the rules text and the bound key.
+    assert len(completions) == 1, [path for path, _, _ in server.requests]
+    assert RULES_SENTENCE in completions[0][1] and "- Reply with exactly the word READY" in completions[0][1]
+    assert completions[0][0] == "Bearer smoke-key-1234"
+    # (b) The snapshot the real binary wrote parses through our reader and carries the exchange.
+    kinds = [event["type"] for event in result.trajectory]
+    assert kinds == ["session", "message", "message"], kinds
+    assert [event["role"] for event in result.trajectory[1:]] == ["user", "assistant"]
+    assert result.trajectory[2]["content"] == "READY"
+    # (c) The cleanup audit found nothing outside the declared whitelist.
+    assert result.residue == ()


### PR DESCRIPTION
## Motivation

The community asked for Hermes Agent support. Reef evolves a harness tree for pi, opencode, Claude Code, and dsh, but a Hermes user cannot point evolution.adapter at it. Hermes also has no package channel Reef's install script could use (PyPI is stale and upstream refuses wheel builds; the supported install is a git checkout) and keeps its transcript in a SQLite store unless a config switch turns on a per session JSON snapshot. This adds hermes as the fifth bundled adapter and a git install kind, with every descriptor fact measured on the real binary at the pinned tag against a stub model endpoint; the same run is now a smoke job. Closes #182. Stacked on #183, which fixes the install route for an adapter whose config file sits below its relocated directory.

## Changes

- A hermes adapter (reef/harness/adapters/hermes): binary hermes, argv chat -Q --oneshot -q {prompt} (answers and exits on a non TTY; a task starting with a dash passes through -q; hermes's own approval policy refuses a command it flags as dangerous with a tool error, so the top level -z one shot that bypasses approvals is not used), HERMES_HOME={root}/hermes, and a cleanup whitelist for the boot scaffold (state store and its lock files, logs, caches, runtime, memories, the seed skill hermes always writes, the bundled skill manifest, the update check stamp, and the uv repair cache the first boot of a fresh venv leaves under HOME)
- The primary config target is config.yaml, emitted as YAML by the quirks. Its defaults keep an episode hermetic and single request: approval.tirith_enabled false (a 32 MB scanner download from GitHub at boot otherwise), auxiliary.title_generation.enabled false (one extra model call per episode otherwise), memory.nudge_interval 0 (the post turn background review agent cannot fire), sessions.write_json_snapshots true (the trajectory), and skills.external_dirs naming the second skill root; a composition that flips the first two or the snapshot is refused at render. The quirks also write the .no-bundled-skills marker so an episode carries the tree's skills, not hermes's bundled catalog
- Rules render to SOUL.md, the one home level rules file hermes reads (AGENTS.md is project scoped, read from the working directory chain and never from the home). Skills render to skills/{name}/SKILL.md; hermes ignores a SKILL.md without name and description frontmatter, so the quirks synthesize it when the node text has none. An agent_command renders as a skill under hermes-commands, the second root skills.external_dirs lists: every hermes skill is also a /name slash command in the interactive CLI and hermes has no other command surface. A code_extension renders as a plugin package (plugins/{name}/__init__.py defining register(ctx)); the quirks add its plugin.yaml manifest and grant it in config.yaml (plugins.enabled plus the tools.override capability), since hermes discovers plugins but loads none without that consent; a plugin tool then sits behind hermes's tool_search and tool_call discovery surface
- The model binding is a custom provider with a literal key in config.yaml (model.provider custom, base_url {base_url}/v1, api_key {api_key}); only the openai dialect is bound
- A hermes-session-json trajectory reader: every session_<id>.json snapshot under sessions/ becomes one session event with the session facts and one message event per message (role, content, tool_calls, finish_reason, tool_name, tool_call_id)
- A git install kind: repository and ref on InstallSpec (validated charsets), and the install script clones the ref at depth 1 into the prefix, strips the checkout's .git so hermes's startup update check has nothing to fetch, creates a venv, and installs the checkout editable; the pin match is a substring of the version label, since a Python CLI prints it inside a sentence. The npm kind is unchanged
- tests/smoke/test_real_hermes.py and a real-hermes job in harness-smoke.yml that installs the tag the same way the script does
- Documented in the harness adapters guide (the table row, a hermes paragraph, the install row), the lane guide, the configuration reference, and the install route

## Compatibility and operational impact

Additive: a fifth bundled adapter and a second install kind; the four adapters, the npm kind, and the served scripts of the other adapters are unchanged. The client wrapper reef-<adapter> gets no hermes branch in this cut, like claude and dsh. Hermes needs Python 3.11 to 3.13 on the host that runs episodes; the pin follows a date tag on upstream main and the smoke job is the tripwire for drift. Hermes is MIT licensed and the adapter carries no hermes code.

## Verification

Measured on the real binary (upstream v2026.8.31 installed editable into a scratch venv) before writing the descriptor: a fresh home with no provider exits 1 with a setup message; config.yaml with a custom provider and a literal key reached the stub as Authorization: Bearer <key>; SOUL.md text reached the model and a home level AGENTS.md did not; a SKILL.md without frontmatter is not indexed while one with frontmatter is; an external skill root with ${HERMES_HOME} expansion is listed by skills_list; a plugin under plugins/ registers only with plugins.enabled and the tools.override grant, after which tool_search finds its tool and tool_call runs it; terminal wrote a file in the workspace with no prompt, rm -rf was refused with a BLOCKED tool error, and hermes -z ran it; title generation made a second model call until auxiliary.title_generation.enabled false; tirith_enabled true downloaded a 32 MB binary into HERMES_HOME/bin; sessions.write_json_snapshots true wrote the snapshot with the tool call and result; PyPI 0.19.0 exits 2 on --oneshot; no process outlived the run.

tests/smoke/test_real_hermes.py passes locally against that venv (exit 0, exactly one chat completion carrying the rules sentence, the dash leading task, and the bound key; a session event then user and assistant messages; no residue). The render suite covers the hermes golden tree, the YAML config with the defaults, the binding, the plugin grant and manifest, the marker, skill frontmatter under both roots, the author's frontmatter left alone, and the three refusals; the episode suite covers the snapshot reader and its two errors; the channel suite covers the git kind (the clone, venv, and editable install lines through git and python3 shims, the version label short circuit, the field charsets) and the wrapper's compose directory for every bundled adapter. tests/reef_service passes on Python 3.12 (1295 tests, the ray and slime bridge modules skipped for lack of those packages locally). The pre-commit hook set, mypy on reef/harness and reef/service, and the docs link and contract checks are clean.

## AI assistance

Claude Code mapped hermes-agent's source, probed the real binary, and wrote the adapter, the install kind, the reader, the tests, and the docs. I set the scope in #182.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
