### PR TITLE
fix(docs): center the header rows at the layout width so the tabs line up with the sidebar on a wide screen

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -91,7 +91,8 @@ button { cursor: pointer; }
 
 /* Header and navigation */
 .site-header { position: sticky; z-index: 50; top: 0; border-bottom: 1px solid color-mix(in srgb, var(--border) 76%, transparent); background: color-mix(in srgb, var(--background) 86%, transparent); backdrop-filter: blur(20px) saturate(140%); }
-.header-row { height: 60px; padding: 0 32px; display: grid; grid-template-columns: 1fr minmax(0, 520px) 1fr; align-items: center; gap: 24px; }
+/* Both header rows share the docs layout's centered 1440px width, so the logo, the tabs and the sidebar keep one left edge on a wide screen. */
+.header-row { width: min(1440px, 100%); height: 60px; margin: 0 auto; padding: 0 32px; display: grid; grid-template-columns: 1fr minmax(0, 520px) 1fr; align-items: center; gap: 24px; }
 .header-brand { display: flex; align-items: center; gap: 12px; }
 .logo { display: inline-flex; align-items: center; gap: 11px; color: var(--foreground); font-weight: 600; }
 .logo-mark { color: var(--brand); stroke-width: 2.4; }
@@ -114,7 +115,7 @@ button { cursor: pointer; }
 .icon-button { width: 36px; height: 36px; padding: 0; display: inline-grid; place-items: center; color: var(--muted); border: 0; border-radius: 10px; background: transparent; }
 .icon-button:hover { color: var(--brand-strong); background: var(--accent); }
 .icon-button.menu-toggle { display: none; }
-.header-tabs { min-height: 44px; padding: 0 24px; display: flex; flex-wrap: wrap; align-items: stretch; gap: 0 4px; }
+.header-tabs { width: min(1440px, 100%); min-height: 44px; margin: 0 auto; padding: 0 24px; display: flex; flex-wrap: wrap; align-items: stretch; gap: 0 4px; }
 .header-tabs a { min-height: 44px; padding: 0 8px; display: flex; align-items: center; color: var(--muted); border-bottom: 2px solid transparent; font-size: 14px; font-weight: 500; white-space: nowrap; }
 .header-tabs a:hover { color: var(--foreground); }
 .header-tabs a.active { color: var(--foreground); border-bottom-color: var(--brand); }


### PR DESCRIPTION
## Motivation

On a screen wider than 1440px the docs layout centers itself but the header stayed full width, so the logo and the section tabs sat at the left edge of the window while the sidebar headings and pages sat up to 240px to the right. #252 aligned them only at 1440px and below. The reference keeps the header content in the same centered container as the page.

## Changes

- Both header rows take the docs layout's centered 1440px width, so the logo mark, the tab text and the sidebar text keep one left edge at every window width

## Compatibility and operational impact

Layout only. At 1440px and below nothing moves.

## Verification

Measured in a headless Chrome at 1440, 1728 and 1920 wide: the logo mark, the first tab's text, the sidebar group title and the sidebar page text start at x=32, 176 and 272, the same three values as the reference site's tab text and sidebar text at those widths. Before the change the live site read 32 for the header against 176 and 272 for the sidebar.

## AI assistance

Claude Code measured the live site and the reference at the three widths and made the change; I saw the misalignment on a wide screen.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
