### PR TITLE
[Bug] Fix duplicate entry when moving loader items

### DIFF
--- a/reef/train/cordis_backend/compose/loader.py
+++ b/reef/train/cordis_backend/compose/loader.py
@@ -208,7 +208,7 @@ class EntryGroup:
 
     def unlink(self, options: EntryOptions) -> None:
         for index, existing in enumerate(self.data):
-            if existing is options:
+            if existing.get("id") == options.get("id"):
                 self.data.pop(index)
                 return
 

--- a/tests/reef_service/test_compose_loader.py
+++ b/tests/reef_service/test_compose_loader.py
@@ -189,6 +189,7 @@ def test_move_entry_between_groups() -> None:
     loader.create({"id": "g", "group": True, "config": []})
     loader.create({"id": "a", "name": "alpha", "config": {"n": 1}})
     loader.update("a", {}, parent="g", move=True)
+    assert [options["id"] for options in loader.root.data] == ["g"]
     entry = loader.resolve("a")
     assert entry.parent is loader.resolve("g").subgroup
     assert entry.fiber.state is FiberState.ACTIVE


### PR DESCRIPTION
## Summary

Fixes #274.

When `Loader.update(..., move=True)` moves an entry between groups, the source group's `unlink()` compared option dictionaries by object identity. Since `Entry.update(..., create=True)` stores a copy of the options, the entry was not removed from the source group and could appear twice.

This change makes `EntryGroup.unlink()` match entries by their ID and adds a regression assertion covering the move behavior.

## Verification

- `pytest tests/reef_service/test_compose_loader.py::test_move_entry_between_groups -q` — passed
- `pytest tests/reef_service/test_compose_loader.py -q` — 18 passed
- `pre-commit run --all-files` — passed
- `git diff --check` — passed
- `pytest tests/` — could not complete because the environment is missing the optional `slime` dependency; collection stopped with unrelated `ModuleNotFoundError` errors.

## AI assistance

Used ChatGPT to help inspect issue #274, reason about the existing `EntryGroup.unlink()` and `Entry.update()` behavior, and review the proposed fix. I reproduced the bug, implemented the change, added the regression test, and manually verified the relevant test and pre-commit results.

[x] The change is focused and contains no unrelated cleanup.
[x] Tests cover behavior changes, or this pull request does not change behavior.
[x] Public interface changes include contract tests, or no public interface changes are present.
[x] Affected user and developer documentation is updated, or no documentation update is required.
[x] Root README changes update both languages and README:i18n.yml, or do not affect README content.
[x] An accepted RFC is linked, or this change does not require an RFC.
[x] Relevant pre-commit and test checks pass.
[x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge On call is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
