### PR TITLE
perf(training): write the adapter slot snapshot off the paused window

### DIFF
--- a/reef/train/slime_backend/reef_adapters/megatron/adapter_slots.py
+++ b/reef/train/slime_backend/reef_adapters/megatron/adapter_slots.py
@@ -21,6 +21,7 @@ import base64
 import contextlib
 import logging
 from collections.abc import Iterator, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -68,6 +69,13 @@ def _adapter_params(model: Sequence[torch.nn.Module]) -> Iterator[tuple[str, tor
                 yield f"chunk{index}.{name}", parameter
 
 
+def _write_snapshot(path: Path, payload: dict[str, Any]) -> None:
+    """Replace ``path`` with ``payload``; an interrupted write keeps the old file."""
+    temporary = path.with_name(path.name + ".tmp")
+    torch.save(payload, temporary)
+    temporary.replace(path)
+
+
 def _to_cpu(value: Any) -> Any:
     if isinstance(value, torch.Tensor):
         return value.detach().to("cpu", copy=True)
@@ -101,6 +109,10 @@ class AdapterSlotSwitcher:
         self._rank = rank
         self._snapshots: dict[str, dict[str, Any]] = {}
         self._active: str | None = None
+        # One writer, so snapshot writes stay ordered among themselves and a
+        # slot movement has exactly one write to wait for.
+        self._writer = ThreadPoolExecutor(max_workers=1, thread_name_prefix="adapter-slot-persist")
+        self._pending_write: Future[None] | None = None
         adapter_count = sum(1 for _ in _adapter_params(model))
         if adapter_count == 0:
             raise RuntimeError("adapter slot switching requires a model with Megatron LoRA parameters")
@@ -128,6 +140,9 @@ class AdapterSlotSwitcher:
         _require(scenario)
         if self._active == scenario:
             return True
+        # The occupant is about to leave the slot, so its file must be on
+        # disk before anything else can overwrite the state it holds.
+        self.wait_for_persist()
         snapshot = self._snapshots.get(scenario)
         existed = snapshot is not None
         if snapshot is None:
@@ -146,19 +161,35 @@ class AdapterSlotSwitcher:
     # -- Persistence -----------------------------------------------------
 
     def persist(self, scenario: str) -> Path | None:
-        """Write ``scenario``'s snapshot for this rank; None without a store."""
+        """Start writing ``scenario``'s snapshot for this rank; None without a store.
+
+        The write runs on the switcher's writer thread and the returned path
+        is where it will land. A colocated save runs with serving paused,
+        while the bytes being written are a host-side copy no later step
+        mutates, so the write overlaps the publication that follows instead
+        of extending the pause. :meth:`wait_for_persist` joins it, and both
+        a slot movement and the next ``persist`` join it first: a scenario's
+        file is durable before its state can leave the slot, and a write that
+        failed is reported rather than dropped.
+        """
         _require(scenario)
         if self._store_dir is None:
             return None
         snapshot = self._snapshots.get(scenario)
         if snapshot is None:
             raise RuntimeError(f"scenario {scenario!r} has no captured adapter state to persist")
+        self.wait_for_persist()
         path = self.snapshot_path(scenario)
         path.parent.mkdir(parents=True, exist_ok=True)
-        temporary = path.with_name(path.name + ".tmp")
-        torch.save({"format": SNAPSHOT_FORMAT, "scenario": scenario, **snapshot}, temporary)
-        temporary.replace(path)
+        payload = {"format": SNAPSHOT_FORMAT, "scenario": scenario, **snapshot}
+        self._pending_write = self._writer.submit(_write_snapshot, path, payload)
         return path
+
+    def wait_for_persist(self) -> None:
+        """Finish the pending snapshot write, raising the failure it hit."""
+        pending, self._pending_write = self._pending_write, None
+        if pending is not None:
+            pending.result()
 
     def snapshot_path(self, scenario: str) -> Path:
         if self._store_dir is None:

--- a/tests/slime_backend/test_adapter_slots.py
+++ b/tests/slime_backend/test_adapter_slots.py
@@ -104,6 +104,7 @@ def test_persisted_snapshots_survive_a_restart(tmp_path: Path) -> None:
     _train_step(model, optimizer, scheduler)
     slots.capture("math")
     path = slots.persist("math")
+    slots.wait_for_persist()
     assert path == tmp_path / scenario_key("math") / "rank_00000.pt" and path.is_file()
     expected = _adapter_values(model)
 
@@ -131,6 +132,7 @@ def test_persist_after_restore_writes_the_slot_without_recapture(tmp_path: Path)
     assert slots.restore("math") is True
 
     slots.persist("math")
+    slots.wait_for_persist()
 
     fresh_model, _, fresh_scheduler, fresh_slots = _build(tmp_path)
     assert fresh_slots.restore("math") is True
@@ -139,11 +141,46 @@ def test_persist_after_restore_writes_the_slot_without_recapture(tmp_path: Path)
     assert fresh_scheduler.num_steps == 1
 
 
+def test_a_slot_movement_waits_for_the_pending_snapshot_write(tmp_path: Path) -> None:
+    model, optimizer, scheduler, slots = _build(tmp_path)
+    slots.restore("math")
+    _train_step(model, optimizer, scheduler)
+    slots.capture("math")
+    trained = _adapter_values(model)
+
+    slots.persist("math")
+    slots.restore("code")
+
+    path = slots.snapshot_path("math")
+    assert path.is_file(), "the file is durable before its state leaves the slot"
+    assert not path.with_name(path.name + ".tmp").exists()
+    fresh_model, _, _, fresh = _build(tmp_path)
+    assert fresh.restore("math") is True
+    for got, want in zip(_adapter_values(fresh_model), trained, strict=True):
+        assert torch.equal(got, want)
+
+
+def test_a_failed_snapshot_write_is_reported_and_not_dropped(tmp_path: Path, monkeypatch) -> None:
+    _, _, _, slots = _build(tmp_path)
+    slots.restore("a")
+
+    def fail_save(*_args, **_kwargs):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(torch, "save", fail_save)
+    slots.persist("a")
+
+    with pytest.raises(OSError, match="simulated write failure"):
+        slots.wait_for_persist()
+    assert not slots.snapshot_path("a").exists()
+
+
 def test_snapshot_layout_mismatch_fails_closed(tmp_path: Path) -> None:
     _, _, _, slots = _build(tmp_path)
     slots.restore("a")
     slots.capture("a")
     slots.persist("a")
+    slots.wait_for_persist()
     loaded = torch.load(slots.snapshot_path("a"), weights_only=False)
     loaded["adapter"] = {name: torch.zeros(1) for name in loaded["adapter"]}
     torch.save(loaded, slots.snapshot_path("a"))


### PR DESCRIPTION
## Motivation

A colocated LoRA save persists the active scenario's slot with generation
paused, and that persist is a full `torch.save` of this rank's adapter, fp32
main parameters, and Adam moments. The bytes are a host-side copy that nothing
later mutates, so holding serving down while they reach the disk buys nothing:
the publication that follows the save can overlap the write.

## Changes

- `AdapterSlotSwitcher` gets one writer thread. `persist` starts the write and
  returns the path it will land at; `wait_for_persist` finishes it and raises
  whatever it hit.
- Both a slot movement (`restore`) and the next `persist` join first. That
  gives three properties: a scenario's file is durable before its state can
  leave the slot, writes stay ordered, and a failed write is reported rather
  than dropped.
- The write still goes to `.tmp` and is renamed into place, so an interrupted
  write leaves the previous file intact. For the active scenario — the only
  one a save writes — the same state is also in the Megatron checkpoint the
  save just wrote, which is what restart recovery uses for it anyway.

## Compatibility and operational impact

- No wire or persisted-format change; the file contents are identical.
- `persist` is no longer synchronous. Its only caller is `_save_lora_model`,
  but a caller that wants the file on disk before it returns must now call
  `wait_for_persist` — the two existing tests that asserted on the file
  immediately do exactly that.
- One extra thread per training worker, spawned on the first persist.

## Verification

Run on macOS/CPU, where `slime`, Megatron, and CUDA are not installed:

- `pytest tests/slime_backend/test_adapter_slots.py` → 8 passed, including two
  new tests: a slot movement waits for the pending write (file present, no
  `.tmp` left, and a fresh switcher restores the trained state from it), and a
  failed write surfaces at the next `wait_for_persist` instead of being
  swallowed.
- `pytest tests/slime_backend` (excluding the two modules that import `slime`
  at module scope) → 99 passed, 2 skipped, 25 failed; the failures are
  `ModuleNotFoundError: No module named 'slime'` and are identical on `main`.
- `pre-commit run --all-files` → all hooks pass.
- `python -m mypy` → 4 errors from local torch stubs, identical on `main`.

Not verified here: how much of the write actually overlaps the publication on
a real deployment. That depends on snapshot size and disk, and needs a GPU run.

## AI assistance

Claude Code (Opus 5) traced the colocated pause window, drafted this change
and its tests, and ran the checks above.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
