### PR TITLE
fix(artifacts): isolate LFS hooks in managed clones

### DIFF
--- a/reef/artifact/git_lfs.py
+++ b/reef/artifact/git_lfs.py
@@ -77,8 +77,13 @@ class _GitWorkspace:
             self._run(("git", "clone", "--no-checkout", self.repository, str(self.clone_dir)))
         self.git("config", "user.name", "Reef Repository Backend")
         self.git("config", "user.email", "reef-artifacts@localhost")
-        self.git("config", "core.hooksPath", str(self.clone_dir / ".git" / "hooks"))
-        self.git("lfs", "install", "--local", "--skip-smudge")
+        self._install_lfs(self.clone_dir)
+
+    def _install_lfs(self, repository: Path) -> None:
+        # Keep LFS hooks separate from global hooks and hooks copied by Git templates.
+        hooks = repository.resolve() / ".git" / "reef-hooks"
+        self._run(("git", "config", "--local", "core.hooksPath", str(hooks)), cwd=repository)
+        self._run(("git", "lfs", "install", "--local", "--skip-smudge"), cwd=repository)
 
     def checkout(self, version: str) -> None:
         self.git("fetch", "origin", version)
@@ -146,7 +151,7 @@ class _GitWorkspace:
 
     def clone_for_materialize(self, destination: Path, version: str) -> None:
         self._run(("git", "clone", "--no-checkout", self.repository, str(destination)))
-        self._run(("git", "lfs", "install", "--local", "--skip-smudge"), cwd=destination)
+        self._install_lfs(destination)
         self._run(("git", "fetch", "origin", version), cwd=destination)
         self._run(("git", "checkout", "--detach", "FETCH_HEAD"), cwd=destination)
         self._run(("git", "lfs", "pull"), cwd=destination)

--- a/tests/reef_service/test_reef_git_lfs.py
+++ b/tests/reef_service/test_reef_git_lfs.py
@@ -40,7 +40,7 @@ def test_git_lfs_repository_initializes_default_local_repository(
     assert remote.is_dir()
     assert run_git("--git-dir", str(remote), "rev-parse", "refs/reef/base") == initial.release_id
     assert run_git("-C", str(tmp_path / "work" / "repository"), "config", "--local", "core.hooksPath") == str(
-        tmp_path / "work" / "repository" / ".git" / "hooks"
+        tmp_path / "work" / "repository" / ".git" / "reef-hooks"
     )
     assert not hasattr(backend.fork(), "scenario")
 
@@ -249,12 +249,28 @@ def test_git_lfs_repository_imports_forks_publishes_and_materializes(
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("hook_source", ["none", "global", "template"])
 def test_fresh_scenario_forks_latest_artifact_with_real_lfs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    hook_source: str,
 ) -> None:
-    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    global_config = tmp_path / "gitconfig"
+    global_config.touch()
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
     monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    hooks = tmp_path / "template" / "hooks"
+    hooks.mkdir(parents=True)
+    hook_contents = "#!/bin/sh\necho 'unrelated user hook must not run' >&2\nexit 1\n"
+    for name in ("pre-push", "post-checkout"):
+        hook = hooks / name
+        hook.write_text(hook_contents)
+        hook.chmod(0o755)
+    if hook_source == "global":
+        run_git("config", "--global", "core.hooksPath", str(hooks))
+    elif hook_source == "template":
+        monkeypatch.setenv("GIT_TEMPLATE_DIR", str(hooks.parent))
+    original_config = global_config.read_text()
     remote = tmp_path / "artifacts.git"
     first = GitLFSRepositoryBackend(
         "scenario-a",
@@ -292,3 +308,9 @@ def test_fresh_scenario_forks_latest_artifact_with_real_lfs(
     materialized = fresh.materialize(forked)
     assert materialized.local_path is not None
     assert materialized.local_path.joinpath(weights.name).read_bytes() == b"trained weights"
+    assert not (materialized.local_path / ".git").exists()
+    assert global_config.read_text() == original_config
+    for name in ("pre-push", "post-checkout"):
+        assert (hooks / name).read_text() == hook_contents
+        if hook_source == "template":
+            assert (tmp_path / "fresh-work" / "repository" / ".git" / "hooks" / name).read_text() == hook_contents


### PR DESCRIPTION
## Motivation

`GET /reef/harness/install` can return HTTP 503 when an artifact clone inherits a custom pre-push hook: `git lfs install --local --skip-smudge` fails with `Hook already exists: pre-push`. Hooks supplied by Git templates can also prevent the repository backend from initializing.

## Changes

- Configure a repository-local `.git/reef-hooks` directory before installing LFS in both backend workspaces and temporary materialization clones.
- Preserve existing global and template-provided hooks while keeping the LFS hooks needed to upload and download artifact objects.
- Extend the real-LFS integration test to cover global and template hook conflicts, successful publish/fork/materialize operations, and preservation of user hooks and global configuration.

## Compatibility and operational impact

No public API, dependency, or artifact format changes. Reef-managed clones use `.git/reef-hooks` instead of inherited hook directories; existing workspaces adopt it when reopened. Restart Reef with the updated code and retry failed install requests.

## Verification

- Reproduced the reported materialization failure with a global pre-push hook, and the initialization failure with a template-provided hook, before applying the fix.
- `python -m pytest tests/reef_service/test_reef_git_lfs.py tests/reef_service/test_reef_artifacts.py tests/reef_service/test_artifact_versions.py tests/reef_service/test_harness_channel.py -q --tb=short --durations=5` — 80 passed on the PR branch.
- `python -m pre_commit run --files reef/artifact/git_lfs.py tests/reef_service/test_reef_git_lfs.py` — passed.

## AI assistance

OpenAI Codex investigated the failure, implemented the fix and regression coverage, ran validation, and prepared this PR.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
