### PR TITLE
test(harness): restore the four example tests dropped by #284

### DIFF
--- a/tests/reef_service/test_harness_example.py
+++ b/tests/reef_service/test_harness_example.py
@@ -344,3 +344,116 @@ def test_native_propose_routes_the_main_graph_through_a_proposed_agent(native_ev
     assert isinstance(
         native_evolution.propose((*NATIVE_NODES, ("native_graph", taken)), SAMPLES, canned(reply)), Mutation
     )
+
+
+def test_native_evaluate_reads_the_last_assistant_message_with_content(native_evolution) -> None:
+    task = "[sieve] count the primes below 100000"
+    call = {
+        "type": "assistant/message",
+        "seq": 2,
+        "time": 0,
+        "data": {"content": "", "tool_calls": [{}], "finish": "x"},
+    }
+    assert native_evolution.evaluate(task, episode((call, native_message("Sieving...\n\n9592")))) == 1.0
+    # A tool-call message carries no text; the last text answer is the one graded.
+    assert native_evolution.evaluate(task, episode((native_message("9592"), call))) == 1.0
+    assert native_evolution.evaluate(task, episode((native_message("The count is 9592"),))) == 0.0
+    assert native_evolution.evaluate(task, episode(())) == 0.0
+
+
+def test_native_example_yaml_boots_the_recipe_with_the_shipped_seed(native_evolution, tmp_path, monkeypatch) -> None:
+    """The run.sh native contract, hermetic: the native serve file materializes
+    like serve.yaml and boots with the loop's own tools and hook seeded by reference."""
+    monkeypatch.setenv("REEF_UPSTREAM_API_KEY", "dummy")
+    config = load_config(EXAMPLE_DIR / "configs" / "serve-native.yaml")
+    recipe_sections = {key: config[key] for key in ("implementation", "model", "evolution", "data")}
+    materialized = tmp_path / "harness_evolve.yaml"
+    materialized.write_text(yaml.safe_dump(recipe_sections))
+    from reef.service.assembly import _upstream_runtime
+
+    service = service_settings_from_config(config)
+    built = CordisRecipe.from_environment(
+        {}, config=load_recipe_config(materialized), runtime=_upstream_runtime(service)
+    )
+    assert built.adapter == "native" and built.binary is None
+    # The same three tasks as the pi variant, so the two runs are comparable.
+    assert built.tasks == tuple(load_config(EXAMPLE_DIR / "configs" / "serve.yaml")["evolution"]["tasks"])
+    assert [entry["id"] for entry in built.seed] == [
+        "read_file",
+        "write_file",
+        "run_bash",
+        "execute",
+        "loop_guard",
+        "main",
+        "answer-style",
+    ]
+    assert "upstream" not in yaml.safe_dump(list(built.seed))
+    assert isinstance(built.build("demo", RecordStore()), Trainer)  # loads the seed; no episodes
+
+
+def test_deployment_yaml_names_directories_that_exist_and_boots_its_named_recipe(monkeypatch) -> None:
+    """The README deployment: ``reef.recipe: deployment`` is read back from the
+    directory the service's own env names, and the harness package is on the
+    PYTHONPATH the same env sets; a stale directory name here fails at boot, so
+    the file's own paths are checked against the checkout."""
+    import os
+
+    from reef.recipe.registry import build_named_recipe
+    from reef.service.assembly import _upstream_runtime
+
+    repo_root = EXAMPLE_DIR.parents[1]
+    monkeypatch.setenv("REEF_UPSTREAM_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("REEF_UPSTREAM_API_KEY", "dummy")
+    monkeypatch.setenv("REEF_PYTHON", sys.executable)
+    monkeypatch.setenv("PWD", str(repo_root))
+    path = EXAMPLE_DIR / "configs" / "deployment.yaml"
+    config = load_config(path)
+    env = next(service for service in config["services"] if service["name"] == "reef")["env"]
+    recipe_dir = repo_root / env["REEF_RECIPE_CONFIG_DIR"]
+    assert (recipe_dir / "deployment.yaml").resolve() == path.resolve()
+    method_root = Path(env["PYTHONPATH"].split(":")[0])
+    assert (method_root / "harness" / "evolution.py").is_file()
+    monkeypatch.syspath_prepend(str(method_root))  # what the service env PYTHONPATH gives the recipe
+    for key in ("agent_record_dir", "artifact_repository", "artifact_work_dir", "artifact_cache_dir"):
+        assert config["reef"][key].startswith("tutorials/evolve-your-harness/")
+    assert config["run_dir"].startswith("tutorials/evolve-your-harness/")
+    service = service_settings_from_config(config)
+    built = build_named_recipe(
+        "deployment",
+        {**os.environ, "REEF_RECIPE_CONFIG_DIR": str(recipe_dir)},
+        default_runtime=_upstream_runtime(service),
+    )
+    assert isinstance(built, CordisRecipe) and built.adapter == "pi"
+
+
+def test_native_example_recipe_renders_its_seed_as_the_base_files(native_evolution, tmp_path, monkeypatch) -> None:
+    """The seed a deployment ships is what a fresh scenario serves, rendered once by the recipe."""
+    monkeypatch.setenv("REEF_UPSTREAM_API_KEY", "dummy")
+    config = load_config(EXAMPLE_DIR / "configs" / "serve-native.yaml")
+    recipe_sections = {key: config[key] for key in ("implementation", "model", "evolution", "data")}
+    materialized = tmp_path / "harness_evolve.yaml"
+    materialized.write_text(yaml.safe_dump(recipe_sections))
+    from reef.service.assembly import _upstream_runtime
+
+    service = service_settings_from_config(config)
+    built = CordisRecipe.from_environment(
+        {}, config=load_recipe_config(materialized), runtime=_upstream_runtime(service)
+    )
+    files = built.base_artifact_files()
+    assert files is not None
+    assert {"native/tools/read_file.py", "native/graphs/main.json", "native/skills/answer-style/SKILL.md"} <= set(
+        files
+    )
+    assert "upstream" not in files["native/models.json"]  # the seed carries no provider
+    info = built.build_surface("demo").harness
+    assert info is not None
+    assert [entry["id"] for entry in info.seed_entries][:3] == ["read_file", "write_file", "run_bash"]
+    assert info.served_model == "qwen3-8b"
+    assert (
+        CordisRecipe.from_environment(
+            {},
+            config={**load_recipe_config(materialized), "evolution": {**recipe_sections["evolution"], "seed": []}},
+            runtime=_upstream_runtime(service),
+        ).base_artifact_files()
+        is None
+    )


### PR DESCRIPTION
## Motivation

#284 rewrote the agent proposal test at the end of `tests/reef_service/test_harness_example.py` and, with it, dropped the four tests that followed it in the file: the native evaluate reader, the native example yaml boot, the native seed render, and the deployment.yaml check that boots the named recipe from the directories the README points at (the test #261 added so a moved tutorial cannot break the deployment again). Nothing in main exercises those paths since that merge.

## Changes

- the four tests are back, verbatim from the version before #284, at the end of the file

## Compatibility and operational impact

Tests only.

## Verification

The file collects 17 tests and all pass on main; every pre-commit hook passes.

## AI assistance

Claude Code made the mistake in #284 and this restore; I checked the four names against the file before #284.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
