### PR TITLE
perf(training): let a disjoint deployment opt into sharing prefixes

### DIFF
--- a/reef/train/slime_backend/reef_adapters/preflight.py
+++ b/reef/train/slime_backend/reef_adapters/preflight.py
@@ -68,9 +68,14 @@ def configure_sglang_runtime(args) -> None:
     flushes the tree before pausing that allocation, so no entry outlives the
     weights that built it. Colocated engines therefore keep cross-request
     prefix reuse, which is where an agent workload's long shared prefixes pay
-    off. A disjoint engine deliberately keeps its KV across the update and has
-    nothing that invalidates shared entries, so reuse stays off there until
-    entries can carry a version.
+    off.
+
+    A disjoint engine keeps its KV across the update by default and so shares
+    nothing. ``--disjoint-prefix-sharing`` trades that: publication retracts
+    in-flight requests and clears the cache before the weights change, so
+    again no entry outlives the weights that built it. The cost is
+    re-prefilling whatever was in flight at each publication; the gain is
+    reuse for every request in between.
 
     One engine also holds several scenarios' adapters, and the same prefix has
     different KV under each. That isolation belongs to SGLang, which folds the
@@ -82,12 +87,18 @@ def configure_sglang_runtime(args) -> None:
     """
     colocate = bool(getattr(args, "colocate", False))
     lora = int(getattr(args, "megatron_lora_rank", 0) or 0) > 0
-    args.sglang_disable_radix_cache = not colocate or (lora and not _adapter_scoped_prefix_cache_supported())
+    # Sharing prefixes and retracting on publication are one decision, not
+    # two: an entry may only be reused while nothing can carry it across a
+    # publication, and clearing the cache is only possible once no request
+    # holds KV. Colocated engines retract already, because their KV has to
+    # leave the GPU regardless.
+    retracts = colocate or bool(getattr(args, "disjoint_prefix_sharing", False))
+    args.weight_update_pause_mode = "retract" if retracts else "in_place"
+    args.sglang_disable_radix_cache = not retracts or (lora and not _adapter_scoped_prefix_cache_supported())
     # Reef consumes /generate as a token-native SSE source. Disjoint chunks
     # keep text, ids, log-probs, and scheduler metadata linear in rollout
     # length and give the capture path one unambiguous wire contract.
     args.sglang_incremental_streaming_output = True
-    args.weight_update_pause_mode = "retract" if colocate else "in_place"
     os.environ[REEF_SGLANG_PLUGIN_ENV] = "1"
     configured_plugins = os.environ.get("SGLANG_PLUGINS")
     plugins = (
@@ -111,16 +122,16 @@ def configure_sglang_runtime(args) -> None:
     config = SglangConfig.from_yaml(config_path)
     if colocate and config.has_pd_disaggregation:
         raise ValueError("colocated Reef serving requires a regular SGLang engine, not PD disaggregation")
-    if colocate:
-        # A colocated group may choose either setting: its KV cache, and with
-        # it every shared entry, is released before each publication.
+    if retracts:
+        # A group that retracts may choose either setting: its cache is
+        # cleared before each publication, so nothing outlives its weights.
         return
     for model in config.models:
         for group in model.server_groups:
             overrides = {key.replace("-", "_"): value for key, value in group.overrides.items()}
             if overrides.get("disable_radix_cache", True) is not True:
                 raise ValueError(
-                    "disjoint Reef weight updates require disable_radix_cache=true "
+                    "Reef weight updates that preserve in-flight KV require disable_radix_cache=true "
                     f"for SGLang model {model.name!r} group {group.worker_type!r}"
                 )
 

--- a/reef/train/slime_backend/reef_adapters/preflight.py
+++ b/reef/train/slime_backend/reef_adapters/preflight.py
@@ -7,6 +7,7 @@ of a half-started cluster.
 
 from __future__ import annotations
 
+import inspect
 import os
 
 from reef.train.slime_backend.algorithm import SlimeAlgorithm
@@ -55,13 +56,33 @@ def configure_sglang_runtime(args) -> None:
 
     Disjoint/PD weight updates preserve each active request's private KV state.
     Colocated regular engines retract instead, because their KV allocation
-    must leave the GPU during training, and recompute it after publication. A
-    shared radix-cache entry has no runtime-load-ID identity, so Reef disables
-    cross-request prefix reuse. SGLang's native plugin hook installs Reef's
-    token metadata and colocated suspension policy inside each scheduler.
+    must leave the GPU during training, and recompute it after publication.
+
+    A shared radix-cache entry carries no runtime-load-ID identity of its own,
+    and reusing one across a publication would let a request generate under
+    new weights from a prefix the previous weights encoded — a provenance the
+    rollout's runtime-load spans cannot express, since the contamination is in
+    the prefix's encoding rather than in a suffix of the sequence. What makes
+    that impossible is releasing the KV cache: a colocated training step
+    releases it before every publication, and SGLang's own release path
+    flushes the tree before pausing that allocation, so no entry outlives the
+    weights that built it. Colocated engines therefore keep cross-request
+    prefix reuse, which is where an agent workload's long shared prefixes pay
+    off. A disjoint engine deliberately keeps its KV across the update and has
+    nothing that invalidates shared entries, so reuse stays off there until
+    entries can carry a version.
+
+    One engine also holds several scenarios' adapters, and the same prefix has
+    different KV under each. That isolation belongs to SGLang, which folds the
+    adapter into the entry's key; a build that does not is left with reuse
+    off rather than trusted to keep the scenarios apart.
+
+    SGLang's native plugin hook installs Reef's token metadata and colocated
+    suspension policy inside each scheduler.
     """
     colocate = bool(getattr(args, "colocate", False))
-    args.sglang_disable_radix_cache = True
+    lora = int(getattr(args, "megatron_lora_rank", 0) or 0) > 0
+    args.sglang_disable_radix_cache = not colocate or (lora and not _adapter_scoped_prefix_cache_supported())
     # Reef consumes /generate as a token-native SSE source. Disjoint chunks
     # keep text, ids, log-probs, and scheduler metadata linear in rollout
     # length and give the capture path one unambiguous wire contract.
@@ -90,14 +111,37 @@ def configure_sglang_runtime(args) -> None:
     config = SglangConfig.from_yaml(config_path)
     if colocate and config.has_pd_disaggregation:
         raise ValueError("colocated Reef serving requires a regular SGLang engine, not PD disaggregation")
+    if colocate:
+        # A colocated group may choose either setting: its KV cache, and with
+        # it every shared entry, is released before each publication.
+        return
     for model in config.models:
         for group in model.server_groups:
             overrides = {key.replace("-", "_"): value for key, value in group.overrides.items()}
             if overrides.get("disable_radix_cache", True) is not True:
                 raise ValueError(
-                    "Reef weight updates require disable_radix_cache=true "
+                    "disjoint Reef weight updates require disable_radix_cache=true "
                     f"for SGLang model {model.name!r} group {group.worker_type!r}"
                 )
+
+
+def _adapter_scoped_prefix_cache_supported() -> bool:
+    """Whether SGLang keys radix-cache entries per LoRA adapter.
+
+    Reef serves one adapter per scenario from one engine, so a shared prefix
+    may only be reused by a request bound to the same adapter. SGLang expresses
+    that by folding the request's adapter into the cache entry's key. An
+    engine that cannot is not asked to keep the scenarios apart: the caller
+    leaves cross-request reuse off instead.
+    """
+    try:
+        from sglang.srt.managers.schedule_batch import Req
+        from sglang.srt.mem_cache.radix_cache import RadixKey
+    except ImportError:
+        return False
+    return (
+        "extra_key" in getattr(RadixKey, "__slots__", ()) and "lora_id" in inspect.signature(Req.__init__).parameters
+    )
 
 
 def _require_lora_distributed_schema() -> None:

--- a/reef/train/slime_backend/reef_adapters/rollout/manager.py
+++ b/reef/train/slime_backend/reef_adapters/rollout/manager.py
@@ -130,8 +130,20 @@ class ReefRolloutManagerImpl:
         return None if not ip or not port else f"http://{ip}:{port}"
 
     def pause_generation_for_update(self):
+        """Stop generation for a publication, leaving nothing that outlives the weights.
+
+        A ``retract`` pause releases every in-flight request's KV, which is
+        what lets the shared prefix cache be cleared: an entry the previous
+        weights built must not be matchable by a request running under the
+        next ones. A colocated engine drops the cache with its KV allocation
+        anyway; clearing it here is what extends the same guarantee to a
+        disjoint engine that opted into sharing prefixes.
+        """
         mode = getattr(self.args, "weight_update_pause_mode", "retract")
-        result = ray.get([engine.pause_generation.remote(mode) for engine in self.updatable_rollout_engines])
+        engines = self.updatable_rollout_engines
+        result = ray.get([engine.pause_generation.remote(mode) for engine in engines])
+        if mode == "retract":
+            ray.get([engine.flush_cache.remote() for engine in engines])
         self._generation_paused_for_update = True
         return result
 

--- a/reef/train/slime_backend/reef_adapters/slime_arguments.py
+++ b/reef/train/slime_backend/reef_adapters/slime_arguments.py
@@ -31,6 +31,16 @@ def add_reef_slime_arguments(parser: argparse.ArgumentParser) -> argparse.Argume
         default=1,
         help="Adapter slots the SGLang engine keeps loaded on the shared base model (>= 1).",
     )
+    parser.add_argument(
+        "--disjoint-prefix-sharing",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Share prefix-cache entries across requests on a disjoint deployment. "
+            "Publication then retracts in-flight requests and clears the cache instead of "
+            "preserving their KV, which is what keeps an entry from outliving its weights."
+        ),
+    )
     parser.add_argument("--check-lora-weight-equal", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--verify-lora-base-weights", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument(

--- a/tests/slime_backend/test_rollout_recovery.py
+++ b/tests/slime_backend/test_rollout_recovery.py
@@ -230,6 +230,39 @@ def test_reef_external_fields_are_tensorized_without_patching_slime(monkeypatch:
 
 
 @pytest.mark.unit
+def test_retracting_pause_clears_the_shared_cache_before_a_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing the previous weights built may survive into the next ones."""
+    raw_rollout, module = _load_manager_module(monkeypatch)
+
+    class _Recorder:
+        def __init__(self, calls: list[tuple[str, object]], name: str) -> None:
+            self.calls = calls
+            self.name = name
+
+        def remote(self, *args, **_kwargs):
+            self.calls.append((self.name, args[0] if args else None))
+            return self.name
+
+    def _paused(mode: str) -> list[tuple[str, object]]:
+        calls: list[tuple[str, object]] = []
+        engine = types.SimpleNamespace(
+            pause_generation=_Recorder(calls, "pause"),
+            flush_cache=_Recorder(calls, "flush"),
+        )
+        group = _ServerGroup([engine], num_new_engines=0)
+        manager = object.__new__(module.ReefRolloutManagerImpl)
+        manager.servers = {"actor": raw_rollout.RolloutServer(server_groups=[group])}
+        manager.args = types.SimpleNamespace(weight_update_pause_mode=mode)
+        manager.pause_generation_for_update()
+        return calls
+
+    assert _paused("retract") == [("pause", "retract"), ("flush", None)]
+    assert _paused("in_place") == [("pause", "in_place")], "an engine that keeps in-flight KV keeps its cache too"
+
+
+@pytest.mark.unit
 def test_uncertain_weight_update_synchronously_retires_managed_engine_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/slime_backend/test_sglang_engine.py
+++ b/tests/slime_backend/test_sglang_engine.py
@@ -431,6 +431,27 @@ def test_reef_config_selects_pause_mode_and_scopes_shared_prefix_cache(
 
 
 @pytest.mark.unit
+def test_disjoint_shares_prefixes_only_by_opting_into_retraction() -> None:
+    """Sharing entries and retracting in-flight KV are one decision."""
+    default = types.SimpleNamespace(colocate=False, megatron_lora_rank=0, sglang_config=None)
+    configure_sglang_runtime(default)
+
+    assert default.sglang_disable_radix_cache is True
+    assert default.weight_update_pause_mode == "in_place"
+
+    sharing = types.SimpleNamespace(
+        colocate=False,
+        megatron_lora_rank=0,
+        disjoint_prefix_sharing=True,
+        sglang_config=None,
+    )
+    configure_sglang_runtime(sharing)
+
+    assert sharing.sglang_disable_radix_cache is False
+    assert sharing.weight_update_pause_mode == "retract", "the cache can only be cleared once no request holds KV"
+
+
+@pytest.mark.unit
 def test_colocated_lora_shares_prefixes_only_when_sglang_keys_them_by_adapter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/slime_backend/test_sglang_engine.py
+++ b/tests/slime_backend/test_sglang_engine.py
@@ -403,7 +403,7 @@ def test_reef_engine_rejects_conflicting_lora_override(monkeypatch: pytest.Monke
 
 
 @pytest.mark.unit
-def test_reef_config_selects_pause_mode_and_disables_shared_prefix_cache(
+def test_reef_config_selects_pause_mode_and_scopes_shared_prefix_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SGLANG_PLUGINS", "telemetry")
@@ -425,6 +425,37 @@ def test_reef_config_selects_pause_mode_and_disables_shared_prefix_cache(
     configure_sglang_runtime(colocated)
     assert colocated.weight_update_pause_mode == "retract"
     assert colocated.sglang_incremental_streaming_output is True
+    # A colocated step releases the KV cache before every publication, so a
+    # shared entry cannot outlive the weights that built it.
+    assert colocated.sglang_disable_radix_cache is False
+
+
+@pytest.mark.unit
+def test_colocated_lora_shares_prefixes_only_when_sglang_keys_them_by_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One engine holds several scenarios' adapters; the engine must keep them apart."""
+    preflight = importlib.import_module("reef.train.slime_backend.reef_adapters.preflight")
+    monkeypatch.setattr(preflight, "_require_lora_tensor_schema", lambda: None)
+    monkeypatch.setattr(preflight, "_require_lora_distributed_schema", lambda: None)
+
+    def _args():
+        return types.SimpleNamespace(
+            colocate=True,
+            megatron_lora_rank=8,
+            prefill_num_servers=0,
+            sglang_config=None,
+        )
+
+    monkeypatch.setattr(preflight, "_adapter_scoped_prefix_cache_supported", lambda: True)
+    keyed = _args()
+    preflight.configure_sglang_runtime(keyed)
+    assert keyed.sglang_disable_radix_cache is False
+
+    monkeypatch.setattr(preflight, "_adapter_scoped_prefix_cache_supported", lambda: False)
+    unkeyed = _args()
+    preflight.configure_sglang_runtime(unkeyed)
+    assert unkeyed.sglang_disable_radix_cache is True, "an engine that cannot isolate adapters shares nothing"
 
 
 @pytest.mark.unit
@@ -475,7 +506,7 @@ def test_native_sglang_plugin_is_explicitly_gated(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.unit
-def test_reef_config_rejects_yaml_that_reenables_shared_prefixes(tmp_path: Path) -> None:
+def test_reef_config_rejects_disjoint_yaml_that_reenables_shared_prefixes(tmp_path: Path) -> None:
     config = tmp_path / "sglang.yaml"
     config.write_text(
         """\
@@ -493,6 +524,17 @@ sglang:
 
     with pytest.raises(ValueError, match="disable_radix_cache=true"):
         configure_sglang_runtime(args)
+
+    colocated = types.SimpleNamespace(
+        colocate=True,
+        megatron_lora_rank=0,
+        prefill_num_servers=0,
+        sglang_config=str(config),
+    )
+
+    configure_sglang_runtime(colocated)
+
+    assert colocated.sglang_disable_radix_cache is False, "a colocated group may choose either setting"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #207. Stacked on #206 — review that one first; this branch contains its
two commits.

## Motivation

A disjoint engine pauses `in_place` and deliberately preserves each in-flight
request's KV across a weight update. That is what makes it disjoint, and it is
also why it could not share prefixes: an entry built under one version stays
matchable by a request running under the next, and the resulting rollout would
claim a provenance it does not have.

#207 proposed giving entries a version. Implementing it surfaced the part that
matters: a version on the entry is only meaningful while no request carries KV
across the boundary. `in_place` guarantees the opposite.

## Changes

- **Sharing and retracting become one decision.** `configure_sglang_runtime`
  derives the pause mode and the radix cache from the same predicate, so a
  deployment cannot end up sharing entries it cannot scope.
- **`--disjoint-prefix-sharing`** (default off) takes the trade for a disjoint
  deployment: publication retracts in-flight requests instead of preserving
  them, and prefix reuse turns on.
- **The pause clears the cache.** `pause_generation_for_update` flushes every
  engine after a retracting pause, which is the point every publication path
  already goes through. Nothing the previous weights built survives into the
  next ones — the same guarantee a colocated engine gets for free, since
  SGLang's release path flushes the tree with the KV allocation.

Colocated deployments are unchanged: they retract already, because their KV
has to leave the GPU regardless.

## Why the flush has to follow a retracting pause

SGLang refuses to flush while requests are pending, and the refusal is not
visible over HTTP: the 200 response's own body says so — *"(When there are
running or waiting requests, the operation will not be performed.)"* — while
the scheduler only logs `"Cache not flushed because there are pending
requests"`. A flush issued against an engine that kept its in-flight KV would
therefore be a no-op that reads as a success, which is the worst possible
outcome here.

A retracting pause is what makes it real: it releases every in-flight
request's KV allocation, and Reef's own `install_colocated_retract_offload`
relaxes `is_fully_idle` so the flush can proceed with the retracted queue in
place. That is the same premise colocate has been relying on for its
release-path flush.

Flushing is also the right instrument only once nothing is mid-flight — it
would otherwise discard entries belonging to requests that legitimately hold
them.

## Compatibility and operational impact

- Default behavior unchanged for both layouts. A disjoint deployment opts in
  explicitly.
- Opting in changes what a publication costs: whatever is in flight is
  re-prefilled rather than resumed from its own KV. Worth it when requests
  share long prefixes and publications are not constant; not worth it when
  publications are frequent relative to traffic. That balance is the
  scheduling question in #202 and the discussion behind it.
- The config validator now rejects a re-enabling override only for a
  deployment that preserves in-flight KV.
- `install_colocated_retract_offload` becomes live for an opted-in disjoint
  engine. It is dormant unless generation is paused in retract mode and
  already excludes health checks, but it is no longer colocate-only in
  practice.

## Verification

Run on macOS/CPU, where `slime`, Megatron, and CUDA are not installed:

- `pytest tests/slime_backend` (excluding the two modules importing `slime` at
  module scope) → 100 passed, 2 skipped, 26 failed, against 99 passed and 25
  failed on this branch's parent (#206). The new pass is the disjoint opt-in
  wiring in `test_sglang_engine.py`; the new failure is
  `test_retracting_pause_clears_the_shared_cache_before_a_publication`, which
  lives in `test_rollout_recovery.py` where every manager test needs the real
  `slime` package and fails the same way here. **That test has therefore not
  been executed** — it will first run in CI.
- `pytest tests/reef_service --ignore=tests/reef_service/test_slime_bridge.py`
  → 1411 passed, 12 failed, 4 skipped (all `slime`, same on `main`).
- `pre-commit run --all-files` → all hooks pass.
- `python -m mypy` → 4 errors from local torch stubs, unchanged from `main`.

**Not verified, and worth confirming on a live disjoint run:** that the flush
actually takes effect there. HTTP 200 does not prove it, so the guarantee
rests on the retracted engine passing `is_fully_idle` — Reef's own premise in
`install_colocated_retract_offload`, which colocate depends on today, but
which has never been exercised on a disjoint engine. A scheduler log line
(`"Cache not flushed because there are pending requests"`) is the thing to
watch for on the first opted-in run.

## AI assistance

Claude Code (Opus 5) traced the invalidation and pause paths through Reef,
slime, and SGLang, wrote this change and its tests, and ran the checks above.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
