### PR TITLE
fix(tttd): preserve training image PYTHONPATH

### DIFF
--- a/recipes/tttd/examples/tttd/run.sh
+++ b/recipes/tttd/examples/tttd/run.sh
@@ -36,7 +36,7 @@ fi
 
 # Start the Reef training stack. The Harbor controller waits for the final
 # durable training commit before this script exits and stops the stack.
-PYTHONPATH=../../../.. python3 -m reef serve -c "$PWD/serve.yaml" > "$TTTD_STATE_DIR/reef.log" 2>&1 &
+PYTHONPATH="$(cd ../../../.. && pwd)${PYTHONPATH:+:$PYTHONPATH}" python3 -m reef serve -c "$PWD/serve.yaml" > "$TTTD_STATE_DIR/reef.log" 2>&1 &
 reef_pid=$!
 cleanup() {
     kill "$reef_pid" 2>/dev/null || true


### PR DESCRIPTION
## Motivation

The TTTD launcher overwrites the training image's `PYTHONPATH`, dropping Megatron and vendored SGLang imports. Its relative repository path also stops resolving recipes when child processes change working directory.

Closes #290.

## Changes

Prepend the absolute repository path to `PYTHONPATH` for `reef serve`, preserving existing entries and avoiding an extra separator when the variable is empty or unset.

## Compatibility and operational impact

Training processes retain the image-provided import paths, and the repository remains importable from the stack run directory. No public API, dependency, or configuration changes.

## Verification

- `bash -n recipes/tttd/examples/tttd/run.sh` — passed.
- `git diff --check` — passed.
- A temporary Python-driven smoke check executed the launcher with stubbed services for unset, empty, and populated `PYTHONPATH` values. All three passed, including changing the service working directory and using a repository path containing spaces.
- Full GPU training and the pre-commit suite were not run.

## AI assistance

Codex implemented the one-line fix, ran the checks described above, and prepared this PR.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [ ] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
