### PR TITLE
fix(native): poll again at the interval when a release poll times out behind a running evolve step

### DIFF
--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -461,7 +461,10 @@ hand stands until the head moves again. A Reef that does not answer logs
 ten minutes, and the process keeps serving. A Reef that is busy is polled
 again at the interval: a catalog read waits behind a running evolve step,
 so a poll that times out during one retries at the interval and the head
-lands as soon as the step ends.
+lands as soon as the step ends. A manifest read that times out the same way
+logs ``harness/mount-failed`` and is retried by the next poll that names
+the head, so a release published between two steps mounts once the steps
+are over.
 
 ``--self-tools`` gives the model three host plane tools. The tree cannot
 remove them or take their names, and they are absent in the episode form,

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -458,7 +458,10 @@ new head and waits for a person. ``reef-native mount <release_id> --tree
 rolls the process back locally; under ``head`` too, a release mounted by
 hand stands until the head moves again. A Reef that does not answer logs
 ``release/poll-failed`` with the error and the next retry, doubling up to
-ten minutes, and the process keeps serving.
+ten minutes, and the process keeps serving. A Reef that is busy is polled
+again at the interval: a catalog read waits behind a running evolve step,
+so a poll that times out during one retries at the interval and the head
+lands as soon as the step ends.
 
 ``--self-tools`` gives the model three host plane tools. The tree cannot
 remove them or take their names, and they are absent in the episode form,

--- a/reef/harness/native/release_client.py
+++ b/reef/harness/native/release_client.py
@@ -24,9 +24,18 @@ MAX_BACKOFF_S = 600.0
 class ReleaseClientError(Exception):
     """Reef did not answer a release request; ``status`` carries the HTTP status when there was one."""
 
-    def __init__(self, message: str, *, status: int | None = None) -> None:
+    def __init__(self, message: str, *, status: int | None = None, timed_out: bool = False) -> None:
         super().__init__(message)
         self.status = status
+        #: Reef was reached but answered nothing within the client timeout: busy, not down.
+        self.timed_out = timed_out
+
+
+def _timed_out(exc: BaseException) -> bool:
+    """Whether a request failure is a timeout: the socket's own, or the one urllib wraps as a URLError reason."""
+    if isinstance(exc, TimeoutError):
+        return True
+    return isinstance(exc, urllib.error.URLError) and isinstance(exc.reason, TimeoutError)
 
 
 class HeadSink(Protocol):
@@ -66,7 +75,9 @@ class ReleaseClient:
             detail = exc.read().decode(errors="replace")[:600]
             raise ReleaseClientError(f"{method} {path} answered {exc.code}: {detail}", status=exc.code) from exc
         except (OSError, ValueError) as exc:
-            raise ReleaseClientError(f"{method} {path} failed: {type(exc).__name__}: {exc}") from exc
+            raise ReleaseClientError(
+                f"{method} {path} failed: {type(exc).__name__}: {exc}", timed_out=_timed_out(exc)
+            ) from exc
 
     def releases(self) -> list[dict[str, Any]]:
         """The catalog rows, oldest first, as ``GET /reef/harness/releases`` lists them."""
@@ -119,6 +130,7 @@ class HeadWatch:
         self._mounted = mounted
         self._announced: str | None = None
         self._failure = ""
+        self._failure_timed_out = False
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
@@ -160,6 +172,7 @@ class HeadWatch:
             self._consider(self._client.poll(), "poll")
         except Exception as exc:
             self._failure = f"{type(exc).__name__}: {exc}"[:600]
+            self._failure_timed_out = isinstance(exc, ReleaseClientError) and exc.timed_out
             return False
         return True
 
@@ -170,9 +183,14 @@ class HeadWatch:
             if self.poll_once():
                 backoff = delay = self._interval_s
                 continue
-            self._log.write("release/poll-failed", {"error": self._failure, "retry_in_s": backoff})
-            delay = backoff
-            backoff = min(backoff * 2, MAX_BACKOFF_S)
+            if self._failure_timed_out:
+                # Reef answered nothing in time but is there: a catalog read waits behind a running evolve
+                # step. The next poll goes at the interval, so the head lands as soon as the step ends.
+                backoff = delay = self._interval_s
+            else:
+                delay = backoff
+                backoff = min(backoff * 2, MAX_BACKOFF_S)
+            self._log.write("release/poll-failed", {"error": self._failure, "retry_in_s": delay})
 
     def start(self) -> None:
         self._thread = threading.Thread(target=self._run, name="reef-native-poll", daemon=True)

--- a/reef/harness/native/release_client.py
+++ b/reef/harness/native/release_client.py
@@ -139,6 +139,12 @@ class HeadWatch:
         with self._lock:
             self._mounted = release_id
 
+    def forget(self, release_id: str) -> None:
+        """A head whose mount could not even fetch its manifest: the next poll that names it announces it again."""
+        with self._lock:
+            if self._announced == release_id:
+                self._announced = None
+
     def _consider(self, release_id: str | None, source: str) -> None:
         with self._lock:
             if not release_id:

--- a/reef/harness/native/serve.py
+++ b/reef/harness/native/serve.py
@@ -313,6 +313,7 @@ class Server:
         reef_url: str | None = None,
         turn_timeout_s: float = DEFAULT_TURN_TIMEOUT_S,
         token: str | None = None,
+        release_timeout_s: float = 30.0,
     ) -> None:
         if follow not in FOLLOW_MODES:
             raise ServeError(f"--follow must be one of {', '.join(FOLLOW_MODES)}, not {follow!r}")
@@ -338,7 +339,7 @@ class Server:
             token if token is not None else (os.environ.get("REEF_TOKEN") or self._installed_binding.api_key or None)
         )
         self.binding: ModelBinding = self._installed_binding
-        self.client = ReleaseClient(self.reef_url, self.token, scenario)
+        self.client = ReleaseClient(self.reef_url, self.token, scenario, timeout_s=release_timeout_s)
         self._served: list[dict[str, Any]] = []
         self._release_id: str | None = None
         self._parent_release_id: str | None = None
@@ -576,6 +577,10 @@ class Server:
                 "harness/mount-failed",
                 {"release_id": pending.release_id, "source": pending.source, "entry": None, "error": str(exc)},
             )
+            if isinstance(exc, ReleaseClientError) and exc.timed_out:
+                # Reef is busy (an evolve step holds the manifest as it holds the catalog), not gone: the next poll
+                # that names this head announces it again, so the mount is retried at the interval, not forgotten.
+                self._watch.forget(pending.release_id)
             return {"mounted": False, "release_id": pending.release_id, "error": str(exc)}
         parent = manifest.get("parent_release_id")
         failure = self._mount(

--- a/tests/reef_service/test_native_serve.py
+++ b/tests/reef_service/test_native_serve.py
@@ -92,6 +92,7 @@ class _FakeReef(ThreadingHTTPServer):
         self.proposals_route = True
         self.fail_releases = False
         self.delay_s = 0.0
+        self.hang_manifest_s = 0.0  # the next manifest read sleeps this long once, as behind a step's lock
         self.polls = 0
         threading.Thread(target=self.serve_forever, daemon=True).start()
 
@@ -141,6 +142,9 @@ class _Handler(BaseHTTPRequestHandler):
                 row["current"] = row["release_id"] == reef.head
             self._json(200, {"scenario": SCENARIO, "releases": rows})
         elif split.path == "/reef/harness":
+            if reef.hang_manifest_s:
+                hang, reef.hang_manifest_s = reef.hang_manifest_s, 0.0
+                time.sleep(hang)
             release_id = parse_qs(split.query).get("release_id", [reef.head])[0]
             row = reef.releases.get(release_id)
             if row is None:
@@ -465,6 +469,20 @@ def test_a_poll_that_times_out_retries_at_the_interval_and_a_reef_that_is_down_b
         watch.stop()
     assert [event["type"] for event in events] == ["release/poll-failed"] * 5
     assert [event["retry_in_s"] for event in events] == [0.01, 0.01, 0.01, 0.01, 0.02]
+
+
+def test_a_manifest_fetch_that_times_out_is_retried_by_the_next_poll(tmp_path: Path, reef: _FakeReef) -> None:
+    """The head moved, the poll saw it, and the manifest read then waited behind the next step's lock: the mount
+    fails on the timeout, and the next poll that names the head announces it again instead of leaving it."""
+    reef.release("r1", [_tool("one")])
+    with _running(_tree(tmp_path, reef, "r1"), poll_interval_s=0.1, release_timeout_s=0.2) as server:
+        log = server.sessions_dir / serve.SERVE_LOG
+        reef.hang_manifest_s = 0.6
+        reef.release("r2", [_tool("one"), _tool("two")], parent="r1")
+        _wait(lambda: server.status()["release_id"] == "r2", timeout_s=10.0)
+        failed = _typed(_events(log), "harness/mount-failed")
+        assert [f["release_id"] for f in failed] == ["r2"] and "timed out" in failed[0]["error"]
+        assert [m["release_id"] for m in _typed(_events(log), "harness/mount")] == ["r1", "r2"]
 
 
 def test_a_release_request_that_times_out_is_marked_busy_and_a_refused_one_is_not() -> None:

--- a/tests/reef_service/test_native_serve.py
+++ b/tests/reef_service/test_native_serve.py
@@ -11,6 +11,7 @@ import contextlib
 import json
 import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -26,6 +27,7 @@ import pytest
 from reef.harness import harness_wrapper
 from reef.harness.harness_wrapper import HARNESS_RELEASE_SIDECAR, CaptureProxy
 from reef.harness.native import serve
+from reef.harness.native.release_client import HeadWatch, ReleaseClient, ReleaseClientError
 from reef.harness.native.selftools import RESERVED_NAMES
 from reef.harness.native.serve import ServeError, Server, admit_mutations
 from reef.train.cordis_backend.strategies import Mutation
@@ -423,6 +425,65 @@ def test_a_poll_failure_is_logged_with_backoff_and_the_process_keeps_serving(tmp
         reef.fail_releases = False
         reef.release("r2", [_tool("one"), _tool("two")], parent="r1")
         _wait(lambda: server.status()["release_id"] == "r2")
+
+
+def test_a_poll_that_times_out_retries_at_the_interval_and_a_reef_that_is_down_backs_off() -> None:
+    """A catalog read that waits behind a running evolve step's lock times out: a busy Reef, polled again at
+    the interval so the head lands as soon as the step ends. Only a Reef that does not answer at all backs off."""
+
+    class _Client:
+        def __init__(self, outcomes: list[Any]) -> None:
+            self.outcomes = outcomes
+
+        def poll(self) -> str | None:
+            outcome = self.outcomes.pop(0) if self.outcomes else "r1"
+            if isinstance(outcome, Exception):
+                raise outcome
+            return str(outcome)
+
+    class _Sink:
+        def __init__(self) -> None:
+            self.heads: list[tuple[str, str]] = []
+
+        def new_head(self, release_id: str, source: str) -> None:
+            self.heads.append((release_id, source))
+
+    events: list[dict[str, Any]] = []
+
+    class _Log:
+        def write(self, type_: str, data: Any) -> None:
+            events.append({"type": type_, **data})
+
+    busy = ReleaseClientError("GET /reef/harness/releases failed: TimeoutError: timed out", timed_out=True)
+    down = ReleaseClientError("GET /reef/harness/releases failed: URLError: Connection refused")
+    sink = _Sink()
+    watch = HeadWatch(_Client([busy, busy, busy, down, down, "r2"]), sink, _Log(), 0.01, mounted="r1")  # type: ignore[arg-type]
+    watch.start()
+    try:
+        _wait(lambda: sink.heads == [("r2", "poll")])
+    finally:
+        watch.stop()
+    assert [event["type"] for event in events] == ["release/poll-failed"] * 5
+    assert [event["retry_in_s"] for event in events] == [0.01, 0.01, 0.01, 0.01, 0.02]
+
+
+def test_a_release_request_that_times_out_is_marked_busy_and_a_refused_one_is_not() -> None:
+    listener = socket.socket()
+    try:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        # A port that accepts the connection and never answers: the read times out, as behind a step's lock.
+        client = ReleaseClient(f"http://127.0.0.1:{listener.getsockname()[1]}", None, "s", timeout_s=0.05)
+        with pytest.raises(ReleaseClientError) as busy:
+            client.releases()
+        assert busy.value.timed_out is True and "timed out" in str(busy.value)
+        listener.close()
+        with pytest.raises(ReleaseClientError) as refused:
+            client.releases()
+        assert refused.value.timed_out is False and refused.value.status is None
+    finally:
+        with contextlib.suppress(OSError):
+            listener.close()
 
 
 def test_the_turn_timeout_ends_the_turn_before_the_next_step(tmp_path: Path, reef: _FakeReef) -> None:

--- a/tutorials/evolve-your-harness/run.py
+++ b/tutorials/evolve-your-harness/run.py
@@ -50,7 +50,9 @@ SCENARIO = "harness-evolve-demo"  # this workload's isolated lane
 TOKEN = "reef-local"  # matches serve.yaml
 MODEL = "qwen3-8b"  # matches serve.yaml's upstream_model
 PULL_TIMEOUT_S = 900.0
-MOUNT_TIMEOUT_S = 60.0  # run.sh polls the head every 5 s
+# run.sh polls the head every 5 s, but a poll that started during the evolve step waits behind the step's
+# lock until the client's 30 s timeout; the mount lands on the poll after that one.
+MOUNT_TIMEOUT_S = 120.0
 
 WORK = Path(__file__).resolve().parent / "work"
 # run.sh copies serve.yaml's evolution.tasks here; the recorded traffic and


### PR DESCRIPTION
## Motivation

The first live run of the serve form (#278) on this Mac published a release the resident process never mounted. The evolve step holds the scenario's commit lock for the whole step, and `GET /reef/harness/releases` waits on the same lock, so every poll the process sent during the step timed out after 30 s. The head watch treated each timeout like a Reef that is down and doubled its backoff: 40 s, 80 s, 160 s. By the time the step ended the next poll was minutes away, and the tutorial gave up after 60 s. A timeout is not an outage: Reef accepted the connection and is busy. Refs #281 for the lock itself.

## Changes

- `ReleaseClientError` gains `timed_out`, set when the request failed on a socket timeout, its own or the one urllib wraps as a `URLError` reason
- the head watch polls again at the interval after a timed out poll and keeps the doubling backoff, capped at ten minutes, for a Reef that does not answer at all; `release/poll-failed` logs the delay it will actually wait
- a manifest read that times out the same way (the poll saw the head, the next batched step already holds the lock) logs `harness/mount-failed` as before and the head watch forgets the announcement, so the next poll that names the head mounts it once the steps are over instead of never; `Server` takes `release_timeout_s` so a test can drive it
- the tutorial waits 120 s for the mount, which covers one poll that started during the step and the next one at the interval
- the user guide says what a busy Reef looks like to the process

## Compatibility and operational impact

No interface changes. A process running against a Reef that is down backs off as before. A process running against a Reef that is busy, which is every deployment whose evolve steps take longer than the client timeout, now picks up the head within one poll interval of the step's end instead of up to ten minutes later.

## Verification

The failing run: `serve.jsonl` of the tutorial's resident process logged three `release/poll-failed` events with `TimeoutError: timed out` and `retry_in_s` 40, 80, 160 while the step ran, and no `harness/mount` for the published release. A fourth run on the first fix, with thread stack dumps every 20 s: the poll timed out every 35 s with `retry_in_s` 5 and the poll thread sat in `getresponse` each time, then the poll after the publish saw the new head and the mount failed 28 s later on the manifest read (`harness/mount-failed` with the same timeout), with three batched steps running back to back and nothing retrying it. Three tests: a head watch fed three timeouts, two refusals and then a head logs retry delays of 0.01, 0.01, 0.01, 0.01, 0.02 for an interval of 0.01 and announces the head once; a request against a port that accepts and never answers is marked timed out, and one against a closed port is not; a fake Reef whose manifest read hangs past the client timeout once logs one `harness/mount-failed` and the process serves the new release on the next poll. The serve suite passes, mypy is clean and every pre-commit hook passes.

## AI assistance

Claude Code diagnosed the run from the process log and wrote the change and the tests; I set the rule that a timeout is a busy Reef, not a lost one.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
