### PR TITLE
feat(docs): lay the site out in two header rows, a full sidebar and a table of contents

### DIFF
--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -1,0 +1,3 @@
+
+# written by scripts/fetch-repo-stats.mjs before dev and build
+lib/repo-stats.generated.json

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -518,6 +518,7 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .icon-button { width: 44px; height: 44px; }
   .theme-switch button { width: 40px; height: 40px; }
   .repo-link { min-height: 40px; }
+  .search-trigger { min-height: 40px; }
   .code-copy { height: 40px; }
   .search-input-row button { width: 44px; height: 44px; }
   .logo { min-height: 44px; }

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -104,7 +104,7 @@ button { cursor: pointer; }
 .search-trigger { width: 100%; height: 36px; padding: 0 8px 0 12px; display: flex; align-items: center; gap: 9px; color: var(--muted); border: 1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius: 10px; background: var(--card); box-shadow: var(--shadow-sm); }
 .search-trigger:hover { border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
 .search-trigger span { flex: 1; text-align: left; font-size: 14px; }
-.search-trigger kbd { padding: 1px 6px; color: var(--muted); border: 1px solid var(--border); border-radius: 5px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
+.search-trigger kbd { padding: 1px 6px; white-space: nowrap; color: var(--muted); border: 1px solid var(--border); border-radius: 5px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
 .header-actions { justify-self: end; display: flex; align-items: center; gap: 8px; }
 .repo-link { height: 36px; padding: 0 10px; display: inline-flex; align-items: center; gap: 8px; color: var(--text); border-radius: 10px; font-size: 13px; font-weight: 500; white-space: nowrap; }
 .repo-link:hover { color: var(--brand-strong); background: var(--accent); }
@@ -116,9 +116,8 @@ button { cursor: pointer; }
 .icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 10px; background: transparent; }
 .icon-button:hover { color: var(--brand-strong); background: var(--accent); }
 .icon-button.menu-toggle { display: none; }
-.header-tabs { height: 44px; padding: 0 24px; display: flex; align-items: stretch; gap: 4px; overflow-x: auto; scrollbar-width: none; }
-.header-tabs::-webkit-scrollbar { display: none; }
-.header-tabs a { padding: 0 8px; display: flex; align-items: center; color: var(--muted); border-bottom: 2px solid transparent; font-size: 14px; font-weight: 500; white-space: nowrap; }
+.header-tabs { min-height: 44px; padding: 0 24px; display: flex; flex-wrap: wrap; align-items: stretch; gap: 0 4px; }
+.header-tabs a { min-height: 44px; padding: 0 8px; display: flex; align-items: center; color: var(--muted); border-bottom: 2px solid transparent; font-size: 14px; font-weight: 500; white-space: nowrap; }
 .header-tabs a:hover { color: var(--foreground); }
 .header-tabs a.active { color: var(--foreground); border-bottom-color: var(--brand); }
 
@@ -149,12 +148,6 @@ button { cursor: pointer; }
 .code-copy { height: 28px; padding: 0 8px; display: inline-flex; align-items: center; gap: 6px; color: var(--muted); border: 0; border-radius: 7px; background: transparent; font-size: 12px; }
 .code-copy:hover { color: var(--foreground); background: var(--accent); }
 .markdown-body .code-block > pre { margin: 0; padding: 16px 20px; border: 0; border-radius: 0; box-shadow: none; }
-.logo { display: inline-flex; align-items: center; gap: 11px; color: var(--foreground); font-weight: 600; }
-.logo-mark { color: var(--brand); stroke-width: 2.4; }
-.logo-name { color: var(--foreground); font-size: 15px; font-weight: 700; letter-spacing: .15em; }
-.header-actions { display: flex; align-items: center; gap: 2px; }
-.icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 10px; background: transparent; }
-.icon-button:hover { color: var(--brand-strong); background: var(--accent); }
 kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); border-radius: 4px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
 
 .mobile-nav-overlay { position: fixed; z-index: 100; inset: 0; background: color-mix(in srgb, var(--foreground) 18%, transparent); }
@@ -185,7 +178,7 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .search-footer span { display: flex; align-items: center; gap: 6px; }
 
 /* Home */
-.home { padding-top: 68px; overflow: hidden; }
+.home { overflow: hidden; }
 .home h1, .home h2, .home h3 { color: var(--foreground); font-family: var(--font-sans); }
 .home-hero { position: relative; width: min(1240px, calc(100% - 48px)); min-height: 680px; margin: 0 auto; padding: 112px 44px 104px; display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(330px, .7fr); align-items: center; gap: 72px; }
 .home-hero::before { position: absolute; z-index: -2; inset: 0 -30vw; content: ""; background: linear-gradient(color-mix(in srgb, var(--brand) 7%, transparent) 1px, transparent 1px), linear-gradient(90deg, color-mix(in srgb, var(--brand) 7%, transparent) 1px, transparent 1px); background-size: 44px 44px; mask-image: linear-gradient(to bottom, rgba(0,0,0,.85), transparent 92%); }
@@ -265,7 +258,6 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .shelf a:hover { color: var(--brand); }
 
 /* Documentation layout */
-.doc-section { padding: 4px 8px; color: var(--brand-strong); border: 1px solid color-mix(in srgb, var(--brand) 25%, var(--border)); border-radius: 999px; background: var(--accent); font-size: 9px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
 
 /* Documentation typography: one serif display face, one sans reading face. */
 .markdown-body { color: var(--text); font-family: var(--font-sans); font-size: 16px; line-height: 1.72; }
@@ -486,15 +478,16 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .site-footer nav { flex-wrap: wrap; }
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1280px) {
   .docs-layout { grid-template-columns: 256px minmax(0, 1fr); }
   .toc { display: none; }
   .docs-main { padding: 36px 36px 88px; }
 }
 
 @media (max-width: 900px) {
-  .header-row { grid-template-columns: auto minmax(0, 1fr) auto; padding: 0 20px; gap: 12px; }
+  .header-row { grid-template-columns: auto minmax(140px, 1fr) auto; padding: 0 20px; gap: 12px; }
   .header-tabs { padding: 0 12px; }
+  .repo-name { display: none; }
   .icon-button.menu-toggle { display: inline-grid; }
   .docs-layout { padding: 0; display: block; }
   .docs-sidebar { display: none; }
@@ -502,7 +495,8 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 }
 
 @media (max-width: 640px) {
-  .header-row { padding: 0 12px; gap: 6px; }
+  html { scroll-padding-top: 84px; }
+  .header-row { grid-template-columns: auto minmax(0, 1fr) auto; padding: 0 12px; gap: 6px; }
   .header-tabs { display: none; }
   .repo-stars { display: none; }
   .header-brand { gap: 8px; }
@@ -511,17 +505,20 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .header-search { justify-self: end; }
   .search-trigger span, .search-trigger kbd { display: none; }
   .repo-link { padding: 0 6px; }
-  .repo-name { display: none; }
   .docs-main { padding: 28px 16px 64px; }
   .markdown-body pre { padding: 14px 14px; }
   .markdown-body pre code { font-size: 13px; }
 }
 
+@media (max-width: 360px) {
+  .logo-name { display: none; }
+}
+
 @media (pointer: coarse) {
   .icon-button { width: 44px; height: 44px; }
-  .theme-switch button { width: 34px; height: 34px; }
-  .code-copy { height: 34px; }
-  /* the button centers in a one-line block; the band fades scrolled text out beside and beneath it */
+  .theme-switch button { width: 40px; height: 40px; }
+  .repo-link { min-height: 40px; }
+  .code-copy { height: 40px; }
   .search-input-row button { width: 44px; height: 44px; }
   .logo { min-height: 44px; }
   .markdown-body a.heading-anchor { padding: 10px 15px; margin-left: 0; }

--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -41,7 +41,7 @@
   --font-mono: "DM Mono", ui-monospace, monospace;
 }
 
-html { color-scheme: light; scroll-padding-top: 92px; } /* auto scroll: smooth raced the late-mounting diagrams and landed deep links hundreds of px off */
+html { color-scheme: light; scroll-padding-top: 128px; } /* auto scroll: smooth raced the late-mounting diagrams and landed deep links hundreds of px off */
 html[data-theme="dark"] {
   color-scheme: dark;
   --background: #100e0c;
@@ -92,25 +92,69 @@ button { cursor: pointer; }
 ::selection { color: var(--foreground); background: color-mix(in srgb, var(--brand) 28%, transparent); }
 
 /* Header and navigation */
-.site-header { position: fixed; z-index: 50; top: 0; right: 0; left: 0; height: 68px; border-bottom: 1px solid color-mix(in srgb, var(--border) 76%, transparent); background: color-mix(in srgb, var(--background) 82%, transparent); backdrop-filter: blur(20px) saturate(140%); }
-.header-inner { width: 100%; height: 68px; padding: 0 28px; display: flex; align-items: center; gap: 32px; }
+.site-header { position: sticky; z-index: 50; top: 0; border-bottom: 1px solid color-mix(in srgb, var(--border) 76%, transparent); background: color-mix(in srgb, var(--background) 86%, transparent); backdrop-filter: blur(20px) saturate(140%); }
+.header-row { height: 60px; padding: 0 32px; display: grid; grid-template-columns: 1fr minmax(0, 520px) 1fr; align-items: center; gap: 24px; }
+.header-brand { display: flex; align-items: center; gap: 12px; }
 .logo { display: inline-flex; align-items: center; gap: 11px; color: var(--foreground); font-weight: 600; }
 .logo-mark { color: var(--brand); stroke-width: 2.4; }
 .logo-name { color: var(--foreground); font-size: 15px; font-weight: 700; letter-spacing: .15em; }
-.header-links { display: flex; align-items: center; gap: 22px; white-space: nowrap; }
-.header-links a { color: var(--muted); font-size: 13px; font-weight: 500; }
-.header-links a:hover, .header-links a.active { color: var(--brand-strong); }
-.header-links a.active { font-weight: 600; }
-.header-search { width: 264px; margin-left: auto; }
-.header-actions { display: flex; align-items: center; gap: 2px; }
+.version-badge { padding: 2px 9px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; font-family: var(--font-mono); font-size: 12px; line-height: 18px; }
+.version-badge:hover { color: var(--brand-strong); border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
+.header-search { min-width: 0; }
+.search-trigger { width: 100%; height: 36px; padding: 0 8px 0 12px; display: flex; align-items: center; gap: 9px; color: var(--muted); border: 1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius: 10px; background: var(--card); box-shadow: var(--shadow-sm); }
+.search-trigger:hover { border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
+.search-trigger span { flex: 1; text-align: left; font-size: 14px; }
+.search-trigger kbd { padding: 1px 6px; color: var(--muted); border: 1px solid var(--border); border-radius: 5px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
+.header-actions { justify-self: end; display: flex; align-items: center; gap: 8px; }
+.repo-link { height: 36px; padding: 0 10px; display: inline-flex; align-items: center; gap: 8px; color: var(--text); border-radius: 10px; font-size: 13px; font-weight: 500; white-space: nowrap; }
+.repo-link:hover { color: var(--brand-strong); background: var(--accent); }
+.repo-stars { display: inline-flex; align-items: center; gap: 4px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.theme-switch { padding: 3px; display: inline-flex; gap: 2px; border: 1px solid var(--border); border-radius: 999px; background: var(--card); }
+.theme-switch button { width: 28px; height: 28px; padding: 0; display: grid; place-items: center; color: var(--muted); border: 0; border-radius: 999px; background: transparent; }
+.theme-switch button:hover { color: var(--foreground); }
+.theme-switch button[aria-checked="true"] { color: var(--foreground); background: var(--accent); box-shadow: var(--shadow-sm); }
 .icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 10px; background: transparent; }
 .icon-button:hover { color: var(--brand-strong); background: var(--accent); }
 .icon-button.menu-toggle { display: none; }
-.theme-toggle .sun-icon, .theme-toggle .moon-icon { display: none; }
-html[data-theme-mode="light"] .theme-toggle .sun-icon { display: block; }
-html[data-theme-mode="dark"] .theme-toggle .moon-icon { display: block; }
-html[data-theme-mode="light"] .theme-toggle .system-icon,
-html[data-theme-mode="dark"] .theme-toggle .system-icon { display: none; }
+.header-tabs { height: 44px; padding: 0 24px; display: flex; align-items: stretch; gap: 4px; overflow-x: auto; scrollbar-width: none; }
+.header-tabs::-webkit-scrollbar { display: none; }
+.header-tabs a { padding: 0 8px; display: flex; align-items: center; color: var(--muted); border-bottom: 2px solid transparent; font-size: 14px; font-weight: 500; white-space: nowrap; }
+.header-tabs a:hover { color: var(--foreground); }
+.header-tabs a.active { color: var(--foreground); border-bottom-color: var(--brand); }
+
+/* Documentation layout: sidebar, content, table of contents */
+.docs-layout { --header-height: 105px; width: min(1440px, 100%); min-height: calc(100vh - var(--header-height)); margin: 0 auto; padding: 0 32px; display: grid; grid-template-columns: 272px minmax(0, 1fr) 232px; }
+.docs-sidebar { position: sticky; top: var(--header-height); height: calc(100vh - var(--header-height)); padding: 32px 20px 48px 0; overflow-y: auto; overscroll-behavior: contain; border-right: 1px solid color-mix(in srgb, var(--border) 72%, transparent); }
+.sidebar-group { margin-bottom: 26px; }
+.sidebar-group-title { margin: 0 0 6px 12px; color: var(--foreground); font-size: 14px; font-weight: 600; line-height: 22px; }
+.sidebar-group-items { display: grid; gap: 2px; }
+.sidebar-group a { padding: 7px 12px; display: block; color: var(--muted); border-radius: 8px; font-size: 14px; line-height: 22px; }
+.sidebar-group a:hover { color: var(--foreground); background: color-mix(in srgb, var(--accent) 70%, transparent); }
+.sidebar-group a.active { color: var(--brand-strong); background: var(--brand-soft); font-weight: 500; }
+.docs-main { width: 100%; max-width: 780px; margin: 0 auto; padding: 40px 48px 96px; }
+.doc-eyebrow { margin: 0 0 12px; font-size: 14px; font-weight: 600; line-height: 20px; }
+.doc-eyebrow a { color: var(--brand-strong); }
+.doc-eyebrow a:hover { text-decoration: underline; text-underline-offset: 4px; }
+.toc { position: sticky; top: var(--header-height); height: calc(100vh - var(--header-height)); padding: 40px 0 48px 24px; overflow-y: auto; overscroll-behavior: contain; }
+.toc-label { margin: 0 0 10px; display: flex; align-items: center; gap: 8px; color: var(--foreground); font-size: 14px; font-weight: 600; line-height: 20px; }
+.toc nav { display: grid; }
+.toc a { padding: 5px 0; color: var(--muted); font-size: 14px; line-height: 20px; }
+.toc a:hover, .toc a.active { color: var(--foreground); }
+.toc a.active { color: var(--brand-strong); font-weight: 500; }
+.toc a.nested { padding-left: 16px; }
+
+/* Code blocks: a head bar with the language and a copy button that is always in view */
+.code-block { margin: 24px 0 32px; overflow: hidden; border: 1px solid color-mix(in srgb, var(--border) 88%, transparent); border-radius: 10px; background: var(--code); }
+.code-head { height: 38px; padding: 0 8px 0 16px; display: flex; align-items: center; justify-content: space-between; color: var(--muted); border-bottom: 1px solid color-mix(in srgb, var(--border) 88%, transparent); background: color-mix(in srgb, var(--accent) 60%, var(--code)); font-size: 12px; font-weight: 500; }
+.code-copy { height: 28px; padding: 0 8px; display: inline-flex; align-items: center; gap: 6px; color: var(--muted); border: 0; border-radius: 7px; background: transparent; font-size: 12px; }
+.code-copy:hover { color: var(--foreground); background: var(--accent); }
+.markdown-body .code-block > pre { margin: 0; padding: 16px 20px; border: 0; border-radius: 0; box-shadow: none; }
+.logo { display: inline-flex; align-items: center; gap: 11px; color: var(--foreground); font-weight: 600; }
+.logo-mark { color: var(--brand); stroke-width: 2.4; }
+.logo-name { color: var(--foreground); font-size: 15px; font-weight: 700; letter-spacing: .15em; }
+.header-actions { display: flex; align-items: center; gap: 2px; }
+.icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 10px; background: transparent; }
+.icon-button:hover { color: var(--brand-strong); background: var(--accent); }
 kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); border-radius: 4px; background: var(--background); font-family: var(--font-sans); font-size: 11px; }
 
 .mobile-nav-overlay { position: fixed; z-index: 100; inset: 0; background: color-mix(in srgb, var(--foreground) 18%, transparent); }
@@ -121,9 +165,6 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .mobile-nav-panel nav a[aria-current="page"] { color: var(--foreground); background: var(--accent); font-weight: 600; }
 
 /* Search */
-.search-trigger { width: 100%; height: 38px; padding: 6px 6px 6px 13px; display: flex; align-items: center; gap: 8px; color: var(--muted); border: 1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius: 10px; background: var(--surface-raised); box-shadow: 0 1px 2px rgba(15, 58, 53, .03); }
-.search-trigger:hover { border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
-.search-trigger span { flex: 1; text-align: left; font-size: 14px; }
 .search-overlay { position: fixed; z-index: 100; inset: 0; padding: 11vh 20px 20px; display: flex; justify-content: center; align-items: flex-start; background: transparent; }
 .search-dialog { width: min(640px, 100%); overflow: hidden; border: 1px solid var(--border); border-radius: 14px; background: color-mix(in srgb, var(--card) 96%, transparent); box-shadow: var(--shadow-lg); backdrop-filter: blur(20px); }
 .search-input-row { height: 60px; padding: 0 16px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid var(--border); }
@@ -224,18 +265,6 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .shelf a:hover { color: var(--brand); }
 
 /* Documentation layout */
-.docs-layout { width: 100%; min-height: 100vh; padding-top: 68px; display: grid; grid-template-columns: 270px minmax(0, 760px) minmax(220px, 1fr); }
-.docs-sidebar { position: fixed; z-index: 20; top: 68px; bottom: 0; left: 0; width: 270px; padding: 38px 18px 48px; overflow-y: auto; border-right: 1px solid color-mix(in srgb, var(--border) 72%, transparent); background: color-mix(in srgb, var(--background) 92%, var(--accent)); }
-.sidebar-group { margin-bottom: 30px; }
-.sidebar-group-items { display: grid; gap: 3px; }
-.sidebar-group a { padding: 7px 10px; color: var(--muted); border-radius: 7px; font-size: 13px; line-height: 20px; }
-.sidebar-group > .sidebar-group-title { margin: 0 10px 9px; padding: 0; color: var(--muted); font-size: 10px; font-weight: 800; letter-spacing: .13em; line-height: 18px; text-transform: uppercase; }
-.sidebar-group a:hover { color: var(--foreground); background: color-mix(in srgb, var(--accent) 65%, transparent); }
-.sidebar-group a.active { position: relative; color: var(--brand-strong); background: var(--accent); font-weight: 600; }
-.sidebar-group a.active::before { position: absolute; top: 7px; bottom: 7px; left: 0; width: 2px; content: ""; border-radius: 2px; background: var(--brand); }
-.docs-main { grid-column: 2; width: 100%; padding: 56px 44px 96px; }
-.doc-context { min-height: 28px; margin-bottom: 26px; display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: 11px; }
-.doc-context a:hover { color: var(--brand-strong); }
 .doc-section { padding: 4px 8px; color: var(--brand-strong); border: 1px solid color-mix(in srgb, var(--brand) 25%, var(--border)); border-radius: 999px; background: var(--accent); font-size: 9px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
 
 /* Documentation typography: one serif display face, one sans reading face. */
@@ -258,13 +287,9 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .markdown-body blockquote p:last-child { margin-bottom: 0; }
 .markdown-body code, .markdown-body .literal { padding: .15em .35em; color: var(--brand-strong); border-radius: 4px; background: var(--accent); font-family: var(--font-mono); font-size: 14px; overflow-wrap: anywhere; }
 .markdown-body .table-scroll code, .markdown-body .table-scroll .literal { overflow-wrap: normal; }
-.markdown-body pre { --scroller-bg: var(--code); margin: 24px 0 32px; padding: 22px 24px; overflow-x: auto; color: var(--code-text); border: 1px solid color-mix(in srgb, var(--border) 88%, transparent); border-radius: 10px; box-shadow: inset 0 1px color-mix(in srgb, var(--foreground) 4%, transparent); font: 13px/1.65 var(--font-mono); }
+.markdown-body pre { --scroller-bg: var(--code); margin: 24px 0 32px; padding: 18px 20px; overflow-x: auto; color: var(--code-text); border: 1px solid color-mix(in srgb, var(--border) 88%, transparent); border-radius: 10px; box-shadow: inset 0 1px color-mix(in srgb, var(--foreground) 4%, transparent); font: 13px/1.65 var(--font-mono); }
 .markdown-body pre, .markdown-body .table-scroll { background: linear-gradient(90deg, var(--scroller-bg) 45%, transparent) left center / 32px 100% no-repeat local, linear-gradient(270deg, var(--scroller-bg) 45%, transparent) right center / 32px 100% no-repeat local, radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) left center / 14px 100% no-repeat scroll, radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--foreground) 28%, transparent), transparent) right center / 14px 100% no-repeat scroll, var(--scroller-bg); }
-.markdown-body pre code { display: block; width: max-content; min-width: 100%; padding: 0; color: inherit; background: transparent; font-size: 13px; }
-.code-block { position: relative; }
-.code-copy { position: absolute; top: 10px; right: 10px; width: 30px; height: 30px; display: grid; place-items: center; color: var(--muted); border: 1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius: 7px; background: color-mix(in srgb, var(--code) 90%, var(--background)); opacity: 0; transition: opacity .12s, color .12s, border-color .12s; }
-.code-block:hover .code-copy, .code-copy:focus-visible { opacity: 1; }
-.code-copy:hover { color: var(--brand-strong); border-color: color-mix(in srgb, var(--brand) 48%, var(--border)); }
+.markdown-body pre code { display: block; width: max-content; min-width: 100%; padding: 0; color: inherit; background: transparent; font-size: 14px; line-height: 1.65; }
 .table-scroll { overflow-x: auto; }
 .markdown-body img { max-width: 100%; height: auto; }
 .markdown-body .table-scroll { --scroller-bg: var(--background); margin: 24px 0 32px; border-radius: 10px; box-shadow: var(--shadow-sm); }
@@ -393,13 +418,6 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
 .pager-link.next { align-items: flex-end; text-align: right; }
 .pager-link.next span { justify-content: flex-end; }
 .pager-link p { max-width: 270px; margin: 2px 0 0; display: -webkit-box; overflow: hidden; color: var(--muted); font-size: 11px; line-height: 1.5; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
-.toc { position: fixed; top: 68px; right: 0; bottom: 0; left: 1030px; padding: 56px 24px; overflow-y: auto; }
-.toc > p { margin: 0 0 12px; color: var(--muted); font-size: 10px; font-weight: 700; letter-spacing: .13em; text-transform: uppercase; }
-.toc nav { display: grid; }
-.toc a { position: relative; padding: 6px 0 6px 13px; color: var(--muted); border-left: 1px solid var(--border); font-size: 12px; line-height: 18px; }
-.toc a:hover, .toc a.active { color: var(--foreground); }
-.toc a.active { color: var(--brand-strong); border-left-color: var(--brand); }
-.toc a.nested { padding-left: 24px; }
 .not-found { min-height: 80vh; padding: 120px 24px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; }
 .not-found h1 { color: var(--foreground); font-family: var(--font-serif); font-size: 40px; }
 .not-found p { color: var(--muted); }
@@ -414,22 +432,7 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .markdown-body .heading-anchor:focus-visible { color: var(--muted); }
 }
 
-@media (max-width: 1050px) {
-  .docs-layout { grid-template-columns: 250px minmax(0, 760px); }
-  .docs-sidebar { width: 250px; }
-  .toc { display: none; }
-  .header-links { gap: 16px; }
-  .header-search { width: 200px; }
-}
-
-@media (max-width: 1000px) {
-  .header-links { display: none; }
-  .icon-button.menu-toggle { display: inline-grid; }
-}
-
 @media (max-width: 800px) {
-  .header-inner { padding: 0 18px; }
-  .header-search { margin-left: auto; }
   .home-hero { min-height: auto; padding-top: 84px; grid-template-columns: 1fr; align-items: start; gap: 54px; }
   .loop-card { max-width: 480px; transform: none; }
   .feature-grid, .path-grid, .path-grid-2, .resource-grid { grid-template-columns: 1fr; }
@@ -438,9 +441,6 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .section-heading-row { grid-template-columns: 1fr; gap: 22px; }
   .path-card { min-height: 260px; }
   .home-table { font-size: 14px; }
-  .docs-layout { display: block; }
-  .docs-sidebar { display: none; }
-  .docs-main { width: min(760px, 100%); margin: 0 auto; padding-top: 48px; }
 }
 
 @media (max-width: 720px) {
@@ -458,12 +458,6 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   /* Code on a phone: tighter padding buys back the horizontal room the
      desktop 24px gutter costs, and 12px fits more of each line before a
      line has to be scrolled sideways. Pad and desktop keep 13px/24px. */
-  .markdown-body pre { padding: 16px 14px; font-size: 12px; }
-  .markdown-body pre code { font-size: 12px; }
-  .header-inner { gap: 8px; }
-  .header-search { width: 44px; }
-  .search-trigger { width: 44px; padding: 0; justify-content: center; border: 0; background: transparent; box-shadow: none; }
-  .search-trigger span, .search-trigger kbd { display: none; }
   .home-hero, .home-section { width: calc(100% - 28px); padding-right: 8px; padding-left: 8px; }
   .home-hero { padding-top: 66px; padding-bottom: 72px; }
   .home h1 { font-size: 46px; }
@@ -473,8 +467,6 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .path-grid { margin-top: 34px; }
   .path-card { min-height: 250px; padding: 22px; }
   .path-card-icon { margin-bottom: 28px; }
-  .docs-main { padding: 40px 20px 72px; }
-  .doc-context { margin-bottom: 22px; }
   .markdown-body { font-size: 16px; line-height: 1.68; }
   .markdown-body h1 { font-size: 31px; }
   .markdown-body td { overflow-wrap: anywhere; }
@@ -494,13 +486,43 @@ kbd { padding: 1px 5px; color: var(--muted); border: 1px solid var(--border); bo
   .site-footer nav { flex-wrap: wrap; }
 }
 
+@media (max-width: 1180px) {
+  .docs-layout { grid-template-columns: 256px minmax(0, 1fr); }
+  .toc { display: none; }
+  .docs-main { padding: 36px 36px 88px; }
+}
+
+@media (max-width: 900px) {
+  .header-row { grid-template-columns: auto minmax(0, 1fr) auto; padding: 0 20px; gap: 12px; }
+  .header-tabs { padding: 0 12px; }
+  .icon-button.menu-toggle { display: inline-grid; }
+  .docs-layout { padding: 0; display: block; }
+  .docs-sidebar { display: none; }
+  .docs-main { max-width: 760px; padding: 32px 24px 72px; }
+}
+
+@media (max-width: 640px) {
+  .header-row { padding: 0 12px; gap: 6px; }
+  .header-tabs { display: none; }
+  .repo-stars { display: none; }
+  .header-brand { gap: 8px; }
+  .version-badge { display: none; }
+  .search-trigger { width: 40px; padding: 0; justify-content: center; border: 0; background: transparent; box-shadow: none; }
+  .header-search { justify-self: end; }
+  .search-trigger span, .search-trigger kbd { display: none; }
+  .repo-link { padding: 0 6px; }
+  .repo-name { display: none; }
+  .docs-main { padding: 28px 16px 64px; }
+  .markdown-body pre { padding: 14px 14px; }
+  .markdown-body pre code { font-size: 13px; }
+}
+
 @media (pointer: coarse) {
   .icon-button { width: 44px; height: 44px; }
+  .theme-switch button { width: 34px; height: 34px; }
+  .code-copy { height: 34px; }
   /* the button centers in a one-line block; the band fades scrolled text out beside and beneath it */
-  .code-block::before { content: ""; position: absolute; top: 1px; right: 1px; width: 72px; height: 58px; max-height: calc(100% - 2px); pointer-events: none; border-radius: 0 9px 9px 0; background: linear-gradient(90deg, transparent, var(--code) 38%); }
-  .code-copy { width: 44px; height: 44px; opacity: 1; top: min(8px, calc(50% - 22px)); right: 8px; }
   .search-input-row button { width: 44px; height: 44px; }
-  .search-trigger { min-width: 44px; min-height: 44px; }
   .logo { min-height: 44px; }
   .markdown-body a.heading-anchor { padding: 10px 15px; margin-left: 0; }
 }

--- a/docs/site/app/layout.tsx
+++ b/docs/site/app/layout.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   twitter: { card: "summary", title: siteConfig.title, description: siteConfig.description },
 };
 
-const themeScript = `(function(){try{var t=localStorage.getItem('reef-theme');var m=t==='light'||t==='dark'?t:'auto';var d=m==='dark'||(m==='auto'&&window.matchMedia('(prefers-color-scheme: dark)').matches);var e=document.documentElement;e.dataset.theme=d?'dark':'light';e.dataset.themeMode=m}catch(e){}})()`;
+const themeScript = `(function(){try{var t=localStorage.getItem('reef-theme');var m=t==='light'||t==='dark'?t:'auto';var d=m==='dark'||(m==='auto'&&window.matchMedia('(prefers-color-scheme: dark)').matches);var e=document.documentElement;e.dataset.theme=d?'dark':'light'}catch(e){}})()`;
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   const searchDocuments = getSearchDocuments();

--- a/docs/site/components/code-block.tsx
+++ b/docs/site/components/code-block.tsx
@@ -31,10 +31,7 @@ function languageOf(className?: string) {
   return name ? (LABELS[name] ?? name) : "";
 }
 
-// Every code block gets a head bar: the language on the left, the copy button
-// on the right, always visible, so a phone needs no hover and the button never
-// covers the first line of code. The text copied is the block's own
-// textContent, which the shiki path stores with real newlines.
+// A head bar per block: the language, and a copy button that is always in view and never covers the code.
 export function CodeBlock({ className, children }: { className?: string; children: ReactNode }) {
   const ref = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
@@ -57,7 +54,7 @@ export function CodeBlock({ className, children }: { className?: string; childre
         <span>{language}</span>
         <button type="button" className="code-copy" onClick={copy} aria-label={copied ? "Copied" : "Copy code"} title={copied ? "Copied" : "Copy"}>
           {copied ? <Check size={14} /> : <Copy size={14} />}
-          <span>{copied ? "Copied" : "Copy"}</span>
+          <span aria-live="polite">{copied ? "Copied" : "Copy"}</span>
         </button>
       </div>
       <pre ref={ref} className={className}>

--- a/docs/site/components/code-block.tsx
+++ b/docs/site/components/code-block.tsx
@@ -4,14 +4,41 @@ import { Check, Copy } from "lucide-react";
 import { useRef, useState } from "react";
 import type { ReactNode } from "react";
 
-// A copy button in the top-right of every code block. The rendered <pre> is
-// wrapped so the button positions against it; the text copied is the block's
-// own textContent, which the shiki path stores with real newlines. On a
-// phone the button is always visible (no hover), so it sits out of the way in
-// the padding and grows to a 44px touch target on coarse pointers.
+const LABELS: Record<string, string> = {
+  bash: "Shell",
+  sh: "Shell",
+  shell: "Shell",
+  console: "Shell",
+  python: "Python",
+  py: "Python",
+  yaml: "YAML",
+  yml: "YAML",
+  json: "JSON",
+  toml: "TOML",
+  text: "Text",
+  ts: "TypeScript",
+  typescript: "TypeScript",
+  js: "JavaScript",
+  javascript: "JavaScript",
+  http: "HTTP",
+  ini: "INI",
+  diff: "Diff",
+  rst: "reStructuredText",
+};
+
+function languageOf(className?: string) {
+  const name = className?.split(" ").find((token) => token.startsWith("language-"))?.slice("language-".length);
+  return name ? (LABELS[name] ?? name) : "";
+}
+
+// Every code block gets a head bar: the language on the left, the copy button
+// on the right, always visible, so a phone needs no hover and the button never
+// covers the first line of code. The text copied is the block's own
+// textContent, which the shiki path stores with real newlines.
 export function CodeBlock({ className, children }: { className?: string; children: ReactNode }) {
   const ref = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
+  const language = languageOf(className);
 
   async function copy() {
     const text = ref.current?.textContent ?? "";
@@ -26,18 +53,16 @@ export function CodeBlock({ className, children }: { className?: string; childre
 
   return (
     <div className="code-block">
+      <div className="code-head">
+        <span>{language}</span>
+        <button type="button" className="code-copy" onClick={copy} aria-label={copied ? "Copied" : "Copy code"} title={copied ? "Copied" : "Copy"}>
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+          <span>{copied ? "Copied" : "Copy"}</span>
+        </button>
+      </div>
       <pre ref={ref} className={className}>
         {children}
       </pre>
-      <button
-        type="button"
-        className="code-copy"
-        onClick={copy}
-        aria-label={copied ? "Copied" : "Copy code"}
-        title={copied ? "Copied" : "Copy"}
-      >
-        {copied ? <Check size={15} /> : <Copy size={15} />}
-      </button>
     </div>
   );
 }

--- a/docs/site/components/docs-page.tsx
+++ b/docs/site/components/docs-page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowLeft, ArrowRight, ChevronRight, PencilLine } from "lucide-react";
+import { ArrowLeft, ArrowRight, PencilLine } from "lucide-react";
 import type { Doc, NavGroup, NavItem } from "@/lib/docs";
 import { siteConfig } from "@/lib/site";
 import { ReStructuredText } from "./markdown";
@@ -17,17 +17,17 @@ function PagerLink({ item, direction }: { item: NavItem; direction: "previous" |
 }
 
 export function DocsPage({ doc, navigation, previous, next }: { doc: Doc; navigation: NavGroup[]; previous?: NavItem; next?: NavItem }) {
-  const section = navigation.find((group) => group.items.some((item) => item.slug === doc.slug))?.title ?? "Documentation";
+  const group = navigation.find((candidate) => candidate.items.some((item) => item.slug === doc.slug));
 
   return (
     <div className="docs-layout">
       <Sidebar navigation={navigation} />
       <main id="main-content" className="docs-main" tabIndex={-1}>
-        <div className="doc-context" aria-label="Breadcrumb">
-          <Link href="/docs">Docs</Link>
-          <ChevronRight size={13} aria-hidden="true" />
-          <span className="doc-section">{section}</span>
-        </div>
+        {group && (
+          <p className="doc-eyebrow" aria-label="Section">
+            <Link href={group.items[0].href}>{group.title}</Link>
+          </p>
+        )}
         <article className="markdown-body">
           <ReStructuredText content={doc.content} sourcePath={doc.sourcePath} />
         </article>

--- a/docs/site/components/header-nav.tsx
+++ b/docs/site/components/header-nav.tsx
@@ -9,13 +9,13 @@ function isCurrent(pathname: string, href: string) {
 }
 
 // One tab per sidebar group, in reading order. A tab opens the group's first
-// page and stays highlighted while the reader is on any page in that group,
-// so the header and the sidebar always agree on where the reader is.
+// page and stays underlined while the reader is on any page in that group,
+// so the tabs and the sidebar always agree on where the reader is.
 export function HeaderNav({ navigation }: { navigation: NavGroup[] }) {
   const pathname = usePathname();
 
   return (
-    <nav className="header-links" aria-label="Primary navigation">
+    <nav className="header-tabs" aria-label="Primary navigation">
       {navigation.map((group) => {
         const active = group.items.some((item) => isCurrent(pathname, item.href));
         return (

--- a/docs/site/components/header.tsx
+++ b/docs/site/components/header.tsx
@@ -11,11 +11,9 @@ import { ThemeToggle } from "./theme-toggle";
 
 type SearchDocument = { slug: string; title: string; description: string; text: string };
 
-// Two rows: identity, search and the repository on the first; the section
-// tabs on their own row below, so the tabs never compete with the search box
-// for width. Under 900px the tabs move into the drawer (MobileNav).
-export async function Header({ documents, navigation }: { documents: SearchDocument[]; navigation: NavGroup[] }) {
-  const { stars, version } = await getRepoStats();
+// Two rows: identity, search and the repository, then the section tabs; under 640px the tabs live in the drawer.
+export function Header({ documents, navigation }: { documents: SearchDocument[]; navigation: NavGroup[] }) {
+  const { stars, version } = getRepoStats();
 
   return (
     <header className="site-header">

--- a/docs/site/components/header.tsx
+++ b/docs/site/components/header.tsx
@@ -1,4 +1,6 @@
+import { Star } from "lucide-react";
 import type { NavGroup } from "@/lib/docs";
+import { formatStars, getRepoStats } from "@/lib/github";
 import { siteConfig } from "@/lib/site";
 import { GitHubIcon } from "./github-icon";
 import { HeaderNav } from "./header-nav";
@@ -9,19 +11,35 @@ import { ThemeToggle } from "./theme-toggle";
 
 type SearchDocument = { slug: string; title: string; description: string; text: string };
 
-export function Header({ documents, navigation }: { documents: SearchDocument[]; navigation: NavGroup[] }) {
+// Two rows: identity, search and the repository on the first; the section
+// tabs on their own row below, so the tabs never compete with the search box
+// for width. Under 900px the tabs move into the drawer (MobileNav).
+export async function Header({ documents, navigation }: { documents: SearchDocument[]; navigation: NavGroup[] }) {
+  const { stars, version } = await getRepoStats();
+
   return (
     <header className="site-header">
-      <div className="header-inner">
-        <Logo />
-        <HeaderNav navigation={navigation} />
+      <div className="header-row">
+        <div className="header-brand">
+          <Logo />
+          {version && (
+            <a className="version-badge" href={`${siteConfig.repository}/releases/tag/${version}`} target="_blank" rel="noreferrer" aria-label={`Reef ${version} release notes`}>
+              {version}
+            </a>
+          )}
+        </div>
         <div className="header-search"><Search documents={documents} /></div>
         <nav className="header-actions" aria-label="Global navigation">
-          <a className="icon-button" href={siteConfig.repository} target="_blank" rel="noreferrer" aria-label="Reef on GitHub"><GitHubIcon size={19} /></a>
+          <a className="repo-link" href={siteConfig.repository} target="_blank" rel="noreferrer" aria-label={`${siteConfig.repoName} on GitHub`}>
+            <GitHubIcon size={17} />
+            <span className="repo-name">{siteConfig.repoName}</span>
+            {stars !== null && <span className="repo-stars"><Star size={13} aria-hidden="true" />{formatStars(stars)}</span>}
+          </a>
           <ThemeToggle />
           <MobileNav navigation={navigation} />
         </nav>
       </div>
+      <HeaderNav navigation={navigation} />
     </header>
   );
 }

--- a/docs/site/components/search.tsx
+++ b/docs/site/components/search.tsx
@@ -126,7 +126,7 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
 
   return (
     <>
-      <button className="search-trigger" type="button" onClick={() => setOpen(true)}>
+      <button className="search-trigger" type="button" onClick={() => setOpen(true)} aria-label="Search documentation" title="Search">
         <SearchIcon size={16} />
         <span>Search</span>
         <kbd>⌘ K</kbd>

--- a/docs/site/components/search.tsx
+++ b/docs/site/components/search.tsx
@@ -37,7 +37,8 @@ export function Search({ documents }: { documents: SearchDocument[] }) {
     function onKeyDown(event: KeyboardEvent) {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
         event.preventDefault();
-        setOpen(true);
+        // One dialog at a time: the shortcut waits while the drawer is open.
+        if (!document.querySelector('[role="dialog"]:not(.search-dialog)')) setOpen(true);
       }
       if (event.key === "Escape") closeSearch();
     }

--- a/docs/site/components/sidebar.tsx
+++ b/docs/site/components/sidebar.tsx
@@ -8,29 +8,30 @@ function isCurrent(pathname: string, href: string) {
   return pathname === href || pathname === `${href}/`;
 }
 
-// The sidebar is scoped to the header tab the reader is on: it lists the pages
-// of the group that owns the current page, and nothing else. Moving between
-// groups is the header's job.
+// The whole tree, every group with its pages, so a reader sees where a page
+// sits among the rest and reaches any page in one click. The header tabs
+// jump between groups; the sidebar scrolls on its own.
 export function Sidebar({ navigation }: { navigation: NavGroup[] }) {
   const pathname = usePathname();
-  const group = navigation.find((candidate) => candidate.items.some((item) => isCurrent(pathname, item.href))) ?? navigation[0];
 
   return (
     <aside className="docs-sidebar">
       <nav aria-label="Documentation navigation">
-        <div className="sidebar-group">
-          <p className="sidebar-group-title">{group.title}</p>
-          <div className="sidebar-group-items">
-            {group.items.map((item) => {
-              const active = isCurrent(pathname, item.href);
-              return (
-                <Link key={item.href} href={item.href} className={active ? "active" : undefined} aria-current={active ? "page" : undefined}>
-                  {item.title}
-                </Link>
-              );
-            })}
+        {navigation.map((group) => (
+          <div key={group.title} className="sidebar-group">
+            <p className="sidebar-group-title">{group.title}</p>
+            <div className="sidebar-group-items">
+              {group.items.map((item) => {
+                const active = isCurrent(pathname, item.href);
+                return (
+                  <Link key={item.href} href={item.href} className={active ? "active" : undefined} aria-current={active ? "page" : undefined}>
+                    {item.title}
+                  </Link>
+                );
+              })}
+            </div>
           </div>
-        </div>
+        ))}
       </nav>
     </aside>
   );

--- a/docs/site/components/sidebar.tsx
+++ b/docs/site/components/sidebar.tsx
@@ -2,20 +2,26 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
 import type { NavGroup } from "@/lib/docs";
 
 function isCurrent(pathname: string, href: string) {
   return pathname === href || pathname === `${href}/`;
 }
 
-// The whole tree, every group with its pages, so a reader sees where a page
-// sits among the rest and reaches any page in one click. The header tabs
-// jump between groups; the sidebar scrolls on its own.
+// The whole tree, every section with its pages; the tabs jump between sections and the sidebar scrolls on its own.
 export function Sidebar({ navigation }: { navigation: NavGroup[] }) {
   const pathname = usePathname();
+  const aside = useRef<HTMLElement>(null);
+
+  // The tree is longer than the viewport, so the current page is brought into view on every page change.
+  useEffect(() => {
+    const active = aside.current?.querySelector<HTMLElement>('a[aria-current="page"]');
+    active?.scrollIntoView({ block: "nearest" });
+  }, [pathname]);
 
   return (
-    <aside className="docs-sidebar">
+    <aside ref={aside} className="docs-sidebar">
       <nav aria-label="Documentation navigation">
         {navigation.map((group) => (
           <div key={group.title} className="sidebar-group">

--- a/docs/site/components/table-of-contents.tsx
+++ b/docs/site/components/table-of-contents.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AlignLeft } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { TocItem } from "@/lib/docs";
 
@@ -15,7 +16,7 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
         const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
         if (visible[0]?.target.id) setActive(visible[0].target.id);
       },
-      { rootMargin: "-96px 0px -72%", threshold: [0, 1] },
+      { rootMargin: "-120px 0px -72%", threshold: [0, 1] },
     );
     headings.forEach((heading) => observer.observe(heading));
     return () => observer.disconnect();
@@ -25,7 +26,7 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
 
   return (
     <aside className="toc">
-      <p>On this page</p>
+      <p className="toc-label"><AlignLeft size={15} aria-hidden="true" />On this page</p>
       <nav aria-label="Table of contents">
         {items.map((item) => (
           <a key={item.id} href={`#${item.id}`} className={`${item.level === 3 ? "nested " : ""}${active === item.id ? "active" : ""}`}>

--- a/docs/site/components/theme-toggle.tsx
+++ b/docs/site/components/theme-toggle.tsx
@@ -4,9 +4,7 @@ import { Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useSyncExternalStore } from "react";
 import { MODES, Mode, THEME_KEY, apply, storedMode } from "@/lib/theme";
 
-// Three modes side by side, the current one filled, so a reader sees all
-// three and picks one in one click. The order is the settled cycle: system,
-// then dark, then light.
+// Three modes side by side, the current one filled, in the settled order: system, dark, light.
 const OPTIONS: { mode: Mode; label: string; Icon: typeof Monitor }[] = [
   { mode: "auto", label: "System color theme", Icon: Monitor },
   { mode: "dark", label: "Dark color theme", Icon: Moon },
@@ -51,13 +49,18 @@ export function ThemeToggle() {
     window.dispatchEvent(new Event(CHANGE));
   }
 
+  // The radio group keys: arrows move, Home and End jump.
   function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
-    if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+    const index = MODES.indexOf(mode);
+    const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 }[event.key];
+    let target: number;
+    if (step !== undefined) target = (index + step + MODES.length) % MODES.length;
+    else if (event.key === "Home") target = 0;
+    else if (event.key === "End") target = MODES.length - 1;
+    else return;
     event.preventDefault();
-    const step = event.key === "ArrowRight" ? 1 : -1;
-    const next = MODES[(MODES.indexOf(mode) + step + MODES.length) % MODES.length];
-    choose(next);
-    (event.currentTarget.querySelector(`[data-mode="${next}"]`) as HTMLElement | null)?.focus();
+    choose(MODES[target]);
+    (event.currentTarget.querySelector(`[data-mode="${MODES[target]}"]`) as HTMLElement | null)?.focus();
   }
 
   return (

--- a/docs/site/components/theme-toggle.tsx
+++ b/docs/site/components/theme-toggle.tsx
@@ -1,30 +1,32 @@
 "use client";
 
-import { Moon, Sun, SunMoon } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useEffect, useSyncExternalStore } from "react";
 import { MODES, Mode, THEME_KEY, apply, storedMode } from "@/lib/theme";
 
-// Click order matches the founder's personal-site toggle: an explicit dark,
-// then light, then back to following the OS. On a light-OS machine the first
-// click must visibly change the page; auto -> light would not.
-const LABELS: Record<Mode, string> = {
-  auto: "Color theme: system. Switch to dark.",
-  dark: "Color theme: dark. Switch to light.",
-  light: "Color theme: light. Switch to system.",
-};
+// Three modes side by side, the current one filled, so a reader sees all
+// three and picks one in one click. The order is the settled cycle: system,
+// then dark, then light.
+const OPTIONS: { mode: Mode; label: string; Icon: typeof Monitor }[] = [
+  { mode: "auto", label: "System color theme", Icon: Monitor },
+  { mode: "dark", label: "Dark color theme", Icon: Moon },
+  { mode: "light", label: "Light color theme", Icon: Sun },
+];
+
+const CHANGE = "reef-theme-change";
+
+function subscribe(onChange: () => void) {
+  window.addEventListener(CHANGE, onChange);
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(CHANGE, onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}
 
 export function ThemeToggle() {
-  const button = useRef<HTMLButtonElement>(null);
-
-  function label(mode: Mode) {
-    const el = button.current;
-    if (!el) return;
-    el.setAttribute("aria-label", LABELS[mode]);
-    el.title = LABELS[mode];
-  }
-
-  // The server renders the system-mode label; sync to storage before paint.
-  useLayoutEffect(() => label(storedMode()), []);
+  // The server renders system mode; the stored choice replaces it on hydration.
+  const mode = useSyncExternalStore(subscribe, storedMode, () => "auto" as Mode);
 
   useEffect(() => {
     const media = window.matchMedia("(prefers-color-scheme: dark)");
@@ -35,8 +37,7 @@ export function ThemeToggle() {
     return () => media.removeEventListener("change", followSystem);
   }, []);
 
-  function cycleTheme() {
-    const next = MODES[(MODES.indexOf(storedMode()) + 1) % MODES.length];
+  function choose(next: Mode) {
     try {
       if (next === "auto") {
         localStorage.removeItem(THEME_KEY);
@@ -47,21 +48,35 @@ export function ThemeToggle() {
       /* private browsing: the theme still applies for this page view */
     }
     apply(next);
-    label(next);
+    window.dispatchEvent(new Event(CHANGE));
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+    event.preventDefault();
+    const step = event.key === "ArrowRight" ? 1 : -1;
+    const next = MODES[(MODES.indexOf(mode) + step + MODES.length) % MODES.length];
+    choose(next);
+    (event.currentTarget.querySelector(`[data-mode="${next}"]`) as HTMLElement | null)?.focus();
   }
 
   return (
-    <button
-      ref={button}
-      className="icon-button theme-toggle"
-      type="button"
-      onClick={cycleTheme}
-      aria-label={LABELS.auto}
-      title={LABELS.auto}
-    >
-      <SunMoon className="system-icon" size={18} />
-      <Moon className="moon-icon" size={18} />
-      <Sun className="sun-icon" size={18} />
-    </button>
+    <div className="theme-switch" role="radiogroup" aria-label="Color theme" onKeyDown={onKeyDown}>
+      {OPTIONS.map(({ mode: option, label, Icon }) => (
+        <button
+          key={option}
+          type="button"
+          role="radio"
+          data-mode={option}
+          aria-checked={mode === option}
+          aria-label={label}
+          title={label}
+          tabIndex={mode === option ? 0 : -1}
+          onClick={() => choose(option)}
+        >
+          <Icon size={15} aria-hidden="true" />
+        </button>
+      ))}
+    </div>
   );
 }

--- a/docs/site/lib/github.ts
+++ b/docs/site/lib/github.ts
@@ -1,35 +1,23 @@
-import { siteConfig } from "./site";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 export type RepoStats = { stars: number | null; version: string | null };
 
-// Read once at build (the site is a static export): the star count and the
-// newest tag, for the header. Either value is null when GitHub is unreachable
-// or rate limited, and the header simply leaves it out.
-export async function getRepoStats(): Promise<RepoStats> {
-  const api = `https://api.github.com/repos/${siteConfig.repoName}`;
-  const init = { headers: { accept: "application/vnd.github+json", "user-agent": "reef-docs" }, cache: "force-cache" as const };
-  const stats: RepoStats = { stars: null, version: null };
+// scripts/fetch-repo-stats.mjs writes this file before dev and build; a missing or bad file means no count and no tag.
+export function getRepoStats(): RepoStats {
   try {
-    const repo = await fetch(api, init);
-    if (repo.ok) {
-      const data: { stargazers_count?: number } = await repo.json();
-      if (typeof data.stargazers_count === "number") stats.stars = data.stargazers_count;
-    }
+    const data = JSON.parse(readFileSync(join(process.cwd(), "lib", "repo-stats.generated.json"), "utf8"));
+    return {
+      stars: typeof data.stars === "number" ? data.stars : null,
+      version: typeof data.version === "string" && data.version ? data.version : null,
+    };
   } catch {
-    /* offline build: no star count */
+    return { stars: null, version: null };
   }
-  try {
-    const tags = await fetch(`${api}/tags?per_page=1`, init);
-    if (tags.ok) {
-      const data: { name?: string }[] = await tags.json();
-      if (data[0]?.name) stats.version = data[0].name;
-    }
-  } catch {
-    /* offline build: no version */
-  }
-  return stats;
 }
 
+const compact = new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 });
+
 export function formatStars(stars: number) {
-  return stars >= 1000 ? `${(stars / 1000).toFixed(stars >= 10000 ? 0 : 1)}k` : String(stars);
+  return compact.format(stars).toLowerCase();
 }

--- a/docs/site/lib/github.ts
+++ b/docs/site/lib/github.ts
@@ -1,0 +1,35 @@
+import { siteConfig } from "./site";
+
+export type RepoStats = { stars: number | null; version: string | null };
+
+// Read once at build (the site is a static export): the star count and the
+// newest tag, for the header. Either value is null when GitHub is unreachable
+// or rate limited, and the header simply leaves it out.
+export async function getRepoStats(): Promise<RepoStats> {
+  const api = `https://api.github.com/repos/${siteConfig.repoName}`;
+  const init = { headers: { accept: "application/vnd.github+json", "user-agent": "reef-docs" }, cache: "force-cache" as const };
+  const stats: RepoStats = { stars: null, version: null };
+  try {
+    const repo = await fetch(api, init);
+    if (repo.ok) {
+      const data: { stargazers_count?: number } = await repo.json();
+      if (typeof data.stargazers_count === "number") stats.stars = data.stargazers_count;
+    }
+  } catch {
+    /* offline build: no star count */
+  }
+  try {
+    const tags = await fetch(`${api}/tags?per_page=1`, init);
+    if (tags.ok) {
+      const data: { name?: string }[] = await tags.json();
+      if (data[0]?.name) stats.version = data[0].name;
+    }
+  } catch {
+    /* offline build: no version */
+  }
+  return stats;
+}
+
+export function formatStars(stars: number) {
+  return stars >= 1000 ? `${(stars / 1000).toFixed(stars >= 10000 ? 0 : 1)}k` : String(stars);
+}

--- a/docs/site/lib/site.ts
+++ b/docs/site/lib/site.ts
@@ -2,6 +2,7 @@ export const siteConfig = {
   title: "Reef — Continual learning infrastructure",
   description: "Reef is continual learning infrastructure for AI agents. Serve inference, collect feedback, and evolve model weights or agent harnesses.",
   repository: "https://github.com/Human-Agent-Society/reef",
+  repoName: "Human-Agent-Society/reef",
   // The canonical origin for sitemap, robots, canonical links, and Open Graph.
   // Vercel previews override it with their own host so shared previews resolve.
   url:

--- a/docs/site/lib/theme.ts
+++ b/docs/site/lib/theme.ts
@@ -22,5 +22,4 @@ export function resolve(mode: Mode): "light" | "dark" {
 
 export function apply(mode: Mode) {
   document.documentElement.dataset.theme = resolve(mode);
-  document.documentElement.dataset.themeMode = mode;
 }

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "predev": "node scripts/fetch-repo-stats.mjs",
+    "prebuild": "node scripts/fetch-repo-stats.mjs",
     "build": "next build --webpack",
     "check:docs": "node scripts/check-doc-links.mjs && node scripts/check-doc-contracts.mjs",
     "start": "next start",

--- a/docs/site/scripts/fetch-repo-stats.mjs
+++ b/docs/site/scripts/fetch-repo-stats.mjs
@@ -1,0 +1,32 @@
+// Before dev and build: write the star count and the newest release tag for the header.
+// The site is a static export, so the values are as of the build. A failure leaves nulls and never fails the build.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repo = "Human-Agent-Society/reef";
+const target = resolve(dirname(fileURLToPath(import.meta.url)), "../lib/repo-stats.generated.json");
+const headers = { accept: "application/vnd.github+json", "user-agent": "reef-docs" };
+
+async function get(url) {
+  const response = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
+  if (!response.ok) throw new Error(`${url}: ${response.status}`);
+  return response.json();
+}
+
+const stats = { stars: null, version: null };
+try {
+  const data = await get(`https://api.github.com/repos/${repo}`);
+  if (typeof data.stargazers_count === "number") stats.stars = data.stargazers_count;
+} catch (error) {
+  console.warn(`repo stats: no star count (${error.message})`);
+}
+try {
+  const data = await get(`https://api.github.com/repos/${repo}/releases/latest`);
+  if (typeof data.tag_name === "string" && data.tag_name) stats.version = data.tag_name;
+} catch (error) {
+  console.warn(`repo stats: no release tag (${error.message})`);
+}
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, JSON.stringify(stats) + "\n");
+console.log(`repo stats: stars=${stats.stars} version=${stats.version}`);


### PR DESCRIPTION
## Motivation

The docs site packed the logo, six section tabs, the search box and the actions into one 68px bar, showed only the current section in the sidebar, and put the copy button over the first line of code. I want the layout readers already find comfortable, the Mintlify layout honcho.dev uses, on a phone, a tablet and a desktop. Layout only: the color tokens, the type faces and the content are unchanged.

## Changes

- Header in two rows: logo with the newest release tag, a centered search box with its shortcut, the repository with its star count and a three state theme control (system, dark, light); the section tabs on the second row, wrapping when narrow
- Sidebar shows every section with its pages, sticky and scrolling on its own, the current page as a filled pill kept in view; a sticky On this page list on the right
- Content column capped at 780px with the section name as an eyebrow above the title; code blocks get a head bar with the language and an always visible Copy button; code moves from 13px to 14px
- Three widths: the table of contents folds away under 1280px, the sidebar folds into the drawer under 900px, and under 640px the tabs and the repository text fold away and the search box becomes an icon
- The star count and release tag are written by scripts/fetch-repo-stats.mjs before dev and build with a five second timeout; a failed call leaves the value out and the build passes

## Compatibility and operational impact

Static export as before; no route, content or docs contract changes. The header is sticky in flow instead of fixed, so the landing page lost its 68px offset. lib/repo-stats.generated.json is ignored by git; a checkout without it renders the header without the count and the tag.

## Verification

Headless Chrome screenshots at 320, 390, 700, 834, 1300 and 1440 wide in light and dark, plus the drawer, the search dialog, a scrolled table of contents, code blocks and the landing page, read against the reference at the same widths. A measurement pass at every width confirms no page scrolls sideways, every header control has room, the tab row wraps instead of clipping, the current sidebar page is in view on a deep page, and the landing page sits flush under the header. A scripted pass drives the theme control through click, arrow keys, a sidebar navigation and a reload. An adversarial review over the first cut found the search box collapsing between 641 and 760px, the phone header overflowing at 320 and 390, the sidebar not scrolling the current page into view, an unnamed search button, the landing page offset, a frozen fetch cache with no timeout, duplicate and dead rules, and touch targets under 40px; each is fixed here and measured again.

## AI assistance

Claude Code measured the reference and the current site, wrote the layout, ran the adversarial review and took the screenshots; I named the reference and the pieces to borrow.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
