### PR TITLE
fix(scenario): serve committed releases during long-running evolution

### DIFF
--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -241,6 +241,13 @@ file and reads the rendered files as before.
 Use ``?release_id=`` on the manifest or install route to request a specific
 catalog release. An unknown or unrestorable release returns HTTP 404.
 
+Catalog and manifest reads do not wait for an evolve step's proposer or
+evaluation episodes: they continue serving the existing releases while a
+candidate is being prepared. Reads still serialize with publication and
+rollback so a manifest's artifact and gate metrics come from the same
+release: reads do not interleave with head movement and its commit-log
+update.
+
 Proposals
 ~~~~~~~~~
 

--- a/reef/scenario/__init__.py
+++ b/reef/scenario/__init__.py
@@ -18,6 +18,10 @@ responsible for each piece:
   record consumption at the committed high-water mark.
 - **rollback** — ``commit_protocol`` republishes an older checkpointed
   version as a new fenced commit; history is never rewritten.
+- **read** — ``commit_protocol`` serializes catalog and artifact snapshots
+  with publication and rollback, but not with long-running step preparation.
+  Writers acquire the operation lock before the publication lock; readers
+  take only the publication lock and must not acquire the operation lock.
 
 The scenario aggregate does not retain recipe identity: the deployment's
 recipe configures its runtime binding through the factory, and the aggregate

--- a/reef/scenario/commit_protocol.py
+++ b/reef/scenario/commit_protocol.py
@@ -68,6 +68,11 @@ class ScenarioCommitProtocol:
         self._commit_log = commit_log
         self._creation_artifact = self._resolve_creation_artifact()
         self._lock = RLock()
+        # Preparation holds the operation lock across proposer calls and
+        # evaluation episodes, neither of which changes committed releases.
+        # Readers share only the publication lock with commit and rollback.
+        # Writers must acquire the operation lock first; readers never take it.
+        self._publication_lock = RLock()
         records = (
             (() if recovered_head_record is None else (recovered_head_record,))
             if commit_log is None
@@ -124,7 +129,7 @@ class ScenarioCommitProtocol:
 
     def releases(self) -> tuple[dict[str, Any], ...]:
         """List committed releases newest first."""
-        with self._lock:
+        with self._publication_lock:
             records = () if self._commit_log is None else self._commit_log.records()
             rows = [
                 self._release_row(
@@ -167,7 +172,7 @@ class ScenarioCommitProtocol:
         if not isinstance(release_id, str) or not release_id.strip():
             raise ValueError("release_id must be a non-empty string")
         release_id = release_id.strip()
-        with self._lock:
+        with self._lock, self._publication_lock:
             current_ref = self._artifacts.current
             if current_ref.release_id == release_id:
                 return current_ref
@@ -236,7 +241,7 @@ class ScenarioCommitProtocol:
 
     def commit(self, result: TrainStepResult) -> Any:
         """Commit a pending training result as one atomic version record."""
-        with self._lock:
+        with self._lock, self._publication_lock:
             next_step = self._step + 1
             prepared = self._trainer.prepare_commit(result)
             recorded = self._recorded_training_retry(prepared, result, next_step)
@@ -554,7 +559,7 @@ class ScenarioCommitProtocol:
         if not isinstance(release_id, str) or not release_id.strip():
             raise ValueError("release_id must be a non-empty string")
         release_id = release_id.strip()
-        with self._lock:
+        with self._publication_lock:
             found = self._find_release_id(release_id)
         if found is None:
             raise ArtifactNotFound(f"scenario {self._name!r} has no release {release_id!r}")
@@ -567,6 +572,20 @@ class ScenarioCommitProtocol:
             return self._artifacts.resolve(ref)
         except ArtifactError as exc:
             raise ArtifactNotFound(f"scenario {self._name!r} cannot restore release {release_id!r}: {exc}") from exc
+
+    def artifact_snapshot(
+        self,
+        release_id: str | None = None,
+    ) -> tuple[Artifact, Mapping[str, Any] | None]:
+        """Capture one artifact and its metrics without waiting for preparation."""
+        with self._publication_lock:
+            artifact = (
+                Artifact(self._artifacts.current, self._artifacts.repository)
+                if release_id is None
+                else self.artifact_for_version(release_id)
+            )
+            metrics = self.metrics_for_version(artifact.ref.release_id)
+            return artifact, metrics
 
     @staticmethod
     def _release_row(

--- a/reef/scenario/scenario.py
+++ b/reef/scenario/scenario.py
@@ -189,15 +189,8 @@ class Scenario:
         self,
         release_id: str | None = None,
     ) -> tuple[Artifact, Mapping[str, Any] | None]:
-        """Freeze one artifact and its gate metrics outside an in-flight commit."""
-        with self._commit_protocol.lock:
-            artifact = (
-                Artifact(self.repository.require_current_artifact(), self.repository)
-                if release_id is None
-                else self._commit_protocol.artifact_for_version(release_id)
-            )
-            metrics = self._commit_protocol.metrics_for_version(artifact.ref.release_id)
-            return artifact, metrics
+        """Freeze one artifact and its gate metrics without waiting for preparation."""
+        return self._commit_protocol.artifact_snapshot(release_id)
 
     def current_artifact_ref(self) -> ArtifactRef:
         return self._artifact_chain.current

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
+from threading import Event
 from urllib.parse import quote
 
 import pytest
@@ -43,6 +44,7 @@ from reef.service.install_script import (
 )
 from reef.train.cordis_backend import CordisRecipe, Mutation
 from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
+from reef.train.evaluation.contracts import EvaluationResult, UpdateCandidate
 
 # The fake harness scores itself, as in test_harness_recipe.py: its
 # trajectory carries the rules text, so the evaluator can rank a composition
@@ -448,6 +450,81 @@ def test_versions_catalog_carries_the_publishing_steps_gate_metrics(tmp_path) ->
             puller = _ReleaseClient(str(client.server.make_url("")))
             assert await asyncio.to_thread(puller.harness_releases, "delivery") == rows
         finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
+def test_release_reads_stay_responsive_during_evaluation(tmp_path, monkeypatch) -> None:
+    evaluation_started = Event()
+    finish_evaluation = Event()
+
+    async def run() -> None:
+        dispatcher = _dispatcher(tmp_path, MUTATIONS)
+        scenario = dispatcher.get_or_create_scenario("delivery")
+        assert scenario is not None
+        backend = scenario.trainer.training_backend
+        assert backend is not None
+        evaluate_candidate = backend.evaluate
+
+        def blocked_evaluate(candidate: UpdateCandidate) -> EvaluationResult:
+            result = evaluate_candidate(candidate)
+            evaluation_started.set()
+            assert finish_evaluation.wait(_ASYNC_UPDATE_TIMEOUT_S), "evaluation was not released"
+            return result
+
+        client = TestClient(TestServer(create_app(dispatcher, inference_backend=_EchoBackend())))
+        await client.start_server()
+        second_step = None
+        try:
+            first = await _gate_step(client)
+            monkeypatch.setattr(backend, "evaluate", blocked_evaluate)
+            second_step = asyncio.create_task(_gate_step(client))
+            assert await asyncio.to_thread(evaluation_started.wait, _ASYNC_UPDATE_TIMEOUT_S)
+
+            async def read_release(path: str, release_id: str | None = None) -> dict:
+                response = await client.get(
+                    path,
+                    params={} if release_id is None else {"release_id": release_id},
+                    headers={"x-reef-scenario": "delivery"},
+                )
+                assert response.status == 200
+                return await response.json()
+
+            # A resident client must keep seeing the committed tree and its
+            # matching gate metrics while the next candidate is being evaluated.
+            catalog, current, pinned = await asyncio.wait_for(
+                asyncio.gather(
+                    read_release("/reef/harness/releases"),
+                    read_release("/reef/harness"),
+                    read_release("/reef/harness", first["release_id"]),
+                ),
+                timeout=1.0,
+            )
+            assert current == pinned == first
+            head = catalog["releases"][-1]
+            assert head["current"] is True
+            assert head["release_id"] == first["release_id"]
+            assert head["content_id"] == first["content_id"]
+            assert head["metrics"] == first["gate"]
+
+            finish_evaluation.set()
+            second = await asyncio.wait_for(second_step, _ASYNC_UPDATE_TIMEOUT_S)
+            updated = await read_release("/reef/harness/releases")
+            assert len(updated["releases"]) == len(catalog["releases"]) + 1
+            assert updated["releases"][-2]["current"] is False
+            head = updated["releases"][-1]
+            assert head["current"] is True
+            assert head["release_id"] == second["release_id"] != first["release_id"]
+            assert head["content_id"] == second["content_id"]
+            assert head["metrics"] == second["gate"]
+            assert second["files"] == render_composition(NODES_V2, get_adapter("pi"))
+            assert await read_release("/reef/harness", first["release_id"]) == first
+        finally:
+            finish_evaluation.set()
+            if second_step is not None:
+                await asyncio.gather(second_step, return_exceptions=True)
             await client.close()
 
     asyncio.run(run())

--- a/tests/reef_service/test_scenario_release_concurrency.py
+++ b/tests/reef_service/test_scenario_release_concurrency.py
@@ -1,0 +1,280 @@
+"""Release readers stay live during evolution without observing partial publication."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Event
+
+import pytest
+
+from reef.artifact import Artifact, InMemoryRepositoryBackend
+from reef.core import AgentRecord, RequestType
+from reef.core.errors import ReefError
+from reef.dispatcher import Dispatcher
+from reef.recipe import Recipe
+from reef.scenario import Scenario
+from reef.train import PreparedStep, Trainer, TrainingBackend, TrainStepResult
+from reef.train.evaluation import EvaluationResult, UpdateCandidate
+
+from ._threshold_processor import ThresholdProcessor
+
+
+class _LocalBackend(TrainingBackend):
+    """An ordinary local candidate cycle with controllable preparation/evaluation."""
+
+    def __init__(self, artifact_dir: Path) -> None:
+        self.artifact_dir = artifact_dir
+        self.block_phase: str | None = None
+        self.started = Event()
+        self.resume = Event()
+        self.result: TrainStepResult | None = None
+
+    def initial_state(self):
+        return {"steps": 0}
+
+    def prepare_step(self, batch, state, scenario_step):
+        step = scenario_step + 1
+        artifact_path = self.artifact_dir / str(step)
+        artifact_path.mkdir(parents=True)
+        (artifact_path / "model.txt").write_text(f"step {step}", encoding="utf-8")
+        self.result = TrainStepResult(
+            {"steps": step},
+            metrics={"score": float(step)},
+            artifact=Artifact.local(artifact_path),
+        )
+        self._wait_if_blocked("prepare")
+        return PreparedStep.with_candidate(UpdateCandidate(batch.batch_id), state={"steps": step})
+
+    def evaluate(self, candidate):
+        self._wait_if_blocked("evaluate")
+        return EvaluationResult("test", "1", {})
+
+    def settle_step(self, prepared, decision):
+        assert self.result is not None
+        return self.result
+
+    def abort_step(self, prepared):
+        pass
+
+    def _wait_if_blocked(self, phase: str) -> None:
+        if self.block_phase == phase:
+            self.started.set()
+            assert self.resume.wait(10), f"test did not release {phase}"
+
+
+@dataclass(frozen=True)
+class _LocalRecipe(Recipe):
+    backend: TrainingBackend
+
+    def build(self, scenario, records, *, algorithm_state=None, experiment_logger=None):
+        return Trainer.build(
+            scenario,
+            records,
+            processor_factory=lambda context: ThresholdProcessor(context.with_config({"batch_size": 1})),
+            training_backend=self.backend,
+            algorithm_state=algorithm_state,
+            experiment_logger=experiment_logger,
+        )
+
+
+@pytest.fixture
+def local_scenario(tmp_path):
+    initial = tmp_path / "initial"
+    initial.mkdir()
+    (initial / "model.txt").write_text("initial", encoding="utf-8")
+    backend = _LocalBackend(tmp_path / "candidates")
+    dispatcher = Dispatcher(
+        _LocalRecipe(backend=backend),
+        InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repository"),
+        local_artifact_dir=tmp_path / "staged",
+        agent_record_dir=tmp_path / "records",
+    )
+    scenario = dispatcher.get_or_create_scenario("math")
+    assert scenario is not None
+    try:
+        yield scenario, backend
+    finally:
+        backend.resume.set()
+        dispatcher.close()
+
+
+def _queue_batch(scenario: Scenario, step: int) -> None:
+    # Append directly so the test, rather than the dispatcher's worker, owns
+    # exactly when the real local training cycle starts and commits.
+    scenario.records.append(
+        AgentRecord.create(
+            scenario="math",
+            request_type=RequestType.INFERENCE,
+            payload={"tokens": [1, 2], "loss_mask": [0, 1], "rollout_log_probs": [-0.2]},
+            agent_record_id=f"i{step}",
+        )
+    )
+    scenario.records.append(
+        AgentRecord.create(
+            scenario="math",
+            request_type=RequestType.REPORT,
+            payload={"score": 1.0, "references": [f"i{step}"]},
+            agent_record_id=f"r{step}",
+            references=(f"i{step}",),
+        )
+    )
+
+
+def _prepare(scenario: Scenario) -> TrainStepResult:
+    _queue_batch(scenario, scenario.scenario_step + 1)
+    result = scenario.prepare_training_step()
+    assert result is not None
+    return result
+
+
+def _model_text(artifact: Artifact) -> str:
+    local_path = artifact.materialize().local_path
+    assert local_path is not None
+    return local_path.joinpath("model.txt").read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("phase", ["prepare", "evaluate"])
+@pytest.mark.parametrize("operation", ["commit", "rollback"])
+def test_release_reads_remain_live_during_local_training(local_scenario, phase, operation) -> None:
+    scenario, backend = local_scenario
+    initial_ref = scenario.current_artifact_ref()
+    scenario.commit(_prepare(scenario))
+    current_ref = scenario.current_artifact_ref()
+    expected_releases = scenario.releases()
+    backend.block_phase = phase
+    _queue_batch(scenario, 2)
+    writer_started = Event()
+
+    def write():
+        writer_started.set()
+        if operation == "commit":
+            assert backend.result is not None
+            return scenario.commit(backend.result)
+        return scenario.rollback(initial_ref.release_id)
+
+    with ThreadPoolExecutor(max_workers=7) as executor:
+        training = executor.submit(scenario.prepare_training_step)
+        try:
+            assert backend.started.wait(2), "local backend did not start"
+            writer = executor.submit(write)
+            assert writer_started.wait(2), "writer did not start"
+            # A queued writer must wait on the operation lock without first
+            # taking the publication lock and starving the read-side callers.
+            catalog = executor.submit(scenario.releases)
+            latest = executor.submit(scenario.artifact_snapshot)
+            historical = executor.submit(scenario.artifact_snapshot, initial_ref.release_id)
+            version = executor.submit(scenario.artifact_for_version, current_ref.release_id)
+            old_version = executor.submit(scenario.artifact_for_version, initial_ref.release_id)
+
+            assert catalog.result(timeout=2) == expected_releases
+            artifact, metrics = latest.result(timeout=2)
+            assert artifact.ref == current_ref
+            assert _model_text(artifact) == "step 1"
+            assert metrics == {"score": 1.0}
+            artifact, metrics = historical.result(timeout=2)
+            assert artifact.ref == initial_ref
+            assert _model_text(artifact) == "initial"
+            assert metrics is None
+            assert version.result(timeout=2).ref == current_ref
+            assert old_version.result(timeout=2).ref == initial_ref
+            with pytest.raises(TimeoutError):
+                writer.result(timeout=0.1)
+            assert not training.done()
+        finally:
+            backend.resume.set()
+
+        result = training.result(timeout=2)
+        assert result is backend.result
+        if operation == "commit":
+            assert writer.result(timeout=2) == {"steps": 2}
+            assert scenario.scenario_step == 2
+            assert scenario.artifact_snapshot()[1] == {"score": 2.0}
+        else:
+            with pytest.raises(ReefError, match="pending commit"):
+                writer.result(timeout=2)
+            assert scenario.current_artifact_ref() == current_ref
+            assert scenario.scenario_step == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("operation", ["commit", "rollback"])
+@pytest.mark.parametrize("phase", ["journal", "settlement"])
+def test_release_reads_wait_for_complete_publication(local_scenario, monkeypatch, operation, phase) -> None:
+    scenario, _ = local_scenario
+    initial_ref = scenario.current_artifact_ref()
+    scenario.commit(_prepare(scenario))
+    scenario.commit(_prepare(scenario))
+    previous_ref = scenario.current_artifact_ref()
+    result = _prepare(scenario) if operation == "commit" else None
+    publication_started = Event()
+    resume_publication = Event()
+
+    assert scenario.commit_log is not None
+    target = scenario.commit_log if phase == "journal" else scenario.trainer
+    method = "append" if phase == "journal" else "commit_applied"
+    original = target.append if phase == "journal" else target.commit_applied
+
+    def block_publication(value):
+        publication_started.set()
+        assert resume_publication.wait(10), "test did not release publication"
+        return original(value)
+
+    monkeypatch.setattr(target, method, block_publication)
+    readers_started = [Event() for _ in range(4)]
+
+    def read_catalog():
+        readers_started[0].set()
+        return scenario.releases()
+
+    def read_latest():
+        readers_started[1].set()
+        return scenario.artifact_snapshot()
+
+    def read_historical():
+        readers_started[2].set()
+        return scenario.artifact_snapshot(previous_ref.release_id)
+
+    def read_version():
+        readers_started[3].set()
+        return scenario.artifact_for_version(previous_ref.release_id)
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        writer = (
+            executor.submit(scenario.commit, result)
+            if operation == "commit"
+            else executor.submit(scenario.rollback, initial_ref.release_id)
+        )
+        try:
+            assert publication_started.wait(2), "publication did not start"
+            # The repository has moved, but the journal or scenario state has
+            # not caught up. This is the precise window readers must exclude.
+            assert scenario.current_artifact_ref() != previous_ref
+            assert scenario.scenario_step == 2
+            readers = [executor.submit(read) for read in (read_catalog, read_latest, read_historical, read_version)]
+            for started in readers_started:
+                assert started.wait(2), "reader did not start"
+            for reader in readers:
+                with pytest.raises(TimeoutError):
+                    reader.result(timeout=0.1)
+        finally:
+            resume_publication.set()
+
+        writer.result(timeout=2)
+        catalog, latest, historical, version = [reader.result(timeout=2) for reader in readers]
+
+    current_ref = scenario.current_artifact_ref()
+    assert scenario.scenario_step == 3
+    assert catalog[0]["release_id"] == current_ref.release_id
+    assert catalog[0]["current"] is True
+    assert catalog[0]["operation"] == ("training" if operation == "commit" else "rollback")
+    assert sum(row["current"] for row in catalog) == 1
+    artifact, metrics = latest
+    assert artifact.ref == current_ref
+    assert _model_text(artifact) == ("step 3" if operation == "commit" else "initial")
+    assert metrics == ({"score": 3.0} if operation == "commit" else None)
+    assert historical[0].ref == previous_ref
+    assert historical[1] == {"score": 2.0}
+    assert version.ref == previous_ref


### PR DESCRIPTION
## Motivation

Closes #281. A local evolve step holds the scenario operation lock across proposer calls and evaluation episodes. Release catalog and manifest reads currently take that same lock, so a resident agent cannot read already-committed releases until the candidate finishes. This addresses the server-side cause and complements the client retry change in #282.

## Changes

- Keep the existing operation lock around preparation, commit, and rollback.
- Add a separate publication lock for catalog reads, version lookup, and artifact/metrics snapshots. Commit and rollback acquire it **after** the operation lock and retain it through settlement; a writer waiting for preparation cannot monopolize the read lock.
- Move artifact snapshot ownership into the commit protocol, preserving the existing `Scenario.artifact_snapshot` interface and its consistent artifact/metrics pair.
- Document the read boundary and lock order.

## Compatibility and operational impact

No configuration, wire format, persisted format, dependency, or existing public API changes. Reads no longer wait for proposal/evaluation work; they still serialize with publication and rollback, including artifact I/O and settlement. Writer exclusion, head fencing, and recovery ordering are unchanged. This does not change registry-level serialization with a queued dispatcher rollback.

## Verification

- Reproduced the original failure before changing production code: the new direct catalog regression timed out at its two-second deadline; the HTTP regression timed out at one second while a real Cordis evaluation was held on an event.
- Nine new regression cases cover preparation and evaluation, queued commit/rollback, head and historical reads, journal/settlement windows for both commit and rollback, and real HTTP catalog/current/pinned manifests before and after publication. **All nine passed after rebasing onto `3141929`.**
- The eight lifecycle cases passed five consecutive runs (40 passes).
- Broad CPU service suite after the rebase: **1,607 passed, 13 skipped, 3 deselected** (one existing multiprocessing/fork warning). Two collection modules require absent Ray/Slime dependencies; the three deselected integration cases require absent Git LFS. Command, with the development environment first on `PATH`:

  ```sh
  GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null python -m pytest tests/reef_service \
    --ignore=tests/reef_service/test_sao_bridge.py \
    --ignore=tests/reef_service/test_slime_bridge.py \
    -k 'not test_fresh_scenario_forks_latest_artifact_with_real_lfs' -q --tb=short --durations=10
  ```
- Repository-wide `pre-commit run --all-files` and `python -m mypy`: passed after rebasing onto `3141929` (205 source files checked).
- Documentation link/contract checks and production site build: passed; site lint has zero errors and one pre-existing font warning.

Local validation uses macOS/Python 3.12; the full repository suite was not run locally. Harness subprocess tests need the development environment first on `PATH`; otherwise Apple's Python creates extra bytecode-cache residue. Those residue failures and the missing Git LFS failures were reproduced on a separate, untouched upstream worktree. The pull request's normal Linux CI covers the complete supported test matrix.

## AI assistance

I directed this contribution, using Codex to help investigate the issue, implement the fix, and develop regression coverage. Codex ran the checks listed above and assisted with code review. This draft is pending my final review.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes.
- [x] Existing public interfaces and wire contracts are unchanged.
- [x] Affected documentation is updated.
- [x] Root README content is unaffected.
- [x] This internal concurrency fix does not require an RFC.
- [x] Relevant pre-commit and focused test checks pass; environment limitations are reported above.
- [x] Non-trivial AI assistance is disclosed above.

## Review and merge

Draft for contributor review. Maintainer review and merge follow the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md).

