### PR TITLE
fix(docs): line the sidebar text up with the logo and the tabs

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -122,8 +122,8 @@ button { cursor: pointer; }
 .header-tabs a.active { color: var(--foreground); border-bottom-color: var(--brand); }
 
 /* Documentation layout: sidebar, content, table of contents */
-.docs-layout { --header-height: 105px; width: min(1440px, 100%); min-height: calc(100vh - var(--header-height)); margin: 0 auto; padding: 0 32px; display: grid; grid-template-columns: 272px minmax(0, 1fr) 232px; }
-.docs-sidebar { position: sticky; top: var(--header-height); height: calc(100vh - var(--header-height)); padding: 32px 20px 48px 0; overflow-y: auto; overscroll-behavior: contain; border-right: 1px solid color-mix(in srgb, var(--border) 72%, transparent); }
+.docs-layout { --header-height: 105px; width: min(1440px, 100%); min-height: calc(100vh - var(--header-height)); margin: 0 auto; padding: 0 32px; display: grid; grid-template-columns: 260px minmax(0, 1fr) 232px; }
+.docs-sidebar { position: sticky; top: var(--header-height); height: calc(100vh - var(--header-height)); margin-left: -12px; padding: 32px 20px 48px 0; overflow-y: auto; overscroll-behavior: contain; border-right: 1px solid color-mix(in srgb, var(--border) 72%, transparent); }
 .sidebar-group { margin-bottom: 26px; }
 .sidebar-group-title { margin: 0 0 6px 12px; color: var(--foreground); font-size: 14px; font-weight: 600; line-height: 22px; }
 .sidebar-group-items { display: grid; gap: 2px; }


### PR DESCRIPTION
## Motivation

The logo and the section tabs start at the page edge while the sidebar text sat 12px to the right of them, because the active pill's padding pushed the text in. The three should share one left edge, as they do on the reference layout.

## Changes

- The sidebar starts 12px left of the page edge, so its titles and page names line up with the logo mark and the tab text, and the active pill extends 12px past that edge

## Compatibility and operational impact

Layout only, desktop widths with the sidebar shown.

## Verification

Measured in a headless Chrome at 1440, 1300 and 1000 wide: the logo mark, the first tab's text, the sidebar group title and the sidebar item text all start at x=32, the active pill at x=20.

## AI assistance

Claude Code measured and applied the shift; I spotted the misalignment.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
