### PR TITLE
docs: catch the reference pages up with native, codex, and terminus

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -1,8 +1,10 @@
 CLI
 ===
 
-Reef has one command. It reads a deployment config and starts every process the
-config declares, in dependency order.
+Reef has one command you run. It reads a deployment config and starts every
+process the config declares, in dependency order. (The wheel also installs
+``reef-native`` and ``reef-terminus``, the loop runners those two harness
+adapters launch per episode; nothing calls them by hand.)
 
 .. code:: bash
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -168,7 +168,7 @@ zero.
    evolution.evaluate | an ``EpisodeScorer``, likewise
    evolution.selection | score_comparison | ``always``, or a dotted reference to an object with ``decide``
    evolution.tasks | non-empty list of episode prompts, scored once per tree per step
-   evolution.adapter | pi | ``opencode``, ``claude``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), ``native`` (Reef's own agent, whose tools are ``native_tool`` nodes and whose loop seams listen to ``native_hook`` nodes), or an entry-point adapter
+   evolution.adapter | pi | ``opencode``, ``claude``, ``codex``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), ``native`` (Reef's own agent, whose tools are ``native_tool`` nodes and whose loop seams listen to ``native_hook`` nodes), ``terminus`` (Terminal-Bench's Terminus 2, through a Reef-owned Harbor runner), or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
    evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
    evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own
@@ -176,7 +176,7 @@ zero.
    evolution.max_steps | 0 | stop after this many evolve steps; 0 disables the limit
    evolution.max_failure_streak | 0 | stop after this many consecutive rejected steps; 0 disables the limit
    evolution.max_model_calls_per_step | 0 | cap the proposer's model calls in one step; 0 disables the limit
-   evolution.executor | local | ``local`` runs episodes as a plain subprocess (development, hermetic tests); ``sandbox`` runs each in a bubblewrap jail for a hosted service and refuses to start without it
+   evolution.executor | local | ``local`` runs episodes as a plain subprocess (development, hermetic tests); ``sandbox`` runs each in a bubblewrap jail for a hosted service and refuses to start without it; it also refuses every episode of a ``self_isolating`` adapter such as ``terminus``, whose Docker task container cannot nest in the jail
    evolution.sandbox | | the sandbox executor's policy: ``egress_hosts`` (allowlisted model endpoints; empty denies network) and ``limits`` (``cpu_seconds``, ``memory_bytes``, ``processes``, ``file_bytes``)
    evolution.promote_failures | false | when true, a failing trace's prompt becomes a permanent gate task, so no later candidate can win while bringing the failure back; the seed tasks stay the floor
    evolution.max_promoted_tasks | 50 | the cap on promoted tasks; admission stops there so the suite is bounded

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -144,7 +144,8 @@ Harness tree
 ------------
 
 Reef's versioned representation of the mutable files in a harness: config,
-rules, prompt templates, skills, and extension code. Reef serves it over
+rules, prompt templates, skills, extension code, and, for the ``native``
+adapter, the loop's own tools and hook listeners. Reef serves it over
 ``GET /reef/harness``. An adapter combines the rendered tree with a harness
 executable; that harness and its configured model form the running agent.
 

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -205,8 +205,11 @@ Harness artifacts
 +--------------------------------+---------------------------------------------------------------+
 
 The first three are read-only and take ``x-reef-scenario``. Install also requires
-``?adapter=``, whose value may be ``pi``, ``opencode``, ``claude``, ``dsh``, ``hermes``, or an external
-descriptor. If install omits ``x-reef-scenario``, Reef creates a scenario with a
+``?adapter=``, whose value may be ``pi``, ``opencode``, ``claude``, ``codex``,
+``dsh``, ``hermes``, or an external descriptor. Only an adapter whose descriptor
+declares an install section can be named here: ``native`` and ``terminus`` ship
+with reef and pin no vendor binary, so they answer HTTP 400 rather than a
+script. If install omits ``x-reef-scenario``, Reef creates a scenario with a
 generated ``harness-`` name and embeds that assignment in the wrapper script;
 when exactly one configured recipe serves harness files, it selects that recipe
 automatically.


### PR DESCRIPTION
The adapter enumerations on the reference pages predate three adapters (`native` #169/#170, `codex` #193, `terminus` #209). The developer guide and the harness user guide already describe all three; only `docs/reference/` was stale.

- **`http-api.rst`** — the `?adapter=` list omitted `codex`, which does declare an install section and is served. It also said nothing about `native` and `terminus`: both ship with reef and pin no vendor binary, so the route answers HTTP 400 (`request_service.py:511`) rather than a script. Readers hitting that had no way to tell it apart from a typo.
- **`configuration.rst`** — `evolution.adapter` listed neither `codex` nor `terminus`. Added a note to `evolution.executor` that `sandbox` refuses every episode of a `self_isolating` adapter (`episode.py:118`), since a Docker task container cannot nest in bubblewrap.
- **`glossary.rst`** — the harness-tree definition stopped at extension code, leaving out the native loop's own `native_tool` and `native_hook` nodes.
- **`cli.rst`** — still said "Reef has one command"; the wheel now installs `reef-native` and `reef-terminus` too (`pyproject.toml:85-88`). Noted that they are per-episode runners the adapters launch, not commands to run by hand.

Docs only, no behavior change.

Verified the claims against `reef/harness/adapters/*/descriptor.yaml` (which declare `install:`), `reef/service/request_service.py`, and `reef/harness/episode.py`. I could not run `npm run check:docs` locally — no node in this environment — so the docs gate runs for the first time in CI here; the edits touch only prose, not the Routes table the contract checker indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)