### PR TITLE
Remove the unreachable clause in the compaction-receipt conflict check

### DIFF
--- a/reef/records.py
+++ b/reef/records.py
@@ -329,17 +329,18 @@ class RecordStore:
         metadata_json = self._json(dict(receipt_metadata or {}))
         with self._lock, self._connection:
             if receipt_id is not None:
+                # A receipt is identified by (scenario, receipt_id, compacted ids), the
+                # primary key of compaction_receipts. One receipt_id may therefore cover
+                # several distinct id sets, so only the metadata can conflict.
                 existing = self._connection.execute(
                     """
-                    SELECT compacted_ids_json, metadata_json
+                    SELECT metadata_json
                     FROM compaction_receipts
                     WHERE scenario = ? AND receipt_id = ? AND compacted_ids_json = ?
                     """,
                     (scenario, receipt_id, compacted_ids_json),
                 ).fetchone()
-                if existing is not None and (
-                    existing["compacted_ids_json"] != compacted_ids_json or existing["metadata_json"] != metadata_json
-                ):
+                if existing is not None and existing["metadata_json"] != metadata_json:
                     raise RecordConflict(
                         f"compaction receipt {receipt_id!r} for scenario {scenario!r} has different content"
                     )


### PR DESCRIPTION
## Motivation

Closes #229.

`RecordStore.compact` selected an existing receipt with `compacted_ids_json = ?` and then compared the returned `compacted_ids_json` against that same bound value. The comparison could never be true, so only the metadata half of the check could ever fire.

The dead half also read as if `receipt_id` alone identified a receipt. It does not: the identity is `(scenario, receipt_id, compacted_ids)`, the primary key of `compaction_receipts`. One `receipt_id` covering several distinct id sets is a supported case — `Trainer.reject_pending` reuses a batch id as the receipt id, and `test_compaction_receipt_is_idempotent_and_conflicting_content_fails` asserts on purpose that a second id set under the same `receipt_id` records a second receipt. Left in place, the clause invited a "fix" that would have broken that.

## Changes

- Drop the always-false `existing["compacted_ids_json"] != compacted_ids_json` comparison; `compact` now conflicts only on differing `metadata_json` for an identical `(scenario, receipt_id, compacted_ids)`.
- Stop selecting `compacted_ids_json`, a column the query already binds as an equality predicate.
- Add a comment stating that receipt identity includes the compacted id set, matching the `compaction_receipts` primary key.

No schema change and no behavior change.

## Compatibility and operational impact

None. No public API, wire contract, configuration, persisted format, or dependency is affected. `RecordConflict` is raised for exactly the same inputs as before.

## Verification

Ran in a local venv (the `slime`/`torch` training stack is not installed here, so the modules requiring it are excluded — they do not touch `reef/records.py`):

- `pytest tests/reef_service/test_records.py -q` → **17 passed**, including `test_compaction_receipt_is_idempotent_and_conflicting_content_fails`.
- `pytest tests/ -q --ignore=tests/plugin_contracts --ignore=tests/slime_backend --ignore=tests/reef_service/test_sao_bridge.py --ignore=tests/reef_service/test_slime_bridge.py` → **1581 passed, 27 skipped**.
- `python -m mypy` (Python 3.10, matching `python_version` in `pyproject.toml`) → **Success: no issues found in 195 source files**.
- `pre-commit run --files reef/records.py` → ruff, autoflake, isort, and Black passed. The two `language: system` hooks could not launch because this environment has no `python` on `PATH`; both scripts were run directly and passed: `check_python_design.py` → "Python design policy passed (27 documented legacy Callable patterns)", `check_python_statements.py` → "Python statement policy passed (no assert or del statements in reef/)".

## AI assistance

Claude Opus 5 (Claude Code) located the dead clause described in #229, made the edit, and ran the checks above. I reviewed the diff and the reported results.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)