### PR TITLE
fix(service): reject invalid nested serve overrides

### DIFF
--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -109,11 +109,14 @@ def _apply_overrides(config: dict[str, Any], overrides: dict[str, str]) -> dict[
             key = f"reef.{key}"
         parts = key.split(".")
         node: dict[str, Any] = config
-        for part in parts[:-1]:
-            existing = node.get(part)
-            if not isinstance(existing, dict):
+        for index, part in enumerate(parts[:-1]):
+            if part not in node:
                 node[part] = {}
-            node = node[part]
+            existing = node[part]
+            if not isinstance(existing, dict):
+                prefix = ".".join(parts[: index + 1])
+                raise InvalidOverrideError(f"override path {prefix!r} is not a section")
+            node = existing
         node[parts[-1]] = _coerce_value(raw_value)
     return config
 
@@ -498,6 +501,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     config_path = args.config or os.environ.get("REEF_CONFIG", "reef.yaml")
     try:
         overrides = _parse_overrides(extras)
+        exit_code = _run_orchestrator(config_path, overrides)
     except InvalidOverrideError as exc:
         parser.error(str(exc))
-    sys.exit(_run_orchestrator(config_path, overrides))
+    sys.exit(exit_code)

--- a/tests/reef_service/test_orchestrator_overrides.py
+++ b/tests/reef_service/test_orchestrator_overrides.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from reef.service.deploy.orchestrator import InvalidOverrideError, _parse_overrides, main
+from reef.service.deploy.orchestrator import InvalidOverrideError, _apply_overrides, _parse_overrides, main
 
 
 def test_key_value_pair() -> None:
@@ -17,6 +17,33 @@ def test_key_equals_value() -> None:
 
 def test_dotted_key() -> None:
     assert _parse_overrides(["--training.checkpoint_dir", "/tmp/ckpt"]) == {"training.checkpoint_dir": "/tmp/ckpt"}
+
+
+def test_apply_overrides_rejects_a_path_through_a_scalar() -> None:
+    with pytest.raises(InvalidOverrideError, match=r"reef\.artifact_dir"):
+        _apply_overrides({"reef": {"artifact_dir": "/data/artifacts"}}, {"reef.artifact_dir.foo": "1"})
+
+
+def test_apply_overrides_rejects_a_path_through_a_list() -> None:
+    with pytest.raises(InvalidOverrideError, match=r"reef\.adapters"):
+        _apply_overrides({"reef": {"adapters": ["primary"]}}, {"reef.adapters.foo": "1"})
+
+
+def test_apply_overrides_creates_and_merges_nested_sections() -> None:
+    assert _apply_overrides(
+        {"reef": {}, "training": {"keep": "yes"}},
+        {"training.checkpoint_dir": "/tmp/ckpt", "new_section.enabled": "true"},
+    ) == {
+        "reef": {},
+        "training": {"keep": "yes", "checkpoint_dir": "/tmp/ckpt"},
+        "new_section": {"enabled": True},
+    }
+
+
+def test_apply_overrides_replaces_a_scalar_at_its_own_path() -> None:
+    assert _apply_overrides({"reef": {"artifact_dir": "/data/artifacts"}}, {"artifact_dir": "/other/artifacts"}) == {
+        "reef": {"artifact_dir": "/other/artifacts"}
+    }
 
 
 def test_bare_boolean_override() -> None:
@@ -66,3 +93,14 @@ def test_cli_exits_with_status_2_on_unknown_short_option(capsys: pytest.CaptureF
     with pytest.raises(SystemExit) as excinfo:
         main(["-p"])
     assert excinfo.value.code == 2
+
+
+def test_cli_exits_with_status_2_before_starting_services_for_an_invalid_path(tmp_path, capsys) -> None:
+    config_path = tmp_path / "reef.yaml"
+    config_path.write_text("reef:\n  artifact_dir: /data/artifacts\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--config", str(config_path), "--reef.artifact_dir.foo", "1"])
+
+    assert excinfo.value.code == 2
+    assert "reef.artifact_dir" in capsys.readouterr().err


### PR DESCRIPTION
## Motivation

Closes #227.

Reject dotted `reef serve` overrides that traverse an existing value instead of
a configuration section. Previously, such an override silently replaced the
value with a mapping and started the stack with altered configuration.

## Changes

- Reject override paths that traverse an existing non-section value.
- Include the invalid dotted prefix in the error message.
- Return CLI exit code 2 for invalid override paths before services start.
- Add coverage for scalar and list paths, valid create/merge behavior, scalar
  replacement, and CLI error handling.

## Compatibility and operational impact

Invalid nested overrides now fail fast with exit code 2 instead of silently
overwriting configuration. Valid section creation, section merging, and scalar
replacement at its own path are unchanged.

## Verification

- `git diff --check` — passed.
- `python -m py_compile reef\service\deploy\orchestrator.py tests\reef_service\test_orchestrator_overrides.py` — passed.
- `python -m ruff check reef\service\deploy\orchestrator.py tests\reef_service\test_orchestrator_overrides.py` — passed.
- `python -m ruff format --check reef\service\deploy\orchestrator.py tests\reef_service\test_orchestrator_overrides.py` — passed.
- Focused pytest was not runnable locally because native Windows Python lacks
  the Linux-only `resource` module. CI is pending.

## AI assistance

OpenAI Codex was used to inspect the relevant code, explain the issue, and
propose the focused implementation and tests. I reviewed the submitted diff
and verification results.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [ ] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.