### PR TITLE
perf(training): sample the adapter checksum verification

### DIFF
--- a/reef/train/slime_backend/reef_adapters/megatron/lora.py
+++ b/reef/train/slime_backend/reef_adapters/megatron/lora.py
@@ -21,6 +21,11 @@ _MEGATRON_TO_HF_TARGETS = {
 }
 _DEFAULT_MEGATRON_TARGETS = tuple(_MEGATRON_TO_HF_TARGETS)
 
+#: Publications between adapter checksum verifications. Unlike the frozen
+#: base, this guard covers the bytes one publication moves, so it samples
+#: tightly: a skipped publication is one whose transport went unchecked.
+DEFAULT_ADAPTER_CHECKSUM_INTERVAL = 4
+
 
 def validate_megatron_lora_args(args: Namespace) -> None:
     """Normalize and validate Slime's optional Megatron LoRA configuration."""
@@ -57,6 +62,29 @@ def validate_megatron_lora_args(args: Namespace) -> None:
     slots = getattr(args, "max_loaded_loras", None)
     if slots is not None and int(slots) < 1:
         raise ValueError("--max-loaded-loras must be at least 1")
+    interval = getattr(args, "check_lora_weight_equal_interval", None)
+    if interval is not None and int(interval) < 1:
+        raise ValueError("--check-lora-weight-equal-interval must be at least 1")
+
+
+def adapter_checksum_verification_due(args: Namespace, publication_sequence: int) -> bool:
+    """Whether publication ``publication_sequence`` checksums its adapter tensors.
+
+    The guard hashes every adapter tensor on the host, compares the digest
+    across data-parallel replicas, and hands the per-tensor checksums to
+    SGLang so the engine can verify what it received. All of that runs with
+    generation paused. It covers the bytes this publication moves, so unlike
+    the frozen-base guard it cannot be recovered by a later check: sampling
+    it trades a bounded number of unverified publications for the cost.
+    Publication 1 always verifies.
+    """
+
+    if not getattr(args, "check_lora_weight_equal", False):
+        return False
+    interval = int(getattr(args, "check_lora_weight_equal_interval", 1))
+    if interval <= 1:
+        return True
+    return (publication_sequence - 1) % interval == 0
 
 
 def lora_engine_slots(args: Namespace) -> int:

--- a/reef/train/slime_backend/reef_adapters/slime_arguments.py
+++ b/reef/train/slime_backend/reef_adapters/slime_arguments.py
@@ -7,7 +7,10 @@ from collections.abc import Sequence
 from typing import Any
 
 from reef.train.slime_backend.loss_families import LOSS_FAMILIES
-from reef.train.slime_backend.reef_adapters.megatron.lora import validate_megatron_lora_args
+from reef.train.slime_backend.reef_adapters.megatron.lora import (
+    DEFAULT_ADAPTER_CHECKSUM_INTERVAL,
+    validate_megatron_lora_args,
+)
 
 REEF_MEGATRON_INIT_PATH = "reef.train.slime_backend.reef_adapters.worker_hooks.initialize_megatron_objective"
 REEF_MODEL_PROVIDER_PATH = "reef.train.slime_backend.reef_adapters.megatron.model_provider.provide_actor_model"
@@ -32,6 +35,16 @@ def add_reef_slime_arguments(parser: argparse.ArgumentParser) -> argparse.Argume
         help="Adapter slots the SGLang engine keeps loaded on the shared base model (>= 1).",
     )
     parser.add_argument("--check-lora-weight-equal", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--check-lora-weight-equal-interval",
+        type=int,
+        default=DEFAULT_ADAPTER_CHECKSUM_INTERVAL,
+        help=(
+            "Publications between adapter checksum verifications; 1 verifies every publication. "
+            "Each verification hashes the adapter on the host and re-hashes it inside SGLang "
+            "while generation is paused."
+        ),
+    )
     parser.add_argument("--verify-lora-base-weights", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument(
         "--critic-steps-per-actor",

--- a/reef/train/slime_backend/reef_adapters/weight_updaters/colocated.py
+++ b/reef/train/slime_backend/reef_adapters/weight_updaters/colocated.py
@@ -21,6 +21,7 @@ from tqdm import tqdm
 
 from reef.train.slime_backend.reef_adapters.megatron.hf_export import MegatronToHfWeightIterator
 from reef.train.slime_backend.reef_adapters.megatron.lora import (
+    adapter_checksum_verification_due,
     build_sglang_lora_config,
     is_lora_weight_name,
     lora_engine_identity,
@@ -90,6 +91,8 @@ class ReefUpdateWeightFromTensor(SynchronizedWeightUpdateMixin, UpdateWeightFrom
             raise RuntimeError("adapter publication requires a LoRA-enabled actor")
         adapter_tensors = self.export_lora_adapter_tensors(self.weights_getter())
         expected_checksums = None
+        # Restart republication runs once per scenario, not once per
+        # training step, so it always verifies rather than sampling.
         if getattr(self.args, "check_lora_weight_equal", False):
             expected_checksums = tensor_checksums(adapter_tensors)
             verify_replica_adapter_checksums(expected_checksums)
@@ -147,7 +150,7 @@ class ReefUpdateWeightFromTensor(SynchronizedWeightUpdateMixin, UpdateWeightFrom
             checksum_error: BaseException | None = None
             expected_checksums = None
             try:
-                if getattr(self.args, "check_lora_weight_equal", False):
+                if adapter_checksum_verification_due(self.args, self.weight_update_sequence):
                     expected_checksums = tensor_checksums(adapter_tensors)
                     verify_replica_adapter_checksums(expected_checksums)
             except BaseException as exc:

--- a/reef/train/slime_backend/reef_adapters/weight_updaters/distributed.py
+++ b/reef/train/slime_backend/reef_adapters/weight_updaters/distributed.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 
 from reef.train.slime_backend.reef_adapters.megatron.hf_export import MegatronToHfWeightIterator
 from reef.train.slime_backend.reef_adapters.megatron.lora import (
+    adapter_checksum_verification_due,
     build_sglang_lora_config,
     is_lora_weight_name,
     megatron_lora_enabled,
@@ -74,6 +75,8 @@ class ReefUpdateWeightFromDistributed(SynchronizedWeightUpdateMixin, UpdateWeigh
             raise RuntimeError("adapter publication requires a LoRA-enabled actor")
         self._reset_source_phases()
         adapter_tensors = self.export_lora_adapter_tensors()
+        # Restart republication runs once per scenario, not once per
+        # training step, so it always verifies rather than sampling.
         if getattr(self.args, "check_lora_weight_equal", False):
             verify_replica_adapter_checksums(tensor_checksums(adapter_tensors))
         publication_error: BaseException | None = None
@@ -162,7 +165,7 @@ class ReefUpdateWeightFromDistributed(SynchronizedWeightUpdateMixin, UpdateWeigh
 
         checksum_error: BaseException | None = None
         try:
-            if getattr(self.args, "check_lora_weight_equal", False):
+            if adapter_checksum_verification_due(self.args, self.weight_update_sequence):
                 verify_replica_adapter_checksums(tensor_checksums(adapter_tensors))
         except BaseException as exc:
             checksum_error = exc

--- a/tests/slime_backend/test_megatron_lora.py
+++ b/tests/slime_backend/test_megatron_lora.py
@@ -13,6 +13,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from reef.train.slime_backend.reef_adapters.megatron.lora import (
+    adapter_checksum_verification_due,
     apply_megatron_lora,
     build_sglang_lora_config,
     collect_lora_train_metrics,
@@ -161,6 +162,7 @@ def test_sglang_adapter_config_matches_bridge_default_targets() -> None:
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
+        ({"check_lora_weight_equal_interval": 0}, "at least 1"),
         ({"megatron_lora_rank": -1}, "non-negative"),
         ({"megatron_lora_dropout": 1.0}, r"\[0, 1\)"),
         ({"megatron_to_hf_mode": "raw"}, "bridge"),
@@ -172,6 +174,24 @@ def test_sglang_adapter_config_matches_bridge_default_targets() -> None:
 def test_validate_megatron_lora_rejects_incompatible_settings(overrides, message) -> None:
     with pytest.raises(ValueError, match=message):
         validate_megatron_lora_args(_args(**overrides))
+
+
+def test_adapter_checksum_verification_samples_publications() -> None:
+    args = _args(check_lora_weight_equal=True, check_lora_weight_equal_interval=4)
+
+    verified = [sequence for sequence in range(1, 11) if adapter_checksum_verification_due(args, sequence)]
+
+    assert verified == [1, 5, 9], "the first publication and every interval-th one after it"
+
+
+def test_adapter_checksum_verification_honors_the_boolean_guard() -> None:
+    every = _args(check_lora_weight_equal=True, check_lora_weight_equal_interval=1)
+    disabled = _args(check_lora_weight_equal=False, check_lora_weight_equal_interval=1)
+    unset = _args(check_lora_weight_equal=True)
+
+    assert all(adapter_checksum_verification_due(every, sequence) for sequence in range(1, 5))
+    assert not any(adapter_checksum_verification_due(disabled, sequence) for sequence in range(1, 5))
+    assert all(adapter_checksum_verification_due(unset, sequence) for sequence in range(1, 5))
 
 
 def test_apply_megatron_lora_freezes_base_and_reports_adapter_update() -> None:
@@ -492,6 +512,8 @@ def test_disjoint_updater_publishes_lora_through_distributed_receiver(monkeypatc
     updater._lora_config = {"r": 1}
     updater.runtime_load_id = "deployment:3"
     updater._base_checksums = None
+    # ``update_weights`` stamps the publication sequence before delegating here.
+    updater.weight_update_sequence = 1
     updater.tie_word_embeddings = False
     updater.active_scenario = "math"
 


### PR DESCRIPTION
## Motivation

Every LoRA publication runs with generation paused, and inside that window it
hashes each adapter tensor on the host (`tensor_checksums`, a per-tensor D2H
copy plus SHA-256 in a Python loop), compares the digest across data-parallel
replicas, and hands the per-tensor checksums to SGLang so the engine re-hashes
what it received.

Unlike the frozen-base guard, this one covers the bytes that *this*
publication moves, so a skipped verification is not recovered later. That
argues for sampling it much more tightly rather than not sampling it at all.

## Changes

- Add `adapter_checksum_verification_due(args, publication_sequence)` and gate
  the per-publication checksum on it in the colocated and the distributed
  updater.
- Add `--check-lora-weight-equal-interval` (default 4), validated as `>= 1`.
  Publication 1 always verifies.
- Restart republication (`publish_lora_adapter`) is deliberately never
  sampled: it runs once per scenario rather than once per training step, so
  verifying it costs nothing per step. The comment says so at both sites.

## Compatibility and operational impact

- New optional driver flag; no wire, persisted-format, or API change.
- Default behavior changes: 3 of every 4 publications no longer hash the
  adapter, compare replicas, or send `expected_checksums` to SGLang. A silent
  transport corruption in one of those publications would reach serving and
  stay until a later gate or checksum catches it — that is the trade this PR
  makes, and `--check-lora-weight-equal-interval=1` declines it.
  `--no-check-lora-weight-equal` still disables the guard entirely.
- The interval default (4) is deliberately much tighter than the frozen-base
  interval (16, #196): the base cannot change, this can.

## Verification

Run on macOS/CPU, where `slime`, Megatron, and CUDA are not installed:

- `pytest tests/slime_backend/test_megatron_lora.py tests/slime_backend/test_adapter_slots.py`
  → 31 passed, 2 skipped (2 new tests for the predicate, 1 new rejection case;
  the distributed-updater fixture now sets `weight_update_sequence`, which
  `update_weights` stamps in production).
- `pytest tests/slime_backend` (excluding the two modules that import `slime`
  at module scope) → 100 passed, 2 skipped, 25 failed; the failures are
  `ModuleNotFoundError: No module named 'slime'` and are identical on `main`.
- `pre-commit run --all-files` → all hooks pass.
- `python -m mypy` → 4 errors from local torch stubs, identical on `main`.

No GPU run: the saving is argued from the code path, not measured.

## AI assistance

Claude Code (Opus 5) surveyed the colocated publication path, drafted this
change and its tests, and ran the checks reported above.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
