### PR TITLE
feat(native): enforce declared tool capabilities per call under the sandbox and log the enforcement

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -115,9 +115,35 @@ defines ``run(args, workdir) -> str``, and after it ``NAME``,
 the tree's values are what the module ends with whatever the code assigned.
 ``capabilities`` is optional: distinct names from ``read``, ``write``,
 ``exec`` and ``network`` that say what the tool does. The loop reports them
-in the session header and hands them to ``pre_execute`` hooks, and the
-sandbox will read them when it enforces policy per tool. The seed tools
-declare theirs; ``run_bash`` declares all three a shell can do.
+in the session header and hands them to ``pre_execute`` hooks. Under the
+``local`` executor nothing enforces them: the tool runs in the loop's own
+process. Under the ``sandbox`` executor, which sets
+``REEF_NATIVE_ENFORCE=bwrap`` for the episodes it launches, the loop runs
+each call in a child process under a bubblewrap profile derived from the
+declaration (it binds the episode's ``/proc`` read only, since a jail inside
+the episode's cannot mount a fresh one): without ``network`` the call gets an
+empty network namespace;
+without ``write`` the workspace is bound read only; without ``exec`` only
+library directories, the interpreter file running the tool and its prefixes
+are bound, so no directory that holds a shell (``/bin``, ``/usr/bin``,
+``/usr/local/bin``) exists in the jail, and ``PATH`` is unset besides.
+``subprocess.run(["bash", ...])`` then fails with a missing file: Python
+falls back to searching ``/bin:/usr/bin`` when ``PATH`` is absent, and
+those directories are not there. The absent directories are the denial;
+binding one of them for any reason reopens ``exec``. bwrap
+cannot deny the rest: the tool can still start ``sys.executable``, run an
+executable installed under a library directory or under a path it can write
+(``/tmp`` inside the jail is a private tmpfs), and read the workspace, so
+``read`` is never withheld. The loop refuses to start when the variable
+names ``bwrap`` and no ``bwrap`` is on ``PATH``, and a call the jail could
+not run at all ends in ``SANDBOX_FAILED`` rather than passing as a tool
+failure; the sandbox executor's preflight runs one jail inside another, so
+a host that cannot nest them fails at build, not at the first call. Every
+``tool/result`` event carries ``enforcement`` with the
+``mode`` (``none`` or ``bwrap``) and ``denied``, the declaration's
+complement over ``write``, ``exec`` and ``network`` (empty under ``none``).
+The seed tools declare theirs; ``run_bash`` declares all three a shell can
+do.
 ``reef.harness.native.seed.SEED_TOOLS`` holds the starting ``read_file``,
 ``write_file``, ``run_bash``, and ``execute`` tools as entries a recipe can
 seed and the loop can then evolve; ``execute`` runs a Python block in the
@@ -225,14 +251,15 @@ tool errors per agent summed over each side's episodes.
 
 The native loop writes its trajectory as ``native-jsonl``: one
 ``{type, seq, time, data}`` object per line, ``seq`` contiguous from 0. A
-``session`` header line names the task, model, tools, and hooks (name to
-event); then ``turn/start``, per step ``step/start``, ``request/header`` (the
+``session`` header line names the task, model, tools, hooks (name to
+event), and the ``enforcement`` mode; then ``turn/start``, per step
+``step/start``, ``request/header`` (the
 rendered system prompt and the tool declarations, logged on the first step so
 the log holds everything the model saw), ``assistant/message`` (``content``,
 ``tool_calls``, ``finish``), ``tool/call`` (the raw argument string),
-``tool/result`` (``content``, ``is_error``, and on error a closed ``code``:
-``UNKNOWN_TOOL``, ``INVALID_ARGS``, ``TOOL_FAILED``, ``HOOK_DENIED``,
-``APPROVAL_REQUIRED``, ``HOOK_BLOCKED``),
+``tool/result`` (``content``, ``is_error``, ``enforcement``, and on error a
+closed ``code``: ``UNKNOWN_TOOL``, ``INVALID_ARGS``, ``TOOL_FAILED``,
+``SANDBOX_FAILED``, ``HOOK_DENIED``, ``APPROVAL_REQUIRED``, ``HOOK_BLOCKED``),
 ``step/end``, and finally ``turn/end`` with a ``reason`` of ``completed``,
 ``max-steps``, ``rejected``, or ``error`` (its ``error`` code ``MODEL_ERROR``
 or ``LOAD_ERROR``). Arguments are validated against the tool's declared

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -198,7 +198,12 @@ hosted service that evaluates model-proposed trees sets ``evolution.executor:
 sandbox`` so each episode runs in a bubblewrap jail (a fresh non-root
 namespace, a read-only base filesystem, no host credentials, resource limits,
 and no network unless a model endpoint is allowlisted); a deployment that
-requires it refuses to start without the sandbox runtime.
+requires it refuses to start without the sandbox runtime. On the native
+adapter the sandbox also runs each tool call in a nested jail that withholds
+the network, workspace writes, or the shell and system binaries a tool did
+not declare in its capabilities; it cannot withhold the tool's own
+interpreter, or reads. The adapter guide states the full boundary. The
+local executor enforces none of this.
 
 The throwaway root contains nothing except the rendered tree: a fresh working
 directory and a fresh ``HOME``, with no repository and no files from your

--- a/reef/harness/adapters/native/descriptor.yaml
+++ b/reef/harness/adapters/native/descriptor.yaml
@@ -27,6 +27,9 @@ files:
 trajectory:
   format: native-jsonl
   path: "native/sessions"
+# The loop writes its session here, so the sandbox executor opens it while the rest of the root stays read only.
+writable_paths:
+  - "native/sessions"
 cleanup_whitelist:
   - "native/sessions/**"
   - "native/tools/__pycache__/**"

--- a/reef/harness/executor.py
+++ b/reef/harness/executor.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Protocol
 
 from reef.core.errors import ReefError
+from reef.harness.native.enforce import ISOLATION as TOOL_ISOLATION
 
 
 class SandboxUnavailable(ReefError):
@@ -141,6 +142,25 @@ class LocalExecutor:
         return _run(argv, cwd=workspace, env={**_inherited_env(), **env}, timeout=timeout)
 
 
+#: What every jail unshares and mounts before its binds; the episode jail and the nesting probe share it.
+_ISOLATION: tuple[str, ...] = (
+    "--unshare-user",
+    "--unshare-ipc",
+    "--unshare-pid",
+    "--unshare-uts",
+    "--unshare-cgroup-try",
+    "--die-with-parent",
+    "--new-session",
+    "--proc",
+    "/proc",
+    "--dev",
+    "/dev",
+    "--tmpfs",
+    "/tmp",
+    "--clearenv",
+)
+
+
 #: Resource limits every sandboxed episode gets unless the config overrides one.
 @dataclass(frozen=True)
 class SandboxLimits:
@@ -160,7 +180,10 @@ class SandboxExecutor:
     dies with its parent. Network is unshared (no egress) unless
     ``egress_hosts`` lists the model endpoint the episode must reach, in which
     case the network namespace is shared so the endpoint is reachable; a
-    single-host firewall is the follow-up (issue #18).
+    single-host firewall is the follow-up (issue #18). The jail also carries
+    ``REEF_NATIVE_ENFORCE=bwrap``, so the native loop runs each tool call in
+    a nested jail derived from the tool's declared capabilities; preflight
+    proves the host can nest one.
     """
 
     egress_hosts: tuple[str, ...] = ()
@@ -174,6 +197,34 @@ class SandboxExecutor:
                 "the sandbox executor requires bubblewrap (bwrap) on PATH; install it or set "
                 "evolution.executor: local for development"
             )
+        # The native loop nests one jail per tool call inside the episode's, so a host that refuses a user namespace
+        # inside another fails here instead of ending every call in SANDBOX_FAILED and tying every pairing.
+        try:
+            done = subprocess.run(
+                self._nested_probe_argv(),
+                env={"PATH": os.environ.get("PATH", "")},
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SandboxUnavailable(
+                f"the sandbox executor cannot nest a bubblewrap jail on this host: {exc}"
+            ) from exc
+        if done.returncode != 0:
+            raise SandboxUnavailable(
+                "the sandbox executor cannot nest a bubblewrap jail on this host, which every sandboxed native "
+                f"tool call needs: {done.stderr.strip()[-600:]}"
+            )
+
+    def _nested_probe_argv(self) -> list[str]:
+        """An episode jail with a tool jail inside it around ``true``: the shape every sandboxed tool call takes."""
+        bwrap = shutil.which("bwrap") or "bwrap"
+        binds = [token for base in self.base_paths if Path(base).exists() for token in ("--ro-bind", base, base)]
+        episode = [bwrap, *_ISOLATION, "--unshare-net", *binds]
+        tool = [bwrap, *TOOL_ISOLATION, "--unshare-net", *binds]
+        return [*episode, "--", *tool, "--", "/bin/true"]
 
     def _bwrap_argv(
         self,
@@ -185,23 +236,7 @@ class SandboxExecutor:
         writable_paths: Sequence[Path] = (),
         readonly_paths: Sequence[Path] = (),
     ) -> list[str]:
-        cmd = [
-            "bwrap",
-            "--unshare-user",
-            "--unshare-ipc",
-            "--unshare-pid",
-            "--unshare-uts",
-            "--unshare-cgroup-try",
-            "--die-with-parent",
-            "--new-session",
-            "--proc",
-            "/proc",
-            "--dev",
-            "/dev",
-            "--tmpfs",
-            "/tmp",
-            "--clearenv",
-        ]
+        cmd = ["bwrap", *_ISOLATION]
         if not self.egress_hosts:
             cmd.append("--unshare-net")
         for base in self.base_paths:
@@ -218,7 +253,7 @@ class SandboxExecutor:
                 cmd += ["--ro-bind", str(path), str(path)]
         cmd += ["--bind", str(workspace), str(workspace)]
         cmd += ["--chdir", str(workspace)]
-        for key, value in {**_inherited_env(), **env}.items():
+        for key, value in {**_inherited_env(), **env, "REEF_NATIVE_ENFORCE": "bwrap"}.items():
             cmd += ["--setenv", key, value]
         cmd += ["--", *argv]
         return cmd

--- a/reef/harness/native/__init__.py
+++ b/reef/harness/native/__init__.py
@@ -3,12 +3,13 @@
 One episode is one process and one turn. The rendered composition root
 (``REEF_NATIVE_DIR``) holds ``RULES.md``, ``skills/``, ``tools/``, ``hooks/``
 and ``models.json``; the loop reads them, talks to the served model through
-the rendered binding, dispatches tool calls to the tool modules, asks the
-hook modules at four events, and appends one JSONL session the
-``native-jsonl`` trajectory reader decodes. Everything the model saw is in
-that log: the rendered system prompt, the tool declarations, every message,
-every call, every result, and every hook decision that changed the loop's
-course.
+the rendered binding, dispatches tool calls to the tool modules through the
+capability enforcer ``REEF_NATIVE_ENFORCE`` selects, asks the hook modules
+at four events, and appends one JSONL session the ``native-jsonl``
+trajectory reader decodes. Everything the model saw is in that log: the
+rendered system prompt, the tool declarations, every message, every call,
+every result with what was enforced on it, and every hook decision that
+changed the loop's course.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ from types import ModuleType
 from typing import Any, Protocol
 
 from reef.harness.model_binding import ModelBinding, ModelBindingError
+from reef.harness.native.enforce import Enforcer, InProcessEnforcer, SandboxFailed, ToolFailed, select_enforcer
 from reef.harness.nodes import NATIVE_EVENTS
 
 #: Step and tool result budgets; an episode also runs under the executor's wall clock.
@@ -91,12 +93,15 @@ class ToolModule:
         parameters: Mapping[str, Any],
         run: ToolRunner,
         capabilities: Sequence[str] = (),
+        path: Path | None = None,
     ) -> None:
         self.name = name
         self.description = description
         self.parameters = dict(parameters) or {"type": "object", "properties": {}}
         self.run = run
         self.capabilities = tuple(str(item) for item in capabilities)
+        # The module file, which a sandboxing enforcer imports afresh in its child; a tool built in code has none.
+        self.path = path
 
     def declaration(self) -> dict[str, Any]:
         return {
@@ -155,7 +160,7 @@ def load_tools(tools_dir: Path) -> dict[str, ToolModule]:
         capabilities = getattr(module, "CAPABILITIES", ())
         description = str(getattr(module, "DESCRIPTION", ""))
         tools[name] = ToolModule(
-            name, description, parameters, run, capabilities if isinstance(capabilities, list) else ()
+            name, description, parameters, run, capabilities if isinstance(capabilities, list) else (), path=path
         )
     return tools
 
@@ -405,10 +410,12 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
             hooks = load_hooks(root / "hooks")
             agents = load_agents(root / "agents")
             graph = graphs.load_graph(root)
+            enforcer = select_enforcer(os.environ)
         except (LoadError, graphs.GraphError, ValueError) as exc:
             session.write("session", {**header, "tools": [], "hooks": {}, "graph": None})
             session.write("turn/start", {"turn": 1})
             return _abort(session, {"code": "LOAD_ERROR", "message": str(exc)[:600]})
+        header["enforcement"] = enforcer.mode
         session.write(
             "session",
             {
@@ -423,7 +430,7 @@ def run_loop(prompt: str, root: Path, session_dir: Path, workdir: Path) -> int:
             },
         )
         session.write("turn/start", {"turn": 1})
-        loop = _Loop(session, root, session_dir, header)
+        loop = _Loop(session, root, session_dir, header, enforcer=enforcer)
         window = context_window_from(root / "models.json")
         run = graphs.Run(loop, prompt, binding, tools, hooks, workdir, context_window=window, agents=agents)
         return graphs.run_graph(run, graph)
@@ -477,8 +484,9 @@ def _invoke(
     *,
     spill: Path | None = None,
     gate: Callable[[ToolModule, dict[str, Any]], Mapping[str, Any]] | None = None,
+    enforcer: Enforcer | None = None,
 ) -> dict[str, Any]:
-    """One result for one call: content, is_error, and a closed error code; run only sees valid arguments the gate allowed."""
+    """One result for one call: content, is_error, and a closed error code; run only sees valid arguments the gate allowed, under the enforcer's profile."""
     try:
         arguments = json.loads(raw) if raw.strip() else {}
     except json.JSONDecodeError:
@@ -507,7 +515,11 @@ def _invoke(
                 return _error("INVALID_ARGS", f"rewritten by a hook: {violation}", arguments)
     started = time.monotonic()
     try:
-        result = tool.run(arguments, str(workdir))
+        result = (enforcer or InProcessEnforcer()).run(tool, arguments, workdir)
+    except SandboxFailed as exc:
+        return _error("SANDBOX_FAILED", str(exc), arguments)
+    except ToolFailed as exc:
+        return _error("TOOL_FAILED", str(exc), arguments)
     except Exception as exc:
         return _error("TOOL_FAILED", f"{type(exc).__name__}: {exc}", arguments)
     text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False, default=str)
@@ -526,11 +538,19 @@ class _Loop:
     SPILL_DIR = SPILL_DIR
     MAX_COMPLETION_TOKENS = MAX_COMPLETION_TOKENS
 
-    def __init__(self, session: Session, root: Path, session_dir: Path, header: Mapping[str, Any] = {}) -> None:
+    def __init__(
+        self,
+        session: Session,
+        root: Path,
+        session_dir: Path,
+        header: Mapping[str, Any] = {},
+        enforcer: Enforcer | None = None,
+    ) -> None:
         self.session = session
         self.root = root
         self.session_dir = session_dir
         self.header = dict(header)
+        self.enforcer = enforcer or InProcessEnforcer()
         self.turns = 1
         self.open: list[Session] = []
 

--- a/reef/harness/native/enforce.py
+++ b/reef/harness/native/enforce.py
@@ -1,0 +1,195 @@
+"""Capability enforcement for native tool calls: the enforcer ``REEF_NATIVE_ENFORCE`` names runs each ``run`` and every ``tool/result`` names the mode and the declaration's complement."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Protocol
+
+ENFORCE_ENV = "REEF_NATIVE_ENFORCE"
+#: What a profile can withhold; ``read`` is not here because every tool sees the workspace, read only at least.
+DENIABLE: tuple[str, ...] = ("write", "exec", "network")
+#: What an interpreter needs to start and to resolve names; no bin or sbin directory is among them, so without
+#: ``exec`` no shell exists in the jail, though an executable installed under a library directory stays reachable.
+LIBRARY_PATHS: tuple[str, ...] = (
+    "/lib",
+    "/lib64",
+    "/usr/lib",
+    "/usr/lib64",
+    "/usr/share",
+    "/etc/alternatives",
+    "/etc/ssl",
+    "/etc/ld.so.cache",
+    "/etc/ld.so.conf",
+    "/etc/ld.so.conf.d",
+    "/etc/localtime",
+    "/etc/resolv.conf",
+    "/etc/hosts",
+    "/etc/nsswitch.conf",
+    "/etc/passwd",
+    "/etc/group",
+)
+#: What the tool jail unshares and mounts before its binds; it binds the episode's ``/proc`` read only rather than
+#: mounting a fresh one, which a jail inside the episode's cannot do, and which the interpreter needs to resolve
+#: ``$ORIGIN`` in its RPATH and so find its own ``libpython``.
+ISOLATION: tuple[str, ...] = (
+    "--unshare-user",
+    "--unshare-ipc",
+    "--unshare-pid",
+    "--unshare-uts",
+    "--unshare-cgroup-try",
+    "--die-with-parent",
+    "--new-session",
+    "--ro-bind",
+    "/proc",
+    "/proc",
+    "--dev",
+    "/dev",
+    "--tmpfs",
+    "/tmp",
+    "--clearenv",
+)
+#: What ``exec`` adds: the base directories the sandbox executor binds for a whole episode.
+EXEC_PATHS: tuple[str, ...] = ("/usr", "/bin", "/lib", "/lib64", "/etc/alternatives", "/etc/ssl", "/opt")
+#: The child side of a sandboxed call; it imports nothing from reef, so only this file needs binding.
+CHILD = Path(__file__).with_name("sandboxed.py")
+
+
+class ToolFailed(Exception):
+    """The tool's ``run`` raised in the child; the message is already the child's type and text."""
+
+
+class SandboxFailed(Exception):
+    """The enforcer could not run the call at all, so the failure is the sandbox's and not the tool's."""
+
+
+class Tool(Protocol):
+    """What an enforcer needs of a tool module: its name, its declaration, its file, and its ``run``."""
+
+    name: str
+    capabilities: tuple[str, ...]
+    path: Path | None
+
+    def run(self, args: dict[str, Any], workdir: str, /) -> Any: ...
+
+
+class Enforcer(Protocol):
+    """One way to run a tool call: a mode name for the log, what it withholds per tool, and the run itself."""
+
+    mode: str
+
+    def describe(self, tool: Tool | None) -> dict[str, Any]: ...
+
+    def run(self, tool: Tool, arguments: dict[str, Any], workdir: Path) -> Any: ...
+
+
+def denied(capabilities: Sequence[str]) -> list[str]:
+    """What a bwrap profile withholds from a tool declaring ``capabilities``, in the closed order."""
+    return [item for item in DENIABLE if item not in capabilities]
+
+
+def bwrap_argv(
+    capabilities: Sequence[str],
+    *,
+    workdir: Path,
+    tools_dir: Path,
+    interpreter: Path,
+    prefix: Path,
+    base_prefix: Path,
+    path: str = "",
+) -> list[str]:
+    """The bubblewrap command one call runs under, derived from its declaration; the adapter guide states the profile."""
+    granted = set(capabilities)
+    cmd = ["bwrap", *ISOLATION]
+    if "network" not in granted:
+        cmd.append("--unshare-net")
+    candidates = [Path(base) for base in ((*EXEC_PATHS, *LIBRARY_PATHS) if "exec" in granted else LIBRARY_PATHS)]
+    candidates += [interpreter, interpreter.resolve()]
+    for root in dict.fromkeys((base_prefix, prefix)):
+        candidates += [root / "lib", root / "lib64", root / "pyvenv.cfg"]
+    candidates += [CHILD, tools_dir]
+    bound: list[Path] = []
+    for candidate in candidates:
+        if candidate.exists() and not any(candidate == seen or seen in candidate.parents for seen in bound):
+            bound.append(candidate)
+            cmd += ["--ro-bind", str(candidate), str(candidate)]
+    cmd += ["--bind" if "write" in granted else "--ro-bind", str(workdir), str(workdir)]
+    cmd += ["--chdir", str(workdir), "--setenv", "HOME", str(workdir)]
+    if "exec" in granted and path:
+        cmd += ["--setenv", "PATH", path]
+    cmd += ["--", str(interpreter), "-I", "-X", "utf8", str(CHILD)]
+    return cmd
+
+
+class InProcessEnforcer:
+    """The default: ``run`` is a plain call in the loop's process and nothing is enforced."""
+
+    mode = "none"
+
+    def describe(self, tool: Tool | None) -> dict[str, Any]:
+        return {"mode": self.mode, "denied": []}
+
+    def run(self, tool: Tool, arguments: dict[str, Any], workdir: Path) -> Any:
+        return tool.run(arguments, str(workdir))
+
+
+class BwrapEnforcer:
+    """Each call imports the tool's module afresh in a child under the profile its declaration derives."""
+
+    mode = "bwrap"
+
+    def describe(self, tool: Tool | None) -> dict[str, Any]:
+        return {"mode": self.mode, "denied": denied(tool.capabilities) if tool is not None else []}
+
+    def run(self, tool: Tool, arguments: dict[str, Any], workdir: Path) -> Any:
+        if tool.path is None:
+            raise SandboxFailed(f"tool {tool.name!r} has no module file to run in a child process")
+        argv = bwrap_argv(
+            tool.capabilities,
+            workdir=workdir,
+            tools_dir=tool.path.parent,
+            interpreter=Path(sys.executable),
+            prefix=Path(sys.prefix),
+            base_prefix=Path(sys.base_prefix),
+            path=os.environ.get("PATH", ""),
+        )
+        request = json.dumps({"path": str(tool.path), "arguments": arguments, "workdir": str(workdir)}, default=str)
+        try:
+            done = subprocess.run(
+                argv,
+                input=request,
+                capture_output=True,
+                text=True,
+                env={"PATH": os.environ.get("PATH", "")},
+                check=False,
+            )
+        except OSError as exc:
+            raise SandboxFailed(f"bwrap could not start: {exc}") from exc
+        reply: Any = None
+        if done.returncode == 0:
+            try:
+                reply = json.loads(done.stdout)
+            except json.JSONDecodeError:
+                reply = None
+        if not isinstance(reply, dict):
+            raise SandboxFailed(f"tool process exited {done.returncode}: {done.stderr.strip()[-600:]}")
+        if not reply.get("ok"):
+            raise ToolFailed(str(reply.get("error") or "the tool failed"))
+        return reply.get("text", "")
+
+
+def select_enforcer(environ: Mapping[str, str]) -> Enforcer:
+    """The enforcer ``REEF_NATIVE_ENFORCE`` names: unset or ``none`` runs tools in process, ``bwrap`` needs bwrap."""
+    mode = environ.get(ENFORCE_ENV) or "none"
+    if mode == "none":
+        return InProcessEnforcer()
+    if mode == "bwrap":
+        if shutil.which("bwrap") is None:
+            raise ValueError(f"{ENFORCE_ENV}=bwrap but bubblewrap (bwrap) is not on PATH")
+        return BwrapEnforcer()
+    raise ValueError(f"{ENFORCE_ENV}={mode!r} names no enforcer; use none or bwrap")

--- a/reef/harness/native/graph.py
+++ b/reef/harness/native/graph.py
@@ -265,7 +265,7 @@ class Run:
                     raise _Escalate(str(decision.get("reason") or f"{tool.name} needs approval"))
                 return decision
 
-            result = loop._invoke(tools, name, raw, self.workdir, spill=spill, gate=gate)
+            result = loop._invoke(tools, name, raw, self.workdir, spill=spill, gate=gate, enforcer=loop.enforcer)
             payload = {
                 "step": step,
                 "call_id": call_id,
@@ -277,7 +277,12 @@ class Run:
             result = loop._judged(result, verdict)
             if result.get("is_error"):
                 self.tool_errors += 1
-            self.session.write("tool/result", {"step": step, "call_id": call_id, "name": name, **result})
+            # The log says what was enforced on this tool, whether or not the call reached its run.
+            enforcement = loop.enforcer.describe(tools.get(name))
+            self.session.write(
+                "tool/result",
+                {"step": step, "call_id": call_id, "name": name, **result, "enforcement": enforcement},
+            )
             self.messages.append({"role": "tool", "tool_call_id": call_id, "content": result["content"]})
             contexts.extend(loop._texts(verdict.get("contexts")))
         # Contexts land after the batch's results, in call order, so the model reads them as one note.

--- a/reef/harness/native/sandboxed.py
+++ b/reef/harness/native/sandboxed.py
@@ -1,0 +1,39 @@
+"""The child side of the bwrap enforcer: read ``{path, arguments, workdir}`` on stdin, run the tool once, and reply ``{ok, text|error}`` on the saved stdout; it imports nothing from reef."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _run(request: dict[str, Any]) -> str:
+    path = Path(str(request["path"]))
+    spec = importlib.util.spec_from_file_location(f"reef_native_tool_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"{path.name} is not an importable module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    result = module.run(request["arguments"], str(request["workdir"]))
+    return result if isinstance(result, str) else json.dumps(result, ensure_ascii=False, default=str)
+
+
+def main() -> int:
+    # The reply owns the original stdout; what the tool or its children write to fd 1 goes to stderr instead.
+    reply_fd = os.dup(1)
+    os.dup2(2, 1)
+    request = json.loads(sys.stdin.read())
+    try:
+        reply: dict[str, Any] = {"ok": True, "text": _run(request)}
+    except Exception as exc:
+        reply = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+    with os.fdopen(reply_fd, "w", encoding="utf-8") as out:
+        json.dump(reply, out, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/reef_service/test_episode_executor.py
+++ b/tests/reef_service/test_episode_executor.py
@@ -111,6 +111,45 @@ def test_sandbox_preflight_fails_fast_without_bubblewrap(monkeypatch) -> None:
         build_executor({"executor": "sandbox"})
 
 
+def _probe_result(monkeypatch, returncode: int, stderr: str = "") -> list[list[str]]:
+    """Stand in for the nesting probe: record the argv and answer with the given exit."""
+    seen: list[list[str]] = []
+
+    def run(argv, **kwargs):
+        seen.append(list(argv))
+        return subprocess.CompletedProcess(argv, returncode, "", stderr)
+
+    monkeypatch.setattr("reef.harness.executor.subprocess.run", run)
+    return seen
+
+
+def test_sandbox_preflight_proves_the_host_can_nest_a_jail(monkeypatch) -> None:
+    monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: "/usr/bin/bwrap")
+    seen = _probe_result(monkeypatch, 1, "bwrap: No permissions to create a new namespace\n")
+    with pytest.raises(SandboxUnavailable, match=r"cannot nest a bubblewrap jail.*No permissions"):
+        SandboxExecutor().preflight()
+    # An episode jail with a tool jail inside it around true: the shape every sandboxed tool call takes.
+    argv = seen[0]
+    episode, tool = argv[: argv.index("--")], argv[argv.index("--") + 1 :]
+    assert episode[0] == tool[0] == "/usr/bin/bwrap" and tool[-2:] == ["--", "/bin/true"]
+    for flag in ("--unshare-user", "--unshare-pid", "--unshare-net", "--dev", "--clearenv"):
+        assert flag in episode and flag in tool
+    # The episode jail mounts a fresh /proc; the tool jail cannot nest that, so it binds the episode's read only.
+    assert "--proc" in episode and "--proc" not in tool
+    assert tool[tool.index("/proc") - 1 : tool.index("/proc") + 2] == ["--ro-bind", "/proc", "/proc"]
+    for jail in (episode, tool):
+        assert jail[jail.index("/usr") - 1 : jail.index("/usr") + 2] == ["--ro-bind", "/usr", "/usr"]
+    _probe_result(monkeypatch, 0)
+    SandboxExecutor().preflight()
+
+    def refuse(argv, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr("reef.harness.executor.subprocess.run", refuse)
+    with pytest.raises(SandboxUnavailable, match="cannot nest a bubblewrap jail on this host: boom"):
+        SandboxExecutor().preflight()
+
+
 def test_sandbox_argv_isolates_the_filesystem_env_and_network(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: "/usr/bin/bwrap")
     monkeypatch.setattr("reef.harness.executor.os.environ", {"PATH": "/usr/bin"})
@@ -133,6 +172,8 @@ def test_sandbox_argv_isolates_the_filesystem_env_and_network(monkeypatch, tmp_p
     assert "--setenv" in argv
     joined = " ".join(argv)
     assert "A b" in joined
+    # The native loop reads this and holds each tool call to its declared capabilities.
+    assert "--setenv REEF_NATIVE_ENFORCE bwrap" in joined
 
 
 def test_sandbox_opens_runtime_state_but_rebinds_rendered_inputs_read_only(monkeypatch, tmp_path: Path) -> None:
@@ -174,6 +215,7 @@ def test_sandbox_shares_the_network_when_egress_is_allowlisted(monkeypatch, tmp_
 
 def test_build_executor_reads_sandbox_limits(monkeypatch) -> None:
     monkeypatch.setattr("reef.harness.executor.shutil.which", lambda name: "/usr/bin/bwrap")
+    _probe_result(monkeypatch, 0)
     executor = build_executor(
         {
             "executor": "sandbox",

--- a/tests/reef_service/test_native_enforce.py
+++ b/tests/reef_service/test_native_enforce.py
@@ -1,0 +1,204 @@
+"""Capability enforcement for native tools: the bwrap profile a declaration derives, the enforcer the
+environment selects, what a call under it looks like to the loop, and, where bubblewrap is installed, what
+the jail denies."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from reef.harness.native import ToolModule, _invoke, load_tools
+from reef.harness.native.enforce import (
+    CHILD,
+    ENFORCE_ENV,
+    BwrapEnforcer,
+    InProcessEnforcer,
+    bwrap_argv,
+    denied,
+    select_enforcer,
+)
+
+PROBE = """\
+import errno
+import json
+import os
+import socket
+import subprocess
+
+
+def run(args, workdir):
+    print("noise on stdout must not reach the reply")
+    seen = {}
+    try:
+        with open(os.path.join(workdir, "probe.txt"), "w") as handle:
+            handle.write("x")
+        seen["write"] = "ok"
+    except OSError as exc:
+        seen["write"] = errno.errorcode.get(exc.errno, str(exc))
+    try:
+        subprocess.run(["sh", "-c", "true"], check=True)
+        seen["exec"] = "ok"
+    except (OSError, subprocess.CalledProcessError) as exc:
+        seen["exec"] = type(exc).__name__
+    # bwrap brings loopback up in an empty namespace, so the interfaces, not a connect, tell the namespaces apart.
+    names = sorted(name for _, name in socket.if_nameindex())
+    seen["network"] = "ok" if names != ["lo"] else "lo only"
+    if args.get("raise"):
+        raise RuntimeError("kaboom")
+    return json.dumps(seen, sort_keys=True)
+"""
+
+
+def _fake_python(tmp_path: Path) -> dict[str, Path]:
+    """A venv shaped interpreter: a prefix with pyvenv.cfg and lib over a base prefix with lib."""
+    base = tmp_path / "base"
+    (base / "lib").mkdir(parents=True)
+    prefix = tmp_path / "venv"
+    (prefix / "lib").mkdir(parents=True)
+    (prefix / "bin").mkdir()
+    (prefix / "pyvenv.cfg").write_text(f"home = {base / 'bin'}\n")
+    interpreter = prefix / "bin" / "python"
+    interpreter.write_text("")
+    return {"interpreter": interpreter, "prefix": prefix, "base_prefix": base}
+
+
+def _mounts(argv: list[str], flag: str) -> list[str]:
+    return [argv[i + 1] for i, token in enumerate(argv) if token == flag]
+
+
+def _covered(mounts: list[str], path: Path) -> bool:
+    return any(Path(mount) == path or Path(mount) in path.parents for mount in mounts)
+
+
+def _tools(tmp_path: Path, capabilities: list[str], code: str = PROBE) -> dict[str, ToolModule]:
+    tools = tmp_path / "tools"
+    tools.mkdir(exist_ok=True)
+    (tools / "probe.py").write_text(
+        f"{code}\nNAME = 'probe'\nDESCRIPTION = 'probe'\nPARAMETERS = {{}}\nCAPABILITIES = {capabilities!r}\n"
+    )
+    return load_tools(tools)
+
+
+def _fake_bwrap(tmp_path: Path, monkeypatch, body: str) -> None:
+    """A ``bwrap`` on PATH that stands in for the real one, so the child protocol runs without a jail."""
+    fake = tmp_path / "fakebin"
+    fake.mkdir(exist_ok=True)
+    (fake / "bwrap").write_text(f"#!{sys.executable}\nimport os, sys\n{body}\n")
+    (fake / "bwrap").chmod(0o755)
+    if str(fake) not in os.environ.get("PATH", "").split(os.pathsep):
+        monkeypatch.setenv("PATH", f"{fake}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+def test_denied_is_the_complement_of_the_declaration_over_what_bwrap_can_withhold() -> None:
+    assert denied(()) == ["write", "exec", "network"]
+    assert denied(("read",)) == ["write", "exec", "network"]
+    assert denied(("read", "write")) == ["exec", "network"]
+    assert denied(("exec", "write", "network")) == []
+
+
+def test_the_profile_follows_the_declaration(tmp_path: Path) -> None:
+    python = _fake_python(tmp_path)
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    work = tmp_path / "work"
+    work.mkdir()
+
+    def profile(*capabilities: str) -> list[str]:
+        return bwrap_argv(capabilities, workdir=work, tools_dir=tools, path="/usr/bin:/bin", **python)
+
+    for capabilities in ((), ("read",), ("write",), ("exec",), ("network",), ("exec", "write", "network")):
+        argv = profile(*capabilities)
+        assert argv[0] == "bwrap" and "--die-with-parent" in argv and "--clearenv" in argv
+        # A jail inside the episode's cannot mount a fresh /proc, so it binds the episode's read only.
+        assert "--unshare-pid" in argv and "--proc" not in argv
+        assert argv[argv.index("/proc") - 1 : argv.index("/proc") + 2] == ["--ro-bind", "/proc", "/proc"]
+        assert ("--unshare-net" in argv) is ("network" not in capabilities)
+        writable, readonly = _mounts(argv, "--bind"), _mounts(argv, "--ro-bind")
+        assert (writable == [str(work)]) is ("write" in capabilities)
+        assert (str(work) in readonly) is ("write" not in capabilities)
+        assert ("/usr" in readonly) is ("exec" in capabilities)
+        assert ("PATH" in argv) is ("exec" in capabilities)
+        if "exec" in capabilities:
+            assert argv[argv.index("PATH") - 1 : argv.index("PATH") + 2] == ["--setenv", "PATH", "/usr/bin:/bin"]
+        # Whatever the declaration, the interpreter, its prefixes, the tools and the child script are bound.
+        for path in (
+            python["interpreter"],
+            python["prefix"] / "lib",
+            python["prefix"] / "pyvenv.cfg",
+            python["base_prefix"] / "lib",
+            tools,
+            CHILD,
+        ):
+            assert _covered(readonly, path)
+        assert argv[argv.index("--") + 1 :] == [str(python["interpreter"]), "-I", "-X", "utf8", str(CHILD)]
+        assert argv[argv.index("--chdir") + 1] == str(work) and argv[argv.index("HOME") + 1] == str(work)
+        # The workspace is the last mount, so nothing bound earlier shadows it.
+        assert argv.index(str(work)) > max(argv.index(mount) for mount in readonly if mount != str(work))
+    # Without exec no directory that holds a shell is bound, so Python's own /bin:/usr/bin fallback finds nothing
+    # once PATH is unset; the interpreter is bound as one file, never through its bin directory.
+    argv = profile("write", "network")
+    assert not {"/bin", "/usr/bin", "/usr", "/opt", "/usr/local"} & set(argv)
+    assert "PATH" not in argv
+    assert not [mount for mount in _mounts(argv, "--ro-bind") if Path(mount).name in ("bin", "sbin")]
+    assert _mounts(argv, "--ro-bind").count(str(python["interpreter"])) == 1
+
+
+def test_the_environment_selects_the_enforcer(monkeypatch) -> None:
+    assert isinstance(select_enforcer({}), InProcessEnforcer)
+    assert isinstance(select_enforcer({ENFORCE_ENV: ""}), InProcessEnforcer)
+    assert select_enforcer({ENFORCE_ENV: "none"}).mode == "none"
+    monkeypatch.setattr("reef.harness.native.enforce.shutil.which", lambda name: "/usr/bin/bwrap")
+    assert isinstance(select_enforcer({ENFORCE_ENV: "bwrap"}), BwrapEnforcer)
+    monkeypatch.setattr("reef.harness.native.enforce.shutil.which", lambda name: None)
+    with pytest.raises(ValueError, match=r"bwrap.*not on PATH"):
+        select_enforcer({ENFORCE_ENV: "bwrap"})
+    with pytest.raises(ValueError, match=r"seccomp.*names no enforcer"):
+        select_enforcer({ENFORCE_ENV: "seccomp"})
+    tool = ToolModule("shout", "", {}, lambda args, workdir: "", ["read", "write"])
+    assert InProcessEnforcer().describe(tool) == {"mode": "none", "denied": []}
+    assert BwrapEnforcer().describe(tool) == {"mode": "bwrap", "denied": ["exec", "network"]}
+    assert BwrapEnforcer().describe(None) == {"mode": "bwrap", "denied": []}
+
+
+def test_a_sandboxed_call_runs_the_child_protocol_and_keeps_the_error_codes(tmp_path: Path, monkeypatch) -> None:
+    # The stand in runs the command after "--" as is, so the child script and the reply path are the real ones.
+    _fake_bwrap(tmp_path, monkeypatch, "argv = sys.argv[sys.argv.index('--') + 1:]\nos.execv(argv[0], argv)")
+    tools = _tools(tmp_path, ["read"])
+    work = tmp_path / "work"
+    work.mkdir()
+    ok = _invoke(tools, "probe", "{}", work, enforcer=BwrapEnforcer())
+    assert ok["is_error"] is False, ok
+    assert json.loads(ok["content"]) == {"exec": "ok", "network": "ok", "write": "ok"}
+    assert ok["arguments"] == {} and ok["meta"]["truncated"] is False
+    failed = _invoke(tools, "probe", '{"raise": true}', work, enforcer=BwrapEnforcer())
+    assert failed["error"] == {"code": "TOOL_FAILED", "message": "RuntimeError: kaboom"}
+    built = {"shout": ToolModule("shout", "", {}, lambda args, workdir: "", ["read"])}
+    assert _invoke(built, "shout", "{}", work, enforcer=BwrapEnforcer())["error"] == {
+        "code": "SANDBOX_FAILED",
+        "message": "tool 'shout' has no module file to run in a child process",
+    }
+    _fake_bwrap(
+        tmp_path, monkeypatch, "print('bwrap: No permissions to create a new namespace', file=sys.stderr)\nsys.exit(1)"
+    )
+    broken = _invoke(tools, "probe", "{}", work, enforcer=BwrapEnforcer())
+    assert broken["error"]["code"] == "SANDBOX_FAILED"
+    assert broken["error"]["message"] == "tool process exited 1: bwrap: No permissions to create a new namespace"
+
+
+@pytest.mark.skipif(shutil.which("bwrap") is None, reason="bubblewrap (bwrap) is not on PATH")
+def test_bwrap_denies_what_the_declaration_withholds(tmp_path: Path) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    bare = _invoke(_tools(tmp_path, []), "probe", "{}", work, enforcer=BwrapEnforcer())
+    assert bare["is_error"] is False, bare
+    assert json.loads(bare["content"]) == {"exec": "FileNotFoundError", "network": "lo only", "write": "EROFS"}
+    assert not (work / "probe.txt").exists()
+    full = _invoke(_tools(tmp_path, ["exec", "write", "network"]), "probe", "{}", work, enforcer=BwrapEnforcer())
+    assert full["is_error"] is False, full
+    assert json.loads(full["content"]) == {"exec": "ok", "network": "ok", "write": "ok"}
+    assert (work / "probe.txt").read_text() == "x"

--- a/tests/reef_service/test_native_harness.py
+++ b/tests/reef_service/test_native_harness.py
@@ -7,15 +7,19 @@ and hook modules, and the trajectory run hermetically."""
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
+from reef_service.test_native_enforce import PROBE
 
 from reef.harness.adapters import available_adapters, get_adapter
 from reef.harness.episode import run_episode
+from reef.harness.executor import SandboxExecutor
 from reef.harness.model_binding import ModelBinding
 from reef.harness.native import (
     _DEFAULTS,
@@ -28,6 +32,7 @@ from reef.harness.native import (
     _waterfall,
     load_hooks,
     load_tools,
+    run_loop,
 )
 from reef.harness.native.seed import SEED_GRAPH, SEED_NODES, SEED_TOOLS
 from reef.harness.nodes import NODE_KINDS
@@ -202,6 +207,8 @@ def test_native_adapter_is_bundled_and_renders_tools_as_modules() -> None:
     assert "native" in available_adapters()
     descriptor = get_adapter("native")
     assert descriptor.binary == "reef-native" and descriptor.trajectory_format == "native-jsonl"
+    # The session directory is the one path the sandbox opens, so the loop can write its log inside the jail.
+    assert descriptor.writable_paths == ("native/sessions",) and descriptor.trajectory_path == "native/sessions"
     files = render_composition([("rules", {"text": "Be brief."}), TOOL, HOOK], descriptor)
     module = files["native/tools/shout.py"]
     assert "NAME = 'shout'" in module and "PARAMETERS = {" in module and "def run(args, workdir):" in module
@@ -425,6 +432,8 @@ def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path:
     header = result.trajectory[0]["data"]
     assert header["version"] == 1 and header["tools"] == ["execute", "read_file", "run_bash", "write_file"]
     assert header["hooks"] == {"loop_guard": "post_execute"} and header["graph"] == "main"
+    # The local executor sets no enforcer, and the log says so on the header and on every result.
+    assert header["enforcement"] == "none"
     request = _events(result.trajectory, "request/header")[0]["data"]
     assert request["system"] == "Be brief."
     assert sorted(tool["function"]["name"] for tool in request["tools"]) == [
@@ -437,6 +446,7 @@ def test_native_loop_runs_seed_tools_and_logs_everything_the_model_saw(tmp_path:
     assert written["name"] == "write_file" and written["content"] == "wrote 5 characters to notes.txt"
     assert written["is_error"] is False and written["arguments"] == {"path": "notes.txt", "content": "hello"}
     assert read["name"] == "read_file" and read["content"] == "hello"
+    assert written["enforcement"] == read["enforcement"] == {"mode": "none", "denied": []}
     assert _events(result.trajectory, "assistant/message")[-1]["data"]["content"] == "The file says: hello"
     assert result.trajectory[-1]["data"]["reason"] == {"kind": "completed"}
     # The first request the fake model saw is the one the log says it saw, with the reply cap on it.
@@ -1330,6 +1340,101 @@ def test_the_execute_seed_tool_runs_code_that_calls_the_other_tools(tmp_path: Pa
     failed = _invoke(tools, "execute", json.dumps({"code": "raise SystemExit(3)"}), workdir)
     assert failed["content"].startswith("exit 3")
     assert _invoke(tools, "execute", json.dumps({"code": "  "}), workdir)["content"] == "refused: empty code"
+
+
+def test_the_loop_runs_every_call_through_the_enforcer_the_environment_names(
+    tmp_path: Path, fake_model, monkeypatch
+) -> None:
+    root = tmp_path / "tree"
+    binding = ModelBinding(base_url=fake_model.base_url, model="fake", api_key="dummy")
+    files = render_composition(
+        [*_seed_nodes(SEED_TOOLS), *binding.compose_nodes(get_adapter("native"))], get_adapter("native")
+    )
+    for relative, text in files.items():
+        (root / relative).parent.mkdir(parents=True, exist_ok=True)
+        (root / relative).write_text(text)
+    work = tmp_path / "work"
+    work.mkdir()
+    task = "put hello in notes.txt and read it back"
+
+    def session(name: str) -> list[dict]:
+        return [json.loads(line) for line in (tmp_path / name / "session.jsonl").read_text().splitlines()]
+
+    # A mode the loop has no enforcer for is a load error, not a run with nothing enforced.
+    monkeypatch.setenv("REEF_NATIVE_ENFORCE", "seccomp")
+    assert run_loop(task, root / "native", tmp_path / "s1", work) == 1
+    assert session("s1")[-1]["data"]["reason"]["error"] == {
+        "code": "LOAD_ERROR",
+        "message": "REEF_NATIVE_ENFORCE='seccomp' names no enforcer; use none or bwrap",
+    }
+    # A bwrap that only runs the command after "--" stands in for the jail; the loop's side is what this checks.
+    fake = tmp_path / "fakebin"
+    fake.mkdir()
+    (fake / "bwrap").write_text(
+        f"#!{sys.executable}\nimport os, sys\nargv = sys.argv[sys.argv.index('--') + 1:]\nos.execv(argv[0], argv)\n"
+    )
+    (fake / "bwrap").chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("REEF_NATIVE_ENFORCE", "bwrap")
+    assert run_loop(task, root / "native", tmp_path / "s2", work) == 0
+    events = session("s2")
+    assert events[0]["data"]["enforcement"] == "bwrap"
+    results = [event["data"] for event in events if event["type"] == "tool/result"]
+    assert [(result["name"], result["enforcement"]) for result in results] == [
+        ("write_file", {"mode": "bwrap", "denied": ["exec", "network"]}),
+        ("read_file", {"mode": "bwrap", "denied": ["write", "exec", "network"]}),
+    ]
+    assert results[1]["content"] == "hello" and (work / "notes.txt").read_text() == "hello"
+
+
+class _ProbingModel(_FakeModel):
+    """Calls probe (declares nothing), then write_file, then read_file, then answers, one tool per turn."""
+
+    def script(self, body: dict) -> dict:
+        done = len([m for m in body["messages"] if m.get("role") == "tool"])
+        if done == 0:
+            return _reply(tool_calls=[_call("probe", {}, "c0")])
+        if done == 1:
+            return _reply(tool_calls=[_call("write_file", {"path": "notes.txt", "content": "hello"}, "c1")])
+        if done == 2:
+            return _reply(tool_calls=[_call("read_file", {"path": "notes.txt"}, "c2")])
+        return _reply(content=f"done: {body['messages'][-1]['content']}")
+
+
+@pytest.mark.skipif(shutil.which("bwrap") is None, reason="bubblewrap (bwrap) is not on PATH")
+def test_a_sandboxed_episode_runs_each_tool_call_in_a_nested_jail(tmp_path: Path) -> None:
+    model = _ProbingModel()
+    try:
+        descriptor = get_adapter("native")
+        binding = ModelBinding(base_url=model.base_url, model="fake", api_key="dummy")
+        probe = (
+            "native_tool",
+            {"name": "probe", "description": "probe", "parameters": {}, "code": PROBE, "capabilities": []},
+        )
+        files = render_composition([*_seed_nodes(SEED_TOOLS), probe, *binding.compose_nodes(descriptor)], descriptor)
+        # The launcher and the checkout live outside the episode root, so the jail binds them like a base path.
+        checkout = Path(__file__).resolve().parents[2]
+        executor = SandboxExecutor(
+            egress_hosts=(model.base_url,), base_paths=(*SandboxExecutor.base_paths, str(tmp_path), str(checkout))
+        )
+        result = run_episode(
+            descriptor, files, "probe, then put hello in notes.txt", binary=_launcher(tmp_path), executor=executor
+        )
+    finally:
+        model.shutdown()
+        model.server_close()
+    assert result.exit_code == 0, result.stderr
+    assert result.trajectory[0]["data"]["enforcement"] == "bwrap"
+    results = [event["data"] for event in result.trajectory if event["type"] == "tool/result"]
+    assert [(r["name"], r["enforcement"]["denied"], r["is_error"]) for r in results] == [
+        ("probe", ["write", "exec", "network"], False),
+        ("write_file", ["exec", "network"], False),
+        ("read_file", ["write", "exec", "network"], False),
+    ]
+    # The loop keeps the model endpoint while the probe, one jail deeper, sees only loopback, a read only
+    # workspace and no shell; the file still round trips through two jails that declare write and read.
+    assert json.loads(results[0]["content"]) == {"exec": "FileNotFoundError", "network": "lo only", "write": "EROFS"}
+    assert results[2]["content"] == "hello"
 
 
 # -- native_agent: agents as root entries, called from a subagent stage ----------------------------


### PR DESCRIPTION
## Motivation

Closes #266, gap 7 of the harness evolution review: a native_tool's capabilities (read, write, exec, network) were a declaration the model under test writes about itself. The loop reported them in the session header and handed them to pre_execute hooks, and nothing enforced them, so a hook that denies exec was filtering a label the candidate wrote, not a boundary; the tool's run executed in the loop's process either way, and the adapter guide said the sandbox "will read them". This makes the declaration enforced where reef has an enforcer, the sandbox executor, and honest where it does not.

## Changes

- The loop picks one enforcer per episode from REEF_NATIVE_ENFORCE: unset, the in process enforcer runs the tool as before; bwrap runs each call's run() in a child process under a bubblewrap profile derived from the declaration
- The profile: an empty network namespace unless network; the workspace bound read only unless write; unless exec, only library directories, the interpreter file running the tool and its prefixes are bound, so no directory that holds a shell exists in the jail and PATH is unset besides
- The tool jail binds the episode jail's /proc read only rather than mounting a fresh one, which a jail nested inside the episode's cannot do, and which the interpreter needs to resolve $ORIGIN in its RPATH and find its own libpython
- The sandbox executor's preflight runs one tool jail inside one episode jail around /bin/true, so a host that cannot nest the two fails at build rather than ending every call in SANDBOX_FAILED and tying every pairing
- The native descriptor declares native/sessions writable, so the loop writes its session log inside the sandbox jail while the rest of the root stays read only
- Every tool/result event carries enforcement {mode: none|bwrap, denied: [...]}, the session header carries the mode, and a call the jail could not run ends in SANDBOX_FAILED, a new closed code, so the tool is not blamed for the sandbox
- The adapter guide states what is enforced under which executor, what bwrap cannot deny, and that the local executor enforces nothing; the user guide's sandbox paragraph names what is withheld

## Compatibility and operational impact

Additive on the local executor: tools run in process as before and the log gains enforcement none on the header and on every tool/result. Under the sandbox executor each native tool call now runs in a nested jail; the host must allow a user namespace inside the outer one, which preflight now proves at build. The tool's module is imported afresh per call, so module level state no longer persists between calls there; the loop keeps the model endpoint while tools without network get no network. What bwrap cannot deny is stated, not claimed: a tool may still start sys.executable, run an executable installed under a library directory or under a path it can write (/tmp in the jail is a private tmpfs), and read the workspace, so read is never withheld. ToolModule gains an optional path; the native descriptor gains writable_paths; one new closed code, SANDBOX_FAILED.

## Verification

In a privileged Debian container with bubblewrap 0.12.0 the new end to end test ran a real run_episode under SandboxExecutor: a tool declaring nothing saw write EROFS, exec FileNotFoundError, and only lo in its network namespace, one jail deeper than the episode jail that kept the model endpoint, while write_file and read_file (declaring write and read) round tripped the file through their own jails; the session header named bwrap and each result carried its denied set. This is the nesting the earlier account could not verify. Diagnosing it surfaced two real defects the nested path had and the enforcer profile now fixes: a jail inside the episode's cannot mount a fresh /proc, and without the episode's /proc bound the interpreter cannot resolve its RPATH to find libpython, so a bare tool jail exited SANDBOX_FAILED on every call. On the local machine, without bwrap, the two live jail tests skip; a bwrap stand in that only runs the command after "--" drives the child protocol and the loop, and the nesting preflight is exercised with subprocess.run stubbed. The command that ran these: PYTHONPATH=$PWD .venv/bin/python -m pytest -q tests/reef_service/test_native_enforce.py tests/reef_service/test_native_harness.py tests/reef_service/test_episode_executor.py -rs.

## AI assistance

Claude Code wrote the enforcer, the profile builder, the child protocol, the nesting preflight, the tests and the docs from the review's gap text, and diagnosed the nested libpython failure in the container; I set the boundary of what is claimed for bwrap and the event shape.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
