### PR TITLE
fix(deploy): clear stale bridge readiness before stack startup

### DIFF
--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -300,6 +300,9 @@ class _Stack:
         _log(f"{name}: ready")
 
     def start(self) -> None:
+        # A crashed run can leave this behind. Clear it before any service
+        # starts so readiness can only come from the current bridge driver.
+        (self.run_dir / "bridge.ready").unlink(missing_ok=True)
         for svc in self.services:
             self._start_service(svc)
         _log(f"stack up. logs: {self.run_dir}/*.log")

--- a/tests/reef_service/test_bridge_readiness.py
+++ b/tests/reef_service/test_bridge_readiness.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from reef.service.deploy.config import validate_services
+from reef.service.deploy.orchestrator import _Stack
+
+
+@pytest.mark.parametrize("stale_marker", [False, True], ids=["fresh-start", "restart"])
+def test_stack_waits_for_current_bridge_marker_before_starting_dependents(tmp_path, monkeypatch, stale_marker):
+    marker = tmp_path / "bridge.ready"
+    if stale_marker:
+        marker.write_text("previous driver")
+    release_driver = tmp_path / "release-driver"
+    dependent_started = tmp_path / "dependent-started"
+    config = {
+        "services": [
+            {
+                "name": "slime-driver",
+                "command": [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import os, time\n"
+                        "from pathlib import Path\n"
+                        f"while not Path({str(release_driver)!r}).exists(): time.sleep(0.01)\n"
+                        "Path(os.environ['REEF_BRIDGE_READY_FILE']).write_text('current driver')\n"
+                        "time.sleep(120)\n"
+                    ),
+                ],
+                "ready": 'test -f "$REEF_BRIDGE_READY_FILE"',
+            },
+            {
+                "name": "reef",
+                "depends_on": ["slime-driver"],
+                "command": [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import time\n"
+                        "from pathlib import Path\n"
+                        f"assert Path({str(marker)!r}).read_text() == 'current driver'\n"
+                        f"Path({str(dependent_started)!r}).touch()\n"
+                        "time.sleep(120)\n"
+                    ),
+                ],
+                "ready": 'test -f "$STARTED_FILE"',
+                "env": {"STARTED_FILE": str(dependent_started)},
+            },
+        ],
+    }
+    spawn = subprocess.Popen
+    probe = subprocess.run
+    readiness = []
+
+    def checked_spawn(command, **options):
+        if command == config["services"][0]["command"]:
+            assert not marker.exists(), "stale marker must be removed before the driver starts"
+        return spawn(command, **options)
+
+    def checked_probe(command, **options):
+        result = probe(command, **options)
+        if command == config["services"][0]["ready"]:
+            readiness.append(result.returncode == 0)
+            if result.returncode != 0:
+                assert not dependent_started.exists()
+                release_driver.touch()
+        return result
+
+    monkeypatch.setattr(subprocess, "Popen", checked_spawn)
+    monkeypatch.setattr(subprocess, "run", checked_probe)
+    stack = _Stack(config, validate_services(config, "test.yaml"), tmp_path, 10, tmp_path / "input.yaml")
+    try:
+        stack.start()
+        assert readiness[0] is False
+        assert readiness[-1] is True
+        assert marker.read_text() == "current driver"
+        assert dependent_started.exists()
+        assert stack._is_alive("slime-driver") and stack._is_alive("reef")
+    finally:
+        stack.shutdown(grace=1)


### PR DESCRIPTION
## Motivation

Restarting `reef serve` after a crash with the same run directory can reuse a stale `bridge.ready`. The driver readiness probe then succeeds before the new bridge actor exists, causing the dependent Reef service to fail its actor lookup.

Closes #289.

## Changes

- Remove the stack-owned `bridge.ready` before launching any services; a missing marker is harmless.
- Add fresh-start and restart regression cases using real child processes and readiness probes. Verify cleanup precedes driver spawn, the first probe fails until the current driver writes its marker, and the dependent service starts only after that marker exists.

## Compatibility and operational impact

No public API, configuration, dependency, or wire-contract changes. Restarting with an existing run directory now waits for the current bridge driver. This fix targets `main` and can merge independently of the executor refactor in #279.

## Verification

- `python -m pytest tests/reef_service/test_bridge_readiness.py -k restart -q --tb=short` before the fix: failed at the stale-marker assertion, reproducing the issue.
- `python -m pytest tests/reef_service/test_bridge_readiness.py tests/reef_service/test_training_server.py tests/reef_service/test_orchestrator_overrides.py tests/reef_service/test_deploy_config_validation.py -q --durations=5`: 75 passed.
- Ruff, Black 24.3.0, and isort 5.13.2 checks passed for both changed files.
- `python .github/scripts/check_python_design.py`, `python .github/scripts/check_python_statements.py`, and `git diff --check`: passed.
- Tests ran on macOS with Python 3.12.9; no live GPU/Ray training stack was needed for the process/readiness regression.

## AI assistance

OpenAI Codex investigated the issue, implemented the fix and regression tests, ran validation, and prepared this PR.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
