### PR TITLE
feat(native): run the loop from a native_graph node

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -156,6 +156,39 @@ retune or drop it. ``SEED_NODES`` is the tools and the hooks together, and
 ``tutorials/harness_evolve/serve-native.yaml`` seeds them by reference to
 run the tutorial on this adapter.
 
+The loop's own control flow is a ``native_graph`` node, rendered to
+``native/graphs/main.json``: named stages from a closed vocabulary and edges
+keyed by each stage's outcome. ``reef.harness.native.seed.SEED_GRAPH`` is
+today's loop as that data (``think`` asks the model, ``act`` runs its tool
+calls, ``done`` ends the turn), the loop runs it when a tree carries no graph,
+and a tree that carries one runs that instead, so a proposal that rewrites
+the graph changes what the loop does between its events while hooks keep
+deciding at them. Admission refuses a graph that could not run: an unknown
+kind or key (no code enters this kind), an outcome without exactly one edge,
+a stage not reachable from ``start``, a stage from which no end stage is
+reachable, and a cycle with no model stage, so the step budget
+(``max_steps``, 1 to 32) ends every run; a ``tools`` allow list naming a
+tool the tree lacks fails at render. The stages:
+
+.. config::
+
+   model | one request over the messages with the declared tools; fires ``pre_step`` and ``request_error``; outcomes ``tool_calls``, ``text``
+   tools | runs the pending calls of the last assistant message, each behind ``pre_execute`` then ``post_execute``; optional ``allow`` restricts them to named tools; outcome ``done``
+   verify | reads the last assistant text: ``check`` is ``last_line_integer``, ``last_line_matches`` with a ``pattern``, or ``nonempty``; an optional ``message`` is appended as a user message on failure; outcomes ``pass``, ``fail``
+   message | appends ``text`` as a user message; outcome ``done``
+   end | ends the turn with ``reason`` ``completed`` or ``gave_up``
+
+Each model stage is one step, so ``max_steps`` bounds model calls as before;
+entering a model stage with the budget spent ends the turn with
+``max-steps``. The log names the path: ``stage/enter`` (``step``, ``stage``,
+``kind``) and ``stage/exit`` (``outcome``, ``to``, and for a verify stage
+``check`` and ``last_line``), text a stage injects is a ``user/message`` with
+``source.kind`` ``stage``, the session header's ``graph`` says whether
+``main`` or the ``seed`` ran, and a graph that cannot load is a
+``LOAD_ERROR`` like a tool. A run that somehow exceeds
+``(max_steps + 1) * 16`` transitions ends with ``GRAPH_ERROR``; admission
+proves that cannot happen, the guard is the backstop.
+
 The native loop writes its trajectory as ``native-jsonl``: one
 ``{type, seq, time, data}`` object per line, ``seq`` contiguous from 0. A
 ``session`` header line names the task, model, tools, and hooks (name to

--- a/docs/developer-guide/write-a-harness-method.rst
+++ b/docs/developer-guide/write-a-harness-method.rst
@@ -249,4 +249,6 @@ the step's ``screened_tasks`` metric; one tagged client holds at most
 most ``evolution.max_promoted_tasks``. A code-bearing mutation
 (``code_extension``, ``native_tool``, ``native_hook``) proposed from client
 text belongs behind ``evolution.review_kinds``, so a person reads it before
-it publishes.
+it publishes. A ``native_graph`` carries no code, so a loop change can
+publish on the gate alone; list the kind in ``review_kinds`` when a person
+should read every loop change.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -168,7 +168,7 @@ zero.
    evolution.evaluate | an ``EpisodeScorer``, likewise
    evolution.selection | score_comparison | ``always``, or a dotted reference to an object with ``decide``
    evolution.tasks | non-empty list of episode prompts, scored once per tree per step
-   evolution.adapter | pi | ``opencode``, ``claude``, ``codex``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), ``native`` (Reef's own agent, whose tools are ``native_tool`` nodes and whose loop seams listen to ``native_hook`` nodes), ``terminus`` (Terminal-Bench's Terminus 2, through a Reef-owned Harbor runner), or an entry-point adapter
+   evolution.adapter | pi | ``opencode``, ``claude``, ``codex``, ``dsh`` (DeepSeek Harness), ``hermes`` (Hermes Agent), ``native`` (Reef's own agent, whose tools are ``native_tool`` nodes, whose loop events listen to ``native_hook`` nodes, and whose loop is a ``native_graph`` node), ``terminus`` (Terminal-Bench's Terminus 2, through a Reef-owned Harbor runner), or an entry-point adapter
    evolution.binary | overrides the adapter's binary name
    evolution.episode_timeout_s | 600 | seconds one evaluation episode may run
    evolution.episode_repeats | 1 | episode pairings per task per step; each repeat tallies on its own

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -43,6 +43,8 @@ Seven kinds are registered in
 +--------------------+----------------------------------------------------------+
 | ``native_hook``    | a named listener at one event of the native loop (code)  |
 +--------------------+----------------------------------------------------------+
+| ``native_graph``   | the native loop's control flow: stages and edges (data)  |
++--------------------+----------------------------------------------------------+
 
 The table describes what each kind contains. Where each kind is written is
 decided by an adapter, which maps every kind to a concrete file for one agent.

--- a/reef/harness/adapters/native/descriptor.yaml
+++ b/reef/harness/adapters/native/descriptor.yaml
@@ -22,6 +22,7 @@ files:
   code_extension: "native/extensions/{name}.py"
   native_tool: "native/tools/{name}.py"
   native_hook: "native/hooks/{name}.py"
+  native_graph: "native/graphs/{name}.json"
 trajectory:
   format: native-jsonl
   path: "native/sessions"

--- a/reef/harness/descriptor.py
+++ b/reef/harness/descriptor.py
@@ -50,7 +50,7 @@ ENTRY_POINT_GROUP = "reef.harness_adapters"
 #: Node kinds rendered to one path per named node; templates need ``{name}``.
 NAMED_NODE_KINDS = ("agent_command", "skill", "code_extension")
 #: Named kinds an adapter may leave out; a mutation of that kind then fails to render under it.
-OPTIONAL_NODE_KINDS = ("native_tool", "native_hook")
+OPTIONAL_NODE_KINDS = ("native_tool", "native_hook", "native_graph")
 
 
 class DescriptorError(ReefError):

--- a/reef/harness/native/__init__.py
+++ b/reef/harness/native/__init__.py
@@ -18,7 +18,6 @@ import copy
 import importlib.util
 import json
 import os
-import re
 import sys
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
@@ -356,7 +355,9 @@ def _judged(result: dict[str, Any], verdict: Mapping[str, Any]) -> dict[str, Any
 
 
 def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
-    """One turn: per step, pre_step, the request (request_error on failure), each call behind pre_execute, then post_execute."""
+    """One turn: the tree's graph (or the seed graph) walked stage by stage; each model stage is one step."""
+    from reef.harness.native import graph as graphs  # late: graph.py imports this module
+
     binding = binding_from(root / "models.json")
     session = Session(session_dir / "session.jsonl")
     header = {
@@ -370,8 +371,9 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
         try:
             tools = load_tools(root / "tools")
             hooks = load_hooks(root / "hooks")
-        except LoadError as exc:
-            session.write("session", {**header, "tools": [], "hooks": {}})
+            graph = graphs.load_graph(root)
+        except (LoadError, graphs.GraphError, ValueError) as exc:
+            session.write("session", {**header, "tools": [], "hooks": {}, "graph": None})
             session.write("turn/start", {"turn": 1})
             return _abort(session, {"code": "LOAD_ERROR", "message": str(exc)[:600]})
         session.write(
@@ -381,91 +383,12 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
                 "tools": sorted(tools),
                 "capabilities": {name: list(tools[name].capabilities) for name in sorted(tools)},
                 "hooks": {hook.name: event for event, listeners in hooks.items() for hook in listeners},
+                "graph": graph.source,
             },
         )
         session.write("turn/start", {"turn": 1})
-        system = system_prompt(root)
-        declarations = [tool.declaration() for tool in tools.values()]
-        messages: list[dict[str, Any]] = [{"role": "system", "content": system}, {"role": "user", "content": prompt}]
-
-        def say(step: int, event: str, content: str) -> None:
-            session.write(
-                "user/message", {"step": step, "source": {"kind": "hook", "event": event}, "content": content}
-            )
-            messages.append({"role": "user", "content": content})
-
-        for step in range(1, MAX_STEPS + 1):
-            entry = _decide(
-                session, hooks["pre_step"], "pre_step", step, {"step": step, "task": prompt, "messages": messages}
-            )
-            if entry.get("kind") == "reject":
-                reason = {"kind": "rejected", "step": step, "message": str(entry.get("reason") or "")}
-                session.write("turn/end", {"turn": 1, "reason": reason})
-                return 0
-            session.write("step/start", {"turn": 1, "step": step})
-            if step == 1:
-                session.write("request/header", {"model": binding.model, "system": system, "tools": declarations})
-            for content in _texts(entry.get("messages")):
-                say(step, "pre_step", content)
-            body: dict[str, Any] = {"messages": messages}
-            if declarations:
-                body["tools"] = declarations
-            message = _request(session, binding, hooks["request_error"], body, step)
-            if message is None:
-                return 1
-            calls = list(message.get("tool_calls") or [])
-            messages.append(message)
-            session.write(
-                "assistant/message",
-                {
-                    "step": step,
-                    "content": message.get("content"),
-                    "tool_calls": calls,
-                    "finish": "tool-calls" if calls else "stop",
-                },
-            )
-            if not calls:
-                session.write("step/end", {"turn": 1, "step": step})
-                session.write("turn/end", {"turn": 1, "reason": {"kind": "completed"}})
-                return 0
-            contexts: list[str] = []
-            for call in calls:
-                function = call.get("function") or {}
-                name = str(function.get("name", ""))
-                raw = function.get("arguments") or "{}"
-                call_id = str(call.get("id") or name)
-                session.write("tool/call", {"step": step, "call_id": call_id, "name": name, "arguments": raw})
-                spill = workdir / SPILL_DIR / f"{step}-{re.sub(r'[^A-Za-z0-9_-]', '_', call_id)}.txt"
-
-                def gate(tool: ToolModule, arguments: dict[str, Any], step=step, call_id=call_id) -> dict[str, Any]:
-                    payload = {
-                        "step": step,
-                        "call_id": call_id,
-                        "name": tool.name,
-                        "arguments": arguments,
-                        "capabilities": list(tool.capabilities),
-                    }
-                    return _decide(session, hooks["pre_execute"], "pre_execute", step, payload)
-
-                result = _invoke(tools, name, raw, workdir, spill=spill, gate=gate)
-                payload = {
-                    "step": step,
-                    "call_id": call_id,
-                    "name": name,
-                    "arguments": result.get("arguments"),
-                    "result": result,
-                }
-                verdict = _decide(session, hooks["post_execute"], "post_execute", step, payload)
-                result = _judged(result, verdict)
-                session.write("tool/result", {"step": step, "call_id": call_id, "name": name, **result})
-                messages.append({"role": "tool", "tool_call_id": call_id, "content": result["content"]})
-                contexts.extend(_texts(verdict.get("contexts")))
-            # Contexts land after the batch's results, in call order, so the model reads them as one note.
-            for content in contexts:
-                say(step, "post_execute", content)
-            session.write("step/end", {"turn": 1, "step": step})
-        session.write("turn/end", {"turn": 1, "reason": {"kind": "max-steps", "steps": MAX_STEPS}})
-        return 0
+        loop = _Loop(session, root)
+        return graphs.run_graph(graphs.Run(loop, prompt, binding, tools, hooks, workdir), graph)
     finally:
         session.close()
 
@@ -557,6 +480,24 @@ def _invoke(
         "arguments": arguments,
         "meta": {"duration_ms": int((time.monotonic() - started) * 1000), **clipped},
     }
+
+
+class _Loop:
+    """What the stage handlers reach of this module: the session, the root, and the loop's own helpers."""
+
+    SPILL_DIR = SPILL_DIR
+
+    def __init__(self, session: Session, root: Path) -> None:
+        self.session = session
+        self.root = root
+
+    system_prompt = staticmethod(system_prompt)
+    _decide = staticmethod(_decide)
+    _request = staticmethod(_request)
+    _invoke = staticmethod(_invoke)
+    _judged = staticmethod(_judged)
+    _texts = staticmethod(_texts)
+    _abort = staticmethod(_abort)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/reef/harness/native/graph.py
+++ b/reef/harness/native/graph.py
@@ -1,0 +1,253 @@
+"""The native loop's interpreter: a graph of stages, run one transition at a time.
+
+The graph is data from the tree (``graphs/main.json``, or the seed graph when
+the tree carries none); the stage handlers are fixed code here. The seed
+graph reproduces the fixed loop this replaced, event for event, apart from
+the ``stage/enter`` and ``stage/exit`` events that now name the path.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from reef.harness.model_binding import ModelBinding
+from reef.harness.native.seed import SEED_GRAPH
+from reef.harness.nodes import validate_native_graph
+
+#: Transitions one run may take beyond what the step budget implies; admission proves termination, this is the guard.
+TRANSITIONS_PER_STEP = 16
+
+
+class GraphError(Exception):
+    """A graph the loop cannot run; the episode ends with LOAD_ERROR like a broken tool."""
+
+
+class Graph:
+    """One validated graph: its stages by name and one target per (stage, outcome)."""
+
+    def __init__(self, config: Mapping[str, Any], *, source: str) -> None:
+        options = validate_native_graph(config)
+        self.name = str(options["name"])
+        self.source = source
+        self.start = str(options["start"])
+        self.max_steps = int(options.get("max_steps", SEED_GRAPH["max_steps"]))
+        self.stages: dict[str, Mapping[str, Any]] = {str(k): v for k, v in options["stages"].items()}
+        self.edges: dict[tuple[str, str], str] = {
+            (str(e["from"]), str(e["when"])): str(e["to"]) for e in options["edges"]
+        }
+
+
+def load_graph(root: Path) -> Graph:
+    """The tree's ``graphs/main.json`` when present, else the seed graph; a bad file is a GraphError."""
+    path = root / "graphs" / "main.json"
+    if not path.is_file():
+        return Graph(SEED_GRAPH, source="seed")
+    try:
+        import json
+
+        return Graph(json.loads(path.read_text(encoding="utf-8")), source="main")
+    except (OSError, ValueError) as exc:
+        raise GraphError(f"graphs/main.json cannot run: {exc}") from exc
+
+
+class _Stop(Exception):
+    """The run ended inside a stage; carries the exit status."""
+
+    def __init__(self, exit_code: int) -> None:
+        super().__init__(exit_code)
+        self.exit_code = exit_code
+
+
+def _last_assistant_text(messages: list[dict[str, Any]]) -> str:
+    for message in reversed(messages):
+        if message.get("role") == "assistant" and isinstance(message.get("content"), str):
+            return message["content"]
+    return ""
+
+
+def _last_line(text: str) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-1] if lines else ""
+
+
+class Run:
+    """One turn's state, shared by every stage handler: the messages, the step counter, the log."""
+
+    def __init__(
+        self,
+        loop: Any,
+        prompt: str,
+        binding: ModelBinding,
+        tools: Mapping[str, Any],
+        hooks: Mapping[str, list],
+        workdir: Path,
+    ) -> None:
+        self.loop = loop
+        self.prompt = prompt
+        self.binding = binding
+        self.tools = tools
+        self.hooks = hooks
+        self.workdir = workdir
+        self.session = loop.session
+        self.system = loop.system_prompt(loop.root)
+        self.declarations = [tool.declaration() for tool in tools.values()]
+        self.messages: list[dict[str, Any]] = [
+            {"role": "system", "content": self.system},
+            {"role": "user", "content": prompt},
+        ]
+        self.step = 0
+        self.step_open = False
+        self.last: dict[str, Any] = {}
+
+    def say(self, content: str, source: Mapping[str, Any]) -> None:
+        self.session.write("user/message", {"step": self.step, "source": dict(source), "content": content})
+        self.messages.append({"role": "user", "content": content})
+
+    def close_step(self) -> None:
+        if self.step_open:
+            self.session.write("step/end", {"turn": 1, "step": self.step})
+            self.step_open = False
+
+    # -- stage handlers, one per kind; each returns the outcome its edges name ------------------------
+
+    def model(self, graph: Graph, stage: Mapping[str, Any]) -> str:
+        loop = self.loop
+        self.close_step()
+        if self.step >= graph.max_steps:
+            self.session.write("turn/end", {"turn": 1, "reason": {"kind": "max-steps", "steps": graph.max_steps}})
+            raise _Stop(0)
+        self.step += 1
+        step = self.step
+        payload = {"step": step, "task": self.prompt, "messages": self.messages}
+        entry = loop._decide(self.session, self.hooks["pre_step"], "pre_step", step, payload)
+        if entry.get("kind") == "reject":
+            reason = {"kind": "rejected", "step": step, "message": str(entry.get("reason") or "")}
+            self.session.write("turn/end", {"turn": 1, "reason": reason})
+            raise _Stop(0)
+        self.session.write("step/start", {"turn": 1, "step": step})
+        self.step_open = True
+        if step == 1:
+            self.session.write(
+                "request/header", {"model": self.binding.model, "system": self.system, "tools": self.declarations}
+            )
+        for content in loop._texts(entry.get("messages")):
+            self.say(content, {"kind": "hook", "event": "pre_step"})
+        body: dict[str, Any] = {"messages": self.messages}
+        if self.declarations:
+            body["tools"] = self.declarations
+        message = loop._request(self.session, self.binding, self.hooks["request_error"], body, step)
+        if message is None:
+            raise _Stop(1)
+        calls = list(message.get("tool_calls") or [])
+        self.messages.append(message)
+        self.last = message
+        self.session.write(
+            "assistant/message",
+            {
+                "step": step,
+                "content": message.get("content"),
+                "tool_calls": calls,
+                "finish": "tool-calls" if calls else "stop",
+            },
+        )
+        return "tool_calls" if calls else "text"
+
+    def tools_stage(self, graph: Graph, stage: Mapping[str, Any]) -> str:
+        loop = self.loop
+        allow = stage.get("allow")
+        tools = self.tools if not allow else {name: tool for name, tool in self.tools.items() if name in allow}
+        step = self.step
+        contexts: list[str] = []
+        for call in list(self.last.get("tool_calls") or []):
+            function = call.get("function") or {}
+            name = str(function.get("name", ""))
+            raw = function.get("arguments") or "{}"
+            call_id = str(call.get("id") or name)
+            self.session.write("tool/call", {"step": step, "call_id": call_id, "name": name, "arguments": raw})
+            spill = self.workdir / loop.SPILL_DIR / f"{step}-{re.sub(r'[^A-Za-z0-9_-]', '_', call_id)}.txt"
+
+            def gate(tool: Any, arguments: dict[str, Any], call_id: str = call_id) -> dict[str, Any]:
+                payload = {
+                    "step": step,
+                    "call_id": call_id,
+                    "name": tool.name,
+                    "arguments": arguments,
+                    "capabilities": list(tool.capabilities),
+                }
+                return loop._decide(self.session, self.hooks["pre_execute"], "pre_execute", step, payload)
+
+            result = loop._invoke(tools, name, raw, self.workdir, spill=spill, gate=gate)
+            payload = {
+                "step": step,
+                "call_id": call_id,
+                "name": name,
+                "arguments": result.get("arguments"),
+                "result": result,
+            }
+            verdict = loop._decide(self.session, self.hooks["post_execute"], "post_execute", step, payload)
+            result = loop._judged(result, verdict)
+            self.session.write("tool/result", {"step": step, "call_id": call_id, "name": name, **result})
+            self.messages.append({"role": "tool", "tool_call_id": call_id, "content": result["content"]})
+            contexts.extend(loop._texts(verdict.get("contexts")))
+        # Contexts land after the batch's results, in call order, so the model reads them as one note.
+        for content in contexts:
+            self.say(content, {"kind": "hook", "event": "post_execute"})
+        return "done"
+
+    def verify(self, graph: Graph, stage: Mapping[str, Any], name: str) -> tuple[str, dict[str, Any]]:
+        text = _last_assistant_text(self.messages)
+        line = _last_line(text)
+        check = stage["check"]
+        if check == "last_line_integer":
+            passed = re.fullmatch(r"-?\d+", line) is not None
+        elif check == "last_line_matches":
+            passed = re.search(stage["pattern"], line) is not None
+        else:
+            passed = bool(line)
+        if not passed and isinstance(stage.get("message"), str):
+            self.say(stage["message"], {"kind": "stage", "stage": name})
+        return ("pass" if passed else "fail"), {"check": check, "last_line": line[:200]}
+
+    def message(self, graph: Graph, stage: Mapping[str, Any], name: str) -> str:
+        self.say(str(stage["text"]), {"kind": "stage", "stage": name})
+        return "done"
+
+    def end(self, graph: Graph, stage: Mapping[str, Any]) -> None:
+        self.close_step()
+        self.session.write("turn/end", {"turn": 1, "reason": {"kind": str(stage.get("reason", "completed"))}})
+        raise _Stop(0)
+
+
+def run_graph(run: Run, graph: Graph) -> int:
+    """Walk the graph from its start until an end stage, a budget stop, or a failure; the exit status."""
+    session = run.session
+    name = graph.start
+    limit = (graph.max_steps + 1) * TRANSITIONS_PER_STEP
+    try:
+        for _ in range(limit):
+            stage = graph.stages[name]
+            kind = str(stage["kind"])
+            session.write("stage/enter", {"step": run.step, "stage": name, "kind": kind})
+            detail: dict[str, Any] = {}
+            if kind == "model":
+                outcome = run.model(graph, stage)
+            elif kind == "tools":
+                outcome = run.tools_stage(graph, stage)
+            elif kind == "verify":
+                outcome, detail = run.verify(graph, stage, name)
+            elif kind == "message":
+                outcome = run.message(graph, stage, name)
+            else:
+                run.end(graph, stage)
+                return 0
+            target = graph.edges[(name, outcome)]
+            session.write("stage/exit", {"step": run.step, "stage": name, "outcome": outcome, "to": target, **detail})
+            name = target
+    except _Stop as stop:
+        return stop.exit_code
+    run.close_step()
+    failure = {"code": "GRAPH_ERROR", "message": f"graph {graph.name!r} took more than {limit} transitions"}
+    return run.loop._abort(session, failure)

--- a/reef/harness/native/seed.py
+++ b/reef/harness/native/seed.py
@@ -127,6 +127,21 @@ SEED_TOOLS: tuple[dict[str, Any], ...] = (
 #: The loop guard is a hook, not loop code: a tree may retune or drop it.
 SEED_HOOKS: tuple[dict[str, Any], ...] = (_hook("loop_guard", "post_execute", _LOOP_GUARD),)
 
-SEED_NODES: tuple[dict[str, Any], ...] = (*SEED_TOOLS, *SEED_HOOKS)
+#: Today's loop as a graph: think, act while the model calls tools, end when it answers. The loop runs this
+#: when a tree carries no graph, so an old tree behaves as before; as a node a proposer may rewrite it.
+SEED_GRAPH: dict[str, Any] = {
+    "name": "main",
+    "start": "think",
+    "max_steps": 12,
+    "stages": {"think": {"kind": "model"}, "act": {"kind": "tools"}, "done": {"kind": "end", "reason": "completed"}},
+    "edges": [
+        {"from": "think", "when": "tool_calls", "to": "act"},
+        {"from": "think", "when": "text", "to": "done"},
+        {"from": "act", "when": "done", "to": "think"},
+    ],
+}
+SEED_GRAPHS: tuple[dict[str, Any], ...] = ({"id": "main", "name": "native_graph", "config": SEED_GRAPH},)
 
-__all__ = ["SEED_HOOKS", "SEED_NODES", "SEED_TOOLS"]
+SEED_NODES: tuple[dict[str, Any], ...] = (*SEED_TOOLS, *SEED_HOOKS, *SEED_GRAPHS)
+
+__all__ = ["SEED_GRAPH", "SEED_GRAPHS", "SEED_HOOKS", "SEED_NODES", "SEED_TOOLS"]

--- a/reef/harness/nodes.py
+++ b/reef/harness/nodes.py
@@ -21,6 +21,8 @@ native harness adds kinds only it renders:
   code defining ``run(args, workdir)`` (``native/tools/``).
 - ``native_hook``: a named listener at one event of the native loop, code
   defining ``listen(payload, next)`` (``native/hooks/``).
+- ``native_graph``: the native loop's control flow as data, stages from a
+  closed vocabulary joined by edges keyed by outcome (``native/graphs/``).
 
 The plugins hold no services and register no effects: the Entry tree itself
 is the state, and ``reef.harness.render`` reads it back out per adapter.
@@ -38,6 +40,20 @@ _NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 NATIVE_EVENTS = ("pre_step", "pre_execute", "request_error", "post_execute")
 #: What a native_tool may declare it does; the loop reports them and a pre_execute hook reads them.
 NATIVE_CAPABILITIES = ("read", "write", "exec", "network")
+#: The native graph's stage vocabulary: the keys a stage may carry and the outcomes its edges may name.
+NATIVE_STAGES: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "model": ((), ("tool_calls", "text")),
+    "tools": (("allow",), ("done",)),
+    "verify": (("check", "pattern", "message"), ("pass", "fail")),
+    "message": (("text",), ("done",)),
+    "end": (("reason",), ()),
+}
+NATIVE_VERIFY_CHECKS = ("last_line_integer", "last_line_matches", "nonempty")
+NATIVE_END_REASONS = ("completed", "gave_up")
+#: Size caps on one graph, so admission and the interpreter's guard stay cheap.
+NATIVE_GRAPH_MAX_STEPS = 32
+NATIVE_GRAPH_MAX_STAGES = 16
+NATIVE_GRAPH_MAX_EDGES = 64
 _SECRET_NAME = re.compile(r"(?i)(api[_-]?keys?([_-]?env)?|tokens?|secrets?|passwords?)$")
 #: Distinctive credential shapes in free text. A tripwire like _SECRET_NAME:
 #: prefixes and key blocks that are never legitimate tree content, chosen so
@@ -238,6 +254,150 @@ def native_hook_node(ctx: Any, config: Any) -> None:
     _require_python(options, "native_hook node")
 
 
+def _graph_stage(name: str, stage: Any) -> str:
+    """Validate one stage's kind and keys; the kind, so the caller can read its outcomes."""
+    if not _NAME.fullmatch(name):
+        raise ValueError(f"native_graph stage name {name!r} must match {_NAME.pattern}")
+    if not isinstance(stage, Mapping):
+        raise ValueError(f"native_graph stage {name!r} must be an object")
+    kind = stage.get("kind")
+    if kind not in NATIVE_STAGES:
+        raise ValueError(f"native_graph stage {name!r} kind must be one of {', '.join(NATIVE_STAGES)}")
+    keys, _ = NATIVE_STAGES[kind]
+    extra = sorted(set(stage) - {"kind", *keys})
+    if extra:
+        raise ValueError(f"native_graph stage {name!r} ({kind}) does not take {', '.join(extra)}")
+    if kind == "tools":
+        allow = stage.get("allow", [])
+        if not isinstance(allow, Sequence) or isinstance(allow, str) or len(set(allow)) < len(allow):
+            raise ValueError(f"native_graph stage {name!r} 'allow' must be a list of distinct tool names")
+        if any(not isinstance(item, str) or not item for item in allow):
+            raise ValueError(f"native_graph stage {name!r} 'allow' must be a list of distinct tool names")
+    elif kind == "verify":
+        check = stage.get("check")
+        if check not in NATIVE_VERIFY_CHECKS:
+            raise ValueError(f"native_graph stage {name!r} 'check' must be one of {', '.join(NATIVE_VERIFY_CHECKS)}")
+        if (check == "last_line_matches") != ("pattern" in stage):
+            raise ValueError(
+                f"native_graph stage {name!r} takes 'pattern' exactly when its check is last_line_matches"
+            )
+        if "pattern" in stage:
+            pattern = stage["pattern"]
+            if not isinstance(pattern, str) or not pattern:
+                raise ValueError(f"native_graph stage {name!r} 'pattern' must be a regular expression")
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError(f"native_graph stage {name!r} 'pattern' must be a regular expression: {exc}") from exc
+        if "message" in stage:
+            _reject_secret_shaped_text(_require_text(stage, "message"), f"native_graph stage {name!r} 'message'")
+    elif kind == "message":
+        _reject_secret_shaped_text(_require_text(stage, "text"), f"native_graph stage {name!r} 'text'")
+    elif kind == "end" and stage.get("reason", "completed") not in NATIVE_END_REASONS:
+        raise ValueError(f"native_graph stage {name!r} 'reason' must be one of {', '.join(NATIVE_END_REASONS)}")
+    return kind
+
+
+def _reachable(start: str, edges: Mapping[str, set[str]]) -> set[str]:
+    seen, queue = {start}, [start]
+    while queue:
+        for target in edges.get(queue.pop(), set()):
+            if target not in seen:
+                seen.add(target)
+                queue.append(target)
+    return seen
+
+
+def _has_cycle(nodes: set[str], edges: Mapping[str, set[str]]) -> bool:
+    """Whether the edges among ``nodes`` close a cycle (depth first, three colors)."""
+    state: dict[str, int] = {}
+
+    def visit(name: str) -> bool:
+        state[name] = 1
+        for target in edges.get(name, ()):
+            if target not in nodes:
+                continue
+            if state.get(target) == 1 or (state.get(target) is None and visit(target)):
+                return True
+        state[name] = 2
+        return False
+
+    return any(state.get(name) is None and visit(name) for name in nodes)
+
+
+def validate_native_graph(config: Any) -> Mapping[str, Any]:
+    """The admission rules of a native_graph, shared by the tree boundary and the loop's loader.
+
+    A graph passes when every stage is a known kind with only its own keys,
+    every outcome of every stage has exactly one edge, every stage is
+    reachable from ``start``, some end stage is reachable from every stage,
+    and every cycle passes through a model stage, so the finite step budget
+    ends every run."""
+    options = _require_mapping(config)
+    _require_name(options)
+    extra = sorted(set(options) - {"name", "start", "max_steps", "stages", "edges"})
+    if extra:
+        raise ValueError(f"native_graph node does not take {', '.join(extra)}")
+    max_steps = options.get("max_steps", NATIVE_GRAPH_MAX_STEPS)
+    if isinstance(max_steps, bool) or not isinstance(max_steps, int) or not 1 <= max_steps <= NATIVE_GRAPH_MAX_STEPS:
+        raise ValueError(f"native_graph node 'max_steps' must be an integer from 1 to {NATIVE_GRAPH_MAX_STEPS}")
+    stages = options.get("stages")
+    if not isinstance(stages, Mapping) or not 1 <= len(stages) <= NATIVE_GRAPH_MAX_STAGES:
+        raise ValueError(f"native_graph node 'stages' must be an object of 1 to {NATIVE_GRAPH_MAX_STAGES} stages")
+    kinds = {str(name): _graph_stage(str(name), stage) for name, stage in stages.items()}
+    start = options.get("start")
+    if start not in kinds:
+        raise ValueError("native_graph node 'start' must name a stage")
+    edges = options.get("edges")
+    if not isinstance(edges, Sequence) or isinstance(edges, str) or len(edges) > NATIVE_GRAPH_MAX_EDGES:
+        raise ValueError(f"native_graph node 'edges' must be a list of at most {NATIVE_GRAPH_MAX_EDGES} edges")
+    seen: set[tuple[str, str]] = set()
+    targets: dict[str, set[str]] = {name: set() for name in kinds}
+    for edge in edges:
+        if not isinstance(edge, Mapping) or set(edge) != {"from", "when", "to"}:
+            raise ValueError("native_graph edges must be objects with from, when and to")
+        source, when, target = edge["from"], edge["when"], edge["to"]
+        if source not in kinds or target not in kinds:
+            raise ValueError(f"native_graph edge {source!r} -> {target!r} must name stages")
+        if when not in NATIVE_STAGES[kinds[source]][1]:
+            raise ValueError(
+                f"native_graph edge from {source!r} names outcome {when!r}, not one of its {kinds[source]} stage"
+            )
+        if (source, when) in seen:
+            raise ValueError(f"native_graph stage {source!r} has two edges for outcome {when!r}")
+        seen.add((source, when))
+        targets[source].add(target)
+    for name, kind in kinds.items():
+        for outcome in NATIVE_STAGES[kind][1]:
+            if (name, outcome) not in seen:
+                raise ValueError(f"native_graph stage {name!r} has no edge for outcome {outcome!r}")
+    unreachable = sorted(set(kinds) - _reachable(start, targets))
+    if unreachable:
+        raise ValueError(f"native_graph stages {', '.join(unreachable)} are not reachable from {start!r}")
+    ends = {name for name, kind in kinds.items() if kind == "end"}
+    if not ends:
+        raise ValueError("native_graph node needs an end stage")
+    reverse: dict[str, set[str]] = {name: set() for name in kinds}
+    for source, names in targets.items():
+        for target in names:
+            reverse[target].add(source)
+    reaches_end: set[str] = set()
+    for end in ends:
+        reaches_end |= _reachable(end, reverse)
+    dead = sorted(set(kinds) - reaches_end)
+    if dead:
+        raise ValueError(f"native_graph stages {', '.join(dead)} cannot reach an end stage")
+    unbudgeted = {name for name, kind in kinds.items() if kind not in ("model", "end")}
+    if _has_cycle(unbudgeted, targets):
+        raise ValueError("native_graph has a cycle without a model stage, so nothing would end it")
+    return options
+
+
+def native_graph_node(ctx: Any, config: Any) -> None:
+    """The native loop's control flow as data: stages from a closed vocabulary and edges keyed by outcome."""
+    validate_native_graph(config)
+
+
 NODE_KINDS: dict[str, Callable[[Any, Any], None]] = {
     "config": config_node,
     "rules": rules_node,
@@ -246,5 +406,6 @@ NODE_KINDS: dict[str, Callable[[Any, Any], None]] = {
     "code_extension": code_extension_node,
     "native_tool": native_tool_node,
     "native_hook": native_hook_node,
+    "native_graph": native_graph_node,
 }
 """Entry ``name`` to node plugin; the resolver of the composition loader."""

--- a/reef/harness/render.py
+++ b/reef/harness/render.py
@@ -37,6 +37,7 @@ def render_composition(nodes: Sequence[tuple[str, Any]], descriptor: AdapterDesc
     """Render ``(kind, config)`` nodes to root-relative file texts."""
     configs = {name: _deep_merge({}, target.defaults) for name, target in descriptor.config_targets.items()}
     rules: list[str] = []
+    graphs: list[Mapping[str, Any]] = []
     files: dict[str, str] = {}
 
     def emit(path: str, text: str) -> None:
@@ -75,8 +76,27 @@ def render_composition(nodes: Sequence[tuple[str, Any]], descriptor: AdapterDesc
                 )
             header = "\n".join(f"{key} = {value!r}" for key, value in fields)
             emit(template.format(name=options.get("name")), f"{str(options.get('code', '')).rstrip()}\n\n{header}\n")
+        elif kind == "native_graph":
+            template = descriptor.node_paths.get(kind)
+            if template is None:
+                raise RenderError(f"adapter {descriptor.name!r} does not render {kind} nodes")
+            # Sorted keys, so a proposal's diff against the previous graph is a few lines.
+            emit(template.format(name=options.get("name")), json.dumps(options, indent=2, sort_keys=True) + "\n")
+            graphs.append(options)
         else:
             raise RenderError(f"unknown node kind {kind!r}")
+
+    # A graph's allow list names tools the same tree carries; the check needs every node, so it lands here.
+    tool_names = {
+        str(config.get("name")) for kind, config in nodes if kind == "native_tool" and isinstance(config, Mapping)
+    }
+    for graph in graphs:
+        for stage_name, stage in (graph.get("stages") or {}).items():
+            missing = sorted(set(stage.get("allow") or ()) - tool_names) if isinstance(stage, Mapping) else []
+            if missing:
+                raise RenderError(
+                    f"native_graph stage {stage_name!r} allows tools the tree lacks: {', '.join(missing)}"
+                )
 
     for name, target in descriptor.config_targets.items():
         files[target.path] = json.dumps(configs[name], indent=2, sort_keys=True) + "\n"

--- a/tests/reef_service/test_harness_example.py
+++ b/tests/reef_service/test_harness_example.py
@@ -304,6 +304,7 @@ def test_native_example_yaml_boots_the_recipe_with_the_shipped_seed(native_evolu
         "write_file",
         "run_bash",
         "loop_guard",
+        "main",
         "answer-style",
     ]
     assert "upstream" not in yaml.safe_dump(list(built.seed))

--- a/tests/reef_service/test_native_harness.py
+++ b/tests/reef_service/test_native_harness.py
@@ -27,7 +27,7 @@ from reef.harness.native import (
     _waterfall,
     load_hooks,
 )
-from reef.harness.native.seed import SEED_NODES, SEED_TOOLS
+from reef.harness.native.seed import SEED_GRAPH, SEED_NODES, SEED_TOOLS
 from reef.harness.nodes import NODE_KINDS
 from reef.harness.render import RenderError, render_composition
 from reef.harness.trajectory import reader_for
@@ -369,7 +369,8 @@ def test_tool_results_carry_closed_error_codes_and_validate_arguments(tmp_path: 
 def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path: Path, fake_model) -> None:
     result = _episode(tmp_path, fake_model, [*_seed_nodes(), ("rules", {"text": "Be brief."})])
     kinds = [event["type"] for event in result.trajectory]
-    assert kinds == [
+    # The seed graph reproduces the fixed loop it replaced: without the stage events the sequence is the old one.
+    assert [kind for kind in kinds if not kind.startswith("stage/")] == [
         "session",
         "turn/start",
         "step/start",
@@ -388,10 +389,40 @@ def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path:
         "step/end",
         "turn/end",
     ]
+    assert kinds == [
+        "session",
+        "turn/start",
+        "stage/enter",
+        "step/start",
+        "request/header",
+        "assistant/message",
+        "stage/exit",
+        "stage/enter",
+        "tool/call",
+        "tool/result",
+        "stage/exit",
+        "stage/enter",
+        "step/end",
+        "step/start",
+        "assistant/message",
+        "stage/exit",
+        "stage/enter",
+        "tool/call",
+        "tool/result",
+        "stage/exit",
+        "stage/enter",
+        "step/end",
+        "step/start",
+        "assistant/message",
+        "stage/exit",
+        "stage/enter",
+        "step/end",
+        "turn/end",
+    ]
     assert [event["seq"] for event in result.trajectory] == list(range(len(kinds)))
     header = result.trajectory[0]["data"]
     assert header["version"] == 1 and header["tools"] == ["read_file", "run_bash", "write_file"]
-    assert header["hooks"] == {"loop_guard": "post_execute"}
+    assert header["hooks"] == {"loop_guard": "post_execute"} and header["graph"] == "main"
     request = _events(result.trajectory, "request/header")[0]["data"]
     assert request["system"] == "Be brief."
     assert sorted(tool["function"]["name"] for tool in request["tools"]) == ["read_file", "run_bash", "write_file"]
@@ -415,7 +446,7 @@ def test_hooks_decide_at_the_first_three_events(tmp_path: Path) -> None:
         model.shutdown()
         model.server_close()
     kinds = [event["type"] for event in result.trajectory]
-    assert kinds == [
+    assert [kind for kind in kinds if not kind.startswith("stage/")] == [
         "session",
         "turn/start",
         "step/start",
@@ -686,3 +717,308 @@ def test_pre_execute_hooks_deny_by_capability_and_ask_with_no_one_to_answer(tmp_
         "content": "Error: writes are off",
     }
     assert result.trajectory[-1]["data"]["reason"] == {"kind": "completed"}
+
+
+# -- native_graph: the loop's control flow as data --------------------------------------------------
+
+VERIFY_GRAPH = {
+    "name": "main",
+    "start": "think",
+    "max_steps": 12,
+    "stages": {
+        "think": {"kind": "model"},
+        "act": {"kind": "tools"},
+        "check": {
+            "kind": "verify",
+            "check": "last_line_integer",
+            "message": "Reply with the final answer as a plain integer alone on the last line.",
+        },
+        "done": {"kind": "end", "reason": "completed"},
+    },
+    "edges": [
+        {"from": "think", "when": "tool_calls", "to": "act"},
+        {"from": "think", "when": "text", "to": "check"},
+        {"from": "act", "when": "done", "to": "think"},
+        {"from": "check", "when": "pass", "to": "done"},
+        {"from": "check", "when": "fail", "to": "think"},
+    ],
+}
+
+
+def _graph(**changes):
+    import copy
+
+    graph = copy.deepcopy(SEED_GRAPH)
+    graph.update(changes)
+    return graph
+
+
+class _ProseThenIntegerModel(_FakeModel):
+    """The measured failure: a tool call, then the count in prose; a bare integer only after being asked again."""
+
+    def script(self, body: dict) -> dict:
+        messages = body["messages"]
+        if not any(m.get("role") == "tool" for m in messages):
+            return _reply(tool_calls=[_call("run_bash", {"command": "python3 -c 'print(9592)'"}, "c1")])
+        if messages[-1].get("role") == "user" and "plain integer" in messages[-1]["content"]:
+            return _reply(content="9592")
+        return _reply(content="The sieve finds 9592 primes below 100000.")
+
+
+def test_native_graph_admission_names_the_rule_a_bad_graph_breaks() -> None:
+    NODE_KINDS["native_graph"](None, SEED_GRAPH)
+    NODE_KINDS["native_graph"](None, VERIFY_GRAPH)
+    stages = SEED_GRAPH["stages"]
+    edges = SEED_GRAPH["edges"]
+    bad = [
+        (_graph(stages={**stages, "x": {"kind": "loop"}}), "kind must be one of"),
+        (_graph(stages={**stages, "think": {"kind": "model", "code": "x"}}), "does not take code"),
+        (_graph(edges=[*edges, {"from": "act", "when": "done", "to": "done"}]), "two edges for outcome 'done'"),
+        (_graph(edges=edges[:2]), "stage 'act' has no edge for outcome 'done'"),
+        (
+            _graph(
+                stages={**stages, "trap": {"kind": "message", "text": "again"}},
+                edges=[
+                    *edges[:1],
+                    {"from": "think", "when": "text", "to": "trap"},
+                    {"from": "act", "when": "done", "to": "done"},
+                    {"from": "trap", "when": "done", "to": "trap"},
+                ],
+            ),
+            "stages trap cannot reach an end stage",
+        ),
+        (
+            _graph(
+                stages={**stages, "lonely": {"kind": "message", "text": "hi"}},
+                edges=[*edges, {"from": "lonely", "when": "done", "to": "done"}],
+            ),
+            "not reachable from 'think'",
+        ),
+        (
+            _graph(
+                edges=[
+                    {"from": "think", "when": "text", "to": "done"},
+                    {"from": "think", "when": "tool_calls", "to": "done"},
+                    {"from": "act", "when": "done", "to": "act"},
+                ]
+            ),
+            "not reachable",
+        ),
+        (_graph(max_steps=0), "'max_steps' must be an integer from 1 to 32"),
+        (_graph(max_steps=33), "'max_steps' must be an integer from 1 to 32"),
+        (_graph(start="nowhere"), "'start' must name a stage"),
+        (
+            _graph(
+                stages={**stages, "v": {"kind": "verify", "check": "last_line_matches"}},
+                edges=[
+                    *edges,
+                    {"from": "v", "when": "pass", "to": "done"},
+                    {"from": "v", "when": "fail", "to": "done"},
+                ],
+            ),
+            "takes 'pattern' exactly when",
+        ),
+        (
+            _graph(
+                stages={**stages, "m": {"kind": "message", "text": "use sk-abcdef1234567890ABCDEFGH"}},
+                edges=[*edges, {"from": "m", "when": "done", "to": "done"}],
+            ),
+            "inline credential",
+        ),
+    ]
+    for graph, message in bad:
+        with pytest.raises(ValueError, match=message):
+            NODE_KINDS["native_graph"](None, graph)
+    # Two text stages that only feed each other never spend the budget.
+    loop = _graph(
+        stages={**stages, "a": {"kind": "message", "text": "a"}, "b": {"kind": "message", "text": "b"}},
+        edges=[
+            *edges[:1],
+            {"from": "act", "when": "done", "to": "done"},
+            {"from": "think", "when": "text", "to": "a"},
+            {"from": "a", "when": "done", "to": "b"},
+            {"from": "b", "when": "done", "to": "a"},
+        ],
+    )
+    with pytest.raises(ValueError, match="stages a, b cannot reach an end stage"):
+        NODE_KINDS["native_graph"](None, loop)
+    cycle = _graph(
+        stages={**stages, "a": {"kind": "message", "text": "a"}, "b": {"kind": "verify", "check": "nonempty"}},
+        edges=[
+            *edges[:1],
+            edges[2],
+            {"from": "think", "when": "text", "to": "a"},
+            {"from": "a", "when": "done", "to": "b"},
+            {"from": "b", "when": "pass", "to": "done"},
+            {"from": "b", "when": "fail", "to": "a"},
+        ],
+    )
+    with pytest.raises(ValueError, match="cycle without a model stage"):
+        NODE_KINDS["native_graph"](None, cycle)
+
+
+def test_native_graph_renders_sorted_json_and_checks_its_allow_list() -> None:
+    descriptor = get_adapter("native")
+    files = render_composition([("native_graph", VERIFY_GRAPH), TOOL], descriptor)
+    assert files["native/graphs/main.json"] == json.dumps(VERIFY_GRAPH, indent=2, sort_keys=True) + "\n"
+    allowed = _graph(stages={**SEED_GRAPH["stages"], "act": {"kind": "tools", "allow": ["shout"]}})
+    assert "native/graphs/main.json" in render_composition([("native_graph", allowed), TOOL], descriptor)
+    with pytest.raises(RenderError, match="allows tools the tree lacks: shout"):
+        render_composition([("native_graph", allowed)], descriptor)
+    with pytest.raises(RenderError, match="does not render native_graph"):
+        render_composition([("native_graph", SEED_GRAPH)], get_adapter("pi"))
+
+
+def test_a_tree_without_a_graph_runs_the_seed_graph_and_a_bad_graph_is_a_load_error(
+    tmp_path: Path, fake_model
+) -> None:
+    result = _episode(tmp_path, fake_model, _seed_nodes(SEED_TOOLS))
+    assert result.trajectory[0]["data"]["graph"] == "seed"
+    assert result.trajectory[-1]["data"]["reason"] == {"kind": "completed"}
+    descriptor = get_adapter("native")
+    binding = ModelBinding(base_url=fake_model.base_url, model="fake", api_key="dummy")
+    files = dict(render_composition([*_seed_nodes(SEED_TOOLS), *binding.compose_nodes(descriptor)], descriptor))
+    files["native/graphs/main.json"] = '{"name": "main", "start": "x", "stages": {}, "edges": []}\n'
+    broken = run_episode(descriptor, files, "hi", binary=_launcher(tmp_path))
+    assert broken.exit_code == 1 and [event["type"] for event in broken.trajectory] == [
+        "session",
+        "turn/start",
+        "turn/end",
+    ]
+    assert broken.trajectory[-1]["data"]["reason"]["error"]["code"] == "LOAD_ERROR"
+
+
+def test_a_verify_stage_asks_once_more_and_the_graph_wins_the_gate(tmp_path: Path) -> None:
+    """The measured sieve failure: prose after a tool call scores 0.0 on the seed; the verify graph asks once more and scores 1.0."""
+
+    def final_line(task, result):
+        answers = [e["data"].get("content") or "" for e in result.trajectory if e["type"] == "assistant/message"]
+        lines = [line.strip() for line in (answers[-1] if answers else "").splitlines() if line.strip()]
+        return 1.0 if lines and lines[-1] == "9592" else 0.0
+
+    model = _ProseThenIntegerModel()
+    try:
+        # The interpreter alone: the verify stage fails, injects its message, and the next answer passes.
+        result = _episode(tmp_path, model, [*_seed_nodes(SEED_TOOLS), ("native_graph", VERIFY_GRAPH)])
+        exits = [e["data"] for e in result.trajectory if e["type"] == "stage/exit" and e["data"]["stage"] == "check"]
+        assert [(e["outcome"], e["to"], e["last_line"]) for e in exits] == [
+            ("fail", "think", "The sieve finds 9592 primes below 100000."),
+            ("pass", "done", "9592"),
+        ]
+        note = next(e["data"] for e in result.trajectory if e["type"] == "user/message")
+        assert note["source"] == {"kind": "stage", "stage": "check"} and note["content"].startswith("Reply with")
+        assert final_line("[sieve]", result) == 1.0 and result.trajectory[-1]["data"]["reason"] == {
+            "kind": "completed"
+        }
+
+        binding = ModelBinding(base_url=model.base_url, model="fake", api_key="dummy")
+        backend = CordisBackend(
+            descriptor=get_adapter("native"),
+            propose=resolve_proposer(
+                lambda nodes, samples, models: Mutation(
+                    "update", "main", {"name": "native_graph", "config": VERIFY_GRAPH}
+                )
+            ),
+            score_episode=resolve_episode_scorer(final_line),
+            tasks=(
+                "[sieve] how many primes are below 100000? Reply with the count as a plain integer alone on the last line.",
+            ),
+            models=binding,
+            binary=_launcher(tmp_path),
+            seed=SEED_NODES,
+        )
+        batch = TraceBatch("demo:trace:graph", (TraceSample("a1", {"messages": []}, 0.0),))
+        prepared = backend.prepare_step(batch, backend.initial_state(), 0)
+        assert prepared.candidate is not None
+        assert json.loads(prepared.candidate.current_files["native/graphs/main.json"]) == SEED_GRAPH
+        assert "check" in json.loads(prepared.candidate.candidate_files["native/graphs/main.json"])["stages"]
+        evaluator = DefaultCandidateEvaluationPlugin(backend, ScoreComparisonSelector())
+        decision = evaluator.decide(prepared.candidate, evaluator.evaluate(prepared.candidate))
+        settled = backend.settle_step(prepared, decision)
+        assert (settled.metrics["wins"], settled.metrics["losses"], settled.metrics["ties"]) == (1, 0, 0)
+        assert settled.metrics["selected"] is True
+    finally:
+        model.shutdown()
+        model.server_close()
+
+
+def test_random_admitted_graphs_terminate_within_the_transition_bound(tmp_path: Path) -> None:
+    """Property: any graph admission accepts ends within (max_steps + 1) * 16 transitions, whatever the model does."""
+    import random
+
+    from reef.harness.native import graph as graphs
+    from reef.harness.native import run_loop
+
+    rng = random.Random(7)
+    texts = ("a", "b", "c")
+
+    def random_graph() -> dict:
+        extras = rng.randint(0, 3)
+        stages = {"think": {"kind": "model"}, "act": {"kind": "tools"}, "done": {"kind": "end"}}
+        names = ["think", "act", "done"]
+        for i in range(extras):
+            kind = rng.choice(("verify", "message"))
+            name = f"s{i}"
+            stages[name] = (
+                {"kind": "message", "text": rng.choice(texts)}
+                if kind == "message"
+                else {"kind": "verify", "check": rng.choice(("nonempty", "last_line_integer"))}
+            )
+            names.append(name)
+        # Text stages only point forward (to a later text stage, think, or done), so no text cycle exists.
+        text_names = [n for n in names if n.startswith("s")]
+
+        def forward(index: int) -> str:
+            later = text_names[index + 1 :]
+            return rng.choice([*later, "think", "done"])
+
+        edges = [
+            {"from": "think", "when": "tool_calls", "to": rng.choice(["act", *text_names])},
+            {"from": "think", "when": "text", "to": rng.choice(["done", *text_names])},
+            {"from": "act", "when": "done", "to": rng.choice(["think", *text_names])},
+        ]
+        for index, name in enumerate(text_names):
+            for outcome in ("pass", "fail") if stages[name]["kind"] == "verify" else ("done",):
+                edges.append({"from": name, "when": outcome, "to": forward(index)})
+        return {"name": "main", "start": "think", "max_steps": rng.randint(1, 4), "stages": stages, "edges": edges}
+
+    class _Chaos(_FakeModel):
+        def script(self, body: dict) -> dict:
+            if rng.random() < 0.5:
+                return _reply(tool_calls=[_call("read_file", {"path": "x"}, f"c{len(self.requests)}")])
+            return _reply(content=rng.choice(("9592", "prose", "")))
+
+    model = _Chaos()
+    try:
+        admitted = 0
+        for _ in range(300):
+            if admitted >= 20:
+                break
+            graph = random_graph()
+            try:
+                NODE_KINDS["native_graph"](None, graph)
+            except ValueError:
+                continue  # an unreachable stage, say; the rule names it and the tree loses at admission
+            admitted += 1
+            root = tmp_path / f"g{admitted}"
+            descriptor = get_adapter("native")
+            binding = ModelBinding(base_url=model.base_url, model="fake", api_key="dummy")
+            files = render_composition(
+                [*_seed_nodes(SEED_TOOLS), ("native_graph", graph), *binding.compose_nodes(descriptor)], descriptor
+            )
+            for relative, text in files.items():
+                (root / relative).parent.mkdir(parents=True, exist_ok=True)
+                (root / relative).write_text(text, encoding="utf-8")
+            (root / "workspace").mkdir()
+            code = run_loop("t", root / "native", root / "native" / "sessions", root / "workspace")
+            events = [
+                json.loads(line) for line in (root / "native" / "sessions" / "session.jsonl").read_text().splitlines()
+            ]
+            reason = events[-1]["data"]["reason"]["kind"]
+            transitions = sum(1 for e in events if e["type"] == "stage/enter")
+            assert code == 0 and reason in ("completed", "gave_up", "max-steps"), (graph, reason)
+            assert transitions <= (graph["max_steps"] + 1) * graphs.TRANSITIONS_PER_STEP
+        assert admitted == 20
+    finally:
+        model.shutdown()
+        model.server_close()

--- a/tutorials/harness_evolve/harness/native_evolution.py
+++ b/tutorials/harness_evolve/harness/native_evolution.py
@@ -1,9 +1,10 @@
-"""The method on reef's native harness: the loop's own tools and hooks are nodes the model may mutate.
+"""The method on reef's native harness: the loop's own tools, hooks and graph are nodes the model may mutate.
 
 ``propose`` is the self proposer of ``evolution.py`` with a wider vocabulary:
 one mutation on a skill, a ``native_tool`` (a schema plus a module defining
-``run(args, workdir) -> str``) or a ``native_hook`` (a module defining
-``listen(payload, next) -> decision`` at one loop event). ``evaluate`` reads
+``run(args, workdir) -> str``), a ``native_hook`` (a module defining
+``listen(payload, next) -> decision`` at one loop event) or the
+``native_graph`` that is the loop's own control flow. ``evaluate`` reads
 the native-jsonl trajectory. The grader and the answer table are shared with
 ``evolution.py``, so ``run.py`` scores recorded traffic the same way for
 both variants.
@@ -13,7 +14,7 @@ import json
 
 from harness.evolution import _ENTRY_NAME, grade_text
 
-KINDS = ("skill", "native_tool", "native_hook")
+KINDS = ("skill", "native_tool", "native_hook", "native_graph")
 EVENTS = ("pre_step", "request_error", "post_execute")
 
 #: The one JSON object the model answers with, per kind.
@@ -22,8 +23,20 @@ SHAPES = (
     '{"id": "<name>", "name": "native_tool", "config": {"name": "<same name>", "description": "<one line>", '
     '"parameters": <JSON schema object>, "code": "<python defining run(args, workdir) -> str>"}}',
     '{"id": "<name>", "name": "native_hook", "config": {"name": "<same name>", '
-    '"event": "<pre_step | request_error | post_execute>", '
+    '"event": "<pre_step | pre_execute | request_error | post_execute>", '
     '"code": "<python defining listen(payload, next) -> decision>"}}',
+    '{"id": "main", "name": "native_graph", "config": {"name": "main", "start": "<stage>", "max_steps": 12, '
+    '"stages": {"<stage>": {"kind": "model | tools | verify | message | end", ...}}, '
+    '"edges": [{"from": "<stage>", "when": "<outcome>", "to": "<stage>"}]}}',
+)
+#: What each graph stage does and the outcomes its edges must cover; the loop's own vocabulary.
+STAGES = (
+    "model: one request to the model; outcomes tool_calls, text",
+    "tools: run the model's pending tool calls (optional allow: [tool names]); outcome done",
+    "verify: check the last assistant text (check: last_line_integer | last_line_matches with pattern | nonempty; "
+    "optional message appended on failure); outcomes pass, fail",
+    "message: append text as a user message; outcome done",
+    "end: finish (reason: completed | gave_up); no outcomes",
 )
 
 
@@ -48,10 +61,12 @@ def propose(nodes, samples, models):
         f"Failing requests:\n{requests}\n\n"
         f"Current nodes:\n{json.dumps(current, indent=2)}\n\n"
         "Propose ONE mutation that would make these requests pass: an improved or new skill, tool, or "
-        "hook. A tool module defines run(args, workdir) -> str and receives arguments validated against "
-        "its parameters schema. A hook module defines listen(payload, next) -> decision at one event, "
-        "where next() returns the decision of the layer below. Respond with exactly one JSON object in "
-        "one of these shapes and nothing else:\n" + "\n".join(SHAPES) + "\n"
+        "hook, or a rewrite of the loop's graph. A tool module defines run(args, workdir) -> str and "
+        "receives arguments validated against its parameters schema. A hook module defines "
+        "listen(payload, next) -> decision at one event, where next() returns the decision of the layer "
+        "below. The graph names stages and the edges between them; every stage is reachable, every "
+        "outcome of every stage has one edge, and every cycle passes a model stage:\n" + "\n".join(STAGES) + "\n"
+        "Respond with exactly one JSON object in one of these shapes and nothing else:\n" + "\n".join(SHAPES) + "\n"
         "Reuse an existing node's name to update it; use a new lowercase-hyphen name to add one."
     )
     try:
@@ -96,6 +111,14 @@ def _parse_proposal(reply: str):
     if kind == "skill":
         text = config.get("text")
         return (kind, entry_id, {"name": entry_id, "text": text}) if _text(text) else None
+    if kind == "native_graph":
+        stages, edges, start = config.get("stages"), config.get("edges"), config.get("start")
+        if not isinstance(stages, dict) or not isinstance(edges, list) or not _text(start):
+            return None
+        graph = {"name": entry_id, "start": start, "stages": stages, "edges": edges}
+        if isinstance(config.get("max_steps"), int):
+            graph["max_steps"] = config["max_steps"]
+        return kind, entry_id, graph
     code = config.get("code")
     if not _text(code):
         return None


### PR DESCRIPTION
## Motivation

The native loop's control flow was fixed code: one model call per step, tool dispatch, twelve steps. A proposer could change what the loop is told and what it can call, never its shape, and the tutorial measured the change it needs is a shape change: with tools in hand qwen2.5:7b runs the sieve and answers in prose, so the last line is not the bare integer the task asks for. This is stage 1 of #248: the loop as a native_graph node the proposer can rewrite and the same gate scores. Refs #248.

## Changes

- native_graph node: named stages from a closed vocabulary (model, tools, verify, message, end) and edges keyed by each stage's outcome; admission refuses an unknown kind or key (no code enters this kind), an outcome without exactly one edge, a stage unreachable from start, a stage from which no end is reachable, and a cycle without a model stage, so the step budget (max_steps 1 to 32) ends every run; verify and message text pass the credential screen
- The seed graph is today's loop as that data (think, act, done) and is the loop's fallback for a tree without a graph, so an old tree runs as before; SEED_NODES gains it as the entry main, so the tutorial's proposer sees it as a node
- reef/harness/native/graph.py is the interpreter: stage handlers are fixed code, the walk is data; each model stage is one step, the log gains stage/enter and stage/exit (a verify exit carries check and last_line), a stage's text lands as a user/message with source kind stage, the session header names which graph ran, a graph that cannot load is LOAD_ERROR, and a run past (max_steps + 1) * 16 transitions ends with GRAPH_ERROR as the backstop admission makes unreachable
- Render writes native/graphs/main.json with sorted keys so a proposal diff is a few lines, and refuses a tools allow list naming a tool the tree lacks; an adapter without files.native_graph refuses the kind like native_tool
- The tutorial proposer gains the graph shape and the stage vocabulary in its prompt and parses a graph proposal; the adapter guide documents the node, the vocabulary and the events, the user guide's kind table, the configuration reference and the method guide's review_kinds sentence follow

## Compatibility and operational impact

A tree with no graph node runs the seed graph and its log keeps every existing event in the same order; the two exact order tests now assert the old sequence with the stage events filtered out, and the full new sequence beside it. Additive keys: the session header's graph, the two stage events, the stage source kind, the gave_up end reason and the GRAPH_ERROR code. SEED_NODES gains one entry, so a recipe that seeds it renders one more file. A published tree with a graph pulled by an older reef-native runs the old fixed loop; the header shows what ran.

## Verification

The gate demo of record is hermetic: a fake model plays the measured failure (a tool call, then the count in prose, the bare integer only after being asked again); on the seed tree the last line is prose and scores 0.0, the proposal inserts a verify stage with a fail edge back to think, the interpreter shows the check failing once with its message injected and passing on the next answer, and the backend scores one win, no losses, no ties, selected. Admission is tested rule by rule with the message each names, and a property test draws random graphs with a seeded generator, keeps the first twenty admission accepts, runs each in process against a model that calls tools or answers at random, and checks every run ends with a closed reason within the transition bound. A tree without a graph runs the seed graph and reports it; a broken graphs/main.json is LOAD_ERROR before any model call. The native, render, episode, credential, tutorial, recipe and wrapper suites pass on Python 3.12 (204 tests); pre-commit, mypy on reef/harness and the docs checks are clean.

## AI assistance

Claude Code wrote the node, the interpreter, the tests and the docs from the design in #248, which I accepted.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
