### PR TITLE
fix(harness): make the README install flow work: seed base artifact and model binding

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Last human-confirmed consistent README pair.
 # After updating and reviewing both files, run:
 #   python .github/scripts/check_readme_i18n.py --write
-README.md: 1164809378548eb69394f49e7b2a4541c5b540f7
-README.zh.md: bca05bc06564b28fb06f2b474ce298b210fc62f2
+README.md: 37a897f42bfed6b6cf16b2b2b8161f87489492f7
+README.zh.md: 086d4bfc45f5bbcaa26975907fe3d8058f5aadd4

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ For another provider, use its base URL, model name, and API key. This config dep
 In another terminal, install the harness and run a task:
 
 ```bash
-export REEF_TOKEN="reef-local"
+export REEF_TOKEN="reef-local"   # the script also writes it into the installed harness's model binding
 curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
   'http://localhost:8901/reef/harness/install?adapter=pi' | bash
 reef-pi -p "fix the failing test in auth.py"

--- a/README.zh.md
+++ b/README.zh.md
@@ -201,7 +201,7 @@ reef serve -c tutorials/harness_evolve/deployment.yaml
 在另一个终端中安装 harness 并运行任务：
 
 ```bash
-export REEF_TOKEN="reef-local"
+export REEF_TOKEN="reef-local"   # the script also writes it into the installed harness's model binding
 curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
   'http://localhost:8901/reef/harness/install?adapter=pi' | bash
 reef-pi -p "fix the failing test in auth.py"

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -203,7 +203,9 @@ Harness artifacts
 |                                | carrying the gate metrics of the step that published it       |
 +--------------------------------+---------------------------------------------------------------+
 | ``GET /reef/harness/install``  | a self-contained POSIX shell script that installs the vendor  |
-|                                | binary and writes the tree                                    |
+|                                | binary, writes the tree, and writes the adapter's model       |
+|                                | binding at the Reef the request reached, the token filled     |
+|                                | from ``REEF_TOKEN`` when the script runs                      |
 +--------------------------------+---------------------------------------------------------------+
 | ``GET /reef/harness/adapters`` | ``{adapters}`` — every harness adapter this process resolves, |
 |                                | each with ``name``, ``binary``, ``trajectory_format``,        |

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -320,7 +320,10 @@ Clients pull an evolved harness the way they install any coding agent:
    reef-pi -p "fix the failing test in auth.py"
    reef-pi report --score 0 --feedback "missed the empty-token case"
 
-The script installs the pinned agent, writes the tree, and puts a
+The script installs the pinned agent, writes the tree, writes the agent's
+model binding pointed at the Reef the script came from (the served tree
+itself carries no endpoint or credential; the binding takes its token from
+``REEF_TOKEN`` in your shell when the script runs), and puts a
 ``reef-<adapter>`` wrapper (here ``reef-pi``) on your PATH. The wrapper keeps
 the receipts from a run, so ``report`` only needs the result. Pinning,
 rollback, and the raw manifest routes are in `HTTP API

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -309,7 +309,9 @@ happens.
 Install the published tree
 --------------------------
 
-Clients pull an evolved harness the way they install any coding agent:
+Clients pull an evolved harness the way they install any coding agent. A
+fresh scenario already serves the recipe's seed as its first release, so
+the install works before any step has run:
 
 .. code:: bash
 

--- a/reef/artifact/git_lfs.py
+++ b/reef/artifact/git_lfs.py
@@ -224,6 +224,7 @@ class GitLFSRepositoryBackend(RepositoryBackend):
         work_dir: Path,
         cache_dir: Path,
         snapshot_download: Callable[..., str] | None = None,
+        bootstrap_files: Mapping[str, str] | None = None,
     ) -> None:
         if not scenario:
             raise ValueError("scenario must be non-empty")
@@ -249,7 +250,7 @@ class GitLFSRepositoryBackend(RepositoryBackend):
         if bootstrap_artifact is not None:
             self._bootstrap(bootstrap_artifact, snapshot_download=snapshot_download)
         elif local_repository is not None:
-            self._bootstrap_empty()
+            self._bootstrap_empty(bootstrap_files or {})
 
     @classmethod
     def factory(
@@ -260,6 +261,7 @@ class GitLFSRepositoryBackend(RepositoryBackend):
         work_dir: Path,
         cache_dir: Path,
         snapshot_download: Callable[..., str] | None = None,
+        bootstrap_files: Mapping[str, str] | None = None,
     ) -> CachedRepositoryBackendFactory:
         _check_tools()
         return _GitLFSRepositoryBackendFactory(
@@ -269,6 +271,7 @@ class GitLFSRepositoryBackend(RepositoryBackend):
             work_dir=work_dir,
             cache_dir=cache_dir,
             snapshot_download=snapshot_download,
+            bootstrap_files=bootstrap_files,
         )
 
     def resolve_release(self, release_id: str | None = None) -> ArtifactRef:
@@ -440,7 +443,11 @@ class GitLFSRepositoryBackend(RepositoryBackend):
             )
             return self._manifest.artifact_ref(commit)
 
-    def _bootstrap_empty(self) -> ArtifactRef:
+    def _bootstrap_empty(self, files: Mapping[str, str] = {}) -> ArtifactRef:
+        """The base artifact of a local repository: ``files`` when the recipe seeds one, else empty.
+
+        An existing base always wins, so a redeploy with a changed seed keeps
+        the base its scenarios forked from."""
         existing = self._bootstrap_ref()
         if existing is not None:
             return existing
@@ -451,10 +458,14 @@ class GitLFSRepositoryBackend(RepositoryBackend):
             raise ArtifactSourceError("artifact repository has refs but no base or head release")
         with self._workspace.lock:
             self._workspace.orphan_checkout()
+            for relative, text in files.items():
+                target = self._workspace.clone_dir / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(text, encoding="utf-8")
             self._manifest.write(
                 content_id=f"content:{uuid.uuid4().hex}",
                 parent_release_id=None,
-                source={"kind": "empty"},
+                source={"kind": "seed" if files else "empty"},
                 metadata={},
             )
             commit = self._workspace.commit("initialize artifact repository")
@@ -505,6 +516,7 @@ class _GitLFSRepositoryBackendFactory(CachedRepositoryBackendFactory):
         work_dir: Path,
         cache_dir: Path,
         snapshot_download: Callable[..., str] | None,
+        bootstrap_files: Mapping[str, str] | None = None,
     ) -> None:
         super().__init__()
         self._backend_type = backend_type
@@ -513,6 +525,7 @@ class _GitLFSRepositoryBackendFactory(CachedRepositoryBackendFactory):
         self._work_dir = Path(work_dir)
         self._cache_dir = Path(cache_dir)
         self._snapshot_download = snapshot_download
+        self._bootstrap_files = None if bootstrap_files is None else dict(bootstrap_files)
 
     def _build_backend(self, scenario: str) -> GitLFSRepositoryBackend:
         encoded = base64.urlsafe_b64encode(scenario.encode()).decode().rstrip("=")
@@ -523,6 +536,7 @@ class _GitLFSRepositoryBackendFactory(CachedRepositoryBackendFactory):
             work_dir=self._work_dir / encoded,
             cache_dir=self._cache_dir,
             snapshot_download=self._snapshot_download,
+            bootstrap_files=self._bootstrap_files,
         )
 
     def _has_persisted_registration(self, scenario: str) -> bool:

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -174,6 +174,17 @@ class Dispatcher:
     def recipe_has_files(self) -> bool:
         return self._registry.recipe_has_files()
 
+    def seed_entries(self) -> tuple[Mapping[str, Any], ...]:
+        """The recipe's seed composition entries, empty for a recipe without one."""
+        return tuple(dict(entry) for entry in getattr(self._recipe, "seed", ()))
+
+    def served_model_name(self) -> str | None:
+        """The model the recipe serves and gates against: its own name, else its runtime's model path."""
+        name = getattr(self._recipe, "model_name", None)
+        if not isinstance(name, str) or not name:
+            name = getattr(getattr(self._recipe, "runtime", None), "model_path", None)
+        return name if isinstance(name, str) and name else None
+
     def list_releases(self, scenario: str) -> tuple[dict[str, Any], ...]:
         with self._registry.lock_for(scenario):
             return self._registry.require(scenario).releases()

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -174,17 +174,6 @@ class Dispatcher:
     def recipe_has_files(self) -> bool:
         return self._registry.recipe_has_files()
 
-    def seed_entries(self) -> tuple[Mapping[str, Any], ...]:
-        """The recipe's seed composition entries, empty for a recipe without one."""
-        return tuple(dict(entry) for entry in getattr(self._recipe, "seed", ()))
-
-    def served_model_name(self) -> str | None:
-        """The model the recipe serves and gates against: its own name, else its runtime's model path."""
-        name = getattr(self._recipe, "model_name", None)
-        if not isinstance(name, str) or not name:
-            name = getattr(getattr(self._recipe, "runtime", None), "model_path", None)
-        return name if isinstance(name, str) and name else None
-
     def list_releases(self, scenario: str) -> tuple[dict[str, Any], ...]:
         with self._registry.lock_for(scenario):
             return self._registry.require(scenario).releases()

--- a/reef/recipe/base.py
+++ b/reef/recipe/base.py
@@ -120,7 +120,7 @@ class Recipe:
         """
         return Surface()
 
-    def seed_files(self) -> Mapping[str, str] | None:
+    def base_artifact_files(self) -> Mapping[str, str] | None:
         """The files a fresh scenario's base artifact starts with, or ``None`` for a recipe with no tree."""
         return None
 

--- a/reef/recipe/base.py
+++ b/reef/recipe/base.py
@@ -120,6 +120,10 @@ class Recipe:
         """
         return Surface()
 
+    def seed_files(self) -> Mapping[str, str] | None:
+        """The files a fresh scenario's base artifact starts with, or ``None`` for a recipe with no tree."""
+        return None
+
     def serving_status(self) -> Mapping[str, Any] | None:
         """Runtime-wide serving state this recipe owns, for ``/reef/status``.
 

--- a/reef/scenario/commit_protocol.py
+++ b/reef/scenario/commit_protocol.py
@@ -10,7 +10,7 @@ operations.
 from __future__ import annotations
 
 import itertools
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
 from threading import RLock
@@ -527,6 +527,18 @@ class ScenarioCommitProtocol:
         for record in self._commit_log.records():
             if record.artifact_ref.release_id == release_id and record.operation == "training":
                 return record.metrics
+        return None
+
+    def entries_for_version(self, release_id: str) -> tuple[Mapping[str, Any], ...] | None:
+        """The composition entries the training step that published ``release_id`` committed, if logged."""
+        if self._commit_log is None:
+            return None
+        for record in self._commit_log.records():
+            if record.artifact_ref.release_id == release_id and record.operation == "training":
+                entries = (record.algorithm_state or {}).get("entries")
+                if isinstance(entries, Sequence) and not isinstance(entries, str):
+                    return tuple(dict(entry) for entry in entries if isinstance(entry, Mapping))
+                return None
         return None
 
     def artifact_for_version(self, release_id: str) -> Artifact:

--- a/reef/scenario/scenario.py
+++ b/reef/scenario/scenario.py
@@ -181,6 +181,10 @@ class Scenario:
         """Materialize a catalog version for read-only serving; absence raises ArtifactNotFound."""
         return self._commit_protocol.artifact_for_version(release_id)
 
+    def entries_for_version(self, release_id: str) -> tuple[Mapping[str, Any], ...] | None:
+        """The composition entries behind a catalog version, if its training commit logged them."""
+        return self._commit_protocol.entries_for_version(release_id)
+
     def artifact_snapshot(
         self,
         release_id: str | None = None,

--- a/reef/service/assembly.py
+++ b/reef/service/assembly.py
@@ -196,7 +196,7 @@ def build_dispatcher(
         _repository_location(settings.artifact_repository),
         work_dir=Path(settings.artifact_work_dir),
         cache_dir=Path(settings.artifact_cache_dir),
-        bootstrap_files=recipe.seed_files(),
+        bootstrap_files=recipe.base_artifact_files(),
     )
     if not isinstance(settings.training_settings, Mapping):
         raise ValueError("training must be an object")

--- a/reef/service/assembly.py
+++ b/reef/service/assembly.py
@@ -190,12 +190,14 @@ def build_dispatcher(
 ) -> Dispatcher:
     selected_recipe = _require_non_empty(settings.recipe, "reef.recipe")
     env = os.environ if environ is None else environ
+    recipe = _serving_recipe(selected_recipe, settings, env, connector)
+    # A harness recipe's seed is the base artifact, so a fresh scenario serves a tree before any step.
     backend_factory = GitLFSRepositoryBackend.factory(
         _repository_location(settings.artifact_repository),
         work_dir=Path(settings.artifact_work_dir),
         cache_dir=Path(settings.artifact_cache_dir),
+        bootstrap_files=recipe.seed_files(),
     )
-    recipe = _serving_recipe(selected_recipe, settings, env, connector)
     if not isinstance(settings.training_settings, Mapping):
         raise ValueError("training must be an object")
     experiment_tracker = build_experiment_tracker(

--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -218,6 +218,43 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
     ]
 
 
+def _binding_lines(bindings: Mapping[str, str]) -> list[str]:
+    """Shell that writes the model binding files over the pulled tree, the token filled from the environment.
+
+    The binding is written after the checksum and on every run, so a rerun
+    re-points an installed tree at the Reef the script came from; the
+    checksum still covers the served composition alone."""
+    if not bindings:
+        return []
+    lines = [
+        "",
+        "# The model binding: the adapter's config pointed at the Reef this script was",
+        "# fetched from, with the client's own token; written on every run, after the",
+        "# checksum, so the served composition stays what the sidecar records.",
+        'if [ -z "${REEF_TOKEN:-}" ]; then',
+        '    echo "reef: REEF_TOKEN is not set; the harness will reach Reef without a token" >&2',
+        "fi",
+    ]
+    for relative in sorted(bindings):
+        lines.append(_write_file_block(relative, bindings[relative]).rstrip("\n"))
+        lines.extend(
+            [
+                f"python3 - \"$DEST/{_double_quoted(relative)}\" <<'REEF_BIND_EOF'",
+                "import os, sys",
+                "path = sys.argv[1]",
+                'text = open(path, encoding="utf-8").read()',
+                f'open(path, "w", encoding="utf-8").write(text.replace({TOKEN_PLACEHOLDER!r}, os.environ.get("REEF_TOKEN", "")))',
+                "REEF_BIND_EOF",
+            ]
+        )
+    return lines
+
+
+#: The literal the model binding overlay carries where the client's own token goes; the script swaps in
+#: ``$REEF_TOKEN`` at install time, so the served script itself never holds a credential.
+TOKEN_PLACEHOLDER = "__REEF_TOKEN__"
+
+
 def render_install_script(
     *,
     descriptor: AdapterDescriptor,
@@ -225,13 +262,18 @@ def render_install_script(
     release_id: str,
     content_id: str,
     scenario: str = "",
+    binding_files: Mapping[str, str] | None = None,
 ) -> str:
     """The complete install script for one adapter and one served manifest.
 
     The manifest side (``files``, ``release_id``) is adapter-agnostic;
     the descriptor contributes the binary's vendor install path. ``scenario``
     is baked into the wrapper so ``reef-<adapter> report`` knows which
-    scenario to report to. Raises ``DescriptorError`` when the descriptor
+    scenario to report to. ``binding_files`` are the adapter's config targets
+    re-rendered with the model binding that points the harness at Reef; they
+    carry ``TOKEN_PLACEHOLDER`` where the token goes, and the script writes
+    them over the pulled files after the checksum, filling the placeholder
+    from ``$REEF_TOKEN``. Raises ``DescriptorError`` when the descriptor
     declares no install section and ``ValueError`` when a composition path is
     absolute or escapes the destination through a ``..`` part, the same rule
     the stdlib client pull applies to served paths.
@@ -245,7 +287,8 @@ def render_install_script(
         raise DescriptorError(f"adapter {descriptor.name!r} declares no install section")
     env_var, compose_dir = _compose_env_var(descriptor)
     wrapper_name = f"reef-{descriptor.name}"
-    for relative in files:
+    bindings = dict(binding_files or {})
+    for relative in (*files, *bindings):
         if PurePosixPath(relative).is_absolute() or ".." in PurePosixPath(relative).parts:
             raise ValueError(f"composition path {relative!r} escapes the destination")
     ordered = sorted(files)
@@ -349,6 +392,7 @@ def render_install_script(
         "    # The same sidecar the stdlib client pull writes: pulled version and file list.",
         _write_file_block(HARNESS_RELEASE_SIDECAR, sidecar_text).rstrip("\n"),
         "fi",
+        *_binding_lines(bindings),
         "",
         f'echo "run:     $DEST/{wrapper_name}"',
         'echo "binary:  $BINARY"',

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -31,7 +31,6 @@ from reef.scenario.scenario import Scenario
 from reef.service.install_script import TOKEN_PLACEHOLDER, render_install_script
 from reef.service.wire import SCENARIO_HEADER, ReportPayload, RequestHeaders, parse_request_headers
 from reef.surface.base import InferenceLease, LeasingInferenceHooks, Surface
-from reef.surface.harnesses import HarnessSurface
 from reef.surface.weights import RuntimeLoadMismatch, reported_runtime_load_id, reported_runtime_load_spans
 
 logger = logging.getLogger(__name__)
@@ -540,12 +539,12 @@ class RequestService:
         host = normalized.get("host")
         gate = manifest.get("gate") or {}
         model = (gate.get("gated_against") or {}).get("model") if isinstance(gate, Mapping) else None
-        surface = scenario.surface
+        info = scenario.surface.harness
         if not isinstance(model, str) or not model:
-            model = surface.served_model if isinstance(surface, HarnessSurface) else None
+            model = None if info is None else info.served_model
         entries = scenario.entries_for_version(manifest["release_id"])
-        if entries is None and isinstance(surface, HarnessSurface):
-            entries = surface.seed_entries
+        if entries is None and info is not None:
+            entries = info.seed_entries
         if not host or not model or not entries:
             return {}
         scheme = normalized.get("x-forwarded-proto") or "http"

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -520,26 +520,31 @@ class RequestService:
             binding_files=self._install_binding(scenario, manifest, descriptor, headers),
         )
 
-    @staticmethod
     def _install_binding(
-        scenario: Scenario, manifest: Mapping[str, Any], descriptor: Any, headers: Mapping[str, str]
+        self, scenario: Scenario, manifest: Mapping[str, Any], descriptor: Any, headers: Mapping[str, str]
     ) -> dict[str, str]:
         """The adapter's config targets re-rendered with a binding at the Reef this request reached.
 
         The served composition never carries an endpoint or a credential, so
         an installed tree needs one written beside it: the release's own
-        entries plus the descriptor's binding template, the base URL taken
-        from the request's Host, the model from the gate the release ran
-        against, and the token left as a placeholder the script fills from
-        the client's environment. Empty when any of those is unknown, and
-        the script then installs the composition as before.
+        entries (the recipe's seed for the base release no step published)
+        plus the descriptor's binding template, the base URL taken from the
+        request's Host, the model from the gate the release ran against (the
+        recipe's served model for the base release), and the token left as a
+        placeholder the script fills from the client's environment. Empty
+        when any of those is unknown, and the script then installs the
+        composition as before.
         """
         normalized = {key.lower(): value.strip() for key, value in headers.items()}
         host = normalized.get("host")
         gate = manifest.get("gate") or {}
         model = (gate.get("gated_against") or {}).get("model") if isinstance(gate, Mapping) else None
+        if not isinstance(model, str) or not model:
+            model = self._dispatcher.served_model_name()
         entries = scenario.entries_for_version(manifest["release_id"])
-        if not host or not isinstance(model, str) or not model or entries is None:
+        if entries is None:
+            entries = self._dispatcher.seed_entries()
+        if not host or not model or not entries:
             return {}
         scheme = normalized.get("x-forwarded-proto") or "http"
         binding = ModelBinding(base_url=f"{scheme}://{host}", model=model, api_key=TOKEN_PLACEHOLDER)

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -21,12 +21,14 @@ from reef.core.errors import ReefError, UnknownScenario
 from reef.core.records_types import RequestType
 from reef.dispatcher import Dispatcher
 from reef.harness.adapters import available_adapters, get_adapter
+from reef.harness.model_binding import ModelBinding, ModelBindingError
+from reef.harness.render import RenderError, render_composition
 from reef.recipe.errors import RecipeConfigError
 from reef.records import AgentRecord
 from reef.runtime.base import InferenceAdmissionHandle, TrainingRuntime
 from reef.runtime.inference import InferenceBackend, InferenceStream
 from reef.scenario.scenario import Scenario
-from reef.service.install_script import render_install_script
+from reef.service.install_script import TOKEN_PLACEHOLDER, render_install_script
 from reef.service.wire import SCENARIO_HEADER, ReportPayload, RequestHeaders, parse_request_headers
 from reef.surface.base import InferenceLease, LeasingInferenceHooks, Surface
 from reef.surface.weights import RuntimeLoadMismatch, reported_runtime_load_id, reported_runtime_load_spans
@@ -508,13 +510,47 @@ class RequestService:
             release_id=release_id,
         )
         manifest = self._harness_manifest_for_scenario(scenario, release_id)
+        descriptor = get_adapter(adapter)
         return render_install_script(
-            descriptor=get_adapter(adapter),
+            descriptor=descriptor,
             files=manifest["files"],
             release_id=manifest["release_id"],
             content_id=manifest["content_id"],
             scenario=scenario.name,
+            binding_files=self._install_binding(scenario, manifest, descriptor, headers),
         )
+
+    @staticmethod
+    def _install_binding(
+        scenario: Scenario, manifest: Mapping[str, Any], descriptor: Any, headers: Mapping[str, str]
+    ) -> dict[str, str]:
+        """The adapter's config targets re-rendered with a binding at the Reef this request reached.
+
+        The served composition never carries an endpoint or a credential, so
+        an installed tree needs one written beside it: the release's own
+        entries plus the descriptor's binding template, the base URL taken
+        from the request's Host, the model from the gate the release ran
+        against, and the token left as a placeholder the script fills from
+        the client's environment. Empty when any of those is unknown, and
+        the script then installs the composition as before.
+        """
+        normalized = {key.lower(): value.strip() for key, value in headers.items()}
+        host = normalized.get("host")
+        gate = manifest.get("gate") or {}
+        model = (gate.get("gated_against") or {}).get("model") if isinstance(gate, Mapping) else None
+        entries = scenario.entries_for_version(manifest["release_id"])
+        if not host or not isinstance(model, str) or not model or entries is None:
+            return {}
+        scheme = normalized.get("x-forwarded-proto") or "http"
+        binding = ModelBinding(base_url=f"{scheme}://{host}", model=model, api_key=TOKEN_PLACEHOLDER)
+        nodes = [(str(entry["name"]), entry.get("config")) for entry in entries if not entry.get("disabled")]
+        try:
+            bound = binding.compose_nodes(descriptor)
+            files = render_composition((*nodes, *bound), descriptor)
+        except (ModelBindingError, RenderError, KeyError, TypeError):
+            return {}
+        targets = {descriptor.config_targets[str(config.get("target", "primary"))].path for _, config in bound}
+        return {path: files[path] for path in sorted(targets) if path in files}
 
     def _file_scenario(
         self,

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -31,6 +31,7 @@ from reef.scenario.scenario import Scenario
 from reef.service.install_script import TOKEN_PLACEHOLDER, render_install_script
 from reef.service.wire import SCENARIO_HEADER, ReportPayload, RequestHeaders, parse_request_headers
 from reef.surface.base import InferenceLease, LeasingInferenceHooks, Surface
+from reef.surface.harnesses import HarnessSurface
 from reef.surface.weights import RuntimeLoadMismatch, reported_runtime_load_id, reported_runtime_load_spans
 
 logger = logging.getLogger(__name__)
@@ -539,11 +540,12 @@ class RequestService:
         host = normalized.get("host")
         gate = manifest.get("gate") or {}
         model = (gate.get("gated_against") or {}).get("model") if isinstance(gate, Mapping) else None
+        surface = scenario.surface
         if not isinstance(model, str) or not model:
-            model = self._dispatcher.served_model_name()
+            model = surface.served_model if isinstance(surface, HarnessSurface) else None
         entries = scenario.entries_for_version(manifest["release_id"])
-        if entries is None:
-            entries = self._dispatcher.seed_entries()
+        if entries is None and isinstance(surface, HarnessSurface):
+            entries = surface.seed_entries
         if not host or not model or not entries:
             return {}
         scheme = normalized.get("x-forwarded-proto") or "http"

--- a/reef/surface/base.py
+++ b/reef/surface/base.py
@@ -92,6 +92,14 @@ class FileTree(Protocol):
 
 
 @dataclass(frozen=True)
+class HarnessInfo:
+    """What the harness routes need beyond the file tree: the seed behind the base release and the served model."""
+
+    seed_entries: tuple[Mapping[str, Any], ...] = ()
+    served_model: str | None = None
+
+
+@dataclass(frozen=True)
 class Surface:
     """The explicit serving capabilities bound to one scenario.
 
@@ -102,12 +110,14 @@ class Surface:
     loader: ArtifactLoader | None = None
     inference: InferenceHooks | None = None
     files: FileTree | None = None
+    harness: HarnessInfo | None = None
 
 
 __all__ = [
     "ArtifactActivator",
     "ArtifactLoader",
     "FileTree",
+    "HarnessInfo",
     "InferenceHooks",
     "InferenceLease",
     "LeasingInferenceHooks",

--- a/reef/surface/harnesses.py
+++ b/reef/surface/harnesses.py
@@ -2,11 +2,31 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
 from reef.surface.base import Surface
 from reef.surface.files import TextFileTree
 
 
-def create_harness_surface() -> Surface:
+@dataclass(frozen=True)
+class HarnessSurface(Surface):
+    """The harness tree plus what the harness routes need that no artifact carries.
+
+    ``seed_entries`` are the recipe's seed, the composition behind the base
+    release no step published; ``served_model`` is the model the recipe
+    serves and gates against. The install route binds an installed tree
+    with them when a release has no training record of its own.
+    """
+
+    seed_entries: tuple[Mapping[str, Any], ...] = field(default_factory=tuple)
+    served_model: str | None = None
+
+
+def create_harness_surface(
+    seed_entries: tuple[Mapping[str, Any], ...] = (), served_model: str | None = None
+) -> HarnessSurface:
     """Build a surface exposing every text file in a harness tree.
 
     The tree is adapter-specific: its paths are whatever the adapter
@@ -14,7 +34,7 @@ def create_harness_surface() -> Surface:
     commands, code extensions). The surface does not validate or
     transform; the client pulls the raw tree and applies it.
     """
-    return Surface(files=TextFileTree())
+    return HarnessSurface(files=TextFileTree(), seed_entries=tuple(seed_entries), served_model=served_model)
 
 
-__all__ = ["create_harness_surface"]
+__all__ = ["HarnessSurface", "create_harness_surface"]

--- a/reef/surface/harnesses.py
+++ b/reef/surface/harnesses.py
@@ -3,38 +3,29 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
 from typing import Any
 
-from reef.surface.base import Surface
+from reef.surface.base import HarnessInfo, Surface
 from reef.surface.files import TextFileTree
-
-
-@dataclass(frozen=True)
-class HarnessSurface(Surface):
-    """The harness tree plus what the harness routes need that no artifact carries.
-
-    ``seed_entries`` are the recipe's seed, the composition behind the base
-    release no step published; ``served_model`` is the model the recipe
-    serves and gates against. The install route binds an installed tree
-    with them when a release has no training record of its own.
-    """
-
-    seed_entries: tuple[Mapping[str, Any], ...] = field(default_factory=tuple)
-    served_model: str | None = None
 
 
 def create_harness_surface(
     seed_entries: tuple[Mapping[str, Any], ...] = (), served_model: str | None = None
-) -> HarnessSurface:
+) -> Surface:
     """Build a surface exposing every text file in a harness tree.
 
     The tree is adapter-specific: its paths are whatever the adapter
     descriptor's render engine produced (config files, rules, agent
     commands, code extensions). The surface does not validate or
-    transform; the client pulls the raw tree and applies it.
+    transform; the client pulls the raw tree and applies it. ``harness``
+    carries the recipe's seed, the composition behind the base release no
+    step published, and the model the recipe serves, which the install
+    route binds an installed tree with when a release has no gate of its own.
     """
-    return HarnessSurface(files=TextFileTree(), seed_entries=tuple(seed_entries), served_model=served_model)
+    return Surface(
+        files=TextFileTree(),
+        harness=HarnessInfo(seed_entries=tuple(seed_entries), served_model=served_model),
+    )
 
 
-__all__ = ["HarnessSurface", "create_harness_surface"]
+__all__ = ["create_harness_surface"]

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -22,6 +22,7 @@ from reef.harness.adapters import get_adapter
 from reef.harness.descriptor import DescriptorError
 from reef.harness.executor import EpisodeExecutor, build_executor
 from reef.harness.model_binding import ModelBinding, ModelBindings
+from reef.harness.render import render_composition
 from reef.harness.version_check import version_check_entry
 from reef.observability import ExperimentLogger
 from reef.recipe.base import Recipe
@@ -369,6 +370,13 @@ class CordisRecipe(Recipe):
 
     def build_surface(self, scenario: str) -> Surface:
         return create_harness_surface()
+
+    def seed_files(self) -> Mapping[str, str] | None:
+        """The seed rendered for the adapter: a fresh scenario serves it before any step publishes."""
+        if not self.seed:
+            return None
+        nodes = tuple((str(entry["name"]), entry.get("config")) for entry in self.seed if not entry.get("disabled"))
+        return render_composition(nodes, get_adapter(self.adapter))
 
     def build(
         self,

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -369,9 +369,13 @@ class CordisRecipe(Recipe):
         return ModelBindings(served=self.model_binding(), named=dict(self.models))
 
     def build_surface(self, scenario: str) -> Surface:
-        return create_harness_surface()
+        model = self.model_name or getattr(self.runtime, "model_path", None)
+        return create_harness_surface(
+            seed_entries=tuple(dict(entry) for entry in self.seed),
+            served_model=model if isinstance(model, str) and model else None,
+        )
 
-    def seed_files(self) -> Mapping[str, str] | None:
+    def base_artifact_files(self) -> Mapping[str, str] | None:
         """The seed rendered for the adapter: a fresh scenario serves it before any step publishes."""
         if not self.seed:
             return None

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -28,12 +28,18 @@ from reef.dispatcher import Dispatcher
 from reef.harness.adapters import get_adapter
 from reef.harness.descriptor import DescriptorError, load_descriptor
 from reef.harness.episode import EpisodeResult
+from reef.harness.model_binding import ModelBinding
 from reef.harness.render import render_composition
 from reef.recipe import Recipe
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.runtime.inference import InferenceBackend
 from reef.service.app import create_app
-from reef.service.install_script import HARNESS_RELEASE_SIDECAR, composition_checksum, render_install_script
+from reef.service.install_script import (
+    HARNESS_RELEASE_SIDECAR,
+    TOKEN_PLACEHOLDER,
+    composition_checksum,
+    render_install_script,
+)
 from reef.train.cordis_backend import CordisRecipe, Mutation
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
 
@@ -559,7 +565,12 @@ def _write_executable(path: Path, text: str) -> None:
 
 
 def _install_fixture(
-    tmp_path: Path, *, binary_version: str | None, npm: str, scenario: str = ""
+    tmp_path: Path,
+    *,
+    binary_version: str | None,
+    npm: str,
+    scenario: str = "",
+    binding_files: dict[str, str] | None = None,
 ) -> tuple[Path, Path, Path, dict]:
     """A rendered script, a PATH shim dir, and an install prefix.
 
@@ -575,6 +586,7 @@ def _install_fixture(
             release_id="v-test",
             content_id="content-test",
             scenario=scenario,
+            binding_files=binding_files,
         )
     )
     prefix = tmp_path / "prefix"
@@ -590,6 +602,41 @@ def _run_install(script: Path, dest: Path, prefix: Path, env: dict) -> subproces
     return subprocess.run(
         ["sh", str(script), str(dest), str(prefix)], env=env, capture_output=True, text=True, timeout=60
     )
+
+
+@pytest.mark.unit
+def test_install_script_writes_the_model_binding_with_the_clients_token(tmp_path) -> None:
+    """The served composition carries no endpoint; the script writes the adapter's binding at the Reef it
+    came from, fills the token from REEF_TOKEN at install time, and the wrapper reads the URL back."""
+    from reef.harness.harness_wrapper import _extract_reef_url
+
+    binding = ModelBinding(base_url="http://reef.test:8901", model="qwen3-8b", api_key=TOKEN_PLACEHOLDER)
+    bound = render_composition(
+        [("rules", {"text": "old rules"}), *binding.compose_nodes(get_adapter("pi"))], get_adapter("pi")
+    )
+    binding_files = {"pi-agent/models.json": bound["pi-agent/models.json"]}
+    assert TOKEN_PLACEHOLDER in binding_files["pi-agent/models.json"]
+    script, dest, prefix, env = _install_fixture(
+        tmp_path, binary_version="0.84.2", npm="#!/bin/sh\nexit 1\n", binding_files=binding_files
+    )
+    result = _run_install(script, dest, prefix, {**env, "REEF_TOKEN": "tok-123"})
+    assert result.returncode == 0, result.stderr
+    models = json.loads((dest / "pi-agent/models.json").read_text(encoding="utf-8"))
+    assert models["providers"]["reef"] == {
+        "api": "openai-completions",
+        "apiKey": "tok-123",
+        "baseUrl": "http://reef.test:8901/v1",
+        "models": [{"id": "qwen3-8b"}],
+    }
+    assert TOKEN_PLACEHOLDER not in (dest / "pi-agent/models.json").read_text(encoding="utf-8")
+    assert _extract_reef_url("pi", dest / "pi-agent") == "http://reef.test:8901"
+    # The composition files and the sidecar are what the manifest served; the binding rides beside them.
+    assert (dest / "pi-agent/AGENTS.md").read_text(encoding="utf-8") == HOSTILE_FILES["pi-agent/AGENTS.md"]
+    # A rerun re-points the tree and exits clean; without a token the script says so and still installs.
+    again = _run_install(script, dest, prefix, {k: v for k, v in env.items() if k != "REEF_TOKEN"})
+    assert again.returncode == 0, again.stderr
+    assert "REEF_TOKEN is not set" in again.stderr
+    assert json.loads((dest / "pi-agent/models.json").read_text(encoding="utf-8"))["providers"]["reef"]["apiKey"] == ""
 
 
 @pytest.mark.unit
@@ -975,6 +1022,11 @@ def test_install_route_serves_the_script_for_head_and_pinned_versions(tmp_path) 
             assert "npm install --prefix \"$PREFIX\" '@earendil-works/pi-coding-agent@0.84.2'" in script
             assert composition_checksum(second["files"]) in script  # head by default
             assert "marker marker rules" in script  # the composition rides inline
+            # The binding at the Reef this request reached, the token left for the client's environment.
+            host = f"{client.host}:{client.port}"
+            assert f'"baseUrl": "http://{host}/v1"' in script
+            assert f'"apiKey": "{TOKEN_PLACEHOLDER}"' in script
+            assert 'os.environ.get("REEF_TOKEN", "")' in script
             response = await client.get(
                 "/reef/harness/install",
                 params={"adapter": "pi", "release_id": first["release_id"]},

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -145,6 +145,7 @@ def _dispatcher(
     bootstrap_files: dict[str, str] | None = None,
     batch_policy: str = "reports",
     batch_size: int = 1,
+    seed: tuple[dict, ...] = (),
 ) -> Dispatcher:
     proposals = iter(mutations)
     binary = tmp_path / "fake-pi"
@@ -158,10 +159,12 @@ def _dispatcher(
         runtime=InferenceProxyRuntime(model_path="demo-model", base_url="http://localhost:8000"),
         batch_policy=batch_policy,
         batch_size=batch_size,
+        seed=seed,
     )
     bootstrap = tmp_path / "bootstrap"
     bootstrap.mkdir()
-    for relative, text in (bootstrap_files or {}).items():
+    # What the service assembly does: the recipe's seed is the base artifact every scenario forks from.
+    for relative, text in {**(recipe.seed_files() or {}), **(bootstrap_files or {})}.items():
         target = bootstrap / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(text, encoding="utf-8")
@@ -1003,6 +1006,38 @@ def test_descriptor_writable_paths_stay_in_managed_state(tmp_path, path: str) ->
     target.write_text(yaml.safe_dump(data), encoding="utf-8")
     with pytest.raises(DescriptorError, match=r"writable_paths.*episode root"):
         load_descriptor(target)
+
+
+@pytest.mark.unit
+def test_a_seeded_recipe_serves_and_installs_a_fresh_scenario_before_any_step(tmp_path) -> None:
+    """The README flow: a fresh scenario against a recipe with a seed answers the manifest and the
+    install script at once, with the seed's files and a binding at the served model, no step needed."""
+    seed = ({"id": "answer-style", "name": "skill", "config": {"name": "answer-style", "text": "# seed skill\n"}},)
+    dispatcher = _dispatcher(tmp_path, (), seed=seed)
+
+    async def run() -> None:
+        client = TestClient(TestServer(create_app(dispatcher, inference_backend=_EchoBackend())))
+        await client.start_server()
+        try:
+            manifest = await client.get("/reef/harness", headers={"x-reef-scenario": "delivery"})
+            assert manifest.status == 200
+            files = (await manifest.json())["files"]
+            assert files["pi-agent/skills/answer-style/SKILL.md"] == "# seed skill\n"
+            assert "pi-agent/models.json" in files and "reef" not in files["pi-agent/models.json"]
+            response = await client.get(
+                "/reef/harness/install", params={"adapter": "pi"}, headers={"x-reef-scenario": "delivery"}
+            )
+            assert response.status == 200
+            script = await response.text()
+            assert "# seed skill" in script
+            host = f"{client.host}:{client.port}"
+            assert f'"baseUrl": "http://{host}/v1"' in script
+            assert '"id": "demo-model"' in script  # the recipe's runtime model, since no gate ran yet
+            assert f'"apiKey": "{TOKEN_PLACEHOLDER}"' in script
+        finally:
+            await client.close()
+
+    asyncio.run(run())
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -164,7 +164,7 @@ def _dispatcher(
     bootstrap = tmp_path / "bootstrap"
     bootstrap.mkdir()
     # What the service assembly does: the recipe's seed is the base artifact every scenario forks from.
-    for relative, text in {**(recipe.seed_files() or {}), **(bootstrap_files or {})}.items():
+    for relative, text in {**(recipe.base_artifact_files() or {}), **(bootstrap_files or {})}.items():
         target = bootstrap / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(text, encoding="utf-8")

--- a/tests/reef_service/test_harness_example.py
+++ b/tests/reef_service/test_harness_example.py
@@ -309,3 +309,32 @@ def test_native_example_yaml_boots_the_recipe_with_the_shipped_seed(native_evolu
     ]
     assert "upstream" not in yaml.safe_dump(list(built.seed))
     assert isinstance(built.build("demo", RecordStore()), Trainer)  # loads the seed; no episodes
+
+
+def test_native_example_recipe_renders_its_seed_as_the_base_files(native_evolution, tmp_path, monkeypatch) -> None:
+    """The seed a deployment ships is what a fresh scenario serves, rendered once by the recipe."""
+    monkeypatch.setenv("REEF_UPSTREAM_API_KEY", "dummy")
+    config = load_config(EXAMPLE_DIR / "serve-native.yaml")
+    recipe_sections = {key: config[key] for key in ("implementation", "model", "evolution", "data")}
+    materialized = tmp_path / "harness_evolve.yaml"
+    materialized.write_text(yaml.safe_dump(recipe_sections))
+    from reef.service.assembly import _upstream_runtime
+
+    service = service_settings_from_config(config)
+    built = CordisRecipe.from_environment(
+        {}, config=load_recipe_config(materialized), runtime=_upstream_runtime(service)
+    )
+    files = built.seed_files()
+    assert files is not None
+    assert {"native/tools/read_file.py", "native/graphs/main.json", "native/skills/answer-style/SKILL.md"} <= set(
+        files
+    )
+    assert "upstream" not in files["native/models.json"]  # the seed carries no provider
+    assert (
+        CordisRecipe.from_environment(
+            {},
+            config={**load_recipe_config(materialized), "evolution": {**recipe_sections["evolution"], "seed": []}},
+            runtime=_upstream_runtime(service),
+        ).seed_files()
+        is None
+    )

--- a/tests/reef_service/test_harness_example.py
+++ b/tests/reef_service/test_harness_example.py
@@ -330,9 +330,10 @@ def test_native_example_recipe_renders_its_seed_as_the_base_files(native_evoluti
         files
     )
     assert "upstream" not in files["native/models.json"]  # the seed carries no provider
-    surface = built.build_surface("demo")
-    assert [entry["id"] for entry in surface.seed_entries][:3] == ["read_file", "write_file", "run_bash"]
-    assert surface.served_model == "qwen3-8b"
+    info = built.build_surface("demo").harness
+    assert info is not None
+    assert [entry["id"] for entry in info.seed_entries][:3] == ["read_file", "write_file", "run_bash"]
+    assert info.served_model == "qwen3-8b"
     assert (
         CordisRecipe.from_environment(
             {},

--- a/tests/reef_service/test_harness_example.py
+++ b/tests/reef_service/test_harness_example.py
@@ -324,17 +324,20 @@ def test_native_example_recipe_renders_its_seed_as_the_base_files(native_evoluti
     built = CordisRecipe.from_environment(
         {}, config=load_recipe_config(materialized), runtime=_upstream_runtime(service)
     )
-    files = built.seed_files()
+    files = built.base_artifact_files()
     assert files is not None
     assert {"native/tools/read_file.py", "native/graphs/main.json", "native/skills/answer-style/SKILL.md"} <= set(
         files
     )
     assert "upstream" not in files["native/models.json"]  # the seed carries no provider
+    surface = built.build_surface("demo")
+    assert [entry["id"] for entry in surface.seed_entries][:3] == ["read_file", "write_file", "run_bash"]
+    assert surface.served_model == "qwen3-8b"
     assert (
         CordisRecipe.from_environment(
             {},
             config={**load_recipe_config(materialized), "evolution": {**recipe_sections["evolution"], "seed": []}},
             runtime=_upstream_runtime(service),
-        ).seed_files()
+        ).base_artifact_files()
         is None
     )

--- a/tests/reef_service/test_reef_git_lfs.py
+++ b/tests/reef_service/test_reef_git_lfs.py
@@ -46,6 +46,39 @@ def test_git_lfs_repository_initializes_default_local_repository(
 
 
 @pytest.mark.integration
+def test_local_repository_base_carries_the_bootstrap_files_and_an_existing_base_wins(
+    tmp_path: Path,
+    fake_git_lfs: None,
+) -> None:
+    """A recipe's seed lands in the base artifact of a new local repository, so a fresh scenario
+    forks a tree with files; a later constructor with a different seed keeps the base that exists."""
+    remote = tmp_path / "artifacts.git"
+    seeded = GitLFSRepositoryBackend(
+        "first",
+        remote,
+        work_dir=tmp_path / "work-first",
+        cache_dir=tmp_path / "cache",
+        bootstrap_files={"pi-agent/AGENTS.md": "seed rules\n", "pi-agent/skills/a/SKILL.md": "# a\n"},
+    )
+    base = seeded.resolve_release()
+    tree = seeded.materialize(base).local_path
+    assert tree is not None
+    assert (tree / "pi-agent" / "AGENTS.md").read_text(encoding="utf-8") == "seed rules\n"
+    assert (tree / "pi-agent" / "skills" / "a" / "SKILL.md").read_text(encoding="utf-8") == "# a\n"
+    later = GitLFSRepositoryBackend(
+        "second",
+        remote,
+        work_dir=tmp_path / "work-second",
+        cache_dir=tmp_path / "cache",
+        bootstrap_files={"pi-agent/AGENTS.md": "other rules\n"},
+    )
+    assert later.resolve_release().release_id == base.release_id
+    kept = later.materialize(later.resolve_release()).local_path
+    assert kept is not None
+    assert (kept / "pi-agent" / "AGENTS.md").read_text(encoding="utf-8") == "seed rules\n"
+
+
+@pytest.mark.integration
 def test_local_repository_bootstrap_recovers_after_missing_git_lfs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Motivation

The README's harness evolving deployment fails at its second and third commands. `curl .../reef/harness/install?adapter=pi | bash` answers 404 on a fresh scenario because nothing renders the recipe's seed into an artifact until the first evolve step, and the first step needs traffic from the agent the install would have produced (#178). Once a tree is installed, `curl .../reef/harness/install?adapter=pi | bash` and `reef-pi -p "..."`, and the second command exits at once with `no Reef URL in the tree's model binding files`. The served composition carries no endpoint or credential by design (the artifact must stay clean), the install script wrote only the pulled files, the wrapper and the sidecar, and the wrapper reads Reef's URL from the adapter's binding file, which was `{}`. Only the native block of the user guide told the reader to write `models.json` by hand. This is #263.

## Changes

- A recipe can name the files a fresh scenario starts with; the harness recipe renders its seed, and the service passes them to the artifact repository as the base artifact of a new local repository, so `GET /reef/harness` and the install route answer before any step (an existing base is kept, so a repository initialised before this change keeps its empty base until it is recreated)
- The install script writes the adapter's model binding over the pulled tree, after the checksum and on every run: the release's own entries plus the descriptor's binding template, rendered through the same engine the gate uses, with the base URL taken from the request's Host (and `x-forwarded-proto` when a proxy sets it), the model from the gate the release ran against, and the token left as a placeholder the script fills from `REEF_TOKEN` in the client's shell; the script warns when the variable is unset
- The commit protocol and the scenario expose the entries a training commit logged for a release, which is what the binding render needs
- The served script still carries no credential and the sidecar still records the served composition alone; a rerun re-points the tree at the Reef it came from
- The user guide, the HTTP API reference and both READMEs say what the script writes

## Compatibility and operational impact

A tree installed by an older script keeps working once the new script runs over it. Adapters whose release has no logged entries or whose gate names no model get the old script unchanged. The wrapper's URL extraction is unchanged; the token now lands in the installed binding file the way any coding agent's provider config holds one.

## Verification

A new test renders a script with the binding, runs it under `sh` with `REEF_TOKEN` set, checks the written `models.json` provider block and that the wrapper's URL extraction reads the Reef URL back, then reruns without a token and checks the warning and the emptied key. The install route test asserts the binding appears at the request's host with the placeholder and the fill step. The golden script test is unchanged because a script without a binding is byte identical to before. The harness channel, scenario and commit protocol tests pass, mypy is clean, and every pre-commit hook passes over all files. An end to end run of the README flow against a local ollama deployment is recorded in the PR log below.

## Log

The README flow on this machine, `tutorials/harness_evolve/deployment.yaml` with `model.path` set to `qwen2.5:7b`, ollama as the upstream, a fresh `work/deployment`, the checkout's venv on PATH:

- Run 1 (main): the install route answered 404, `scenario 'harness-05aca3f0a678' serves no files: no harness composition has been published yet` (#178 reproduced).
- Run 2 (seed base): the install route answered 200, the script installed pi 0.84.2 and wrote the binding, `reef-pi -p` reached Reef and Reef forwarded to ollama with `your-model-name`, because I had set the model in a copy of the file while the named recipe reads the checkout's; the README's instruction to set `model.path` in the file itself stands.
- Run 3 (seed base, model set in the file): install route 200; `sh install.sh` exit 0 with `pi-agent/models.json` holding `providers.reef` at `http://127.0.0.1:8901/v1`, `apiKey` `reef-local`, model `qwen2.5:7b`; `reef-pi -p "Reply with the single word ok."` printed `ok` and exited 0; `reef-pi report --score 0 --feedback "e2e probe"` printed `reported 1 receipt(s) to harness-b612a244ab3c (one report)` and exited 0.

## AI assistance

Claude Code found the gap in an adversarial review of the merged harness evolution tree and wrote the fix and the tests; I decided that the binding is written by the client step and never published.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

Closes #263
Closes #178
