### PR TITLE
refactor: make a pending release an explicit publication field

### DIFF
--- a/reef/scenario/commit_protocol.py
+++ b/reef/scenario/commit_protocol.py
@@ -264,6 +264,9 @@ class ScenarioCommitProtocol:
             raise ReefError(
                 "checkpoint-selected training results must include the artifact returned by execute_training_job"
             )
+        if result.pending:
+            # Live weights have no durable bytes to promote later, so holding them back is not expressible.
+            raise ReefError("a pending release requires a durable checkpoint; this step publishes live weights only")
         head, live_ref = artifacts.prepare_live(step=next_step, runtime_load_id=publication.runtime_load_id)
         prepared = self._trainer.commit()
         self._append_commit_record(
@@ -278,6 +281,7 @@ class ScenarioCommitProtocol:
         return result.state
 
     def _commit_without_artifact(self, result: TrainStepResult) -> Any:
+        # No pending check: a pending step carries durable bytes by construction, so it never lands here.
         next_step = self._step + 1
         prepared = self._trainer.commit()
         self._append_commit_record(
@@ -299,7 +303,7 @@ class ScenarioCommitProtocol:
         prepared = self._trainer.commit()
         local_artifact = artifacts.stage(next_step, publication.artifact, parent=checkpoint)
         # A pending release is minted into the catalog but never activated and moves no head.
-        pending = bool(result.metrics.get("pending"))
+        pending = result.pending
         try:
             # The engine must confirm the new revision before anything moves
             # the served head: the staged bytes load first, and the version

--- a/reef/train/cordis_backend/__init__.py
+++ b/reef/train/cordis_backend/__init__.py
@@ -658,9 +658,8 @@ class CordisBackend(TrainingBackend):
             self._loader.root.update(entries)
             artifact = Artifact.local(_write_rendered_files(candidate.candidate_files))
             # Under review, or when a reviewed kind is touched, the release waits for a promote.
-            if self._publish == "review" or self._review_kinds & self._mutation_kinds(candidate):
-                metrics["pending"] = True
-            return TrainStepResult({**state, "entries": entries}, metrics, artifact=artifact)
+            pending = self._publish == "review" or bool(self._review_kinds & self._mutation_kinds(candidate))
+            return TrainStepResult({**state, "entries": entries}, metrics, artifact=artifact, pending=pending)
 
         entries = [dict(entry) for entry in candidate.current_entries]
         self._loader.root.update(entries)

--- a/reef/train/types/results.py
+++ b/reef/train/types/results.py
@@ -62,6 +62,12 @@ class TrainStepResult:
     ``artifact`` and ``runtime_load_id`` is normal for a durable train step; the
     version travels in the artifact's metadata. Combinations with no meaning
     are rejected here instead of being silently dropped by ``publication``.
+
+    ``pending`` asks for the publication to be minted into the catalog without
+    being served, for a person to promote later. It is a publication decision,
+    so it travels as a field rather than as a metrics key: only durable bytes
+    can be held back, and a step that publishes live weights or nothing at all
+    is rejected here instead of having the request silently dropped.
     """
 
     state: Mapping[str, Any] | None
@@ -71,6 +77,7 @@ class TrainStepResult:
     checkpoint_path: str | None = None
     training_job_id: str | None = None
     source_runtime_load_id: str | None = None
+    pending: bool = False
 
     def __post_init__(self) -> None:
         if self.checkpoint_path is not None and self.runtime_load_id is None:
@@ -84,6 +91,10 @@ class TrainStepResult:
             not isinstance(self.source_runtime_load_id, str) or not self.source_runtime_load_id
         ):
             raise ValueError("source_runtime_load_id must be a non-empty string or None")
+        if not isinstance(self.pending, bool):
+            raise ValueError("pending must be a boolean")
+        if self.pending and self.artifact is None and self.checkpoint_path is None:
+            raise ValueError("a pending step must carry durable bytes: set artifact or checkpoint_path")
 
     @property
     def has_model_update(self) -> bool:

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -13,8 +13,9 @@ import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
 import reef.train.cordis_backend as reef_cordis_backend
-from reef.artifact import InMemoryRepositoryBackend
+from reef.artifact import Artifact, InMemoryRepositoryBackend
 from reef.core import AgentRecord, RequestType
+from reef.core.errors import ReefError
 from reef.core.reports import ScoredRolloutReport
 from reef.dispatcher import Dispatcher
 from reef.harness.adapters import get_adapter
@@ -25,6 +26,7 @@ from reef.recipe import RecipeConfigError
 from reef.recipe.registry import recipe_class_for
 from reef.records import RecordStore
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
+from reef.scenario.checkpoint_strategy import EveryNVersions
 from reef.service.app import create_app
 from reef.train.cordis_backend import (
     CordisBackend,
@@ -1730,7 +1732,7 @@ def test_review_publish_holds_the_win_as_a_pending_release_until_promoted(tmp_pa
         head_before = scenario.current_artifact_ref()
         _report_once(scenario, "review", "1")
         result = scenario.prepare_training_step()
-        assert result is not None and result.metrics["pending"] is True
+        assert result is not None and result.pending is True
         scenario.commit(result)
 
         record = scenario.commit_log.records()[-1]
@@ -1773,11 +1775,11 @@ def test_review_kinds_hold_only_wins_that_touch_a_listed_kind(tmp_path: Path) ->
         )
 
     held = build(review_kinds=("rules",))
-    assert run_backend_step(held, batch(), held.initial_state()).metrics["pending"] is True
+    assert run_backend_step(held, batch(), held.initial_state()).pending is True
     free = build(review_kinds=("skill",))
-    assert "pending" not in run_backend_step(free, batch(), free.initial_state()).metrics
+    assert run_backend_step(free, batch(), free.initial_state()).pending is False
     reviewed = build(publish="review")
-    assert run_backend_step(reviewed, batch(), reviewed.initial_state()).metrics["pending"] is True
+    assert run_backend_step(reviewed, batch(), reviewed.initial_state()).pending is True
     with pytest.raises(ValueError, match="publish must be 'auto' or 'review'"):
         build(publish="staged")
 
@@ -1850,5 +1852,45 @@ def test_promote_http_route_serves_a_pending_release(tmp_path: Path) -> None:
 
     try:
         asyncio.run(run())
+    finally:
+        dispatcher.close()
+
+
+def test_pending_requires_durable_bytes() -> None:
+    """Only a step with bytes to promote later can ask to be held back, so a
+    live-weights or no-artifact step is refused where it is built."""
+    assert TrainStepResult({}, {}, artifact=Artifact.local(Path(".")), pending=True).pending is True
+    assert TrainStepResult({}, {}, runtime_load_id="w1", checkpoint_path="/ckpt", pending=True).pending is True
+    with pytest.raises(ValueError, match="pending step must carry durable bytes"):
+        TrainStepResult({}, {}, runtime_load_id="w1", pending=True)
+    with pytest.raises(ValueError, match="pending step must carry durable bytes"):
+        TrainStepResult({}, {}, pending=True)
+    with pytest.raises(ValueError, match="pending must be a boolean"):
+        TrainStepResult({}, {}, artifact=Artifact.local(Path(".")), pending="yes")
+
+
+def test_a_pending_step_published_as_live_weights_is_rejected(tmp_path: Path) -> None:
+    """Checkpoint policy runs after the result is built, so a durable-weights
+    step can still land on the live path; holding it back there is not
+    expressible and must fail loudly rather than serve the tree anyway."""
+    built = CordisRecipe(
+        resolve_proposer(lambda nodes, samples, model: None),
+        resolve_episode_scorer(evaluate),
+        ("task one",),
+        binary=str(make_binary(tmp_path)),
+        seed=(SEED_MODELS, SEED_SETTINGS),
+        runtime=runtime(),
+        checkpoint_strategy=EveryNVersions(1000),
+    )
+    initial = tmp_path / "initial"
+    initial.mkdir()
+    factory = InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository")
+    dispatcher = Dispatcher(built, factory, agent_record_dir=tmp_path / "agent-record")
+    try:
+        scenario = dispatcher.get_or_create_scenario("live-pending")
+        assert scenario is not None
+        held = TrainStepResult({}, {}, runtime_load_id="w1", checkpoint_path=str(tmp_path / "ckpt"), pending=True)
+        with pytest.raises(ReefError, match="pending release requires a durable checkpoint"):
+            scenario.commit(held)
     finally:
         dispatcher.close()


### PR DESCRIPTION
Stacked on #166 — base is `bo/staged-publish`, so this diff is only the refactor.

## Why

#166 carries the review-mode hold as a `metrics["pending"]` key. `metrics` is free-form telemetry, merged in the weights path from three algorithm-supplied dicts (`candidate.training_metrics`, `prepared.metrics`, `decision.metrics`). Two consequences:

- **The harness-only scope is a coincidence, not an invariant.** `_commit_saved_artifact` is the shared commit path — a weight checkpoint (`DurableWeightsPublication` that the checkpoint policy resolves to `SavedArtifactPublication`) goes through the exact same function. Any algorithm that emits a metric named `pending` would silently stage its checkpoint as an unserved release and stop advancing the head. Nothing in the types or the tests would catch it.
- **Two of the three commit paths ignore the request.** `_commit_live_weights` and `_commit_without_artifact` never looked at the key, so a hold asked for there was silently dropped and the tree served anyway.

This also sits against the file's own stated design: `TrainStepResult` keeps every publication decision as an explicit typed field with `__post_init__` validation, and `ArtifactPublication` is deliberately a closed sum type so "a type checker could not prove a new member is handled everywhere it must be" cannot happen. A publication decision routed through a telemetry dict is the one thing that file is written to prevent.

## What changed

- `TrainStepResult` gains `pending: bool = False` alongside the other publication fields. `__post_init__` rejects a non-bool, and rejects a hold with no durable bytes to promote later (`artifact` or `checkpoint_path` must be set).
- `_commit_saved_artifact` reads the field instead of the metrics key.
- `_commit_live_weights` raises `ReefError` on a pending step. This is reachable, not defensive: checkpoint policy runs in the commit protocol *after* the result is built, so a durable-weights step with the flag set can still be resolved to live weights. The producer cannot know, so the protocol has to say so.
- `CordisBackend.settle_step` passes `pending=` instead of writing into `metrics`.

`_commit_without_artifact` gets a comment rather than a guard: `NoArtifactPublication` requires `artifact is None and runtime_load_id is None`, while `pending` requires `artifact` or `checkpoint_path` (which itself requires `runtime_load_id`). The combination is unconstructible, so a raise there would be untestable dead code.

Release rows no longer carry `pending` inside `metrics`; the row's own `pending` field is unchanged, so nothing is lost from the catalog.

## Tests

`tests/reef_service`: **1285 passed, 12 skipped**. The one failure, `test_reef_git_lfs.py::test_fresh_scenario_forks_latest_artifact_with_real_lfs`, is pre-existing — it fails identically on the unmodified base (no git-lfs in this environment). `test_sao_bridge.py` / `test_slime_bridge.py` are uncollectable here for want of `ray` / `slime`. `ruff check reef tests` clean.

New:

- `test_pending_requires_durable_bytes` — construction-time validation.
- `test_a_pending_step_published_as_live_weights_is_rejected` — the protocol-level guard, via `EveryNVersions(1000)` to force a non-checkpoint step.

#166's three `metrics["pending"]` assertions now read `.pending`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaxMApc1kGd5RHc62hsE7
