### PR TITLE
docs: clarify page titles and connect learning guides

### DIFF
--- a/docs/getting-started/architecture.rst
+++ b/docs/getting-started/architecture.rst
@@ -1,5 +1,5 @@
-Architecture
-============
+Reef architecture: inference to learning
+========================================
 
 An agent is a model plus its harness. Reef sits between the harness and the
 runtime that executes the model. It records the release that served

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,5 +1,5 @@
-Installation
-============
+Install Reef on a laptop or GPU server
+======================================
 
 Installation depends on what you want Reef to evolve:
 
@@ -71,3 +71,11 @@ stdlib-only wire client:
 .. code:: bash
 
    pip install reef-client
+
+Run your first request
+----------------------
+
+Continue with the `inference and feedback quickstart <quickstart.rst>`__
+to start the service, capture a receipt, and submit feedback. If you installed
+the GPU image for weight training, follow `Train model weights from agent
+feedback <../user-guide/evolve-your-model.rst>`__ for the training stack.

--- a/docs/getting-started/intro.rst
+++ b/docs/getting-started/intro.rst
@@ -1,5 +1,5 @@
-Introduction
-============
+Reef: continual learning for AI agents
+======================================
 
 Reef is a continual learning infrastructure. It sits between your agent's
 harness and the model that harness calls. It records each request, its
@@ -79,3 +79,10 @@ Reef is capable of evolve both the model weights and the `harness tree
 - **The harness tree.** Reef proposes an edit, runs the current and proposed
   versions on your tasks, and keeps the winner. See `Evolve your harness
   <../user-guide/evolve-your-harness.rst>`__.
+
+Start using Reef
+----------------
+
+Follow the `inference and feedback quickstart <quickstart.rst>`__ to run
+Reef locally and submit your first report. Then `choose a learning recipe
+<../user-guide/recipes.rst>`__ for your workload and compute budget.

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -1,5 +1,10 @@
-Quickstart
-==========
+Quickstart: serve inference and report feedback
+===============================================
+
+Start Reef locally, send an inference request through a hosted provider,
+report feedback on the response, and inspect the release history. This
+quickstart needs no GPU; the final section links to recipes that learn
+from the records you collect.
 
 A typical Reef workflow includes the following steps:
 
@@ -160,3 +165,16 @@ file: a **preset** naming your ``propose`` and ``evaluate`` callables and the
 tasks to evaluate on. ``tutorials/harness_evolve/run.sh`` wires the whole loop
 together. Run it, then read `Evolve your harness
 <../user-guide/evolve-your-harness.rst>`__ for an explanation of each piece.
+
+Choose your next step
+---------------------
+
+- `Compare learning recipes <../user-guide/recipes.rst>`__ to choose between
+  model training and harness evolution based on the feedback you have.
+- Try `GEPA harness optimization <../user-guide/recipes/gepa.rst>`__ or
+  `SkillClaw skill evolution <../user-guide/recipes/skillclaw.rst>`__ for
+  worked harness examples, or `SAO rollout training
+  <../user-guide/recipes/sao.rst>`__ for a GPU training example with results.
+- Use the `HTTP API reference <../reference/http-api.rst>`__ when connecting
+  your own agent: it covers inference headers, feedback reports, and release
+  management.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -1,5 +1,5 @@
-CLI
-===
+Reef CLI: start a deployment
+============================
 
 Reef has one command you run. It reads a deployment config and starts every
 process the config declares, in dependency order. (The wheel also installs

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1,5 +1,5 @@
-Configuration
-=============
+Configure Reef serving and training
+===================================
 
 A deployment config is one YAML file. ``reef serve -c <file>`` reads it, starts
 every process in its ``services`` list in dependency order, and hands the

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -1,10 +1,16 @@
-HTTP API
-========
+HTTP API: inference, feedback, and releases
+===========================================
 
 Reef serves the provider's own inference routes: OpenAI at
 ``/v1/chat/completions`` and Anthropic at ``/v1/messages``. It forwards each
 request to the runtime unchanged. It adds a small set of ``/reef/*`` routes for
 feedback, scenarios, artifacts, and status.
+
+For a complete request, receipt, and feedback example, start with the
+`inference and feedback quickstart <../getting-started/quickstart.rst>`__.
+To put the release routes into practice, follow the `agent harness tutorial
+<../user-guide/evolve-your-harness.rst>`__ or the `model weight training guide
+<../user-guide/evolve-your-model.rst>`__.
 
 .. code:: bash
 

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -1,5 +1,5 @@
-Python API
-==========
+Python API for custom learning methods
+======================================
 
 The Python API is the set of extension points a learning method plugs into. Reef
 owns everything around them: accepting and replaying records, holding a batch

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -1,5 +1,5 @@
-Evolve agent prompts, rules, and skills
-=======================================
+Evolve your harness
+===================
 
 A harness is everything around the model: the control loop, rules, prompt
 templates, skills, tools, config, and extension code. Together, the model and
@@ -12,10 +12,6 @@ the paired episodes, and publishes or reverts. You supply two Python
 callables, ``propose`` (which edit to try) and ``evaluate`` (how an episode
 scored). `Write a harness method <../developer-guide/write-a-harness-method.rst>`__ documents the
 contract.
-
-If this is your first Reef deployment, run the `inference and feedback
-quickstart <../getting-started/quickstart.rst>`__ to learn how scenarios,
-receipts, and reports connect before starting the harness tutorial below.
 
 The harness tree
 ----------------
@@ -303,12 +299,3 @@ Connect a different agent
 
 `Harness adapters <../developer-guide/harness-adapters.rst>`__ is the descriptor reference and
 how to connect an agent that has no adapter yet.
-
-Try a learning recipe
----------------------
-
-Use `GEPA harness optimization <recipes/gepa.rst>`__ to reflect on agent
-transcripts and propose better prompts, rules, and skills. Use `SkillClaw
-skill evolution <recipes/skillclaw.rst>`__ to grow a skill pool from agent
-feedback. Both pages include runnable examples; `Compare learning recipes
-<recipes.rst>`__ explains their feedback and compute requirements.

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -1,5 +1,5 @@
-Evolve your harness
-===================
+Evolve agent prompts, rules, and skills
+=======================================
 
 A harness is everything around the model: the control loop, rules, prompt
 templates, skills, tools, config, and extension code. Together, the model and
@@ -12,6 +12,10 @@ the paired episodes, and publishes or reverts. You supply two Python
 callables, ``propose`` (which edit to try) and ``evaluate`` (how an episode
 scored). `Write a harness method <../developer-guide/write-a-harness-method.rst>`__ documents the
 contract.
+
+If this is your first Reef deployment, run the `inference and feedback
+quickstart <../getting-started/quickstart.rst>`__ to learn how scenarios,
+receipts, and reports connect before starting the harness tutorial below.
 
 The harness tree
 ----------------
@@ -299,3 +303,12 @@ Connect a different agent
 
 `Harness adapters <../developer-guide/harness-adapters.rst>`__ is the descriptor reference and
 how to connect an agent that has no adapter yet.
+
+Try a learning recipe
+---------------------
+
+Use `GEPA harness optimization <recipes/gepa.rst>`__ to reflect on agent
+transcripts and propose better prompts, rules, and skills. Use `SkillClaw
+skill evolution <recipes/skillclaw.rst>`__ to grow a skill pool from agent
+feedback. Both pages include runnable examples; `Compare learning recipes
+<recipes.rst>`__ explains their feedback and compute requirements.

--- a/docs/user-guide/evolve-your-model.rst
+++ b/docs/user-guide/evolve-your-model.rst
@@ -1,5 +1,5 @@
-Evolve your model
-=================
+Train model weights from agent feedback
+=======================================
 
 Weight training runs three processes. Reef hot-swaps each accepted update into
 the serving engine, so inference keeps answering across the update.
@@ -55,10 +55,13 @@ Start from a config
 Each weight-training example ships a complete ``serve.yaml`` that starts the
 three processes in the required order. Copy the closest one and edit it.
 
-- ``recipes/sao/examples/sao/serve.yaml``, the smallest: two GPUs, one actor
+- `SAO rollout training <recipes/sao.rst>`__ uses
+  ``recipes/sao/examples/sao/serve.yaml``, the smallest: two GPUs, one actor
   with the critic colocated on it, one rollout engine.
-- ``recipes/tttd/examples/tttd/serve.yaml``, two GPUs with LoRA training.
-- ``recipes/openclawrl/examples/openclawrl/serve.yaml``, the paper's seven-GPU
+- `TTT-Discover test-time training <recipes/tttd.rst>`__ uses
+  ``recipes/tttd/examples/tttd/serve.yaml``, two GPUs with LoRA training.
+- `OpenClaw-RL conversation learning <recipes/openclawrl.rst>`__ uses
+  ``recipes/openclawrl/examples/openclawrl/serve.yaml``, the paper's seven-GPU
   stack with a PRM engine and a student model.
 
 `Configuration <../reference/configuration.rst>`__ covers interpolation, command-line
@@ -176,3 +179,11 @@ is admitted the same way. It enters the release chain only if
 ``adapter_config.json`` declares a
 ``peft_type``, the weights are present, and its base model matches the one the
 engine holds.
+
+Connect your agent
+------------------
+
+Use the `HTTP API reference <../reference/http-api.rst>`__ for inference,
+feedback reports, and release queries. To compare learning signals before
+choosing a training config, see `Choose a recipe for agent learning
+<recipes.rst>`__.

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -1,5 +1,5 @@
-Choosing a recipe
-=================
+Choose a recipe for agent learning
+==================================
 
 A recipe is picked along two axes: **what it evolves**, and **how it learns**.
 
@@ -63,3 +63,13 @@ describes each spelling.
 
 Every recipe has a checkpoint strategy, defaulting to ``EveryNVersions(1)``.
 ``checkpoint_every_n_versions`` is the shorter spelling in deployment YAML.
+
+Run the recipe you chose
+------------------------
+
+Start with the `inference and feedback quickstart
+<../getting-started/quickstart.rst>`__ if you have not sent traffic through
+Reef yet. For a harness recipe, follow `Evolve agent prompts, rules, and skills
+<evolve-your-harness.rst>`__. For a weight recipe, follow `Train model weights
+from agent feedback <evolve-your-model.rst>`__. Each recipe page above provides
+its own configuration and example.

--- a/docs/user-guide/recipes/gepa.rst
+++ b/docs/user-guide/recipes/gepa.rst
@@ -1,5 +1,5 @@
-gepa
-====
+GEPA: reflective agent harness optimization
+===========================================
 
 GEPA (`arXiv:2507.19457 <https://arxiv.org/abs/2507.19457>`__) is reflective prompt
 evolution. Instead of training weights, it improves the words an agent is given.

--- a/docs/user-guide/recipes/openclawrl.rst
+++ b/docs/user-guide/recipes/openclawrl.rst
@@ -1,5 +1,5 @@
-openclawrl
-==========
+OpenClaw-RL: learn from agent conversations
+===========================================
 
 OpenClaw-RL (`arXiv:2603.10165 <https://arxiv.org/abs/2603.10165>`__) trains
 a personal agent to satisfy the preferences of its user. It learns from their
@@ -152,3 +152,13 @@ training goes on, and the run reaches the paper's adaptation criterion
 The demo above replays two sessions from the same run. In session 1 the
 student rejects a formatted reply, reef keeps the training going, and by
 session 16 the first reply passes directly.
+
+Related guides
+--------------
+
+- `Inference and feedback quickstart <../../getting-started/quickstart.rst>`__:
+  learn the request, receipt, and report workflow.
+- `Train model weights from agent feedback <../evolve-your-model.rst>`__:
+  set up the GPU stack and inspect published updates.
+- `HTTP API reference <../../reference/http-api.rst>`__: connect your agent
+  and query feedback, scenarios, and releases.

--- a/docs/user-guide/recipes/sao.rst
+++ b/docs/user-guide/recipes/sao.rst
@@ -1,5 +1,5 @@
-sao
-===
+SAO: learn from individual rollouts
+===================================
 
 Single-Rollout Asynchronous Optimization (`arXiv:2607.07508
 <https://arxiv.org/abs/2607.07508>`__) trains on one graded rollout at a
@@ -101,3 +101,13 @@ untrained base at 0.458 above GRPO(+DIS) at 0.417.
 
 .. image:: ../../assets/sao/learning-curve.png
    :alt: Cumulative mean reward over the 48 scored rollouts per arm
+
+Related guides
+--------------
+
+- `Inference and feedback quickstart <../../getting-started/quickstart.rst>`__:
+  learn the request, receipt, and report workflow.
+- `Train model weights from agent feedback <../evolve-your-model.rst>`__:
+  set up the GPU stack and inspect published updates.
+- `HTTP API reference <../../reference/http-api.rst>`__: connect your agent
+  and query feedback, scenarios, and releases.

--- a/docs/user-guide/recipes/skillclaw.rst
+++ b/docs/user-guide/recipes/skillclaw.rst
@@ -1,5 +1,5 @@
-skillclaw
-=========
+SkillClaw: evolve skills from agent feedback
+============================================
 
 SkillClaw (`arXiv:2604.08377 <https://arxiv.org/abs/2604.08377>`__) grows an
 agent's skill pool from the agent's own traffic. By day the agent drains a

--- a/docs/user-guide/recipes/tttd.rst
+++ b/docs/user-guide/recipes/tttd.rst
@@ -1,5 +1,5 @@
-tttd
-====
+TTT-Discover: train a model at test time
+========================================
 
 TTT-Discover (`arXiv:2601.16175 <https://arxiv.org/abs/2601.16175>`__) specializes
 a model to one problem while it searches for the highest-scoring solution. The
@@ -469,3 +469,13 @@ Add tests for the program contract, invalid outputs, reward calculation, and
 task registration. ``tests/test_tttd_harness.py`` and
 ``tests/test_tttd_packing_tasks.py`` show how the shared harness hands programs
 to a task-specific judge.
+
+Related guides
+--------------
+
+- `Inference and feedback quickstart <../../getting-started/quickstart.rst>`__:
+  learn the request, receipt, and report workflow.
+- `Train model weights from agent feedback <../evolve-your-model.rst>`__:
+  set up the GPU stack and inspect published updates.
+- `HTTP API reference <../../reference/http-api.rst>`__: connect your agent
+  and query feedback, scenarios, and releases.


### PR DESCRIPTION
## Motivation

Generic titles such as “Quickstart”, “HTTP API”, and “gepa” give readers little context in search results. The documentation also leaves gaps between first-run instructions, learning tutorials, recipe examples, and API reference pages.

## Changes

- Give 15 documentation pages descriptive, task-specific headings. The existing renderer also uses these headings for page metadata and site search; for example, “Quickstart” becomes “Quickstart: serve inference and report feedback”.
- Connect introduction and installation pages to the quickstart, then link the quickstart to learning guides, recipe examples, and the HTTP API.
- Add contextual links from the model training tutorial and recipe examples to related guides and API reference pages, with link text describing the destination.

## Compatibility and operational impact

Documentation-only changes; page URLs remain unchanged. Top-level heading anchors change with the renamed headings, and navigation labels inherit the new titles. Existing repository links pass validation. No API, configuration, dependency, or runtime changes.

## Verification

- `npm run check:docs` — passed; checked 140 Markdown files, 35 RST files, internal routes, and documentation contracts.
- `npm run lint` — passed.
- `npm run build` — passed; generated all 35 static pages.
- Inspected generated HTML for the quickstart, model training tutorial, and HTTP API: metadata titles match the visible headings and the expected links render in the article body.
- `git diff --check origin/main...HEAD` — passed.

## AI assistance

Codex helped edit the documentation headings and links, run validation, and prepare this pull request.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
