### PR TITLE
feat(native): spill a tool result over the cap to a workspace file the model can read

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -160,7 +160,11 @@ the log holds everything the model saw), ``assistant/message`` (``content``,
 ``step/end``, and finally ``turn/end`` with a ``reason`` of ``completed``,
 ``max-steps``, ``rejected``, or ``error`` (its ``error`` code ``MODEL_ERROR``
 or ``LOAD_ERROR``). Arguments are validated against the tool's declared
-schema before ``run`` sees them. A failed model call logs ``request/error``
+schema before ``run`` sees them. A result over 20,000 characters is spilled:
+the whole text is written to ``.reef/spill/<step>-<call_id>.txt`` under the
+workspace, the model reads the head, one marker line naming that file and the
+omitted count, and the last 2,000 characters, and ``tool/result`` carries the
+file in ``meta.spill``. A failed model call logs ``request/error``
 (``attempt`` and the ``MODEL_ERROR`` failure) before the ``request_error``
 seam runs. A hook whose decision differs from the layer
 below it logs ``hook/decision`` (``seam``, ``step``, ``hook``, ``owned``, and

--- a/reef/harness/native/__init__.py
+++ b/reef/harness/native/__init__.py
@@ -18,6 +18,7 @@ import copy
 import importlib.util
 import json
 import os
+import re
 import sys
 import time
 from collections.abc import Iterator, Mapping, Sequence
@@ -31,6 +32,10 @@ from reef.harness.nodes import NATIVE_SEAMS
 #: Step and tool result budgets; an episode also runs under the executor's wall clock.
 MAX_STEPS = 12
 MAX_RESULT_CHARS = 20_000
+#: A result over the cap is spilled whole to this directory under the workspace; the model reads the head, a
+#: marker naming the file, and this many characters of tail.
+SPILL_DIR = ".reef/spill"
+SPILL_TAIL_CHARS = 2_000
 #: Provider attempts one step may spend and the longest wait between them, whatever a request_error hook asks.
 MAX_REQUEST_ATTEMPTS = 4
 MAX_RETRY_DELAY_MS = 10_000
@@ -414,7 +419,8 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
                 raw = function.get("arguments") or "{}"
                 call_id = str(call.get("id") or name)
                 session.write("tool/call", {"step": step, "call_id": call_id, "name": name, "arguments": raw})
-                result = _invoke(tools, name, raw, workdir)
+                spill = workdir / SPILL_DIR / f"{step}-{re.sub(r'[^A-Za-z0-9_-]', '_', call_id)}.txt"
+                result = _invoke(tools, name, raw, workdir, spill=spill)
                 payload = {
                     "step": step,
                     "call_id": call_id,
@@ -437,7 +443,24 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
         session.close()
 
 
-def _invoke(tools: Mapping[str, ToolModule], name: str, raw: str, workdir: Path) -> dict[str, Any]:
+def _clip(text: str, workdir: Path, spill: Path | None) -> tuple[str, dict[str, Any]]:
+    """What the model reads of a result over the cap: with ``spill``, the whole text lands there and the model gets the head, a marker naming the file, and the tail; without it, the head alone."""
+    if len(text) <= MAX_RESULT_CHARS:
+        return text, {"truncated": False}
+    if spill is None:
+        return text[:MAX_RESULT_CHARS], {"truncated": True}
+    spill.parent.mkdir(parents=True, exist_ok=True)
+    spill.write_text(text, encoding="utf-8")
+    relative = spill.relative_to(workdir).as_posix()
+    tail = text[-SPILL_TAIL_CHARS:]
+    marker = f"\n... [{len(text) - MAX_RESULT_CHARS} characters omitted; the full result is in {relative}] ...\n"
+    head = text[: max(0, MAX_RESULT_CHARS - len(marker) - len(tail))]
+    return head + marker + tail, {"truncated": True, "spill": relative}
+
+
+def _invoke(
+    tools: Mapping[str, ToolModule], name: str, raw: str, workdir: Path, *, spill: Path | None = None
+) -> dict[str, Any]:
     """One result for one call: content, is_error, and a closed error code; run only sees valid arguments."""
     try:
         arguments = json.loads(raw) if raw.strip() else {}
@@ -466,12 +489,12 @@ def _invoke(tools: Mapping[str, ToolModule], name: str, raw: str, workdir: Path)
     except Exception as exc:
         return error("TOOL_FAILED", f"{type(exc).__name__}: {exc}")
     text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False, default=str)
-    truncated = len(text) > MAX_RESULT_CHARS
+    content, clipped = _clip(text, workdir, spill)
     return {
-        "content": text[:MAX_RESULT_CHARS],
+        "content": content,
         "is_error": False,
         "arguments": arguments,
-        "meta": {"duration_ms": int((time.monotonic() - started) * 1000), "truncated": truncated},
+        "meta": {"duration_ms": int((time.monotonic() - started) * 1000), **clipped},
     }
 
 

--- a/tests/reef_service/test_native_harness.py
+++ b/tests/reef_service/test_native_harness.py
@@ -17,7 +17,16 @@ import pytest
 from reef.harness.adapters import available_adapters, get_adapter
 from reef.harness.episode import run_episode
 from reef.harness.model_binding import ModelBinding
-from reef.harness.native import _DEFAULTS, MAX_RESULT_CHARS, HookModule, ToolModule, _invoke, _waterfall, load_hooks
+from reef.harness.native import (
+    _DEFAULTS,
+    MAX_RESULT_CHARS,
+    SPILL_TAIL_CHARS,
+    HookModule,
+    ToolModule,
+    _invoke,
+    _waterfall,
+    load_hooks,
+)
 from reef.harness.native.seed import SEED_NODES, SEED_TOOLS
 from reef.harness.nodes import NODE_KINDS
 from reef.harness.render import RenderError, render_composition
@@ -345,6 +354,13 @@ def test_tool_results_carry_closed_error_codes_and_validate_arguments(tmp_path: 
     assert ok["meta"]["truncated"] is False
     long = _invoke(tools, "shout", '{"text": "long"}', tmp_path)
     assert len(long["content"]) == MAX_RESULT_CHARS and long["meta"]["truncated"] is True
+    # With a spill path the whole result lands on disk and the model reads head, marker, and tail within the cap.
+    spilled = _invoke(tools, "shout", '{"text": "long"}', tmp_path, spill=tmp_path / ".reef" / "spill" / "1-c1.txt")
+    assert (tmp_path / ".reef" / "spill" / "1-c1.txt").read_text() == "x" * (MAX_RESULT_CHARS + 5)
+    assert spilled["meta"]["truncated"] is True and spilled["meta"]["spill"] == ".reef/spill/1-c1.txt"
+    assert len(spilled["content"]) <= MAX_RESULT_CHARS
+    assert "[5 characters omitted; the full result is in .reef/spill/1-c1.txt]" in spilled["content"]
+    assert spilled["content"].startswith("x" * 100) and spilled["content"].endswith("x" * SPILL_TAIL_CHARS)
 
 
 def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path: Path, fake_model) -> None:
@@ -479,6 +495,39 @@ def test_seed_loop_guard_reminds_the_model_at_the_third_repeat(tmp_path: Path) -
     assert reminder.startswith("You have called read_file with the same arguments 3 times in a row.")
     assert model.requests[3]["messages"][-1] == {"role": "user", "content": reminder}
     assert result.trajectory[-1]["data"]["reason"] == {"kind": "completed"}
+
+
+class _DumpModel(_FakeModel):
+    """Asks for one long tool result, then answers."""
+
+    def script(self, body: dict) -> dict:
+        if not [m for m in body["messages"] if m.get("role") == "tool"]:
+            return _reply(tool_calls=[_call("dump", {}, "c1")])
+        return _reply(content="READY")
+
+
+def test_a_long_tool_result_is_spilled_under_the_workspace(tmp_path: Path) -> None:
+    dump = (
+        "native_tool",
+        {
+            "name": "dump",
+            "description": "Return a long text.",
+            "code": "def run(args, workdir):\n    return 'y' * 25000\n",
+        },
+    )
+    model = _DumpModel()
+    try:
+        result = _episode(tmp_path, model, [*_seed_nodes(SEED_TOOLS), dump])
+    finally:
+        model.shutdown()
+        model.server_close()
+    assert result.exit_code == 0
+    logged = _events(result.trajectory, "tool/result")[0]["data"]
+    assert logged["meta"]["spill"] == ".reef/spill/1-c1.txt" and logged["meta"]["truncated"] is True
+    assert len(logged["content"]) <= MAX_RESULT_CHARS
+    assert "[5000 characters omitted; the full result is in .reef/spill/1-c1.txt]" in logged["content"]
+    # The clipped content is what the model read on its next request.
+    assert model.requests[1]["messages"][-1] == {"role": "tool", "tool_call_id": "c1", "content": logged["content"]}
 
 
 def test_native_harness_runs_through_the_evolution_gate(tmp_path: Path, fake_model) -> None:


### PR DESCRIPTION
## Motivation

A native harness tool result over 20,000 characters was cut at the cap and the rest was gone: a long test log or a big file read lost its end, which is usually where the failure is, and the model had no way to get it back. deepseek-harness spills such a result to a file the model can page through. This is the first item of #235. Refs #235.

## Changes

- A result over MAX_RESULT_CHARS is written whole to .reef/spill/<step>-<call_id>.txt under the episode workspace, where the seed read_file and run_bash tools can reach it; the model reads the head, one marker line naming that file and the omitted count, and the last 2,000 characters (SPILL_TAIL_CHARS), the three together within the cap
- tool/result carries the file in meta.spill next to truncated; a call id that is not a plain token is sanitized for the file name
- _invoke takes an optional spill path, so a caller without a workspace keeps the plain head cut and the same truncated flag as before
- Documented in the harness adapters guide's native trajectory paragraph

## Compatibility and operational impact

Additive. A result under the cap is unchanged. Over the cap the model now reads head plus tail instead of head alone, and one file appears under the workspace's .reef/spill directory; the workspace is the task's own output area, outside the residue audit, and .reef is already the name reef uses for its own state. The trajectory's tool/result meta gains spill.

## Verification

The _invoke unit test now drives a spill path: the file holds the whole 20,005 character result, the content stays within the cap, starts with the head, carries the marker with the omitted count and the relative path, and ends with the 2,000 character tail; meta names the file. An episode test runs the real loop through run_episode with a native_tool returning 25,000 characters against a fake model: tool/result carries meta.spill .reef/spill/1-c1.txt and the marker, and the fake model's next request holds exactly the clipped content. The native, render, episode, and recipe suites pass on Python 3.12 (149 tests). The pre-commit hook set, mypy on reef/harness/native, and the docs checks are clean.

## AI assistance

Claude Code wrote the spill and the tests. I set the scope in #235.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
