### PR TITLE
perf(training): persist the adapter slot without capturing it twice

### DIFF
--- a/reef/train/slime_backend/reef_adapters/megatron/train_actor.py
+++ b/reef/train/slime_backend/reef_adapters/megatron/train_actor.py
@@ -273,7 +273,11 @@ class ReefMegatronTrainRayActor(MegatronTrainRayActor):
             if slots is not None and slots.active is not None:
                 # The Megatron checkpoint above holds only the active slot;
                 # every scenario's state must survive a restart on its own.
-                slots.capture(slots.active)
+                # The slot and its snapshot already agree: training captures
+                # the slot on its way out and ``restore`` records whatever it
+                # put back, so re-capturing here would copy the whole adapter
+                # and optimizer shard to the host a second time inside the
+                # window where serving is paused.
                 slots.persist(slots.active)
                 dist.barrier(group=get_gloo_group())
         finally:

--- a/tests/slime_backend/test_adapter_slots.py
+++ b/tests/slime_backend/test_adapter_slots.py
@@ -115,6 +115,30 @@ def test_persisted_snapshots_survive_a_restart(tmp_path: Path) -> None:
     assert all(p in fresh_optimizer.optimizer.state for p in fresh_optimizer.main)
 
 
+def test_persist_after_restore_writes_the_slot_without_recapture(tmp_path: Path) -> None:
+    """A save can persist the active scenario without capturing it again.
+
+    The training actor relies on this: ``train_actor`` captures the slot on
+    its way out and ``restore`` records what it put back, so the snapshot the
+    switcher holds for the active scenario is already the slot's state.
+    """
+    model, optimizer, scheduler, slots = _build(tmp_path)
+    slots.restore("math")
+    _train_step(model, optimizer, scheduler)
+    slots.capture("math")
+    trained = _adapter_values(model)
+    assert slots.restore("code") is False, "the slot moves to another scenario"
+    assert slots.restore("math") is True
+
+    slots.persist("math")
+
+    fresh_model, _, fresh_scheduler, fresh_slots = _build(tmp_path)
+    assert fresh_slots.restore("math") is True
+    for got, want in zip(_adapter_values(fresh_model), trained, strict=True):
+        assert torch.equal(got, want)
+    assert fresh_scheduler.num_steps == 1
+
+
 def test_snapshot_layout_mismatch_fails_closed(tmp_path: Path) -> None:
     _, _, _, slots = _build(tmp_path)
     slots.restore("a")


### PR DESCRIPTION
## Motivation

`_save_lora_model` captured the active scenario's adapter slot and then
persisted it. The capture is redundant. `AdapterSlotSwitcher` keeps its
snapshot in step with the slot on every path that reaches a save:
`train_actor` captures the slot after the optimizer step, and `restore`
records whatever it just put back (including the pristine adapter for a
first-time scenario). So `_snapshots[active]` already *is* the slot when the
save runs.

What the extra capture cost was a second host-side copy of the whole adapter,
this rank's fp32 main parameters, and its Adam moments — inside the window
where colocated serving is paused.

## Changes

- Persist the recorded snapshot directly instead of re-capturing first.
- State the invariant the removal rests on in the comment, since it is a
  property of the two callers rather than of `persist` itself.
- Add a test that a scenario can be persisted after a `restore` with no
  capture in between and still round-trips exactly — the property that
  removing the capture depends on.

## Compatibility and operational impact

None. No interface, wire, or persisted-format change; the file written is the
same bytes as before.

## Verification

Run on macOS/CPU, where `slime`, Megatron, and CUDA are not installed:

- `pytest tests/slime_backend/test_adapter_slots.py` → 7 passed (1 new).
- `pytest tests/slime_backend/test_megatron_lora.py tests/slime_backend/test_adapter_slots.py`
  → 29 passed, 2 skipped.
- `pre-commit run --all-files` → all hooks pass.
- `python -m mypy` → 4 errors from local torch stubs, identical on `main`.

`train_actor.py` itself has no CPU test coverage (it imports `slime` and
Megatron and is in the coverage `omit` list), so the invariant is covered at
the `AdapterSlotSwitcher` level.

## AI assistance

Claude Code (Opus 5) found the duplicate capture while reading the colocated
training step, drafted this change and its test, and ran the checks above.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
