### PR TITLE
Keep a stored report canonical when discarding it

### DIFF
--- a/reef/records.py
+++ b/reef/records.py
@@ -205,6 +205,16 @@ class RecordStore:
                     item.references,
                 ).fetchone()
                 if consumed is not None:
+                    # A report is discarded once its references are gone, but a row
+                    # already stored under this id stays canonical: check the discard
+                    # against that row so a divergent retry cannot register its own
+                    # content as the receipt and reject the honest retry that follows.
+                    existing = self._connection.execute(
+                        "SELECT * FROM agent_record WHERE agent_record_id = ?",
+                        (item.agent_record_id,),
+                    ).fetchone()
+                    if existing is not None and self._content(self._row_content(existing)) != self._content(encoded):
+                        raise RecordConflict(f"agent_record_id {item.agent_record_id!r} already has different content")
                     self._connection.execute(
                         "INSERT INTO consumed_agent_record (agent_record_id, content_sha256) VALUES (?, ?)",
                         (item.agent_record_id, self._content_sha256(encoded)),

--- a/tests/reef_service/test_records.py
+++ b/tests/reef_service/test_records.py
@@ -189,6 +189,29 @@ def test_compacted_record_id_rejects_a_retry_with_different_content(tmp_path) ->
 
 
 @pytest.mark.unit
+def test_discarded_report_keeps_the_stored_content_canonical() -> None:
+    records = RecordStore()
+    records.append(item("inference", "math"))
+    stored = item("report", "math", RequestType.REPORT, references=("inference",))
+    records.append(stored)
+    records.compact("math", frozenset({"inference"}))
+
+    divergent = AgentRecord.create(
+        agent_record_id="report",
+        scenario="math",
+        request_type=RequestType.REPORT,
+        payload={"value": "changed"},
+        created_at=6.0,
+        references=("inference",),
+    )
+    with pytest.raises(RecordConflict, match="report"):
+        records.append(divergent)
+
+    assert records.get("math", "report") == stored
+    assert records.append_result(stored).inserted is False
+
+
+@pytest.mark.unit
 def test_compact_is_a_noop_for_empty_id_set() -> None:
     records = RecordStore()
     records.append(item("a", "math"))


### PR DESCRIPTION
## Motivation

Fixes #230.

#222 established that a retry whose content differs from what is stored must fail closed, and it extended that rule to compacted records by fingerprinting their tombstones. The report-discard path was left outside the rule.

When a report's references have been compacted, that branch fingerprints the **incoming** item without ever reading `agent_record`, and it returns before the live-row content check further down. So a divergent retry of a report that is already stored is accepted silently and registers its own digest as the receipt; the next honest retry — the content actually stored — then fails the receipt check at the top of `append_result` and raises `RecordConflict`.

The wrong content wins and the right content is rejected: the same inverted conflict #222 set out to remove, surviving on the one path the fix did not cover. `INSERT OR IGNORE` in `compact()` preserves the poisoned digest afterwards, so the inversion is durable.

The unconditional tombstone predates #222 and was harmless while the receipt carried no content. Adding `content_sha256` turned it into a correctness bug.

## Changes

- Compare the incoming content against any row already stored under the id before writing a discard receipt, and raise `RecordConflict` on divergence.
- Cover the inversion with a regression test: the divergent retry raises, the stored row is unchanged, and the honest retry afterwards still deduplicates.

The matching case needs no fingerprint recomputation from the stored row: `_content_sha256` hashes `_content()`, which already excludes `created_at`, so the incoming digest equals the stored one whenever the contents match. `INSERT` rather than `INSERT OR IGNORE` stays safe because the check at the top of `append_result` has already established that no receipt exists for this id, and the whole body runs under `self._lock` inside one transaction.

## Compatibility and operational impact

No schema change and no migration. Discard semantics are otherwise unchanged: a report whose references are consumed is still not inserted, still returns `inserted=False`, and still leaves a receipt.

The only behavior change is that a divergent retry on this path now raises `RecordConflict` instead of being accepted, which is the documented contract for every other append path.

## Verification

- `python -m pytest tests/reef_service/test_records.py` — 18 passed.
- The new test fails on `main` with `DID NOT RAISE RecordConflict`, confirming it guards the fix rather than restating it.
- `python -m pytest tests/reef_service` — 1411 passed, 13 skipped. `test_sao_bridge.py` and `test_slime_bridge.py` were not collected because the optional `sao` and `slime` packages are absent from this environment; neither is touched by this change.
- `ruff check` and `ruff format --check` pass for both changed files.

## AI assistance

Claude Code (Opus 5) reviewed #222, identified the inverted conflict, wrote the fix and the regression test, and ran the checks reported above. The author reviewed the diff, the reasoning, and the test output.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
