### PR TITLE
fix(harness): refuse an update that changes an entry's kind

### DIFF
--- a/reef/train/cordis_backend/backend.py
+++ b/reef/train/cordis_backend/backend.py
@@ -784,6 +784,8 @@ class CordisBackend(TrainingBackend):
     @staticmethod
     def _mutation_kinds(candidate: HarnessCandidate) -> frozenset[str]:
         """Node kinds the mutations touch; update and remove read the kind off the pre-mutation tree."""
+        # The kind after the mutation: an update cannot change it (_apply refuses), and a remove reads it
+        # off the tree it left, so the pre-mutation entries answer for every op that is not a create.
         by_id = {str(entry.get("id")): str(entry.get("name")) for entry in candidate.current_entries}
         kinds: set[str] = set()
         for mutation in candidate.mutations:
@@ -830,9 +832,17 @@ class CordisBackend(TrainingBackend):
                 raise MutationError("create mutation must carry options")
             self._loader.create({**mutation.options, "id": mutation.id})
         elif mutation.op == "update":
-            self._resolve(mutation.id)
+            entry = self._resolve(mutation.id)
             if mutation.options is None:
                 raise MutationError("update mutation must carry options")
+            # The kind's plugin is the entry's admission gate and stays bound to the live fiber, so an
+            # update that renamed the kind would validate under the old one; a kind change is remove + create.
+            kind = mutation.options.get("name")
+            if kind is not None and str(kind) != str(entry.options.get("name")):
+                raise MutationError(
+                    f"update {mutation.id!r} cannot change the entry's kind from {entry.options.get('name')!r} "
+                    f"to {kind!r}; remove the entry and create it under the new kind"
+                )
             self._loader.update(mutation.id, dict(mutation.options))
         else:
             self._resolve(mutation.id)

--- a/tests/reef_service/test_harness_recipe.py
+++ b/tests/reef_service/test_harness_recipe.py
@@ -429,6 +429,21 @@ def test_update_missing_id_is_rejected(tmp_path: Path) -> None:
         b._apply(Mutation("update", "x", RULES))
 
 
+def test_update_cannot_change_an_entrys_kind(tmp_path: Path) -> None:
+    """A kind change through update would validate the new config under the old kind's plugin and hide
+    the new kind from review_kinds; it is refused, and remove plus create is the way to change a kind."""
+    b = backend(tmp_path, lambda n, s, m: None)
+    run_backend_step(b, batch(), b.initial_state())
+    b._apply(Mutation("create", "notes", SKILL))
+    swapped = {"name": "native_tool", "config": {**SKILL["config"], "description": "d", "parameters": {}, "code": "("}}
+    with pytest.raises(MutationError, match="cannot change the entry's kind from 'skill' to 'native_tool'"):
+        b._apply(Mutation("update", "notes", swapped))
+    assert [entry["name"] for entry in b._entries()] == ["skill"]
+    # The same kind, restated, is an ordinary update.
+    b._apply(Mutation("update", "notes", {"name": "skill", "config": {**SKILL["config"], "text": "# more"}}))
+    assert b._entries()[0]["config"]["text"] == "# more"
+
+
 def test_update_merges_and_disabled_hides(tmp_path: Path) -> None:
     b = backend(tmp_path, lambda n, s, m: None)
     run_backend_step(b, batch(), b.initial_state())


### PR DESCRIPTION
## Motivation

An update mutation could carry a new name and turn a skill into a native_tool. The entry's kind plugin is its admission gate and stays bound to the live fiber, so the new config was validated under the old kind: a native_tool whose code does not compile passed as a skill, rendered to native/tools/, and review_kinds classified the win as a skill change because it reads the kind off the tree before the mutation. The reproduction is in the test.

## Changes

- _apply refuses an update whose name differs from the entry's current kind; the step is skipped with the reason, and a kind change is remove plus create
- A test creates a skill, tries to update it into a native_tool with non compiling code, and checks the refusal and that a same kind update still applies

## Compatibility and operational impact

A proposer that changed a kind through update now gets a skipped step with the reason in the commit instead of a published tree under the wrong kind. No config or interface change.

## Verification

The new test fails on main and passes here; the reviewer's reproduction script now reports the skip for the swapped update and the compile refusal for the direct create. test_harness_recipe.py and test_native_harness.py pass, and every pre-commit hook passes over all files.

## AI assistance

Claude Code found the bypass in an adversarial review of the merged harness evolution code and wrote the guard and the test; I confirmed the fix belongs in _apply.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
