### PR TITLE
docs: keep English and Chinese READMEs synchronized

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,9 @@
 /.github/ @BobbyZhouZijian
 /docker/ @BobbyZhouZijian
 /pyproject.toml @BobbyZhouZijian
+/README.md @BobbyZhouZijian
+/README.zh.md @BobbyZhouZijian
+/README.i18n.yaml @BobbyZhouZijian
 
 # Core product areas. Keep these entries separate so ownership can be
 # delegated one subsystem at a time as the maintainer group grows.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,7 @@ remains responsible for every submitted line, claim, and test result.
 - [ ] Tests cover behavior changes, or this pull request does not change behavior.
 - [ ] Public interface changes include contract tests, or no public interface changes are present.
 - [ ] Affected user and developer documentation is updated, or no documentation update is required.
+- [ ] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
 - [ ] An accepted RFC is linked, or this change does not require an RFC.
 - [ ] Relevant pre-commit and test checks pass.
 - [ ] Non-trivial AI assistance is disclosed above, or none was used.

--- a/.github/scripts/check_readme_i18n.py
+++ b/.github/scripts/check_readme_i18n.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Keep the root English and Chinese READMEs structurally synchronized."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "README.md"
+TRANSLATION = ROOT / "README.zh.md"
+RECORD = ROOT / "README.i18n.yaml"
+PAIR_PATHS = (SOURCE, TRANSLATION)
+
+FENCE_RE = re.compile(r"^(`{3,}|~{3,})(.*)$")
+HEADING_RE = re.compile(r"^(#{1,6})\s+")
+LIST_RE = re.compile(r"^\s*(?:[-+*]|\d+[.)])\s+")
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^]]*\]\(([^)\s]+)(?:\s+['\"].*?['\"])?\)")
+HTML_TARGET_RE = re.compile(r"\b(?:href|src|srcset)=[\"']([^\"']+)[\"']")
+HASH_RE = re.compile(r"^(README(?:\.zh)?\.md):\s*([0-9a-f]+)\s*$")
+
+
+class ReadmeContractError(RuntimeError):
+    """A README pair violates the synchronization contract."""
+
+
+def git_blob_hash(path: Path) -> str:
+    result = subprocess.run(
+        ["git", "hash-object", str(path.relative_to(ROOT))],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def parse_record() -> dict[str, str]:
+    if not RECORD.is_file():
+        raise ReadmeContractError("README.i18n.yaml is missing")
+    values: dict[str, str] = {}
+    for line in RECORD.read_text(encoding="utf-8").splitlines():
+        match = HASH_RE.match(line)
+        if match:
+            values[match.group(1)] = match.group(2)
+    expected = {path.name for path in PAIR_PATHS}
+    if set(values) != expected:
+        raise ReadmeContractError("README.i18n.yaml must record exactly README.md and README.zh.md")
+    return values
+
+
+def fenced_blocks(text: str) -> tuple[list[str], list[tuple[str, str]]]:
+    outside: list[str] = []
+    blocks: list[tuple[str, str]] = []
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        match = FENCE_RE.match(lines[index])
+        if not match:
+            outside.append(lines[index])
+            index += 1
+            continue
+        marker, info = match.groups()
+        body: list[str] = []
+        index += 1
+        while index < len(lines) and not re.match(rf"^{re.escape(marker[0])}{{{len(marker)},}}\s*$", lines[index]):
+            body.append(lines[index])
+            index += 1
+        if index == len(lines):
+            raise ReadmeContractError(f"unclosed code fence: {marker}{info}")
+        blocks.append((info.strip(), "\n".join(body)))
+        index += 1
+    return outside, blocks
+
+
+def table_shapes(lines: list[str]) -> list[tuple[int, int]]:
+    shapes: list[tuple[int, int]] = []
+    index = 0
+    while index < len(lines):
+        if not lines[index].lstrip().startswith("|"):
+            index += 1
+            continue
+        table: list[str] = []
+        while index < len(lines) and lines[index].lstrip().startswith("|"):
+            table.append(lines[index].strip())
+            index += 1
+        if len(table) >= 2 and re.fullmatch(r"\|[|:\- ]+\|", table[1]):
+            columns = len(table[0].strip("|").split("|"))
+            shapes.append((len(table), columns))
+    return shapes
+
+
+def normalized_target(target: str) -> str:
+    if target in {"README.md", "README.zh.md"}:
+        return "<readme-counterpart>"
+    return target
+
+
+def structure(path: Path) -> dict[str, object]:
+    text = path.read_text(encoding="utf-8")
+    outside, blocks = fenced_blocks(text)
+    outside_text = "\n".join(outside)
+    links = [normalized_target(target) for target in MARKDOWN_LINK_RE.findall(outside_text)]
+    html_targets = [normalized_target(target) for target in HTML_TARGET_RE.findall(outside_text)]
+    return {
+        "heading levels": [len(match.group(1)) for line in outside for match in [HEADING_RE.match(line)] if match],
+        "list markers": [match.group(0).strip() for line in outside for match in [LIST_RE.match(line)] if match],
+        "table shapes": table_shapes(outside),
+        "link targets": links,
+        "HTML targets": html_targets,
+        "code fences": blocks,
+    }
+
+
+def verify_structure() -> None:
+    source = structure(SOURCE)
+    translation = structure(TRANSLATION)
+    differences = [name for name in source if source[name] != translation[name]]
+    if differences:
+        details = ", ".join(differences)
+        raise ReadmeContractError(
+            f"README.md and README.zh.md differ in: {details}. "
+            "Keep headings, lists, tables, targets, and fenced code synchronized."
+        )
+
+
+def render_record() -> str:
+    hashes = {path.name: git_blob_hash(path) for path in PAIR_PATHS}
+    return (
+        "# Last human-confirmed consistent README pair.\n"
+        "# After updating and reviewing both files, run:\n"
+        "#   python .github/scripts/check_readme_i18n.py --write\n"
+        f"README.md: {hashes['README.md']}\n"
+        f"README.zh.md: {hashes['README.zh.md']}\n"
+    )
+
+
+def verify_hashes() -> None:
+    recorded = parse_record()
+    stale = [path.name for path in PAIR_PATHS if recorded[path.name] != git_blob_hash(path)]
+    if stale:
+        names = ", ".join(stale)
+        raise ReadmeContractError(
+            f"README translation record is stale for: {names}. Update and review "
+            "both READMEs, then run this command with --write."
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="record the current pair after structural checks and human review",
+    )
+    args = parser.parse_args()
+    try:
+        verify_structure()
+        if args.write:
+            RECORD.write_text(render_record(), encoding="utf-8")
+            print("Recorded the reviewed README pair in README.i18n.yaml.")
+        verify_hashes()
+    except (ReadmeContractError, subprocess.CalledProcessError) as error:
+        print(f"README i18n check failed: {error}", file=sys.stderr)
+        return 1
+    print("README.md and README.zh.md are synchronized.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Validate community automation
         run: python .github/scripts/check_community_files.py
+      - name: Validate README translations
+        run: python .github/scripts/check_readme_i18n.py
       - name: Validate GitHub Actions workflows
         run: |
           archive=actionlint_1.7.12_linux_amd64.tar.gz

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,11 @@ repos:
         entry: python .github/scripts/check_python_statements.py
         language: system
         pass_filenames: false
+      - id: readme-i18n
+        name: Check README translation pairing
+        entry: python .github/scripts/check_readme_i18n.py
+        language: system
+        pass_filenames: false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,22 @@ pre-commit run --all-files
 pytest tests/
 ```
 
+### Keep the root READMEs synchronized
+
+`README.md` and `README.zh.md` are one reviewed documentation pair. A change to
+either file must update the other when needed and preserve the same headings,
+lists, tables, link targets, and fenced code. After reviewing both languages,
+record their exact Git blob hashes and verify the pair:
+
+```bash
+python .github/scripts/check_readme_i18n.py --write
+python .github/scripts/check_readme_i18n.py
+```
+
+The record in `README.i18n.yaml` makes any later one-sided edit fail local
+pre-commit checks and CI. The structural check does not judge translation
+quality, so its success does not replace human review of meaning and wording.
+
 The full test suite needs the supported container environment and training
 dependencies. See the [testing guide](https://reefinfra.ai/docs/contributing/testing/) for
 focused commands and dependency details.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,0 +1,5 @@
+# Last human-confirmed consistent README pair.
+# After updating and reviewing both files, run:
+#   python .github/scripts/check_readme_i18n.py --write
+README.md: 1164809378548eb69394f49e7b2a4541c5b540f7
+README.zh.md: bca05bc06564b28fb06f2b474ce298b210fc62f2

--- a/README.zh.md
+++ b/README.zh.md
@@ -16,29 +16,68 @@
 
 <div align="left">
 
-Reef 是一套持续学习的后端基础设施，通过标准 HTTP 接口对外提供服务：你可以像用
-`curl` 安装 `codex`、`opencode` 那样安装 agent，也可以把 agent 的模型请求发往
-Reef 的推理接口，而不是模型厂商的接口。
+Reef 是首个面向持续自我进化 Agent 的开源基础设施。它连接 Agent 推理、反馈、学习与
+版本化交付。你可以用它配合 Slime 和 SGLang 训练模型权重，也可以改进 Agent 的
+harness，包括提示词、规则和技能。
 
-区别在于，Reef 会持续评估 agent 的表现，并在后端不断改进所提供的 harness 和模型
-权重。你不需要做任何改动，就能持续得到更好的效果。
 
 </div>
 
 **[快速上手](https://reefinfra.ai/docs/getting-started/quickstart/) |
 [路线图](https://github.com/Human-Agent-Society/reef/issues/25) |
-[博客](https://x.com/ao_qu18465/status/2094867930081337730) |
+[发布文章](https://x.com/ao_qu18465/status/2094867930081337730) |
 [加入 Discord](https://discord.gg/5y8e5f937k)**
 
 </div>
+
+
+## 何时使用 Reef
+
+如果你希望 Agent 通过与你的日常交互不断学习、持续进化，就适合使用 Reef。
+
+| 你的目标 | 学习路径 | 所需条件 |
+|---|---|---|
+| 持续获得更贴合自身需求的强大模型 | 模型权重训练 | 可训练模型、受支持的 GPU 栈，以及 recipe 可利用的反馈 |
+| 让 harness 自我进化 | Harness 优化 | 模型端点、有代表性的任务和评估器；无需本地训练 GPU |
+| 进行科学发现 | 测试时训练 | 执行环境、正确性检查器和可度量的目标 |
+
+
+## Reef 在技术栈中的位置
+
+| 能力 | 推理引擎（vLLM、SGLang…） | RL 训练框架（Slime、veRL、AReaL…） | **Reef** |
+|---|:---:|:---:|:---:|
+| 承接线上流量 | ✅ | ❌ | ✅ |
+| 训练权重 | ❌ | ✅ | ✅ |
+| 版本管理 | ❌ | ❌ | ✅ |
+| 更新期间持续服务 | ❌ | ❌ | ✅ |
+| 可进化权重以外的部分（技能、harness） | ❌ | ❌ | ✅ |
+
+
+## 工作原理
+
+<div align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/loop-animation-dark.svg">
+  <img src="docs/assets/loop-animation-light.svg" alt="Reef 响应请求、记录反馈、产出更新，并将通过的更新提交至版本历史。" width="76%">
+</picture>
+</div>
+
+Reef 的每个学习周期分为四步，下表同时列出各步骤对应的模块。
+
+| 步骤 | 说明 | 对应模块 |
+|---|---|---|
+| **1&nbsp;·&nbsp;Serve** | 响应 Agent 请求，记录每次交互。 | [`service/`](reef/service) — Agent 请求与交互记录<br>[`runtime/`](reef/runtime) — 推理与 artifact 更新 |
+| **2&nbsp;·&nbsp;Observe** | 将反馈匹配到已记录的交互。 | [`records.py`](reef/records.py) — 已存储的交互与反馈<br>[`train/processors/`](reef/train/processors) — 反馈匹配与条件判定 |
+| **3&nbsp;·&nbsp;Grow** | 从符合条件的记录中产出一次更新。 | [`recipe/`](reef/recipe) — recipe 接入<br>[`train/`](reef/train) — 批次与更新任务 |
+| **4&nbsp;·&nbsp;Commit** | 应用配置的选择策略并发布通过的更新。 | [`train/evaluation/`](reef/train/evaluation) — 候选评估<br>[`artifact/`](reef/artifact) — 版本历史<br>[`surface/`](reef/surface) — artifact 分发 |
 
 
 ## 安装
 
 > 💡 **注意**
 >
-> artifact 与 checkpoint 功能依赖系统的 `git-lfs`，Reef 会在本地为自身的 artifact
-> 仓库初始化 Git LFS。
+> Reef 的 artifact 和 checkpoint 功能依赖系统的 `git-lfs` 包。Reef 会在本地为自身的
+> artifact 仓库初始化 Git LFS。
 
 推荐使用 [uv](https://docs.astral.sh/uv/) 管理依赖，下文命令均基于 uv。
 
@@ -64,35 +103,17 @@ python3 -c "import reef; print(reef.__version__)"
 开发或运行下文的训练示例时，请使用源码安装。
 
 
-## 工作原理
-
-<div align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/loop-animation-dark.svg">
-  <img src="docs/assets/loop-animation-light.svg" alt="Reef 响应请求、记录反馈、产出更新，并将通过的更新提交至版本历史。" width="76%">
-</picture>
-</div>
-
-Reef 的每个学习周期分为四步，下表同时列出各步骤对应的模块。
-
-| 步骤 | 说明 | 对应模块 |
-|---|---|---|
-| **1&nbsp;·&nbsp;Serve** | 响应 agent 请求，记录每次交互。 | [`service/`](reef/service) — agent 请求与交互记录<br>[`runtime/`](reef/runtime) — 推理与 artifact 更新 |
-| **2&nbsp;·&nbsp;Observe** | 将反馈匹配到已记录的交互。 | [`records.py`](reef/records.py) — 已存储的交互与反馈<br>[`train/processors/`](reef/train/processors) — 反馈匹配与条件判定 |
-| **3&nbsp;·&nbsp;Grow** | 从符合条件的记录中产出一次更新。 | [`recipe/`](reef/recipe) — recipe 接入<br>[`train/`](reef/train) — 批次与更新任务 |
-| **4&nbsp;·&nbsp;Commit** | 评估更新，通过后发布。 | [`train/evaluation/`](reef/train/evaluation) — 候选评估<br>[`artifact/`](reef/artifact) — 版本历史<br>[`surface/`](reef/surface) — artifact 分发 |
-
-
 ## 使用 Reef
 
-Reef 可以学习两类东西：模型**权重**和 agent 的 **harness**。scenario 更新哪一种，
-取决于部署所用的 recipe。
+Reef 支持两类学习载体：模型**权重**和 Agent 的 **harness**。每个部署使用的 recipe
+决定其 scenario 更新哪一种载体。
 
-### 1 · 启动服务
+### 模型权重训练部署
 
-下面的示例启动 SAO（arXiv:2607.07508）示例部署，需在 Reef 源码目录下运行，且运行环境
-需满足[进化你的模型](https://reefinfra.ai/docs/user-guide/evolve-your-model/)中的
-GPU 要求。
+#### 启动部署
+
+下面的示例启动 SAO（arXiv:2607.07508）示例部署。请在 Reef 源码目录下运行，并确保
+运行环境满足[进化你的模型](https://reefinfra.ai/docs/user-guide/evolve-your-model/)中的 GPU 要求。
 
 ```bash
 uv pip install -e ".[slime]" && uv pip install --no-deps --group runtime
@@ -104,23 +125,21 @@ reef serve -c recipes/sao/examples/sao/serve.yaml \
   --reef.model_path "$MODEL_PATH" \
   --reef.port "8900"
 
-curl -f http://127.0.0.1:8900/healthz          # 服务就绪
+curl -f http://127.0.0.1:8900/healthz          # ready to serve
 ```
 
-### 2 · 训练权重
+#### 发送推理请求并上报反馈
 
 将推理请求发送至 Reef，并为每个响应上报分数。SAO recipe 使用每条符合条件的带分
 rollout 执行一次训练。
 
-#### 发送推理请求并上报反馈
+Reef 的推理端点兼容 OpenAI 和 Anthropic：`/v1/chat/completions` 与 `/v1/messages`
+直接接收相应模型提供商的请求体。请求需包含 `x-reef-scenario` 请求头；新的名称会使用
+部署配置的 recipe 创建 scenario。请求本身不选择 recipe。
 
-Reef 的推理接口同时兼容 OpenAI 与 Anthropic：`/v1/chat/completions` 与 `/v1/messages`
-直接接收两者原本的请求体。请求需带 `x-reef-scenario` 头，使用未出现过的名称时，会按
-部署配置的 recipe 新建一个 scenario。recipe 无法在请求中指定。
-
-响应体沿用各自的 OpenAI 兼容格式，Reef 额外返回 `x-reef-agent-record-id` 响应头。该值
-即**回执**（receipt），后续上报凭它定位本次交互。一次上报可包含分数 `score`、文本或
-结构化的 `feedback`，以及其所评价的回执。下面的示例同时上报分数与简短说明。
+响应体使用模型提供商的 OpenAI 兼容格式。Reef 会添加 `x-reef-agent-record-id` 响应头，
+其值是后续报告用来标识本次交互的**回执**。报告可以包含数值 `score`、文本或结构化
+`feedback`，以及它所评估的回执。下面的示例同时上报分数和简短说明。
 
 ```python
 import os
@@ -132,7 +151,7 @@ reef = httpx.Client(
     timeout=300,
 )
 
-# 使用 OpenAI 兼容格式发送推理请求
+# Send a provider-compatible inference request
 response = reef.post(
     "/v1/chat/completions",
     json={
@@ -141,10 +160,11 @@ response = reef.post(
     },
 )
 
+response.raise_for_status()
 receipt = response.headers["x-reef-agent-record-id"]
 answer = response.json()["choices"][0]["message"]["content"]
 
-# 上报本次推理的结果
+# Sending report about the inference
 matched = answer.strip() == "reef is ready"
 
 reef.post(
@@ -153,104 +173,128 @@ reef.post(
 ).raise_for_status()
 ```
 
-部分 recipe 需要的不止一个分数，`feedback` 用于承载更丰富的信号，纯文本或结构化对象
-均可。接口会校验**上报 schema**（[`reef/core/reports/`](reef/core/reports)）。
+部分 recipe 需要的不止一个分数，`feedback` 用于承载更丰富的信号，可以是纯文本或
+结构化对象。端点会校验**上报 schema**（[`reef/core/reports/`](reef/core/reports)）。
 
 
-#### 观察学习效果
+#### 观察学习与进化
 
-反馈积累到一定数量后，recipe 会执行一次训练，并将更新后的权重同步至推理运行时。后续
-请求直接使用新版本，无需重启 Reef。
+反馈积累到一定数量后，recipe 会执行一次训练，并将更新后的权重同步至推理运行时。
+后续推理请求直接使用当前版本，无需重启 Reef。
 
-### 3 · 进化 harness
+### Harness 进化部署
 
-`harness_evolve` recipe 更新的是一棵 harness 树，其中可包含规则、技能、配置、提示词与
-扩展。它基于上报的交互构建候选 harness，在配置的任务上与当前版本对比评估，胜出后才会
-发布。各 harness scenario 之间不共享数据与版本。
-
-#### 安装持续进化的 Reef harness
-
-安装 Reef harness 与安装大多数编程 agent 类似，示例如下。安装过程会自动创建一个新的
-scenario，并与下载的 harness 绑定。
+使用模型 API 改进 harness 技能，无需 GPU。将
+[deployment.yaml](tutorials/harness_evolve/deployment.yaml) 中的 `model.path` 设置为你的
+模型名称，然后在 Reef 源码目录及已激活的 Python 环境中运行：
 
 ```bash
+npm install -g @earendil-works/pi-coding-agent@0.84.2
+export REEF_UPSTREAM_URL="https://api.openai.com"  # No /v1 suffix
+export REEF_UPSTREAM_API_KEY="your-openai-api-key"
+reef serve -c tutorials/harness_evolve/deployment.yaml
+```
+
+如使用其他模型提供商，请填写对应的基础 URL、模型名称和 API key。此配置在 `8901`
+端口部署 Reef，并使用 `reef-local` 作为访问 token。
+
+在另一个终端中安装 harness 并运行任务：
+
+```bash
+export REEF_TOKEN="reef-local"
 curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
-  'http://localhost:8900/reef/harness/install?adapter=pi' | bash
-
-reef-pi -p "fix the bug"
-```
-
-也可以在请求头中指定 scenario，获取已经进化过的 harness。例如已有 scenario
-`harness-evolve-code-repair`：
-
-```bash
-curl -fsS -H 'x-reef-scenario: harness-evolve-code-repair' \
-  -H "Authorization: Bearer $REEF_TOKEN" \
-  'http://localhost:8900/reef/harness/install?adapter=pi' | bash
-```
-
-#### 上报任务结果
-
-`reef-pi` 会保存每次运行产生的回执，因此 `report` 只需提供要关联到上一次交互的结果：
-
-```bash
+  'http://localhost:8901/reef/harness/install?adapter=pi' | bash
 reef-pi -p "fix the failing test in auth.py"
 
-# ... 运行测试并评估结果 ...
-
+# After running your tests, report the actual result:
 reef-pi report --score 0 --feedback "missed the empty-token case"
-# reef-pi: reported 1 receipt(s) to harness-evolve-code-repair
 ```
 
-Reef 按 recipe 配置将符合条件的上报合并成批。开启版本检查后，adapter 会在下次启动时
-检查是否有新发布的版本：交互式会话在等待输入前提供 **Update with …** 与 **Skip** 选项，
-选择更新将直接运行安装脚本；无头会话仅打印提示信息。提案、评估与发布的完整流程见
-[harness 进化指南](https://reefinfra.ai/docs/user-guide/evolve-your-harness/)。
+失败报告会触发候选技能更新。Reef 会在教程的三个编程任务上对候选技能和当前 harness
+进行评估，仅在候选胜出时才发布。如何自定义任务和评估方式，请参阅
+[教程](tutorials/harness_evolve/README.md)。
 
 
-## Cookbook recipes
+## Recipes 与示例
 
-选择 recipe 主要看两点：你的场景能提供什么反馈，以及需要更新哪个 artifact。下列实现位于
-本仓库的 `recipes/` 目录，通过带点号的类路径指定，不随 Reef wheel 发布。
+请根据工作负载可提供的反馈和需要更新的 artifact 选择 recipe。这些实现位于本仓库的
+`recipes/` cookbook 中，通过带点号的类路径指定，不随 Reef wheel 发布。
 
-| 适用场景 | recipe 模块 | 更新对象 | 文档 |
+| 工作负载 | Recipe 指南 | 更新的 artifact | 示例与结果 |
 |---|---|---|---|
-| 由测试或校验器打分的任务流 | <code>recipes.sao.recipe:SAORecipe</code> | 模型权重 | [指南](https://reefinfra.ai/docs/user-guide/recipes/sao/) · [示例](recipes/sao/examples/sao/README.md) |
-| 具备可用的下一状态信号、但无显式上报的 agent 流量 | <code>recipes.openclawrl.recipe:OpenClawRLRecipe</code> | 模型权重 | [指南](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) · [示例](recipes/openclawrl/examples/openclawrl/README.md) |
-| 对同一问题的多次带分尝试 | <code>recipes.tttd.recipe:TTTDRecipe</code> | 模型权重 | [指南](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [示例](recipes/tttd/examples/tttd/README.md) |
-| 带分数的代码搜索：引导模型可训练，执行器冻结 | <code>recipes.tttd.recipe:TTTDRecipe</code> | 引导模型权重 | [指南](https://reefinfra.ai/docs/user-guide/recipes/tttd/) · [示例](recipes/tttd/examples/guidance_ttt/README.md) |
-| 使用 agent 反馈进化其技能池 | <code>recipes.skillclaw.recipe:SkillClawRecipe</code> | 技能池（harness 树），无需 GPU | [指南](https://reefinfra.ai/docs/user-guide/recipes/skillclaw/) · [示例](recipes/skillclaw/README.md) |
+| 由测试或校验器打分的任务流 | [SAO](https://reefinfra.ai/docs/user-guide/recipes/sao/) | 模型权重 | [示例](recipes/sao/examples/sao/README.md) · [结果](recipes/sao/examples/sao/README.md#results) |
+| 具备可用的下一状态信号、但无显式上报的 Agent 流量 | [OpenClaw-RL](https://reefinfra.ai/docs/user-guide/recipes/openclawrl/) | 模型权重 | [示例](recipes/openclawrl/examples/openclawrl/README.md) |
+| 对同一问题的多次带分尝试 | [TTT-Discover](https://reefinfra.ai/docs/user-guide/recipes/tttd/) | 模型权重 | [示例](recipes/tttd/examples/tttd/README.md) · [结果](recipes/tttd/examples/tttd/README.md#formal-8x64-results) |
+| 带分数的代码搜索：引导模型可训练，执行器冻结 | [Guidance-TTT / TTTD](https://reefinfra.ai/docs/user-guide/recipes/tttd/) | 引导模型权重 | [示例](recipes/tttd/examples/guidance_ttt/README.md) · [结果](recipes/tttd/examples/guidance_ttt/results/README.md) |
+| 使用 Agent 反馈进化其技能池 | [SkillClaw](https://reefinfra.ai/docs/user-guide/recipes/skillclaw/) | Harness 技能；无需训练 GPU | [示例](recipes/skillclaw/README.md) |
+| 使用分数和交互记录改进提示词与指令 | [GEPA](https://reefinfra.ai/docs/user-guide/recipes/gepa/) | Harness；模型权重不变 | [示例与结果](recipes/gepa/examples/aime/README.md) |
+
+如果想快速了解反馈、候选修改和发布流程，可以从[编程 harness
+教程](tutorials/harness_evolve/README.md)开始。每个结果页面都会说明任务、评估设置、
+测量结果和局限性。
 
 
-## Reef 有何不同
+## 架构
 
-Reef 为会持续成长的 AI 提供基础设施：
+```mermaid
+sequenceDiagram
+    accTitle: How Reef serves, records, trains, evaluates, and publishes
+    autonumber
+    participant H as Harness
+    participant S as Scenario
+    participant I as Inference
+    participant T as Trainer
+    participant G as Training*
+    participant E as Artifact evaluation
 
-| 能力 | 推理引擎（vLLM、SGLang…） | RL 训练框架（slime、veRL、AReaL…） | **Reef** |
-|---|:---:|:---:|:---:|
-| 承接线上流量 | ✅ | ❌ | ✅ |
-| 训练权重 | ❌ | ✅ | ✅ |
-| 版本管理 | ❌ | ❌ | ✅ |
-| 更新期间持续服务 | ❌ | ❌ | ✅ |
-| 可进化权重以外的部分（技能、harness） | ❌ | ❌ | ✅ |
+    opt Harness recipe: pull the served tree
+      H->>S: GET /reef/harness for scenario
+      S-->>H: Harness tree and release
+      Note over H: Agent runs on that tree
+    end
+    Note over H,I: Serve and record each request
+    H->>S: Inference request for scenario
+    S->>S: Freeze current release
+    S->>I: Provider-native request
+    I-->>S: Provider response
+    S->>S: Validate frozen release and store record
+    S-->>H: Response and receipt
+    H->>S: Feedback quotes the receipt
+    S->>T: Eligible record
+    opt Processor has a batch
+      Note over S,E: Produce, evaluate, and select a candidate
+      T->>G: Prepared step
+      G-->>T: Candidate artifact ready
+      T->>E: evaluate(candidate)
+      E-->>T: Evaluation result
+      T->>E: decide(candidate, result)
+      E-->>T: Select or reject
+      alt Candidate selected
+        T->>S: Commit new release
+      else Candidate rejected
+        Note over S,I: Previous release keeps serving
+      end
+    end
+```
 
+请求路径、scenario 和 release 生命周期详见[架构指南](https://reefinfra.ai/docs/getting-started/architecture/)。
 
-## 技术文档
+## 进一步了解
 
 [文档](https://reefinfra.ai/docs/)按以下顺序组织：
 
 - [快速上手](https://reefinfra.ai/docs/getting-started/quickstart/)：安装 Reef，接入客户端，查看版本历史
-- [HTTP API](https://reefinfra.ai/docs/reference/http-api/)：接口调用与反馈上报
+- [HTTP API](https://reefinfra.ai/docs/reference/http-api/)：使用 HTTP API 并上报反馈
 - [编写 recipe](https://reefinfra.ai/docs/developer-guide/write-a-recipe/)：配置 Reef 如何处理数据、产出更新
 - [进化你的 harness](https://reefinfra.ai/docs/user-guide/evolve-your-harness/)：不训练权重，改进 harness
-- [进化你的模型](https://reefinfra.ai/docs/user-guide/evolve-your-model/)：训练部署的配置与运维
+- [进化你的模型](https://reefinfra.ai/docs/user-guide/evolve-your-model/)：配置并运维训练部署
 - [Recipes](https://reefinfra.ai/docs/user-guide/recipes/)：本仓库 cookbook 实现的进一步说明
 - [架构](https://reefinfra.ai/docs/getting-started/architecture/)：Reef 的整体架构
 - [术语表](https://reefinfra.ai/docs/reference/glossary/)：文档所用术语的解释
 
 ## 社区与贡献
 
-欢迎参与 Reef 的讨论和开发：
+你是否也在研究持续自我进化的 Agent？
 
 - 加入 [Discord](https://discord.gg/5y8e5f937k)，分享 recipe、交流实现细节、讨论新功能。
 - 在 [GitHub Discussions](https://github.com/orgs/Human-Agent-Society/discussions) 提问、分享想法、与社区交流。
@@ -263,7 +307,7 @@ Reef 为会持续成长的 AI 提供基础设施：
 
 ## 团队
 
-Reef 汇聚了一群探索 agent 如何从经验中学习、持续进化的人。以下成员共同将这一想法
+Reef 汇聚了一群探索 Agent 如何从经验中学习、持续进化的人。以下成员共同将这一想法
 变成可用的基础设施。
 
 这份名单并未列尽所有团队成员，以下按姓氏字母顺序排列：


### PR DESCRIPTION
## Motivation

The Chinese README fell behind the English README after the positioning, deployment, recipe, and architecture sections were reorganized. The repository also had no mechanical way to detect future one-sided edits.

## Changes

- Align `README.zh.md` with the current English structure and technical content.
- Record the last reviewed pair using Git blob hashes in `README.i18n.yaml`.
- Add a structural and freshness checker for headings, lists, tables, link targets, HTML assets, and fenced code.
- Run the checker in pre-commit and CI.
- Document the update workflow and add explicit PR checklist and CODEOWNERS entries.

## Compatibility and operational impact

None. This changes documentation and repository validation only.

## Verification

- `python .github/scripts/check_readme_i18n.py`
- `pre-commit run --files .github/scripts/check_readme_i18n.py README.i18n.yaml README.zh.md CONTRIBUTING.md .github/CODEOWNERS .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ci.yml .pre-commit-config.yaml`
- `git diff --check`
- Negative smoke tests confirmed an English-only edit fails the hash check and a one-sided heading addition fails the structural check.

## AI assistance

OpenAI Codex researched established localization workflows, aligned the Chinese translation, implemented the checker, and ran the reported validation. The resulting content and code were reviewed during this change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
