### PR TITLE
perf(service): resume serving on the durable commit, not on the telemetry round trip

### DIFF
--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -53,6 +53,14 @@ _UNDRAINED_WARNING_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
+class _CommittedStep:
+    """One durably committed training step, before its telemetry is recorded."""
+
+    context: TrainingExperimentContext
+    result: TrainStepResult
+
+
+@dataclass(frozen=True)
 class _LocalBackendWorkerState:
     ready: Event
     thread: Thread
@@ -264,12 +272,14 @@ class Dispatcher:
             # compaction, and moves the serving head — in that order, so a
             # crash in any gap is recovered by replaying the scenario's
             # commit log instead of silently losing the batch.
-            self._commit_result(current.name, result)
+            committed = self._commit_result(current.name, result)
+            self._record_committed_step(current.name, committed)
         return stored
 
     # -- Commit & publication --------------------------------------------
 
-    def _commit_result(self, scenario: str, result: TrainStepResult) -> None:
+    def _commit_result(self, scenario: str, result: TrainStepResult) -> _CommittedStep:
+        """Commit one training result durably and move the scenario's head."""
         current = self._registry.get(scenario)
         context = self._experiment_context(current)
         tracked_result = result
@@ -282,17 +292,23 @@ class Dispatcher:
 
         value = current.commit(tracked_result)
         self._publication.record(scenario, value)
+        return _CommittedStep(context=context, result=tracked_result)
+
+    def _record_committed_step(self, scenario: str, committed: _CommittedStep) -> None:
+        """Report a committed step to the experiment tracker; never fatal."""
+        current = self._registry.get(scenario)
+        result = committed.result
         try:
             self._experiment_tracker.record(
                 TrainingExperimentEvent(
-                    context=context,
+                    context=committed.context,
                     produced_artifact_ref=current.current_artifact_ref(),
-                    metrics=dict(tracked_result.metrics),
-                    outcome="rejected" if tracked_result.metrics.get("selected") is False else "committed",
-                    training_job_id=tracked_result.training_job_id,
-                    source_runtime_load_id=tracked_result.source_runtime_load_id,
-                    produced_runtime_load_id=tracked_result.runtime_load_id,
-                    checkpoint_path=tracked_result.checkpoint_path,
+                    metrics=dict(result.metrics),
+                    outcome="rejected" if result.metrics.get("selected") is False else "committed",
+                    training_job_id=result.training_job_id,
+                    source_runtime_load_id=result.source_runtime_load_id,
+                    produced_runtime_load_id=result.runtime_load_id,
+                    checkpoint_path=result.checkpoint_path,
                 )
             )
         except Exception:
@@ -424,13 +440,14 @@ class Dispatcher:
             if self._registry.get_optional(scenario) is not current:
                 raise RuntimeContractError(f"local backend scenario {scenario!r} changed before commit")
             try:
-                self._commit_result(scenario, result)
+                committed = self._commit_result(scenario, result)
             except Exception:
                 # A record may already have crossed the fsync commit point.
                 # Reload before rollback or acceptance can observe the stale
                 # in-memory step and append the same step number again.
                 self._reload_durable_local_scenario(scenario, current)
                 raise
+            self._record_committed_step(scenario, committed)
         return True
 
     def _run_training(self) -> None:
@@ -556,9 +573,17 @@ class Dispatcher:
         result = execution.result
         if execution.outcome != "commit" or result is None:
             raise RuntimeContractError(f"training backend returned unsupported outcome: {execution.outcome!r}")
-        self._commit_result(current.name, result)
-        if result.training_job_id is not None:
-            backend.acknowledge_commit(current.scenario_step, result.training_job_id)
+        committed = self._commit_result(current.name, result)
+        # A colocated backend holds serving paused until the commit is
+        # acknowledged, so nothing that is not part of the durable commit
+        # belongs between the two. Experiment telemetry is best effort and
+        # can involve a provider round trip; record it once generation is
+        # free to resume, and still record it if the resume itself fails.
+        try:
+            if result.training_job_id is not None:
+                backend.acknowledge_commit(current.scenario_step, result.training_job_id)
+        finally:
+            self._record_committed_step(current.name, committed)
         return True
 
     def _record_training_error(self, scenario: str, value: str | None) -> None:

--- a/tests/reef_service/test_async_pipeline_core.py
+++ b/tests/reef_service/test_async_pipeline_core.py
@@ -160,6 +160,42 @@ class RecordingExperimentTracker:
         self.closed = True
 
 
+class CommitOrderRuntime(DurableRuntime):
+    """Records the moment Reef tells the runtime its commit is durable.
+
+    That call is what lets a colocated backend resume generation, so the
+    recorded order shows what Reef makes serving wait for.
+    """
+
+    def __init__(self, checkpoint_root: Path, *, order: list[tuple[str, str | None]], **options) -> None:
+        super().__init__(checkpoint_root, **options)
+        self.order = order
+
+    def reconcile_training_job(
+        self,
+        scenario_step,
+        *,
+        committed_training_job_id=None,
+        committed_training_without_job_id=False,
+        scenario=None,
+    ):
+        del scenario_step, committed_training_without_job_id, scenario
+        if committed_training_job_id is not None:
+            self.order.append(("acknowledged", committed_training_job_id))
+
+
+class CommitOrderExperimentTracker(RecordingExperimentTracker):
+    """A tracker that records when its provider round trip happened."""
+
+    def __init__(self, order: list[tuple[str, str | None]]) -> None:
+        super().__init__()
+        self.order = order
+
+    def record(self, event):
+        self.order.append(("recorded", event.training_job_id))
+        super().record(event)
+
+
 class RecordingExperimentLogger:
     def __init__(self) -> None:
         self.logged = []
@@ -172,10 +208,10 @@ class RecordingExperimentLogger:
 def start_dispatcher(tmp_path: Path):
     opened = []
 
-    def start(backend_type=None, *, experiment_tracker=None, **runtime_options):
+    def start(backend_type=None, *, experiment_tracker=None, runtime_type=DurableRuntime, **runtime_options):
         initial = tmp_path / "initial"
         initial.mkdir(exist_ok=True)
-        runtime = DurableRuntime(tmp_path / "checkpoints", **runtime_options)
+        runtime = runtime_type(tmp_path / "checkpoints", **runtime_options)
         factory = (backend_type or InMemoryRepositoryBackend).factory(initial, root=tmp_path / "repository")
         dispatcher = Dispatcher(
             TestPolicyRecipe(runtime, batch_size=1),
@@ -394,6 +430,29 @@ def test_experiment_provider_observes_the_generic_commit_boundary(start_dispatch
         ("recipe", {"batch_size": 1}),
         ("processor", {"accepted": 1}),
     ]
+
+
+@pytest.mark.unit
+def test_commit_is_acknowledged_before_experiment_telemetry(start_dispatcher) -> None:
+    order: list[tuple[str, str | None]] = []
+    tracker = CommitOrderExperimentTracker(order)
+    _, dispatcher = start_dispatcher(
+        experiment_tracker=tracker,
+        runtime_type=CommitOrderRuntime,
+        order=order,
+    )
+
+    _submit_pair(dispatcher)
+    _wait_for_step(dispatcher, 1)
+    deadline = time.monotonic() + _ASYNC_WAIT_TIMEOUT_S
+    while len(order) < 2 and time.monotonic() < deadline:
+        time.sleep(_ASYNC_WAIT_POLL_S)
+
+    assert order[:2] == [
+        ("acknowledged", "job-0"),
+        ("recorded", "job-0"),
+    ], "serving resumes on the durable commit, not on the telemetry round trip"
+    assert len(tracker.events) == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Motivation

A colocated backend keeps generation paused from the start of a training step
until Reef acknowledges the commit (`acknowledge_training_commit` is what
resumes it). Everything the dispatcher does between `scenario.commit` and
`backend.acknowledge_commit` is therefore added serving downtime.

Experiment telemetry sat in that gap. It is best effort — already wrapped so a
failure cannot fail training — and for a real provider it is a network round
trip. Nothing about it belongs inside the pause.

## Changes

- Split `_commit_result` into the durable commit (which now returns a
  `_CommittedStep`) and `_record_committed_step`, which reports it to the
  experiment tracker.
- In the training thread, acknowledge the commit first and record after, in a
  `finally` so a committed step is still reported when the acknowledgement
  itself fails.
- The two in-process callers (`_accept_record`, `_process_local_backend_step`)
  keep their previous ordering and locking; the record stays inside the
  scenario lock where it was.

## Compatibility and operational impact

- No interface, wire, or persisted-format change; both private methods.
- Observable ordering change: the tracker now sees a committed step after
  serving has been told to resume. Event contents are unchanged
  (`current_artifact_ref()` does not move between the two points).
- For a disjoint (non-colocated) deployment this is a no-op in effect —
  serving was never paused for the commit.

## Verification

- `pytest tests/reef_service/test_async_pipeline_core.py tests/reef_service/test_commit_log.py tests/reef_service/test_multi_scenario_training.py`
  → 39 passed, including the new
  `test_commit_is_acknowledged_before_experiment_telemetry`. Reverting only
  `reef/dispatcher.py` makes that test fail with
  `[('recorded', 'job-0'), ('acknowledged', 'job-0')]`, so it is testing the
  ordering and not itself.
- `pytest tests/reef_service --ignore=tests/reef_service/test_slime_bridge.py`
  → 1361 passed, 12 failed, 4 skipped; the failures are
  `ModuleNotFoundError: No module named 'slime'` on a macOS/CPU box and are
  identical on `main`.
- `pre-commit run --all-files` → all hooks pass.
- `python -m mypy` → 4 errors from local torch stubs, identical on `main`.

## AI assistance

Claude Code (Opus 5) traced the colocated pause window through the dispatcher,
drafted this change and its test, and ran the checks above.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
