### PR TITLE
perf(docs): redirect the docs entry at the edge and load the fonts in parallel

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;600;800&family=Source+Serif+4:opsz,wght@8..60,500;8..60,600&display=swap");
-
 /* Site design tokens */
 :root {
   --background: #ffffff;

--- a/docs/site/app/layout.tsx
+++ b/docs/site/app/layout.tsx
@@ -33,6 +33,12 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
 
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Linked here, not imported from the stylesheet, so the browser fetches the fonts in parallel with the CSS. */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;600;800&family=Source+Serif+4:opsz,wght@8..60,500;8..60,600&display=swap" />
+      </head>
       <body>
         {/* Inline so it runs at parse time, before first paint. */}
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />

--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -11,6 +11,16 @@
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "redirects": [
     {
+      "source": "/docs",
+      "destination": "/docs/getting-started/intro/",
+      "permanent": false
+    },
+    {
+      "source": "/docs/",
+      "destination": "/docs/getting-started/intro/",
+      "permanent": false
+    },
+    {
       "source": "/docs/concepts",
       "destination": "/docs/getting-started/quickstart",
       "permanent": true


### PR DESCRIPTION
## Motivation

The first visit to reefinfra.ai/docs/ felt slow. Profiled from Seoul against the live site: the server is not the cause (time to first byte 39ms, edge cache hit, first paint at 188ms on a fast link). /docs/ is a static page that carries only a client side redirect to the first doc, so a cold visit downloads that page (247KB) and the whole script bundle (about 440KB for a modern browser) and hydrates before it can even ask for the real page, which then loads on its own. On a 4x slowed CPU with a fast 3G link the first doc's title appears 3.9s after the request, while the same click from the landing page takes 103ms because the page is prefetched. The fonts add a round trip on top: a CSS import inside the site stylesheet cannot start until that stylesheet has arrived.

## Changes

- Vercel answers /docs and /docs/ with a redirect to the first doc at the edge (about 40ms), so the browser loads one page instead of a redirect page plus a page; the in app redirect stays as the fallback for other hosts
- The Google Fonts stylesheet is linked from the head with preconnects to both font hosts, in parallel with the site stylesheet, instead of imported from it

## Compatibility and operational impact

No route or content change. The redirect is temporary (307), so the first doc can move without a cached permanent redirect pointing at the old one. Colors, faces and sizes are unchanged; the same font request URL moved from the stylesheet to the head.

## Verification

Live profile with a headless Chrome before the change: navigation timing, paints, the 61 resources of a cold load, the client side redirect in the served /docs/ page (NEXT_REDIRECT;replace;/docs/getting-started/intro), the bundle sizes by content length, and the throttled timings above. After the change on the dev server: the head carries the two preconnects and the font stylesheet link, the site stylesheet has no import rule, and all seven font faces report loaded with the serif face on the title. The static export builds and check:docs passes. Measured live after the merge with the same script: /docs/ answers 307 to the first doc from the edge (57ms warm), the head carries the preconnects and the font stylesheet, and on the 4x slowed CPU with a fast 3G link the first doc's title now appears 2.3s after the request, at DOMContentLoaded, where it took 3.9s and a second page load before.

## AI assistance

Claude Code profiled the live site and made the change; I reported the slow first click.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
