### PR TITLE
refactor: use declared interfaces and plain value types

### DIFF
--- a/.github/python-design-baseline.txt
+++ b/.github/python-design-baseline.txt
@@ -19,7 +19,6 @@ PYD003|reef/harness/nodes.py|<module>|NODE_KINDS
 PYD003|reef/recipe/config_fields.py|<module>|_PARSERS
 PYD003|reef/recipe/config_fields.py|ConfigField|parse
 PYD003|reef/scenario/registry.py|ScenarioRegistry|self._on_training_scenario_resolved
-PYD003|reef/service/request_service.py|RequestPayloadNormalizer|self._normalizers
 PYD003|reef/train/cordis_backend/compose/events.py|Hook|callback
 PYD003|reef/train/cordis_backend/compose/fiber.py|EffectHandle|self._collected
 PYD003|reef/train/cordis_backend/compose/fiber.py|Fiber|self._hooks

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -637,9 +637,7 @@ class Dispatcher:
                         "processor": current.trainer.processor_status(),
                         "inference_admission": inference_admission,
                     }
-                    if isinstance(runtime, TrainingRuntime) and getattr(
-                        runtime, "concurrent_training_scenarios", False
-                    ):
+                    if isinstance(runtime, TrainingRuntime) and runtime.concurrent_training_scenarios:
                         block["adapter_runtime_load_id"] = runtime.serving_adapter_runtime_load_id(scenario_name)
                     scenarios[scenario_name] = block
             except Exception as exc:  # noqa: PERF203

--- a/reef/records.py
+++ b/reef/records.py
@@ -10,11 +10,29 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
+from typing import NamedTuple
 from weakref import WeakValueDictionary
 
 from reef.core.artifact_ref import decode_artifact_ref, encode_artifact_ref
 from reef.core.errors import ReefError
 from reef.core.records_types import AgentRecord, RequestType
+
+
+class EncodedRecord(NamedTuple):
+    """One record in its stored column order, as the ``agent_record`` row.
+
+    The field names are the column names, so the same tuple binds the INSERT
+    parameters and names the fields that participate in retry-content
+    comparison.
+    """
+
+    agent_record_id: str
+    scenario: str
+    request_type: str
+    created_at: float
+    payload_json: str
+    references_json: str
+    artifact_json: str | None
 
 
 class RecordConflict(ReefError):
@@ -106,19 +124,6 @@ class RecordStore:
                 """
             )
 
-    #: Column order of the tuples produced by :meth:`_encode` and
-    #: :meth:`_row_content`; :meth:`_content` uses it to name the fields that
-    #: participate in retry-content comparison.
-    _ENCODED_FIELDS = (
-        "agent_record_id",
-        "scenario",
-        "request_type",
-        "created_at",
-        "payload_json",
-        "references_json",
-        "artifact_json",
-    )
-
     @staticmethod
     def _json(value: object) -> str:
         try:
@@ -127,19 +132,19 @@ class RecordStore:
             raise TypeError("a record must contain JSON-serializable values") from exc
 
     @classmethod
-    def _encode(cls, item: AgentRecord) -> tuple[str, str, str, float, str, str, str | None]:
+    def _encode(cls, item: AgentRecord) -> EncodedRecord:
         artifact = item.artifact_ref
         artifact_json = None
         if artifact is not None:
             artifact_json = cls._json(encode_artifact_ref(artifact))
-        return (
-            item.agent_record_id,
-            item.scenario,
-            item.request_type.value,
-            item.created_at,
-            cls._json(dict(item.payload)),
-            cls._json(item.references),
-            artifact_json,
+        return EncodedRecord(
+            agent_record_id=item.agent_record_id,
+            scenario=item.scenario,
+            request_type=item.request_type.value,
+            created_at=item.created_at,
+            payload_json=cls._json(dict(item.payload)),
+            references_json=cls._json(item.references),
+            artifact_json=artifact_json,
         )
 
     @staticmethod
@@ -159,28 +164,20 @@ class RecordStore:
         )
 
     @staticmethod
-    def _row_content(row: sqlite3.Row) -> tuple[str, str, str, float, str, str, str | None]:
-        return (
-            row["agent_record_id"],
-            row["scenario"],
-            row["request_type"],
-            row["created_at"],
-            row["payload_json"],
-            row["references_json"],
-            row["artifact_json"],
-        )
+    def _row_content(row: sqlite3.Row) -> EncodedRecord:
+        return EncodedRecord(*(row[name] for name in EncodedRecord._fields))
 
     @classmethod
-    def _content(cls, encoded: tuple[str, str, str, float, str, str, str | None]) -> dict[str, object]:
+    def _content(cls, encoded: EncodedRecord) -> dict[str, object]:
         """The encoded fields that define row content, excluding ``created_at``.
 
         A client retrying with its own agent_record_id regenerates the
         timestamp, so a timestamp difference alone must dedup, not conflict.
         """
-        return {name: value for name, value in zip(cls._ENCODED_FIELDS, encoded, strict=True) if name != "created_at"}
+        return {name: value for name, value in encoded._asdict().items() if name != "created_at"}
 
     @classmethod
-    def _content_sha256(cls, encoded: tuple[str, str, str, float, str, str, str | None]) -> str:
+    def _content_sha256(cls, encoded: EncodedRecord) -> str:
         canonical = cls._json(cls._content(encoded)).encode("utf-8")
         return hashlib.sha256(canonical).hexdigest()
 

--- a/reef/scenario/commit_log.py
+++ b/reef/scenario/commit_log.py
@@ -32,6 +32,7 @@ import os
 import time
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
+from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock
 from typing import Any
@@ -47,6 +48,7 @@ class CommitLogError(ReefError):
     """The commit log is corrupt or a record does not match the schema."""
 
 
+@dataclass(frozen=True, kw_only=True, eq=False)
 class CommitRecord:
     """One committed training step: the atomic release record.
 
@@ -57,64 +59,60 @@ class CommitRecord:
     a crash.
     """
 
-    def __init__(
-        self,
-        *,
-        scenario: str,
-        step: int,
-        artifact_ref: ArtifactRef,
-        checkpoint: bool,
-        algorithm_state: Mapping[str, Any] | None,
-        high_water_sequence: int,
-        high_water_offset: int,
-        compacted_ids: frozenset[str] = frozenset(),
-        consumed_ids: frozenset[str] = frozenset(),
-        recorded_at: float | None = None,
-        operation: str = "training",
-        operation_verified: bool = True,
-        pending: bool = False,
-        rollback_target_release_id: str | None = None,
-        metrics: Mapping[str, Any] | None = None,
-        training_job_id: str | None = None,
-    ) -> None:
-        if not isinstance(step, int) or isinstance(step, bool) or step < 1:
+    scenario: str
+    step: int
+    artifact_ref: ArtifactRef
+    checkpoint: bool
+    algorithm_state: Mapping[str, Any] | None
+    high_water_sequence: int
+    high_water_offset: int
+    compacted_ids: frozenset[str] = frozenset()
+    consumed_ids: frozenset[str] = frozenset()
+    recorded_at: float = field(default_factory=time.time)
+    operation: str = "training"
+    operation_verified: bool = True
+    pending: bool = False
+    rollback_target_release_id: str | None = None
+    metrics: Mapping[str, Any] | None = None
+    training_job_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.step, int) or isinstance(self.step, bool) or self.step < 1:
             raise CommitLogError("commit record step must be a positive integer")
-        for name, value in (("high_water_sequence", high_water_sequence), ("high_water_offset", high_water_offset)):
+        for name, value in (
+            ("high_water_sequence", self.high_water_sequence),
+            ("high_water_offset", self.high_water_offset),
+        ):
             if not isinstance(value, int) or isinstance(value, bool) or value < 0:
                 raise CommitLogError(f"commit record {name} must be a non-negative integer")
-        self.scenario = scenario
-        self.step = step
-        self.artifact_ref = artifact_ref
-        self.checkpoint = checkpoint
-        self.algorithm_state = None if algorithm_state is None else dict(algorithm_state)
-        self.high_water_sequence = high_water_sequence
-        self.high_water_offset = high_water_offset
-        self.compacted_ids = frozenset(compacted_ids)
-        self.consumed_ids = frozenset(consumed_ids)
-        self.recorded_at = time.time() if recorded_at is None else recorded_at
-        if operation not in ("training", "rollback", "promote"):
+        if self.operation not in ("training", "rollback", "promote"):
             raise CommitLogError("commit record operation must be 'training', 'rollback', or 'promote'")
-        if not isinstance(operation_verified, bool):
+        if not isinstance(self.operation_verified, bool):
             raise CommitLogError("commit record operation_verified must be a boolean")
-        if operation in ("rollback", "promote"):
-            if not isinstance(rollback_target_release_id, str) or not rollback_target_release_id:
-                raise CommitLogError(f"{operation} commit requires rollback_target_release_id")
-        elif rollback_target_release_id is not None:
+        if self.operation in ("rollback", "promote"):
+            if not isinstance(self.rollback_target_release_id, str) or not self.rollback_target_release_id:
+                raise CommitLogError(f"{self.operation} commit requires rollback_target_release_id")
+        elif self.rollback_target_release_id is not None:
             raise CommitLogError("training commit must not carry rollback_target_release_id")
-        if not isinstance(pending, bool) or (pending and operation != "training"):
+        if not isinstance(self.pending, bool) or (self.pending and self.operation != "training"):
             raise CommitLogError("only a training commit may be pending")
-        self.operation = operation
-        self.operation_verified = operation_verified
-        self.rollback_target_release_id = rollback_target_release_id
-        self.pending = pending
-        if metrics is not None and not isinstance(metrics, Mapping):
+        if self.metrics is not None and not isinstance(self.metrics, Mapping):
             raise CommitLogError("commit record metrics must be an object or null")
-        self.metrics = None if metrics is None else deepcopy(dict(metrics))
-        if training_job_id is not None and (not isinstance(training_job_id, str) or not training_job_id):
+        if self.training_job_id is not None and (
+            not isinstance(self.training_job_id, str) or not self.training_job_id
+        ):
             raise CommitLogError("commit record training_job_id must be a non-empty string or null")
-        if operation != "training" and training_job_id is not None:
+        if self.operation != "training" and self.training_job_id is not None:
             raise CommitLogError("only training commits may carry training_job_id")
-        self.training_job_id = training_job_id
+        # Own every mutable value the record was handed: the log is the durable
+        # commit point, so a caller mutating its state or metrics afterwards
+        # must not change what was recorded.
+        object.__setattr__(
+            self, "algorithm_state", None if self.algorithm_state is None else dict(self.algorithm_state)
+        )
+        object.__setattr__(self, "metrics", None if self.metrics is None else deepcopy(dict(self.metrics)))
+        object.__setattr__(self, "compacted_ids", frozenset(self.compacted_ids))
+        object.__setattr__(self, "consumed_ids", frozenset(self.consumed_ids))
 
     def to_dict(self) -> dict[str, Any]:
         record_progress: dict[str, Any] = {

--- a/reef/scenario/registry.py
+++ b/reef/scenario/registry.py
@@ -207,22 +207,23 @@ class ScenarioRegistry:
             self._scenario_factory.validate_existing(current, release_id)
             return current
         current = self._scenario_factory.load_or_create(scenario, release_id)
-        training = isinstance(current.runtime, TrainingRuntime)
+        runtime = current.runtime
+        training_runtime = runtime if isinstance(runtime, TrainingRuntime) else None
         with self._lock:
-            shared_runtime = training and getattr(current.runtime, "concurrent_training_scenarios", False)
-            if training and not shared_runtime and self._training_scenario not in (None, scenario):
+            shared_runtime = training_runtime is not None and training_runtime.concurrent_training_scenarios
+            if training_runtime is not None and not shared_runtime and self._training_scenario not in (None, scenario):
                 current.close()
                 raise ReefError(
                     f"training is already bound to scenario {self._training_scenario!r}: a reef process "
                     f"trains one scenario for its lifetime, so {scenario!r} needs its own stack "
                     f"(restart this one, or run a second stack on other ports)"
                 )
-            if training:
+            if training_runtime is not None:
                 if self._training_scenario is None:
                     self._training_scenario = scenario
                 if scenario not in self._training_scenarios:
                     self._training_scenarios.append(scenario)
             self._scenarios[scenario] = current
-        if training and self._on_training_scenario_resolved is not None:
+        if training_runtime is not None and self._on_training_scenario_resolved is not None:
             self._on_training_scenario_resolved(current)
         return current

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -59,31 +59,15 @@ def _inference_aborted(response: Mapping[str, Any]) -> bool:
     )
 
 
-class RequestPayloadNormalizer:
-    """Normalize only typed Reef payloads while preserving native bodies."""
-
-    def __init__(self) -> None:
-        self._normalizers: dict[
-            RequestType,
-            Callable[[Mapping[str, Any]], tuple[Mapping[str, Any], tuple[str, ...]]],
-        ] = {
-            RequestType.REPORT: self._normalize_report,
-        }
-
-    def normalize(
-        self,
-        request_type: RequestType,
-        payload: Mapping[str, Any],
-    ) -> tuple[Mapping[str, Any], tuple[str, ...]]:
-        normalizer = self._normalizers.get(request_type)
-        if normalizer is None:
-            return dict(payload), ()
-        return normalizer(payload)
-
-    @staticmethod
-    def _normalize_report(payload: Mapping[str, Any]) -> tuple[Mapping[str, Any], tuple[str, ...]]:
-        report = ReportPayload.from_dict(payload)
-        return report.to_dict(), report.references
+def normalize_request_payload(
+    request_type: RequestType,
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], tuple[str, ...]]:
+    """Normalize a typed Reef payload; a native provider body passes through."""
+    if request_type is not RequestType.REPORT:
+        return dict(payload), ()
+    report = ReportPayload.from_dict(payload)
+    return report.to_dict(), report.references
 
 
 @dataclass(frozen=True)
@@ -139,7 +123,6 @@ class InferenceRetryTimeout(ReefError):
 class RequestService:
     def __init__(self, dispatcher: Dispatcher, *, retry_policy: InferenceRetryPolicy | None = None) -> None:
         self._dispatcher = dispatcher
-        self._payload_normalizer = RequestPayloadNormalizer()
         self._retry_policy = retry_policy or InferenceRetryPolicy()
 
     @property
@@ -578,7 +561,7 @@ class RequestService:
         agent_record_id: str | None = None,
         artifact_ref: ArtifactRef | None = None,
     ) -> AgentRecord:
-        normalized_payload, references = self._payload_normalizer.normalize(parsed.request_type, payload)
+        normalized_payload, references = normalize_request_payload(parsed.request_type, payload)
         normalized_payload = _with_tags(normalized_payload, parsed)
         item = AgentRecord.create(
             scenario=parsed.scenario,
@@ -638,7 +621,7 @@ __all__ = [
     "InferenceRetryTimeout",
     "PendingInference",
     "PreparedInference",
-    "RequestPayloadNormalizer",
     "RequestService",
     "client_inference_response",
+    "normalize_request_payload",
 ]

--- a/reef/train/slime_backend/backend.py
+++ b/reef/train/slime_backend/backend.py
@@ -92,7 +92,7 @@ class SlimeTrainingBackend(TrainingBackend):
         Single-scenario runtimes (including user-written ones) keep the
         original ``reconcile_training_job`` signature.
         """
-        if self._scenario is not None and getattr(self._runtime, "concurrent_training_scenarios", False):
+        if self._scenario is not None and self._runtime.concurrent_training_scenarios:
             return self._scenario
         return None
 
@@ -116,7 +116,7 @@ class SlimeTrainingBackend(TrainingBackend):
             raise RuntimeContractError("training runtime prepared a train step without a payload")
         runtime = self._runtime
         payload = dict(prepared.payload)
-        if self._scenario is not None and getattr(runtime, "concurrent_training_scenarios", False):
+        if self._scenario is not None and runtime.concurrent_training_scenarios:
             # A runtime that trains several scenarios' adapters needs to know
             # whose slot this job fills; the job identity then includes it.
             payload["scenario"] = self._scenario

--- a/reef/train/slime_backend/reef_adapters/preflight.py
+++ b/reef/train/slime_backend/reef_adapters/preflight.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 import os
 
 from reef.train.slime_backend.algorithm import SlimeAlgorithm
+from reef.train.slime_backend.reef_adapters.sglang.lora_schema import (
+    require_lora_distributed_request_schema,
+    require_lora_tensor_request_schema,
+)
 from reef.train.slime_backend.reef_adapters.sglang.plugin import REEF_SGLANG_PLUGIN_ENV, SGLANG_PLUGIN_NAME
 from reef.train.slime_backend.reef_adapters.training_job.marker import marker_rollouts, read_marker
 from reef.train.slime_backend.reef_adapters.training_job.storage import CheckpointStorage, RetentionConfig
@@ -75,8 +79,8 @@ def configure_sglang_runtime(args) -> None:
     os.environ["SGLANG_PLUGINS"] = ",".join(dict.fromkeys((*plugins, SGLANG_PLUGIN_NAME)))
 
     if int(getattr(args, "megatron_lora_rank", 0) or 0) > 0:
-        _require_lora_tensor_schema()
-        _require_lora_distributed_schema()
+        require_lora_tensor_request_schema()
+        require_lora_distributed_request_schema()
 
     if colocate and int(getattr(args, "prefill_num_servers", 0) or 0) > 0:
         raise ValueError("colocated Reef serving requires a regular SGLang engine, not PD disaggregation")
@@ -98,34 +102,6 @@ def configure_sglang_runtime(args) -> None:
                     "Reef weight updates require disable_radix_cache=true "
                     f"for SGLang model {model.name!r} group {group.worker_type!r}"
                 )
-
-
-def _require_lora_distributed_schema() -> None:
-    """Fail before GPU startup when SGLang cannot receive distributed LoRA updates."""
-    required = {"lora_name", "config_dict", "names", "dtypes", "shapes", "group_name", "upsert"}
-    message = "loaded SGLang does not support Reef's distributed LoRA upsert schema"
-    try:
-        from sglang.srt.managers.io_struct import LoadLoRAAdapterFromDistributedReqInput
-    except ImportError as exc:
-        raise RuntimeError(message) from exc
-    fields = set(getattr(LoadLoRAAdapterFromDistributedReqInput, "__struct_fields__", ()))
-    missing = sorted(required - fields)
-    if missing:
-        raise RuntimeError(f"{message}; missing fields: {missing}")
-
-
-def _require_lora_tensor_schema() -> None:
-    """Fail before GPU startup when SGLang cannot receive colocated LoRA updates."""
-    required = {"lora_name", "config_dict", "serialized_named_tensors", "load_format", "expected_checksums"}
-    message = "loaded SGLang does not support Reef's colocated LoRA tensor schema"
-    try:
-        from sglang.srt.managers.io_struct import LoadLoRAAdapterFromTensorsReqInput
-    except ImportError as exc:
-        raise RuntimeError(message) from exc
-    fields = set(getattr(LoadLoRAAdapterFromTensorsReqInput, "__struct_fields__", ()))
-    missing = sorted(required - fields)
-    if missing:
-        raise RuntimeError(f"{message}; missing fields: {missing}")
 
 
 def configure_megatron_runtime(args) -> None:

--- a/reef/train/slime_backend/reef_adapters/sglang/engine.py
+++ b/reef/train/slime_backend/reef_adapters/sglang/engine.py
@@ -11,6 +11,10 @@ from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from urllib3.exceptions import NewConnectionError
 
 from reef.train.slime_backend.reef_adapters.megatron.lora import megatron_lora_enabled, sglang_lora_target_modules
+from reef.train.slime_backend.reef_adapters.sglang.lora_schema import (
+    require_lora_distributed_request_schema,
+    require_lora_tensor_request_schema,
+)
 from reef.train.slime_backend.reef_adapters.worker_hooks import reef_node_ip_and_free_port, reef_rollout_env_vars
 
 logger = logging.getLogger(__name__)
@@ -251,32 +255,6 @@ class ReefSGLangEngine(SGLangEngine):
         return float(minutes) * 60
 
 
-def require_lora_distributed_request_schema() -> None:
-    required = {"lora_name", "config_dict", "names", "dtypes", "shapes", "group_name", "upsert"}
-    message = "loaded SGLang does not support Reef's distributed LoRA upsert schema"
-    try:
-        from sglang.srt.managers.io_struct import LoadLoRAAdapterFromDistributedReqInput
-    except ImportError as exc:
-        raise RuntimeError(message) from exc
-    fields = set(getattr(LoadLoRAAdapterFromDistributedReqInput, "__struct_fields__", ()))
-    missing = sorted(required - fields)
-    if missing:
-        raise RuntimeError(f"{message}; missing fields: {missing}; use Reef's pinned SGLang image")
-
-
-def require_lora_tensor_request_schema() -> None:
-    required = {"lora_name", "config_dict", "serialized_named_tensors", "load_format", "expected_checksums"}
-    message = "loaded SGLang does not support Reef's colocated LoRA tensor schema"
-    try:
-        from sglang.srt.managers.io_struct import LoadLoRAAdapterFromTensorsReqInput
-    except ImportError as exc:
-        raise RuntimeError(message) from exc
-    fields = set(getattr(LoadLoRAAdapterFromTensorsReqInput, "__struct_fields__", ()))
-    missing = sorted(required - fields)
-    if missing:
-        raise RuntimeError(f"{message}; missing fields: {missing}; use Reef's pinned SGLang image")
-
-
 def install_sglang_extensions() -> None:
     """Install extensions in the dedicated rollout-manager process only."""
     from slime.ray import rollout, utils
@@ -293,6 +271,4 @@ def install_sglang_extensions() -> None:
 __all__ = [
     "ReefSGLangEngine",
     "install_sglang_extensions",
-    "require_lora_distributed_request_schema",
-    "require_lora_tensor_request_schema",
 ]

--- a/reef/train/slime_backend/reef_adapters/sglang/lora_schema.py
+++ b/reef/train/slime_backend/reef_adapters/sglang/lora_schema.py
@@ -1,0 +1,41 @@
+"""The SGLang LoRA request schemas Reef's weight updates depend on.
+
+Both the driver preflight (before any GPU worker exists) and each rollout
+engine actor's constructor check these, so the required field sets live here
+once: a loaded SGLang that drifts from them fails the same way on both paths.
+"""
+
+from __future__ import annotations
+
+DISTRIBUTED_UPSERT_FIELDS = frozenset(
+    {"lora_name", "config_dict", "names", "dtypes", "shapes", "group_name", "upsert"}
+)
+TENSOR_LOAD_FIELDS = frozenset(
+    {"lora_name", "config_dict", "serialized_named_tensors", "load_format", "expected_checksums"}
+)
+
+
+def _require_struct_fields(request_type: type, required: frozenset[str], message: str) -> None:
+    missing = sorted(required - set(getattr(request_type, "__struct_fields__", ())))
+    if missing:
+        raise RuntimeError(f"{message}; missing fields: {missing}; use Reef's pinned SGLang image")
+
+
+def require_lora_distributed_request_schema() -> None:
+    """Fail when SGLang cannot receive Reef's distributed LoRA upsert."""
+    message = "loaded SGLang does not support Reef's distributed LoRA upsert schema"
+    try:
+        from sglang.srt.managers.io_struct import LoadLoRAAdapterFromDistributedReqInput
+    except ImportError as exc:
+        raise RuntimeError(message) from exc
+    _require_struct_fields(LoadLoRAAdapterFromDistributedReqInput, DISTRIBUTED_UPSERT_FIELDS, message)
+
+
+def require_lora_tensor_request_schema() -> None:
+    """Fail when SGLang cannot receive Reef's colocated LoRA tensor update."""
+    message = "loaded SGLang does not support Reef's colocated LoRA tensor schema"
+    try:
+        from sglang.srt.managers.io_struct import LoadLoRAAdapterFromTensorsReqInput
+    except ImportError as exc:
+        raise RuntimeError(message) from exc
+    _require_struct_fields(LoadLoRAAdapterFromTensorsReqInput, TENSOR_LOAD_FIELDS, message)

--- a/tests/reef_service/test_training_wait.py
+++ b/tests/reef_service/test_training_wait.py
@@ -121,6 +121,9 @@ def test_status_keeps_the_published_version_until_inference_reopens(monkeypatch)
     class Runtime:
         open = False
         current = "engine:old"
+        # This double stands in for TrainingRuntime, so it carries every
+        # attribute the dispatcher reads off that interface.
+        concurrent_training_scenarios = False
 
         @property
         def inference_admission_status(self):

--- a/tests/slime_backend/test_sglang_engine.py
+++ b/tests/slime_backend/test_sglang_engine.py
@@ -9,12 +9,12 @@ from pathlib import Path
 
 import pytest
 
-from reef.train.slime_backend.reef_adapters.preflight import (
-    _require_lora_distributed_schema,
-    _require_lora_tensor_schema,
-    configure_sglang_runtime,
-)
+from reef.train.slime_backend.reef_adapters.preflight import configure_sglang_runtime
 from reef.train.slime_backend.reef_adapters.sglang import plugin as sglang_plugin
+from reef.train.slime_backend.reef_adapters.sglang.lora_schema import (
+    require_lora_distributed_request_schema,
+    require_lora_tensor_request_schema,
+)
 from reef.train.slime_backend.reef_adapters.sglang.plugin import (
     REEF_SGLANG_PLUGIN_ENV,
     install_colocated_retract_offload,
@@ -127,16 +127,13 @@ def _install_lora_request_schema(
 
 @pytest.mark.unit
 def test_lora_schema_preflight_accepts_distributed_upsert(monkeypatch: pytest.MonkeyPatch) -> None:
-    module = _load_sglang_engine_module(monkeypatch)
     _install_lora_request_schema(
         monkeypatch,
         ("lora_name", "config_dict", "names", "dtypes", "shapes", "group_name", "upsert"),
     )
 
-    module.require_lora_distributed_request_schema()
-    _require_lora_distributed_schema()
-    module.require_lora_tensor_request_schema()
-    _require_lora_tensor_schema()
+    require_lora_distributed_request_schema()
+    require_lora_tensor_request_schema()
 
 
 @pytest.mark.unit
@@ -145,14 +142,11 @@ def test_lora_schema_preflight_rejects_incomplete_distributed_receiver(
     monkeypatch: pytest.MonkeyPatch,
     missing: str,
 ) -> None:
-    module = _load_sglang_engine_module(monkeypatch)
     fields = {"lora_name", "config_dict", "names", "dtypes", "shapes", "group_name", "upsert"} - {missing}
     _install_lora_request_schema(monkeypatch, tuple(sorted(fields)))
 
     with pytest.raises(RuntimeError, match=missing):
-        _require_lora_distributed_schema()
-    with pytest.raises(RuntimeError, match=missing):
-        module.require_lora_distributed_request_schema()
+        require_lora_distributed_request_schema()
 
 
 @pytest.mark.unit
@@ -164,7 +158,6 @@ def test_lora_schema_preflight_rejects_incomplete_colocated_receiver(
     monkeypatch: pytest.MonkeyPatch,
     missing: str,
 ) -> None:
-    module = _load_sglang_engine_module(monkeypatch)
     distributed_fields = ("lora_name", "config_dict", "names", "dtypes", "shapes", "group_name", "upsert")
     tensor_fields = {
         "lora_name",
@@ -176,9 +169,7 @@ def test_lora_schema_preflight_rejects_incomplete_colocated_receiver(
     _install_lora_request_schema(monkeypatch, distributed_fields, tuple(sorted(tensor_fields)))
 
     with pytest.raises(RuntimeError, match=missing):
-        _require_lora_tensor_schema()
-    with pytest.raises(RuntimeError, match=missing):
-        module.require_lora_tensor_request_schema()
+        require_lora_tensor_request_schema()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Motivation

A style pass over `reef/` turned up three places where the code carries more
machinery than the design needs, and one where two copies of the same check
have to be kept in step by hand. None of these change behavior; each removes a
way for a future change to go wrong quietly.

## Changes

**Read `concurrent_training_scenarios` off the declared interface.**
`TrainingRuntime` declares the attribute with a `False` default and
`reef/recipe/base.py` reads it directly, but four other call sites went through
`getattr(runtime, "concurrent_training_scenarios", False)`. Two access styles
for one declared attribute leave the reader unable to tell whether it can
actually be absent. Every site is guarded by an `isinstance(TrainingRuntime)`
check or holds a `TrainingRuntime`-typed field, so nothing real can lack it.

The fallback turned out to cover only a test double: `test_training_wait.py`
patches the name `TrainingRuntime` with a class that does not implement the
interface. That double now carries the attribute it stands in for, rather than
the production path carrying a fallback for it.

In `ScenarioRegistry._resolve` the parallel `training` boolean becomes an
optional `TrainingRuntime`, which is what lets mypy narrow the attribute access
instead of tracking the type in a separate flag.

**Share one LoRA request schema check.** `preflight.py` and
`sglang/engine.py` each carried their own copy of the same two checks,
differing only in function name and a trailing hint in the error message. Both
spell out the required SGLang field sets, so an upstream field rename has to be
tracked in two places; missing one turns a startup error into a runtime
failure. The test file guarded the duplication by asserting the two copies
behave identically. They now live once in `sglang/lora_schema.py`.

**State three value types instead of hand-writing them.**

- `CommitRecord` took 17 keyword arguments into a 58-line `__init__` whose body
  was 17 assignments interleaved with validation. It is now a frozen dataclass
  validating in `__post_init__`, which also makes the atomic release record
  actually immutable.
- `records.py` passed a positional 7-tuple between four methods alongside a
  separate `_ENCODED_FIELDS` constant that had to stay in step with the tuple's
  order. `EncodedRecord` is a `NamedTuple`, so the names come from the type.
- `RequestPayloadNormalizer` was a 25-line class whose entire state was a
  one-entry dispatch dict; it is now a function, and its entry leaves the Python
  design baseline (28 → 27 documented `Callable` patterns).

Net −78 lines.

## Compatibility and operational impact

No public API, wire contract, configuration, or persisted-data change.

Two details were checked explicitly because they could have broken stored data
or callers:

- **Stored `content_sha256` is unchanged.** `_content` sorts keys before
  hashing, so the `NamedTuple` conversion produces byte-identical digests.
  Verified against `origin/main` on the same record: both produce
  `8ae95df040f5c6bf73ae450e46f78a5b2f8a1663b5d144ca976d048fcf04e4b0`. Existing
  SQLite record stores keep deduplicating correctly.
- **`CommitRecord` semantics are unchanged.** The custom `__repr__` and
  `__eq__` are preserved (`eq=False`, and `dataclass` does not overwrite a
  `__repr__` defined in the class body), `__hash__` stays `None`, `recorded_at`
  is still generated when omitted, `algorithm_state` and `metrics` are still
  defensively copied, `to_dict`/`from_dict` still round-trips, and every
  validation message is byte-identical.

`RequestPayloadNormalizer` was exported from `reef.service.request_service`;
it is an internal service detail with no importer inside or outside the
package, and `normalize_request_payload` replaces it in `__all__`.

## Verification

`slime` and its GPU stack are not installable on the dev machine, so the
comparison below is against a second checkout of `origin/main` in its own
virtualenv, running the identical command. Six modules fail to collect without
`slime`/`ray` and are excluded on both sides.

```
pytest tests/ --ignore=<6 modules needing slime/ray>
  origin/main:  9 failed, 1624 passed, 36 skipped
  this branch:  9 failed, 1624 passed, 36 skipped
```

The failure sets are identical line for line. All 9 are pre-existing
environment failures (`ModuleNotFoundError: No module named 'slime'` in the
sglang tests, and the tttd sandbox/judge tests). One test did fail from the
first change before it was fixed — `test_status_keeps_the_published_version_until_inference_reopens`,
the incomplete test double described above.

```
python -m mypy                                 Success: no issues found in 194 source files
.github/scripts/check_python_design.py         passed (27 documented legacy Callable patterns)
.github/scripts/check_python_statements.py     passed
ruff / black / isort on the changed files      passed
```

`pre-commit run --all-files` was not run as a whole; the hooks it would run
over the changed files (ruff 0.14.7, black 24.3.0, isort 5.13.2, and both local
policy scripts) were run at the pinned versions individually.

## AI assistance

Claude Code (Opus 5) surveyed the package for style and maintainability issues,
proposed this shortlist, and wrote the diff and this description. I directed
the scope, reviewed every line, and ran the checks reported above. The
`getattr` finding is worth a maintainer's eye specifically: the tool's first
patch left the incomplete test double in place, and the failing test is what
showed the fallback was covering the double rather than any real runtime.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
