### PR TITLE
fix(harness): make the README harness evolution flow work end to end

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Last human-confirmed consistent README pair.
 # After updating and reviewing both files, run:
 #   python .github/scripts/check_readme_i18n.py --write
-README.md: 37a897f42bfed6b6cf16b2b2b8161f87489492f7
-README.zh.md: 086d4bfc45f5bbcaa26975907fe3d8058f5aadd4
+README.md: f34772d215a47810c66709e3e45dd18415f6f669
+README.zh.md: 6081e763ea9b8df25185e39f1d00f0f00c2f50ae

--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ For another provider, use its base URL, model name, and API key. This config dep
 In another terminal, install the harness and run a task:
 
 ```bash
-export REEF_TOKEN="reef-local"   # the script also writes it into the installed harness's model binding
+export REEF_TOKEN="reef-local"   # the script writes it into the installed harness's
+                                 # model binding; keep it exported for `report`
 curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
   'http://localhost:8901/reef/harness/install?adapter=pi' | bash
 reef-pi -p "fix the failing test in auth.py"

--- a/README.zh.md
+++ b/README.zh.md
@@ -201,7 +201,8 @@ reef serve -c tutorials/harness_evolve/deployment.yaml
 在另一个终端中安装 harness 并运行任务：
 
 ```bash
-export REEF_TOKEN="reef-local"   # the script also writes it into the installed harness's model binding
+export REEF_TOKEN="reef-local"   # the script writes it into the installed harness's
+                                 # model binding; keep it exported for `report`
 curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
   'http://localhost:8901/reef/harness/install?adapter=pi' | bash
 reef-pi -p "fix the failing test in auth.py"

--- a/reef/harness/model_binding.py
+++ b/reef/harness/model_binding.py
@@ -32,6 +32,15 @@ from reef.runtime.base import InferenceRuntime
 #: The API dialects a binding can speak. ``openai`` is Chat Completions,
 #: ``responses`` is OpenAI Responses, and ``anthropic`` is Messages.
 MODEL_APIS = ("openai", "responses", "anthropic")
+
+#: What an episode's rendered config carries where the key goes when the
+#: endpoint needs none (a local vllm or ollama, the tutorial's case). Agent
+#: binaries read the rendered key to decide a provider is usable and refuse
+#: to start on an empty one - pi exits 1 with "No API key found for the
+#: selected model" before it ever reaches the endpoint, so every episode
+#: fails and no gate can publish. Endpoints without auth ignore the value.
+NO_KEY_PLACEHOLDER = "no-key"
+
 ANTHROPIC_VERSION = "2023-06-01"
 ANTHROPIC_DEFAULT_MAX_TOKENS = 4096
 
@@ -245,7 +254,7 @@ class ModelBinding:
                 f"adapter {descriptor.name!r} declares no model_binding for the {self.api!r} api "
                 f"(declared: {known}); episodes cannot reach a model"
             )
-        values = {"base_url": self.base_url, "api_key": self.api_key or "", "model": self.model}
+        values = {"base_url": self.base_url, "api_key": self.api_key or NO_KEY_PLACEHOLDER, "model": self.model}
         return tuple(("config", _substitute(node, values)) for node in templates)
 
 

--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -143,9 +143,13 @@ def _wrapper_lines(
         'exec python3 -m reef.harness.harness_wrapper "\\$@"',
         "REEF_WRAPPER_EOF",
         f'    chmod +x "$DEST/{_double_quoted(wrapper_name)}"',
-        f"    # Symlink into ~/.local/bin so {wrapper_name} is on PATH.",
+        f"    # Symlink into ~/.local/bin so {wrapper_name} is on PATH. The link target",
+        "    # must be absolute: DEST defaults to the relative ./reef-harness, and a",
+        "    # relative target resolves against the link's own directory, so the link",
+        f"    # dangles and {wrapper_name} is not runnable from anywhere.",
+        '    DEST_ABS="$(cd "$DEST" && pwd)"',
         '    mkdir -p "$HOME/.local/bin"',
-        f'    ln -sf "$DEST/{_double_quoted(wrapper_name)}" "$HOME/.local/bin/{_double_quoted(wrapper_name)}"',
+        f'    ln -sf "$DEST_ABS/{_double_quoted(wrapper_name)}" "$HOME/.local/bin/{_double_quoted(wrapper_name)}"',
         '    case ":$PATH:" in',
         '        *":$HOME/.local/bin:"*) ;;',
         f"        *) echo \"reef: add '$HOME/.local/bin' to your PATH to run {wrapper_name} from anywhere\" >&2 ;;",
@@ -211,9 +215,20 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
         "esac",
         "",
         "# Ensure reef-client (capture proxy) and reef (harness wrapper) are installed.",
+        # The distribution is `reef-infra`; naming it `reef` here makes pip
+        # reject the requirement ("produced metadata for project name
+        # reef-infra") on every run. The install stays best effort - a managed
+        # interpreter (PEP 668) refuses it too - so the import is rechecked
+        # after and the wrapper's own failure is named here rather than
+        # surfacing later as a bare ModuleNotFoundError from the launcher.
         (
             "python3 -c 'import reef_client.serve, reef.harness.harness_wrapper' 2>/dev/null || "
-            'python3 -m pip install --quiet --user reef-client "reef @ git+https://github.com/Human-Agent-Society/reef.git" 2>/dev/null || true'
+            'python3 -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" 2>/dev/null || true'
+        ),
+        (
+            "python3 -c 'import reef_client.serve, reef.harness.harness_wrapper' 2>/dev/null || "
+            'echo "reef: warning: reef-client and reef-infra are not importable by python3; '
+            'install them into the environment that runs the wrapper" >&2'
         ),
     ]
 

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path, PurePosixPath
 from urllib.parse import quote
 
@@ -597,7 +598,22 @@ def _install_fixture(
         _write_executable(prefix / "node_modules/.bin/pi", f"#!/bin/sh\necho {binary_version}\n")
     shim = tmp_path / "shim"
     _write_executable(shim / "npm", npm)
-    env = {**os.environ, "PATH": f"{shim}:{os.environ['PATH']}"}
+    # The script's own python3: the interpreter running the tests, so its
+    # reef bootstrap sees an environment where reef is already importable and
+    # never shells out to `pip install --user` from GitHub, which would install
+    # reef-infra into user site-packages and change what every later
+    # subprocess reports as the reef version.
+    _write_executable(shim / "python3", f'#!/bin/sh\nexec "{sys.executable}" "$@"\n')
+    # ... and the checkout on its path, so the bootstrap's import check passes
+    # from any cwd. CI runs the suite against the source tree rather than an
+    # installed reef-infra, so without this a test that runs the script from a
+    # temp cwd reaches the pip branch.
+    repo_root = str(Path(__file__).resolve().parents[2])
+    env = {
+        **os.environ,
+        "PATH": f"{shim}:{os.environ['PATH']}",
+        "PYTHONPATH": os.pathsep.join(filter(None, (repo_root, os.environ.get("PYTHONPATH", "")))),
+    }
     return script, tmp_path / "dest", prefix, env
 
 
@@ -892,6 +908,7 @@ def test_the_path_symlink_resolves_when_dest_is_the_relative_default(tmp_path) -
         timeout=60,
     )
     assert result.returncode == 0, result.stderr
+    assert "not importable by python3" not in result.stderr  # the bootstrap short-circuited
     link = Path.home() / ".local" / "bin" / "reef-pi"
     try:
         assert link.is_symlink()

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -695,7 +695,8 @@ case " $installed " in
 esac
 
 # Ensure reef-client (capture proxy) and reef (harness wrapper) are installed.
-python3 -c 'import reef_client.serve, reef.harness.harness_wrapper' 2>/dev/null || python3 -m pip install --quiet --user reef-client "reef @ git+https://github.com/Human-Agent-Society/reef.git" 2>/dev/null || true
+python3 -c 'import reef_client.serve, reef.harness.harness_wrapper' 2>/dev/null || python3 -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" 2>/dev/null || true
+python3 -c 'import reef_client.serve, reef.harness.harness_wrapper' 2>/dev/null || echo "reef: warning: reef-client and reef-infra are not importable by python3; install them into the environment that runs the wrapper" >&2
 
 # The checksum stream, as baked into CHECKSUM: each sorted relative path,
 # its byte length, then its bytes, newline separated. The unquoted wc
@@ -758,9 +759,13 @@ export REEF_HARNESS_ENV_VAR="PI_CODING_AGENT_DIR"
 exec python3 -m reef.harness.harness_wrapper "\$@"
 REEF_WRAPPER_EOF
     chmod +x "$DEST/reef-pi"
-    # Symlink into ~/.local/bin so reef-pi is on PATH.
+    # Symlink into ~/.local/bin so reef-pi is on PATH. The link target
+    # must be absolute: DEST defaults to the relative ./reef-harness, and a
+    # relative target resolves against the link's own directory, so the link
+    # dangles and reef-pi is not runnable from anywhere.
+    DEST_ABS="$(cd "$DEST" && pwd)"
     mkdir -p "$HOME/.local/bin"
-    ln -sf "$DEST/reef-pi" "$HOME/.local/bin/reef-pi"
+    ln -sf "$DEST_ABS/reef-pi" "$HOME/.local/bin/reef-pi"
     case ":$PATH:" in
         *":$HOME/.local/bin:"*) ;;
         *) echo "reef: add '$HOME/.local/bin' to your PATH to run reef-pi from anywhere" >&2 ;;
@@ -864,6 +869,37 @@ def test_install_script_writes_executable_wrapper_with_baked_paths(tmp_path) -> 
     assert "reef-pi" in result.stdout
     # clean up the symlink so it doesn't leak between tests
     link.unlink(missing_ok=True)
+
+
+@pytest.mark.unit
+def test_the_path_symlink_resolves_when_dest_is_the_relative_default(tmp_path) -> None:
+    """The README installs into the default relative ./reef-harness.
+
+    ``ln -s`` reads a relative target against the link's own directory, so
+    linking "$DEST/reef-pi" from ~/.local/bin left a dangling link pointing at
+    ~/.local/bin/reef-harness/reef-pi and ``reef-pi`` was not on PATH at all.
+    Every other install test passes an absolute DEST and cannot see it.
+    """
+    script, _, prefix, env = _install_fixture(tmp_path, binary_version="0.84.2", npm="#!/bin/sh\nexit 1\n")
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    result = subprocess.run(
+        ["sh", str(script), "./reef-harness", str(prefix)],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    link = Path.home() / ".local" / "bin" / "reef-pi"
+    try:
+        assert link.is_symlink()
+        assert Path(os.readlink(link)).is_absolute()
+        assert link.resolve() == (workdir / "reef-harness" / "reef-pi").resolve()
+        assert link.exists()  # not dangling
+    finally:
+        link.unlink(missing_ok=True)
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_model_binding.py
+++ b/tests/reef_service/test_model_binding.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 from reef.harness.adapters import get_adapter
-from reef.harness.model_binding import ModelBinding, ModelBindings
+from reef.harness.model_binding import NO_KEY_PLACEHOLDER, ModelBinding, ModelBindings
 from reef.harness.render import render_composition
 from reef.recipe import RecipeConfigError
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
@@ -142,6 +142,24 @@ def test_episode_templates_follow_the_dialect() -> None:
     assert json.loads(anthropic["pi-agent/models.json"])["providers"]["reef"]["baseUrl"] == "http://up"
     for files in (openai, anthropic):
         assert json.loads(files["pi-agent/settings.json"])["defaultModel"] == "reef/m"
+
+
+def test_an_endpoint_without_a_key_still_renders_a_key_the_agent_accepts() -> None:
+    """A local endpoint needs no key, but pi refuses to start without one.
+
+    Rendering the empty string made every evaluation episode exit 1 with
+    "No API key found for the selected model" before reaching the endpoint,
+    so both sides of the gate scored 0 and no proposal could ever publish.
+    """
+    pi = get_adapter("pi")
+    files = render_composition(ModelBinding("http://127.0.0.1:11434", "m").compose_nodes(pi), pi)
+    assert json.loads(files["pi-agent/models.json"])["providers"]["reef"]["apiKey"] == NO_KEY_PLACEHOLDER
+
+
+def test_a_real_key_is_rendered_verbatim_over_the_placeholder() -> None:
+    pi = get_adapter("pi")
+    files = render_composition(ModelBinding("http://up", "m", api_key="sk-real").compose_nodes(pi), pi)
+    assert json.loads(files["pi-agent/models.json"])["providers"]["reef"]["apiKey"] == "sk-real"
 
 
 def test_the_dialect_rides_the_proxy_runtime_into_the_binding() -> None:


### PR DESCRIPTION
Ran the root README's [harness-evolving deployment](https://github.com/Human-Agent-Society/reef/blob/main/README.md#harness-evolving-deployment) from a clean machine against a local ollama endpoint. Three defects sit between those instructions and a working evolve step. One of them makes the gate structurally unable to publish.

## An endpoint that needs no key makes the gate unable to publish

The tutorial invites exactly this: *"Use your provider's API key, or omit it for a local endpoint without authentication."* Omitting it renders every evaluation episode's binding with an empty `apiKey`:

```json
{"providers": {"reef": {"api": "openai-completions", "apiKey": "",
                        "baseUrl": "http://127.0.0.1:11434/v1", "models": [{"id": "qwen2.5:7b"}]}}}
```

pi reads the rendered key to decide a provider is usable and exits 1 with `No API key found for the selected model` **before it ever reaches the endpoint**. All six episodes die, both sides of the gate score 0, and the step can only tie and reject. The recorded commit from that run:

```
current_scores  [0.0, 0.0, 0.0]      wins 0 / losses 0 / ties 3
candidate_scores[0.0, 0.0, 0.0]      published: false
cause: exit 1:   .../@earendil-works/pi-coding-agent/docs/models.md
```

There is no input that produces any other outcome, so on a keyless endpoint the loop can never publish anything.

Episodes now render a placeholder where the key goes; endpoints without auth ignore the value, and a real key is still passed through verbatim. Chain was `assembly.py:134` (`api_key=settings.upstream_api_key or None`) → `model_binding.py` (`self.api_key or ""`).

A/B through `run_episode`, reef's own episode runner, against a keyless ollama:

| rendered `apiKey` | exit code | trajectory events |
|---|---|---|
| `""` (before) | 1 | 0 |
| `"no-key"` (after) | 0 | 5 |

## The wrapper's PATH symlink dangles

`DEST` defaults to the relative `./reef-harness`, and `ln -s` reads a relative target against the *link's own* directory. So the install left:

```
~/.local/bin/reef-pi -> ./reef-harness/reef-pi     # i.e. ~/.local/bin/reef-harness/reef-pi
```

a dangling link, and the README's `reef-pi -p "..."` is `command not found`. Every existing install test passes an absolute `DEST` and cannot see this; the new test installs into the relative default and asserts the link is absolute and resolves.

## The reef bootstrap can never succeed

`install_script.py` ran `pip install --user reef-client "reef @ git+..."`. The distribution is `reef-infra`, so pip rejects it on every run — *"Generating metadata for package reef produced metadata for project name reef-infra"* → `No matching distribution found for reef` — and on a PEP 668 interpreter it is refused regardless. Both were swallowed by `2>/dev/null || true` and surfaced later as a bare `ModuleNotFoundError: No module named 'reef'` from the launcher's `exec python3 -m reef.harness.harness_wrapper`.

The requirement is now named correctly, and the import is rechecked afterwards so a still-missing module is reported where it happens rather than at first use.

## Also

The README's `REEF_TOKEN` comment now says the export is needed for `report` too, not just install — `harness_wrapper` reads it from the environment only, so a shell without it gets `401 invalid service token` on report while inference keeps working off the binding file.

Related, not changed here: when `REEF_TOKEN` is unset at install time the *client* tree also gets `apiKey: ""` and pi refuses to start on it, the same trap on the other side of the wire. That path warns (`REEF_TOKEN is not set`) and an empty key there is arguably the right signal for an authenticated Reef, so I left it alone — happy to fold it in if you'd rather it match.

## Testing

- `pytest tests/reef_service` — 1481 passed, 10 skipped (excludes `test_sao_bridge` / `test_slime_bridge`, which need the GPU training stack)
- `ruff check` and `ruff format --check` clean on the touched files
- new `test_the_path_symlink_resolves_when_dest_is_the_relative_default` fails on the unfixed code (`assert Path(os.readlink(link)).is_absolute()`) and passes with the fix
- README pair re-synchronized via `.github/scripts/check_readme_i18n.py --write`
- the documented flow run end to end on ollama `qwen2.5:7b` — install, run, report, propose, gate, publish (release `4ba74dc9a9ad`, 1 win / 0 losses / 2 ties), evolved skill present in the pulled tree. That run had a throwaway key set. The keyless case is measured directly through `run_episode` (table above) rather than by a full published run: on this box a concurrent GPU job made the proposer's own model call time out, so the keyless full run committed `skipped: no proposal` before reaching the gate. Reruns are in progress and I'll post the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)