### PR TITLE
[Task] Close five small documentation, tooling, and test gaps

### DIFF
--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -31,3 +31,19 @@ Markers
 
 ``unit``, ``integration``, and ``acceptance``. Run one with ``pytest -m
 <marker>``.
+
+Coverage
+--------
+
+CI runs the suite under coverage, and ``[tool.coverage.report] fail_under`` in
+``pyproject.toml`` is a gate: the run exits non-zero when total coverage falls
+below the floor. Reproduce it the way CI does:
+
+.. code:: bash
+
+   pytest tests --cov=reef --cov-report=term
+
+``pytest-cov`` ships in the ``dev`` extra. The floor applies to the whole
+package, so a partial run reports far less than CI does; measure against the
+full suite before reading a number as a regression. ``[tool.coverage.run]``
+omits the four Megatron modules that only execute inside a live CUDA worker.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -17,6 +17,7 @@ unexpectedly.
 
    -c, --config | the config file. Defaults to ``reef.yaml``, or ``$REEF_CONFIG``.
    --help | the command list
+   -V, --version | the installed reef version. Takes no command: ``reef --version``.
 
 Overriding config values
 ------------------------

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -37,6 +37,8 @@ Routes
 +-------------------------------------------------+---------------------------------------------------+
 | ``POST /reef/scenarios/{scenario}/rollback``    | republish an earlier release as the head          |
 +-------------------------------------------------+---------------------------------------------------+
+| ``POST /reef/scenarios/{scenario}/promote``     | serve a release held for review                   |
++-------------------------------------------------+---------------------------------------------------+
 | ``GET /reef/harness``                           | the served harness tree                           |
 +-------------------------------------------------+---------------------------------------------------+
 | ``GET /reef/harness/releases``                  | the harness release catalog, oldest first         |

--- a/docs/site/scripts/check-doc-contracts.mjs
+++ b/docs/site/scripts/check-doc-contracts.mjs
@@ -81,9 +81,15 @@ if (!homeSource.includes(`localhost:${port}${health}`)) {
 if (!rootReadme.includes(`127.0.0.1:${port}${health}`)) {
   failures.push(`README.md must use 127.0.0.1:${port}${health}`);
 }
+// Scoped to the Routes table, not the whole page: a route named only in the
+// prose of a later section still leaves the table an incomplete index.
+const routesTable = wireGuide.match(/\nRoutes\n-+\n([\s\S]*?)\n[A-Z][^\n]*\n-{3,}\n/)?.[1];
+if (!routesTable) {
+  throw new Error("Could not find the Routes table in docs/reference/http-api.rst");
+}
 for (const { method, path } of routes) {
-  if (!wireGuide.includes(`\`${method} ${path}\``)) {
-    failures.push(`docs/reference/http-api.rst is missing the ${method} ${path} route`);
+  if (!routesTable.includes(`\`${method} ${path}\``)) {
+    failures.push(`docs/reference/http-api.rst Routes table is missing the ${method} ${path} route`);
   }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,9 @@ dev = [
     "mypy",
     "pre-commit",
     "pytest",
-    "ruff==0.16.5",
+    # CI measures coverage against the [tool.coverage.report] floor below.
+    "pytest-cov",
+    "ruff==0.14.7",
 ]
 
 [dependency-groups]

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -143,7 +143,7 @@ def resolve_hf_snapshot(repo_id: str) -> str:
     If the value is already a local path, return it unchanged.
     """
     value = os.path.expanduser(repo_id)
-    if Path(value).exists():
+    if is_local_path(repo_id):
         return value
     if "/" not in value or value.startswith(("/", "~")):
         raise DeployConfigError(

--- a/tests/reef_service/test_error_translation.py
+++ b/tests/reef_service/test_error_translation.py
@@ -1,0 +1,121 @@
+"""The error-to-status table is the service's whole error contract.
+
+Every route raises domain errors and lets ``translate_errors`` answer, so the
+table in ``reef/service/errors.py`` decides what a client sees. Two properties
+carry the contract and neither is visible from a single route test: the table's
+most-specific-first ordering (a subclass must not inherit its base's status),
+and the upstream relay, which passes a provider's own 4xx through so an agent
+can repair the next attempt but refuses to blame the caller for a 5xx.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from reef.artifact.artifact import ArtifactConflict, ArtifactNotFound, ArtifactSourceError
+from reef.artifact.release_chain import ReleaseNotRestorable
+from reef.core.errors import ReefError, UnknownScenario
+from reef.records import RecordConflict
+from reef.runtime.inference import UpstreamStatusError
+from reef.service.errors import translate_error, translate_errors
+from reef.service.request_service import InferenceRetryTimeout
+from reef.surface.weights import RuntimeLoadMismatch
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("error", "status"),
+    [
+        # ArtifactNotFound and ArtifactConflict precede ArtifactError: a
+        # missing or conflicting artifact is the caller's answer, not the
+        # 503 that its base class reports for unreachable storage.
+        (ArtifactNotFound("no such artifact"), 404),
+        (ArtifactConflict("artifact moved under you"), 409),
+        (ArtifactSourceError("source unreachable"), 503),
+        (UnknownScenario("no such scenario"), 404),
+        (ReleaseNotRestorable("release has no durable bytes"), 409),
+        (RecordConflict("record id already used"), 409),
+        (RuntimeLoadMismatch("engine served other weights"), 409),
+        (InferenceRetryTimeout("retries exhausted"), 503),
+        (ReefError("generic reef failure"), 400),
+        (ValueError("bad field"), 400),
+    ],
+)
+def test_domain_errors_translate_to_their_status(error: Exception, status: int) -> None:
+    translated = translate_error(error)
+
+    assert translated is not None, type(error).__name__
+    assert translated.status == status
+    # The message travels: agents read these bodies to repair the next attempt.
+    assert str(error) in translated.text
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("upstream_status", "status"),
+    [
+        (400, 400),
+        (401, 401),
+        (403, 403),
+        (404, 404),
+        (408, 408),
+        (409, 409),
+        (422, 422),
+        (429, 429),
+        # 413's aiohttp class needs a max_size argument, so it is deliberately
+        # absent from the relay table and falls back to 400 rather than crash.
+        (413, 400),
+        (451, 400),
+        # The upstream's own fault, not the caller's request.
+        (500, 502),
+        (503, 502),
+    ],
+)
+def test_upstream_statuses_relay_or_become_a_bad_gateway(upstream_status: int, status: int) -> None:
+    error = UpstreamStatusError(f"upstream said {upstream_status}", status=upstream_status)
+
+    translated = translate_error(error)
+
+    assert translated is not None
+    assert translated.status == status
+    assert str(error) in translated.text
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("error", [RuntimeError("boom"), KeyError("missing"), TypeError("wrong type")])
+def test_unmapped_errors_stay_untranslated(error: Exception) -> None:
+    assert translate_error(error) is None
+
+
+@pytest.mark.unit
+def test_middleware_answers_mapped_errors_and_lets_the_rest_become_a_500() -> None:
+    async def run() -> None:
+        app = web.Application(middlewares=[translate_errors])
+
+        async def conflict(request: web.Request) -> web.Response:
+            raise RecordConflict("record id already used")
+
+        async def unmapped(request: web.Request) -> web.Response:
+            raise RuntimeError("boom")
+
+        app.router.add_get("/conflict", conflict)
+        app.router.add_get("/unmapped", unmapped)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        try:
+            answered = await client.get("/conflict")
+            assert answered.status == 409
+            assert "record id already used" in await answered.text()
+
+            # An unmapped error is a bug, not a client-facing contract: it
+            # stays a 500 and never leaks a translated status.
+            crashed = await client.get("/unmapped")
+            assert crashed.status == 500
+        finally:
+            await client.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Motivation

Five small gaps found in one pass over the repository. None changes behavior;
each is either documentation that has drifted from the code, a stated contract
that is not held, or a contract with no test.

## Changes

- **The promote route was missing from the HTTP API routes table.** The table
  indexed 15 of the 16 registered routes; `POST /reef/scenarios/{scenario}/promote`
  appeared only in the prose of "Review before serving". That prose is also why
  `check-doc-contracts.mjs` missed it — the check searched the whole page, so one
  mention anywhere satisfied it. The check is now scoped to the Routes table.
- **`reef --version` and the coverage gate were undocumented.** The CLI has
  answered `-V/--version` since the initial import and its own help text lists it,
  but `docs/reference/cli.rst` did not. `docs/contributing/testing.rst` never
  mentioned coverage even though `[tool.coverage.report] fail_under` is a gate.
- **The ruff pin disagreed with itself.** The `dev` extra pinned `ruff==0.16.5`
  while the pre-commit rev — what CI lint actually runs — was `v0.14.7`, against
  the extra's own comment that its lint tool versions track the pre-commit revs.
  It now follows the pre-commit rev. `pytest-cov` was also missing from the extra
  although CI measures coverage with it.
- **`is_local_path` had no callers** anywhere in the repository while
  `resolve_hf_snapshot` re-implemented it inline.
- **The error-to-status table had no direct test.** Two properties carry the
  service's error contract and neither is visible from a single route test: the
  table's most-specific-first ordering, where a subclass must not inherit its
  base's status, and the upstream relay, which passes a provider's own 4xx
  through but answers 502 for a 5xx. The only existing coverage was one indirect
  502 assertion.

## Compatibility and operational impact

None. No public interface, wire contract, configuration, or persisted format
changes. The `dev` extra moves ruff from 0.16.5 to the 0.14.7 that CI already
enforces, and adds `pytest-cov`.

## Verification

- `pytest tests/reef_service` → 1261 passed, 12 skipped. 8 modules fail to
  collect locally for missing `ray`/`slime` and an uninitialised
  `third_party/reef-client`; unrelated to this branch and unchanged by it.
- `mypy` → `Success: no issues found in 180 source files`.
- `ruff check` (0.14.7), `black --check` (24.3.0), `isort --check-only` → clean.
- `check_python_design.py`, `check_python_statements.py`,
  `check_community_files.py` → all pass.
- The new tests were mutation-checked: moving `ArtifactNotFound` after
  `ArtifactError` in the table fails `test_domain_errors_translate_to_their_status[error0-404]`.
- `check-doc-contracts.mjs` could not be executed (no node available locally).
  Its regex and comparison were ported to Python and run against the real files:
  all 16 routes are found in the table; deleting the new promote row reproduces
  `missing POST /reef/scenarios/{scenario}/promote`; the extracted section stops
  before the `Headers` heading. **Worth confirming under the real script in CI.**
- The claim that pytest-cov enforces `fail_under` without `--cov-fail-under` was
  verified on a scratch project, not assumed: it exits 1.

## AI assistance

Claude Code (Opus 5) reviewed the repository for these gaps, wrote the diff and
the tests, and ran every check listed above. Reviewed before submission.

## Checklist

- [ ] The change is focused and contains no unrelated cleanup. — **Not ticked:**
      this bundles five independent fixes, one per commit. Say the word and I will
      split it into separate pull requests.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
