### PR TITLE
perf(training): sample the frozen-base checksum instead of hashing it every publication

### DIFF
--- a/reef/train/slime_backend/reef_adapters/megatron/lora.py
+++ b/reef/train/slime_backend/reef_adapters/megatron/lora.py
@@ -21,6 +21,11 @@ _MEGATRON_TO_HF_TARGETS = {
 }
 _DEFAULT_MEGATRON_TARGETS = tuple(_MEGATRON_TO_HF_TARGETS)
 
+#: Publications between frozen-base checksum verifications. The base is frozen
+#: for the life of the run, so a fault that corrupts it is still observable at
+#: the next sampled publication.
+DEFAULT_BASE_CHECKSUM_INTERVAL = 16
+
 
 def validate_megatron_lora_args(args: Namespace) -> None:
     """Normalize and validate Slime's optional Megatron LoRA configuration."""
@@ -57,6 +62,30 @@ def validate_megatron_lora_args(args: Namespace) -> None:
     slots = getattr(args, "max_loaded_loras", None)
     if slots is not None and int(slots) < 1:
         raise ValueError("--max-loaded-loras must be at least 1")
+    interval = getattr(args, "verify_lora_base_weights_interval", None)
+    if interval is not None and int(interval) < 1:
+        raise ValueError("--verify-lora-base-weights-interval must be at least 1")
+
+
+def base_checksum_verification_due(args: Namespace, publication_sequence: int) -> bool:
+    """Whether publication ``publication_sequence`` re-verifies the frozen base.
+
+    The guard exists to catch an engine or transport fault that writes into
+    the base weights SGLang holds, and it pays for that with two full-model
+    checksums per publication, both inside the window where generation is
+    paused. Those weights never change, so a corruption is still there at the
+    next sampled publication: verifying every
+    ``--verify-lora-base-weights-interval``-th publication keeps the guard and
+    takes its cost off the other steps. The first publication always verifies,
+    so a deployment that is broken from the start fails immediately.
+    """
+
+    if not getattr(args, "verify_lora_base_weights", False):
+        return False
+    interval = int(getattr(args, "verify_lora_base_weights_interval", 1))
+    if interval <= 1:
+        return True
+    return (publication_sequence - 1) % interval == 0
 
 
 def lora_engine_slots(args: Namespace) -> int:

--- a/reef/train/slime_backend/reef_adapters/slime_arguments.py
+++ b/reef/train/slime_backend/reef_adapters/slime_arguments.py
@@ -7,7 +7,10 @@ from collections.abc import Sequence
 from typing import Any
 
 from reef.train.slime_backend.loss_families import LOSS_FAMILIES
-from reef.train.slime_backend.reef_adapters.megatron.lora import validate_megatron_lora_args
+from reef.train.slime_backend.reef_adapters.megatron.lora import (
+    DEFAULT_BASE_CHECKSUM_INTERVAL,
+    validate_megatron_lora_args,
+)
 
 REEF_MEGATRON_INIT_PATH = "reef.train.slime_backend.reef_adapters.worker_hooks.initialize_megatron_objective"
 REEF_MODEL_PROVIDER_PATH = "reef.train.slime_backend.reef_adapters.megatron.model_provider.provide_actor_model"
@@ -33,6 +36,15 @@ def add_reef_slime_arguments(parser: argparse.ArgumentParser) -> argparse.Argume
     )
     parser.add_argument("--check-lora-weight-equal", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--verify-lora-base-weights", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--verify-lora-base-weights-interval",
+        type=int,
+        default=DEFAULT_BASE_CHECKSUM_INTERVAL,
+        help=(
+            "Publications between frozen-base checksum verifications; 1 verifies every publication. "
+            "Each verification hashes the engine's whole base model twice while generation is paused."
+        ),
+    )
     parser.add_argument(
         "--critic-steps-per-actor",
         type=int,

--- a/reef/train/slime_backend/reef_adapters/weight_updaters/colocated.py
+++ b/reef/train/slime_backend/reef_adapters/weight_updaters/colocated.py
@@ -21,6 +21,7 @@ from tqdm import tqdm
 
 from reef.train.slime_backend.reef_adapters.megatron.hf_export import MegatronToHfWeightIterator
 from reef.train.slime_backend.reef_adapters.megatron.lora import (
+    base_checksum_verification_due,
     build_sglang_lora_config,
     is_lora_weight_name,
     lora_engine_identity,
@@ -123,7 +124,7 @@ class ReefUpdateWeightFromTensor(SynchronizedWeightUpdateMixin, UpdateWeightFrom
             ray.get([engine.flush_cache.remote() for engine in serving_engines])
 
         if self.rank == 0:
-            if self.is_lora and getattr(self.args, "verify_lora_base_weights", False):
+            if self.is_lora and base_checksum_verification_due(self.args, self.weight_update_sequence):
                 self._capture_or_verify_base_checksums("before adapter publication")
             elif self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
                 post_process_weights(
@@ -196,7 +197,7 @@ class ReefUpdateWeightFromTensor(SynchronizedWeightUpdateMixin, UpdateWeightFrom
         dist.barrier(group=get_gloo_group())
         if self.rank == 0:
             if self.is_lora:
-                if getattr(self.args, "verify_lora_base_weights", False):
+                if base_checksum_verification_due(self.args, self.weight_update_sequence):
                     self._capture_or_verify_base_checksums("after adapter publication")
                 ray.get([engine.set_runtime_load_id.remote(str(self.runtime_load_id)) for engine in serving_engines])
             elif self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:

--- a/reef/train/slime_backend/reef_adapters/weight_updaters/distributed.py
+++ b/reef/train/slime_backend/reef_adapters/weight_updaters/distributed.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 
 from reef.train.slime_backend.reef_adapters.megatron.hf_export import MegatronToHfWeightIterator
 from reef.train.slime_backend.reef_adapters.megatron.lora import (
+    base_checksum_verification_due,
     build_sglang_lora_config,
     is_lora_weight_name,
     megatron_lora_enabled,
@@ -146,7 +147,7 @@ class ReefUpdateWeightFromDistributed(SynchronizedWeightUpdateMixin, UpdateWeigh
                 lambda: ray.get([engine.flush_cache.remote() for engine in self.rollout_engines]),
                 phase="flush rollout cache",
             )
-        if getattr(self.args, "verify_lora_base_weights", False):
+        if base_checksum_verification_due(self.args, self.weight_update_sequence):
             self._run_rank_zero_action(
                 lambda: self._capture_or_verify_base_checksums("before adapter publication"),
                 phase="verify frozen base before adapter publication",
@@ -185,7 +186,7 @@ class ReefUpdateWeightFromDistributed(SynchronizedWeightUpdateMixin, UpdateWeigh
             publication_error = exc
         self._raise_synchronized_update_error(publication_error, phase="distributed LoRA publication")
 
-        if getattr(self.args, "verify_lora_base_weights", False):
+        if base_checksum_verification_due(self.args, self.weight_update_sequence):
             self._run_rank_zero_action(
                 lambda: self._capture_or_verify_base_checksums("after adapter publication"),
                 phase="verify frozen base after adapter publication",

--- a/tests/slime_backend/test_megatron_lora.py
+++ b/tests/slime_backend/test_megatron_lora.py
@@ -14,6 +14,7 @@ torch = pytest.importorskip("torch")
 
 from reef.train.slime_backend.reef_adapters.megatron.lora import (
     apply_megatron_lora,
+    base_checksum_verification_due,
     build_sglang_lora_config,
     collect_lora_train_metrics,
     is_lora_weight_name,
@@ -161,6 +162,7 @@ def test_sglang_adapter_config_matches_bridge_default_targets() -> None:
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
+        ({"verify_lora_base_weights_interval": 0}, "at least 1"),
         ({"megatron_lora_rank": -1}, "non-negative"),
         ({"megatron_lora_dropout": 1.0}, r"\[0, 1\)"),
         ({"megatron_to_hf_mode": "raw"}, "bridge"),
@@ -172,6 +174,24 @@ def test_sglang_adapter_config_matches_bridge_default_targets() -> None:
 def test_validate_megatron_lora_rejects_incompatible_settings(overrides, message) -> None:
     with pytest.raises(ValueError, match=message):
         validate_megatron_lora_args(_args(**overrides))
+
+
+def test_frozen_base_verification_samples_publications() -> None:
+    args = _args(verify_lora_base_weights=True, verify_lora_base_weights_interval=16)
+
+    verified = [sequence for sequence in range(1, 34) if base_checksum_verification_due(args, sequence)]
+
+    assert verified == [1, 17, 33], "the first publication and every interval-th one after it"
+
+
+def test_frozen_base_verification_honors_the_boolean_guard() -> None:
+    every = _args(verify_lora_base_weights=True, verify_lora_base_weights_interval=1)
+    disabled = _args(verify_lora_base_weights=False, verify_lora_base_weights_interval=1)
+    unset = _args(verify_lora_base_weights=True)
+
+    assert all(base_checksum_verification_due(every, sequence) for sequence in range(1, 5))
+    assert not any(base_checksum_verification_due(disabled, sequence) for sequence in range(1, 5))
+    assert all(base_checksum_verification_due(unset, sequence) for sequence in range(1, 5))
 
 
 def test_apply_megatron_lora_freezes_base_and_reports_adapter_update() -> None:
@@ -492,6 +512,8 @@ def test_disjoint_updater_publishes_lora_through_distributed_receiver(monkeypatc
     updater._lora_config = {"r": 1}
     updater.runtime_load_id = "deployment:3"
     updater._base_checksums = None
+    # ``update_weights`` stamps the publication sequence before delegating here.
+    updater.weight_update_sequence = 1
     updater.tie_word_embeddings = False
     updater.active_scenario = "math"
 


### PR DESCRIPTION
## Motivation

Colocated training holds generation paused for the whole train → checkpoint →
publish window, so every second spent there is serving downtime. Inside that
window each LoRA publication asks every SGLang engine to checksum its **whole
base model twice** — once before the adapter load and once after
(`_capture_or_verify_base_checksums`). Those weights are frozen for the life of
the run: nothing in a publication is supposed to touch them, and a fault that
does write into them is still observable at the next publication that looks.

## Changes

- Add `base_checksum_verification_due(args, publication_sequence)` next to the
  other LoRA policy helpers, and gate both the "before" and the "after"
  checksum on it in the colocated and the distributed updater.
- Add `--verify-lora-base-weights-interval` (default 16), validated as `>= 1`
  by `validate_megatron_lora_args`.
- Publication 1 always verifies, so a deployment that is broken from the start
  still fails on its first publication. Both sites share the predicate, so a
  sampled publication always verifies as a before/after pair and the captured
  baseline stays comparable.

## Compatibility and operational impact

- New optional driver flag; no wire, persisted-format, or API change.
- Default behavior changes: the guard samples instead of running on every
  publication. `--verify-lora-base-weights-interval=1` restores the previous
  behavior and `--no-verify-lora-base-weights` still disables the guard.
- Cost removed per publication: two `weights_checker` round trips per engine.
  SGLang hashes on the GPU (`gpu_tensor_hash`, a Triton kernel plus a tree
  reduce and one `.item()` sync per tensor), so a call costs about one
  full-model HBM read plus a few hundred device syncs, not a host copy — order
  tens of milliseconds for an 8B bf16 model rather than seconds. This is a
  "stop paying for it every step" change, not a large win; the scheduler is
  also blocked for the duration, which matters more on a paused colocated
  engine than the wall time does.

## Verification

Run on macOS/CPU, where `slime`, Megatron, and CUDA are not installed:

- `pytest tests/slime_backend/test_megatron_lora.py tests/slime_backend/test_adapter_slots.py`
  → 31 passed, 2 skipped (2 new tests for the predicate, 1 new rejection case;
  the distributed-updater fixture now sets `weight_update_sequence`, which
  `update_weights` stamps in production).
- `pytest tests/reef_service --ignore=tests/reef_service/test_slime_bridge.py`
  → 1360 passed, 12 failed, 4 skipped — the 12 failures are
  `ModuleNotFoundError: No module named 'slime'` and are identical on `main`.
- `pre-commit run --all-files` → all hooks pass.
- `python -m mypy` → 4 errors in `weight_updaters/lora_transport.py` and
  `weight_updaters/checkpoint.py`, all from local torch stubs and identical on
  `main`.

No GPU run. The saving is argued from the code path, not measured. SGLang
reports the real per-call number itself — `[WeightChecker] checksum computed
for N tensors in X.XXXs` — so a deployment log gives the exact figure this PR
removes from all but every 16th publication.

## AI assistance

Claude Code (Opus 5) surveyed the colocated publication path, drafted this
change and its tests, and ran the checks reported above.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
