### PR TITLE
optimize docs

### DIFF
--- a/docs/site/app/docs/[...slug]/page.tsx
+++ b/docs/site/app/docs/[...slug]/page.tsx
@@ -20,6 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     description: doc.description,
     alternates: { canonical: path },
     openGraph: { title: doc.title, description: doc.description, type: "article", url: path },
+    twitter: { card: "summary", title: doc.title, description: doc.description },
   };
 }
 

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -154,6 +154,9 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .home h1::after { display: inline-block; width: .17em; height: .17em; margin-left: .09em; content: ""; border-radius: 50%; background: var(--coral); }
 .lead { max-width: 700px; margin: 30px 0 0; color: var(--text); font-size: 20px; line-height: 1.62; }
 .home-actions { margin-top: 38px; display: flex; flex-wrap: wrap; gap: 10px; }
+.home-doc-links { margin-top: 24px; display: flex; flex-wrap: wrap; column-gap: 20px; row-gap: 4px; }
+.home-doc-links a { padding: 8px 0; color: var(--brand-strong); font-size: 14px; font-weight: 500; text-decoration: underline; text-underline-offset: 4px; }
+.home-doc-links a:hover { color: var(--foreground); }
 .primary-action, .secondary-action { min-height: 46px; padding: 11px 19px; display: inline-flex; align-items: center; justify-content: center; border-radius: 10px; font-size: 14px; font-weight: 500; transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease; }
 .primary-action { color: var(--background); background: var(--brand-strong); box-shadow: 0 8px 22px color-mix(in srgb, var(--brand) 24%, transparent); }
 .primary-action:hover { box-shadow: 0 12px 30px color-mix(in srgb, var(--brand) 32%, transparent); transform: translateY(-1px); }

--- a/docs/site/app/page.tsx
+++ b/docs/site/app/page.tsx
@@ -1,12 +1,22 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowRight, Boxes, PlugZap } from "lucide-react";
+import { siteConfig } from "@/lib/site";
 
 export const metadata: Metadata = {
-  title: { absolute: "Reef — Continual learning infrastructure" },
+  title: { absolute: siteConfig.title },
+  description: siteConfig.description,
   alternates: { canonical: "/" },
-  openGraph: { title: "Reef — Continual learning infrastructure", url: "/" },
+  openGraph: { title: siteConfig.title, description: siteConfig.description, url: "/" },
 };
+
+const documentationLinks = [
+  { title: "Quickstart", href: "/docs/getting-started/quickstart" },
+  { title: "Installation", href: "/docs/getting-started/installation" },
+  { title: "Recipes", href: "/docs/user-guide/recipes" },
+  { title: "Harness Evolution", href: "/docs/user-guide/evolve-your-harness" },
+  { title: "API Reference", href: "/docs/reference/http-api" },
+];
 
 const surfaces = [
   {
@@ -96,13 +106,16 @@ export default function Home() {
         <div>
           <p className="pill">Continual learning infrastructure</p>
           <h1>Agents that improve from every run</h1>
-          <p className="lead">
-            Reef serves an inference endpoint in front of the model your agent already calls. It records what it served, accepts feedback about it, and publishes a better version of the weights or the harness.
-          </p>
+          <p className="lead">{siteConfig.description}</p>
           <div className="home-actions">
-            <Link className="primary-action" href="/docs/getting-started/intro">Get started</Link>
-            <a className="secondary-action" href="https://github.com/Human-Agent-Society/reef">View on GitHub</a>
+            <Link className="primary-action" href="/docs/getting-started/quickstart">Quickstart</Link>
+            <a className="secondary-action" href={siteConfig.repository}>View on GitHub</a>
           </div>
+          <nav className="home-doc-links" aria-label="Documentation shortcuts">
+            {documentationLinks.map((link) => (
+              <Link key={link.href} href={link.href}>{link.title}</Link>
+            ))}
+          </nav>
         </div>
         <aside className="loop-card">
           <p>The Reef loop</p>

--- a/docs/site/lib/docs.ts
+++ b/docs/site/lib/docs.ts
@@ -424,14 +424,35 @@ function tableOfContents(html: string) {
   return items;
 }
 
+// Page summaries are independent of the opening paragraph: a walkthrough
+// often starts with an introduction that does not describe the whole page.
+// Pages without an authored summary continue to use their first paragraph.
+const docDescriptions: Partial<Record<string, string>> = {
+  "getting-started/intro":
+    "Learn how Reef connects inference, feedback, and continual learning to evolve model weights or agent harnesses.",
+  "getting-started/installation":
+    "Install Reef for harness evolution on a laptop, GPU-based model training, or client-only access to an existing deployment.",
+  "getting-started/quickstart":
+    "Start Reef locally without a GPU, send an inference request, report feedback, and inspect the release history.",
+  "user-guide/recipes":
+    "Compare Reef recipes for model training and harness evolution. Choose a method based on your workload, feedback, and compute requirements.",
+  "user-guide/evolve-your-harness":
+    "Evolve agent rules, prompts, skills, and configuration with Reef. Evaluate candidate changes and publish accepted harness versions without a GPU.",
+  "user-guide/evolve-your-model":
+    "Configure Reef to train model weights from feedback and serve accepted updates through the same inference endpoint.",
+  "reference/http-api":
+    "Use the Reef HTTP API to send inference requests, report feedback, inspect scenarios, and manage model and harness releases.",
+};
+
 function loadDoc(sourcePath: string): Doc {
   const source = readFileSync(join(docsRoot, sourcePath), "utf8");
   const content = compileRst(source, sourcePath);
   const title = heading(content, 1)?.title;
   if (!title) throw new Error(`${sourcePath} is missing a level-one heading`);
-  const description = plainHtml(content.match(/<p>([\s\S]*?)<\/p>/)?.[1] ?? "");
+  const slug = slugFromSourcePath(sourcePath);
+  const description = docDescriptions[slug] ?? plainHtml(content.match(/<p>([\s\S]*?)<\/p>/)?.[1] ?? "");
   return {
-    slug: slugFromSourcePath(sourcePath),
+    slug,
     title,
     description,
     content,

--- a/docs/site/lib/site.ts
+++ b/docs/site/lib/site.ts
@@ -1,6 +1,6 @@
 export const siteConfig = {
-  title: "Reef Documentation",
-  description: "Documentation for Reef, a continual learning controller: it serves an inference endpoint, records what it served, and publishes the next version of the weights or the harness.",
+  title: "Reef — Continual learning infrastructure",
+  description: "Reef is continual learning infrastructure for AI agents. Serve inference, collect feedback, and evolve model weights or agent harnesses.",
   repository: "https://github.com/Human-Agent-Society/reef",
   // The canonical origin for sitemap, robots, canonical links, and Open Graph.
   // Vercel previews override it with their own host so shared previews resolve.


### PR DESCRIPTION
## Motivation

Make the documentation easier to navigate and give core guides clear, consistent page summaries.

## Changes

- Add five documentation shortcuts near the top of the homepage and link the primary action directly to Quickstart.
- Provide dedicated summaries for seven core guides, retaining the opening-paragraph fallback for other pages.
- Reuse the shared Reef title and introduction, and use each guide's title and summary in link previews.

## Compatibility and operational impact

Documentation website only. No public API, configuration, persisted data, or dependency changes.

## Verification

- `npm run check:docs` — passed.
- `npm run build` — passed, including TypeScript checks and static export.
- Verified generated summaries, canonical URLs, link-preview metadata, and all five shortcut destinations.
- `git diff --check` — passed.

## AI assistance

Codex implemented the documentation changes and ran validation.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.
