### PR TITLE
docs(harness): add an at a glance summary and the adapter table to the harness evolution guide

### DIFF
--- a/docs/getting-started/intro.rst
+++ b/docs/getting-started/intro.rst
@@ -77,8 +77,10 @@ Reef is capable of evolve both the model weights and the `harness tree
   into the serving engine. See `Evolve your model
   <../user-guide/evolve-your-model.rst>`__.
 - **The harness tree.** Reef proposes an edit, runs the current and proposed
-  versions on your tasks, and keeps the winner. See `Evolve your harness
-  <../user-guide/evolve-your-harness.rst>`__.
+  versions on your tasks, and keeps the winner. Adapters cover pi, opencode,
+  Claude Code, Codex, DeepSeek Harness, Hermes Agent, Terminus 2, and Reef's
+  own native harness, whose tools, hook listeners, and loop graph evolve too.
+  See `Evolve your harness <../user-guide/evolve-your-harness.rst>`__.
 
 Start using Reef
 ----------------

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -145,7 +145,8 @@ Harness tree
 
 Reef's versioned representation of the mutable files in a harness: config,
 rules, prompt templates, skills, extension code, and, for the ``native``
-adapter, the loop's own tools and hook listeners. Reef serves it over
+adapter, the loop's own tools, hook listeners, and control flow graph. Reef
+serves it over
 ``GET /reef/harness``. An adapter combines the rendered tree with a harness
 executable; that harness and its configured model form the running agent.
 

--- a/docs/site/app/page.tsx
+++ b/docs/site/app/page.tsx
@@ -22,7 +22,7 @@ const surfaces = [
   {
     eyebrow: "No GPU",
     title: "Evolve the harness",
-    text: "Reef proposes an edit to your agent's rules, prompts, skills, and config, runs the agent both ways on your tasks, and publishes the winner.",
+    text: "Reef proposes an edit to your agent's rules, skills, config, tools, or loop, runs the agent both ways on your tasks, and publishes the winner. Eight coding agents, including Reef's own.",
     href: "/docs/user-guide/evolve-your-harness",
     cta: "Harness evolution",
     icon: PlugZap,
@@ -41,7 +41,7 @@ const methods = [
   { name: "sao", href: "/docs/user-guide/recipes/sao", signal: "Feedback on each attempt, over a stream of tasks", evolves: "model weights", gpu: "yes" },
   { name: "tttd", href: "/docs/user-guide/recipes/tttd", signal: "A fixed grid of sibling attempts at one problem", evolves: "model weights", gpu: "yes" },
   { name: "openclawrl", href: "/docs/user-guide/recipes/openclawrl", signal: "Nothing on the wire — just agent conversations", evolves: "model weights", gpu: "yes" },
-  { name: "harness_evolve", href: "/docs/user-guide/recipes/harness-evolve", signal: "Scores on requests, and failures worth learning from", evolves: "harness tree", gpu: "no" },
+  { name: "skillclaw", href: "/docs/user-guide/recipes/skillclaw", signal: "Scores on requests, and failures worth learning from", evolves: "harness tree", gpu: "no" },
 ];
 
 const steps = [

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -13,6 +13,38 @@ callables, ``propose`` (which edit to try) and ``evaluate`` (how an episode
 scored). `Write a harness method <../developer-guide/write-a-harness-method.rst>`__ documents the
 contract.
 
+At a glance
+-----------
+
++-------------------+--------------------------------------------------------------+
+| What evolves      | Config, rules, prompt templates, skills, and extension code; |
+|                   | on the native harness also its tools, its hook listeners,    |
+|                   | and the graph that is its control loop.                      |
++-------------------+--------------------------------------------------------------+
+| Which agents      | pi, opencode, Claude Code, Codex, DeepSeek Harness, Hermes   |
+|                   | Agent, Terminus 2, and ``native``, Reef's own loop. One      |
+|                   | adapter per agent maps the tree onto that agent's files.     |
++-------------------+--------------------------------------------------------------+
+| What decides      | The candidate and the current tree run the same tasks in     |
+|                   | fresh roots. The candidate is published only when it wins    |
+|                   | more tasks than it loses, by more than a margin you set.     |
++-------------------+--------------------------------------------------------------+
+| What holds it     | A rejected candidate reverts to the snapshot. A failing      |
+|                   | prompt joins the task suite only after a credential and an   |
+|                   | instruction override screen, with a cap per client. Wins     |
+|                   | that touch code can wait for a person before they are        |
+|                   | served. A periodic recheck rolls back a publish that a       |
+|                   | grown suite now scores as a regression. Episodes can run in  |
+|                   | a sandbox with no host credentials and no network beyond the |
+|                   | model endpoint.                                              |
++-------------------+--------------------------------------------------------------+
+| Where to start    | `Run the example <#run-the-example>`__ evolves one skill on  |
+|                   | ``pi`` with a local model and no GPU. The tutorial's         |
+|                   | ``serve-native.yaml`` runs the same loop on the native       |
+|                   | harness, where the model proposes tools, hooks, and graph    |
+|                   | changes to its own loop.                                     |
++-------------------+--------------------------------------------------------------+
+
 The harness tree
 ----------------
 
@@ -22,7 +54,7 @@ fields: ``id`` is unique within the tree, ``name`` selects one of the node
 kinds below, and ``config`` holds that kind's own fields. For the named kinds
 (``agent_command``, ``skill``, ``code_extension``, ``native_tool``,
 ``native_hook``), ``config.name`` is the file name the entry renders to.
-Seven kinds are registered in
+Eight kinds are registered in
 `reef/harness/nodes.py <../../reef/harness/nodes.py>`__:
 
 +--------------------+----------------------------------------------------------+
@@ -51,11 +83,12 @@ decided by an adapter, which maps every kind to a concrete file for one agent.
 Reef bundles adapters for third-party coding agent CLIs (``pi``, ``opencode``,
 ``claude``, ``codex``, ``dsh`` (DeepSeek Harness), and ``hermes`` (Hermes
 Agent)); ``native``, its own agent: a loop inside the reef tree whose tools
-are ``native_tool`` nodes and whose loop events listen to ``native_hook``
-nodes, so the agent can evolve the tools it runs and how its loop behaves, not
+are ``native_tool`` nodes, whose loop events listen to ``native_hook``
+nodes, and whose control flow is a ``native_graph`` node, so the agent can
+evolve the tools it runs, how its loop reacts, and the loop itself, not
 only the text around a vendor binary; and ``terminus``, Terminal-Bench's
 Terminus 2, run through a Reef-owned Harbor runner. Only ``native`` renders
-those two kinds.
+those three kinds.
 
 Codex and Terminus support ``config``, ``rules``, ``agent_command``, and
 ``skill``. Both reject ``code_extension``: Codex lifecycle hooks run outside
@@ -316,6 +349,36 @@ Reef ships no proposer and no episode scorer. You supply ``propose``,
 
 Connect a different agent
 -------------------------
+
+An adapter is one descriptor: where each node kind is written, which kinds
+the agent accepts, how the binary is launched, and where the proxy captures
+the model calls. The bundled descriptors cover these agents:
+
++---------------+----------------------------------+----------------------------------------+
+| Adapter       | Agent                            | Kinds it renders                       |
++===============+==================================+========================================+
+| ``pi``        | pi coding agent                  | config, rules, agent_command, skill,   |
+|               |                                  | code_extension                         |
++---------------+----------------------------------+----------------------------------------+
+| ``opencode``  | OpenCode                         | config, rules, agent_command, skill,   |
+|               |                                  | code_extension                         |
++---------------+----------------------------------+----------------------------------------+
+| ``claude``    | Claude Code                      | config, rules, agent_command, skill,   |
+|               |                                  | code_extension                         |
++---------------+----------------------------------+----------------------------------------+
+| ``codex``     | Codex CLI                        | config, rules, agent_command, skill    |
++---------------+----------------------------------+----------------------------------------+
+| ``dsh``       | DeepSeek Harness                 | config, rules, agent_command, skill,   |
+|               |                                  | code_extension                         |
++---------------+----------------------------------+----------------------------------------+
+| ``hermes``    | Hermes Agent                     | config, rules, agent_command, skill,   |
+|               |                                  | code_extension                         |
++---------------+----------------------------------+----------------------------------------+
+| ``terminus``  | Terminus 2 (Terminal-Bench)      | config, rules, agent_command, skill    |
++---------------+----------------------------------+----------------------------------------+
+| ``native``    | Reef's own loop                  | the five above plus native_tool,       |
+|               |                                  | native_hook, native_graph              |
++---------------+----------------------------------+----------------------------------------+
 
 `Harness adapters <../developer-guide/harness-adapters.rst>`__ is the descriptor reference and
 how to connect an agent that has no adapter yet.

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -14,8 +14,8 @@ A recipe is picked along two axes: **what it evolves**, and **how it learns**.
 |                         | reward read from the next state                  |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+
 | **Harness:** prompts,   | ``skillclaw``: grows a skill pool from           | not available                            |
-| rules, skills, config   | the failures in its own served traffic           |                                          |
-|                         |                                                  |                                          |
+| rules, skills, config,  | the failures in its own served traffic           |                                          |
+| tools, loop             |                                                  |                                          |
 |                         | ``gepa``: rewrites the tree by reflecting on     |                                          |
 |                         | the transcripts it already served                |                                          |
 +-------------------------+--------------------------------------------------+------------------------------------------+


### PR DESCRIPTION
## Motivation

Readers meet harness evolution on the docs before they meet the code, and the docs did not say what it can do today. The user guide opened with the mechanism and a node table that still said seven kinds after the graph node made eight, the landing card listed rules, prompts, skills and config only, the intro named no agent, and the recipes table stopped at config. Someone who wants to tell others about Reef needs the whole picture on one screen: what evolves, on which agents, what decides a publish, and what holds the loop back.

## Changes

- An At a glance table at the top of Evolve your harness: what evolves, which eight agents, what decides, what holds it (revert, the credential and instruction override screens, the per client cap, review before serving, recheck and rollback, the sandbox), and where to start
- An adapter table under Connect a different agent: the eight bundled adapters, the agent each one drives, and the node kinds each one renders
- The node kind count corrected to eight and the native adapter sentence extended to the graph node
- The landing card, the intro bullet, the glossary entry for the harness tree, and the recipes table now name tools, hooks and the loop, and the landing methods row links to the skillclaw page directly instead of through a redirect

## Compatibility and operational impact

Docs only. No route, config or code change.

## Verification

The kinds column of the adapter table is read from each adapter's descriptor.yaml and the codex and terminus quirks, not from memory. check:docs, lint and the static build pass locally, and the two new grid tables were screenshotted from the built export at 390 and 1440 wide.

## AI assistance

Claude Code drafted the tables and the copy and checked them against the descriptors; I set the audience and the scope.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
