### PR TITLE
[Example] CORAL test-time training: gateway middleware, call journal, reporter, training recipe (issue #3)

### DIFF
--- a/recipes/coral/README.md
+++ b/recipes/coral/README.md
@@ -1,0 +1,64 @@
+# CORAL test-time training through Reef and Slime
+
+Runs a CORAL discovery task with fully attributable inference: every agent call flows
+through Reef, evaluator scores return as training data, weights update, and later
+attempts serve from the new revision. Implements
+[issue #3](https://github.com/Human-Agent-Society/reef/issues/3).
+
+Pinned upstream: [CORAL](https://github.com/Human-Agent-Society/CORAL) commit `a69cbc2`.
+
+## Quickstart (2 GPUs)
+
+```bash
+cd recipes/coral/examples/coral_demo
+pip install -e .[coral]     # demo deps + CORAL at the pinned commit
+./run.sh
+```
+
+`run.sh` boots the Reef training stack (`serve.yaml`: `CoralRecipe`, Qwen3-8B LoRA),
+then `run.py` builds CORAL's `GatewayManager` against the Reef endpoint, splices the
+correlation layer, and drives two demo agents whose graded attempts train the served
+model. The run's result bundle lands in `work/coral-demo/bundle.json`.
+
+The adapter tests need neither GPU nor CORAL: `python -m pytest tests/test_coral_*.py`.
+
+## How the pieces line up
+
+```
+CORAL agents (parallel worktrees, per-agent proxy keys)
+   v
+CORAL gateway (identity: x-coral-agent-id, x-coral-session-id)
+   v
+recipes.coral.middleware      stamps x-reef-scenario + x-reef-tag-coral-{run,agent,commit},
+   v                          captures reef receipts -> journal
+LiteLLM -> reef serve         stores INFERENCE records with tags,
+   v                          answers with x-reef-agent-record-id / receipt SSE frame
+CORAL grader finalizes the attempt
+   -> recipes.coral.reporter: POST /reef/report {score, references, metadata.coral}
+   -> CoralProcessor groups siblings of one parent commit -> Slime LoRA step
+   -> new revision served to the next attempts
+```
+
+One discovery problem is one reef scenario; agent and worktree identity live in tags,
+so parallel agents share the evolving policy without fragmenting the scenario.
+
+## Correlation model
+
+The `coral-agent`/`coral-commit` tags reef stores with each INFERENCE record are the
+primary correlation key and survive any proxy behavior. The journal additionally
+captures reef's response receipts, so reports reference exact record ids; a stripped
+receipt degrades to tag-only correlation and is never fatal. Reports carry a
+deterministic client-supplied id, so grader re-runs dedup server-side. Sibling attempts
+run from the same worktree state; resolve their references with the journal cursor
+(`size()` before the attempt's calls, `record_ids_since()` after).
+
+## Known limitations
+
+- `attach_reef_adapter` splices under CORAL's middleware object because CORAL builds it
+  inline at the pinned commit; CORAL's gateway `header_provider` hook (merged upstream)
+  will replace the splice once released.
+- LiteLLM builds a fresh upstream request, so the middleware mirrors the scenario and
+  tags into the body's `extra_headers`; receipt headers are matched by suffix because a
+  forwarding proxy prefixes them. Both behaviors came out of live GPU runs.
+- The demo grader is deterministic and local; replace it and the scripted agents with
+  CORAL's real task and runtimes for a full deployment — the wiring is unchanged.

--- a/recipes/coral/__init__.py
+++ b/recipes/coral/__init__.py
@@ -1,0 +1,27 @@
+"""CORAL test-time training through Reef: one method, one package.
+
+- ``middleware`` — the ASGI layer that stamps Reef scenario/tag headers onto
+  CORAL gateway traffic and captures Reef receipts.
+- ``journal`` — the append-only call journal correlation reads.
+- ``reporter`` — finalized CORAL attempts posted to ``/reef/report``.
+- ``processor``/``recipe`` — sibling groups as grouped relative-reward
+  training units, reusing the tttd preparer and loss family.
+- ``bundle`` — the run's result bundle, derived from journal + reports.
+- ``gateway_launcher`` — splices the middleware under CORAL's gateway.
+
+The runnable example lives in ``examples/coral_demo``.
+"""
+
+from recipes.coral.journal import CallJournal, CallRecord
+from recipes.coral.middleware import ReefGatewayMiddleware
+from recipes.coral.recipe import CoralRecipe
+from recipes.coral.reporter import AttemptReport, report_attempt
+
+__all__ = [
+    "AttemptReport",
+    "CallJournal",
+    "CallRecord",
+    "CoralRecipe",
+    "ReefGatewayMiddleware",
+    "report_attempt",
+]

--- a/recipes/coral/bundle.py
+++ b/recipes/coral/bundle.py
@@ -1,0 +1,108 @@
+"""The result bundle: what a finished CORAL x Reef run leaves behind.
+
+Issue #3's Done-when asks the bundle for score-over-time, the best artifact,
+model/skill versions, token/cost accounting, and enough metadata to replay
+the run. All of it derives from two artifacts this example already produces:
+the call journal (per-call: agent, commit, release id, token usage)
+and the sequence of finalized attempt reports (per-attempt: score, status,
+parent links). The builder is pure — inputs in, JSON-serializable dict out — so
+it runs after the fact on any journal+reports pair, including one recovered
+from a crashed run.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import Any
+
+from recipes.coral.journal import CallJournal
+from recipes.coral.reporter import AttemptReport
+
+
+def build_result_bundle(
+    journal: CallJournal,
+    reports: Iterable[AttemptReport],
+    *,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Assemble the run's result bundle.
+
+    ``reports`` is every finalized attempt report, in grading order (the
+    order ``score_over_time`` preserves). ``run_id`` filters the journal to
+    one run when several share a journal file; reports are trusted as
+    pre-filtered by the caller.
+    """
+    reports = list(reports)
+    records = journal.records()
+    if run_id is not None:
+        records = [r for r in records if r.tags.get("coral-run") == run_id]
+
+    # --- score over time and the best attempt -----------------------------
+    score_over_time = [
+        {
+            "agent_id": report.agent_id,
+            "commit_hash": report.commit_hash,
+            "parent_hash": report.parent_hash,
+            "score": report.score,
+            "status": report.status,
+        }
+        for report in reports
+    ]
+    scored = [r for r in reports if r.score is not None]
+    best = max(scored, key=lambda r: r.score) if scored else None
+
+    # --- correlated calls + serving revisions per attempt -----------------------
+    by_attempt: dict[tuple[str, str], list] = defaultdict(list)
+    for record in records:
+        by_attempt[(record.agent_id, record.commit_hash)].append(record)
+
+    attempts: list[dict[str, Any]] = []
+    for report in reports:
+        calls = by_attempt.get((report.agent_id, report.commit_hash), [])
+        attempts.append(
+            {
+                "agent_id": report.agent_id,
+                "commit_hash": report.commit_hash,
+                "score": report.score,
+                "status": report.status,
+                "inference_calls": len(calls),
+                "inference_record_ids": [c.agent_record_id for c in calls if c.agent_record_id],
+                "release_ids": sorted({c.release_id for c in calls if c.release_id}),
+                "prompt_tokens": sum(c.prompt_tokens or 0 for c in calls),
+                "completion_tokens": sum(c.completion_tokens or 0 for c in calls),
+            }
+        )
+
+    # --- run-level accounting ----------------------------------------------
+    total_prompt = sum(r.prompt_tokens or 0 for r in records)
+    total_completion = sum(r.completion_tokens or 0 for r in records)
+    revisions = sorted({r.release_id for r in records if r.release_id})
+
+    return {
+        "run_id": run_id,
+        "scenario": reports[0].scenario if reports else None,
+        "attempt_count": len(reports),
+        "score_over_time": score_over_time,
+        "best_attempt": (
+            None
+            if best is None
+            else {
+                "agent_id": best.agent_id,
+                "commit_hash": best.commit_hash,
+                "score": best.score,
+                "parent_hash": best.parent_hash,
+            }
+        ),
+        "model_revisions_served": revisions,
+        "token_accounting": {
+            "inference_calls": len(records),
+            "prompt_tokens": total_prompt,
+            "completion_tokens": total_completion,
+        },
+        "attempts": attempts,
+        "replay": {
+            "journal_path": str(journal.path),
+            "correlation": "x-reef-tag-coral-{run,agent,commit} on stored INFERENCE records",
+        },
+    }

--- a/recipes/coral/examples/coral_demo/pyproject.toml
+++ b/recipes/coral/examples/coral_demo/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "coral-demo"
+version = "0.0.1"
+description = "Reef adapter for CORAL multi-agent test-time training (reef issue #3)"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+# The runnable entry (run.py) drives a real CORAL gateway; the adapter
+# modules themselves have no CORAL dependency. Pinned to the commit the
+# example was developed and smoke-tested against.
+coral = [
+    "coral @ git+https://github.com/Human-Agent-Society/CORAL.git@a69cbc22f4c160f211573bc6a4fb5b9f46068a98",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["recipes.coral*"]

--- a/recipes/coral/examples/coral_demo/run.py
+++ b/recipes/coral/examples/coral_demo/run.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Run CORAL test-time training against a live Reef stack.
+
+This is the piece that imports CORAL. The adapter modules under
+``recipes/coral/`` stay import-free of it so they test standalone; this entry
+point wires the two systems for a real run:
+
+1. builds CORAL's ``GatewayManager`` (its embedded LiteLLM proxy) with a
+   model entry that routes to the Reef service ``run.sh`` started,
+2. splices the Reef correlation layer under CORAL's middleware
+   (``attach_reef_adapter``),
+3. runs a small demo loop — one or two agents making attempts from git
+   worktrees, graded by a deterministic local grader — reporting every
+   finalized attempt to Reef, which trains on sibling groups and serves the
+   updated weights to the next attempts,
+4. writes the run's result bundle to ``work/<run>/bundle.json``.
+
+The demo agent is scripted (its "intelligence" is a fixed prompt); every
+wire interaction — gateway key swap, header stamping, receipt capture,
+grading, reporting, training, serving update — is real. Replace
+``demo_attempt`` with CORAL's real agent runtimes for a full deployment;
+the wiring does not change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+import urllib.request
+from pathlib import Path
+
+from coral.gateway.server import GatewayManager  # CORAL: pinned commit, see README
+from recipes.coral.bundle import build_result_bundle
+from recipes.coral.gateway_launcher import attach_reef_adapter
+from recipes.coral.journal import CallJournal
+from recipes.coral.reporter import AttemptReport, report_attempt
+
+REEF_URL = "http://127.0.0.1:8900"
+GATEWAY_PORT = 8091
+SCENARIO = "coral-demo"
+
+
+def _probe(url: str) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=5):
+            return True
+    except Exception:
+        return False
+
+
+def wait_healthy(url: str, deadline_s: int = 600) -> None:
+    end = time.time() + deadline_s
+    while time.time() < end:
+        if _probe(url):
+            return
+        time.sleep(5)
+    raise RuntimeError(f"{url} not healthy within {deadline_s}s")
+
+
+def chat(api_key: str, prompt: str, max_tokens: int = 512) -> str:
+    body = json.dumps(
+        {
+            "model": "reef-policy",
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.8,
+        }
+    ).encode()
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{GATEWAY_PORT}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+    )
+    with urllib.request.urlopen(request, timeout=600) as response:
+        return json.loads(response.read())["choices"][0]["message"]["content"]
+
+
+def grade(text: str) -> float:
+    """Deterministic demo grader: reward proximity to a 12-line answer."""
+    lines = [line for line in text.splitlines() if line.strip()]
+    return max(0.0, 1.0 - abs(len(lines) - 12) / 12.0)
+
+
+def git(worktree: Path, *args: str, capture: bool = False) -> str | None:
+    result = subprocess.run(
+        ["git", "-c", "user.name=coral-demo", "-c", "user.email=demo@localhost", *args],
+        cwd=worktree,
+        check=True,
+        capture_output=capture,
+        text=True,
+    )
+    return result.stdout.strip() if capture else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--work", type=Path, default=Path("work") / "coral-demo")
+    parser.add_argument("--agents", type=int, default=2)
+    parser.add_argument("--generations", type=int, default=2)
+    parser.add_argument("--siblings", type=int, default=2, help="attempts per agent per generation")
+    parser.add_argument("--reef-token", default="reef-local")
+    args = parser.parse_args()
+    state = args.work.resolve()
+    state.mkdir(parents=True, exist_ok=True)
+
+    wait_healthy(f"{REEF_URL}/healthz")
+
+    config_path = state / "litellm_config.yaml"
+    config_path.write_text(
+        "model_list:\n"
+        "  - model_name: reef-policy\n"
+        "    litellm_params:\n"
+        "      model: openai/reef-policy\n"
+        f"      api_base: {REEF_URL}/v1\n"
+        f"      api_key: {args.reef_token}\n"
+        "litellm_settings:\n"
+        "  drop_params: true\n"
+        "  return_response_headers: true\n"
+    )
+    manager = GatewayManager(port=GATEWAY_PORT, config_path=str(config_path), log_dir=state / "gateway")
+    journal: CallJournal = attach_reef_adapter(
+        manager,
+        scenario=SCENARIO,
+        journal_path=state / "reef" / "calls.jsonl",
+        extra_tags={"coral-run": "demo-1"},
+    )
+    manager.start()
+
+    agents = [f"agent-{n + 1}" for n in range(args.agents)]
+    worktrees: dict[str, Path] = {}
+    keys: dict[str, str] = {}
+    bases: dict[str, str] = {}
+    for agent in agents:
+        worktree = state / "worktrees" / agent
+        worktree.mkdir(parents=True, exist_ok=True)
+        git(worktree, "init", "-q")
+        git(worktree, "commit", "-q", "--allow-empty", "-m", "seed")
+        worktrees[agent] = worktree
+        keys[agent] = manager.register_agent(agent, worktree)
+        bases[agent] = git(worktree, "rev-parse", "HEAD", capture=True)[:12]
+
+    reports: list[AttemptReport] = []
+    for generation in range(args.generations):
+        for sibling in range(args.siblings):
+            for agent in agents:
+                worktree = worktrees[agent]
+                git(worktree, "checkout", "-q", bases[agent])
+                cursor = journal.size()
+                answer = chat(keys[agent], "Write a Python function (about 12 lines) that merges two sorted lists.")
+                (worktree / "solution.py").write_text(answer)
+                git(worktree, "add", "-A")
+                git(worktree, "commit", "-q", "--allow-empty", "-m", f"{agent} gen{generation} sib{sibling}")
+                commit = git(worktree, "rev-parse", "HEAD", capture=True)[:12]
+                score = grade(answer)
+                report = AttemptReport(
+                    scenario=SCENARIO,
+                    agent_id=agent,
+                    commit_hash=commit,
+                    score=score,
+                    status="improved",
+                    parent_hash=bases[agent],
+                    run_id="demo-1",
+                    references=tuple(journal.record_ids_since(cursor, agent, bases[agent])),
+                )
+                ack = report_attempt(REEF_URL, report, token=args.reef_token)
+                reports.append(report)
+                print(
+                    f"{agent} gen{generation} sib{sibling}: score={score:.2f} refs={len(report.references)} ack={ack.get('agent_record_id')}"
+                )
+        # next generation branches from each agent's best sibling would go
+        # here in a real run; the demo keeps the base fixed per agent and
+        # relies on the trained weights (served after each sibling group
+        # completes) to move the answers.
+        time.sleep(30)
+
+    bundle = build_result_bundle(journal, reports, run_id="demo-1")
+    bundle_path = state / "bundle.json"
+    bundle_path.write_text(json.dumps(bundle, indent=2))
+    print(f"bundle: {bundle_path}")
+    print(json.dumps(bundle["token_accounting"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipes/coral/examples/coral_demo/run.sh
+++ b/recipes/coral/examples/coral_demo/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Serve + run for the CORAL test-time-training example.
+# Setup (once): pip install -e .[coral]  — see README. State goes to ./work.
+set -e
+cd "$(dirname "$0")"
+export PYTHONPATH="$(cd ../../../.. && pwd):${PYTHONPATH:-}"  # recipes.coral importable
+
+# The values serve.yaml cannot compute itself.
+export CORAL_TTT_STATE_DIR="$PWD/work/coral-demo"
+export REEF_INFERENCE_HOST=$(hostname -I | awk '{print $1}')
+mkdir -p "$CORAL_TTT_STATE_DIR"
+
+# Download the model on first run (serve.yaml expects it at work/model).
+if [ ! -f work/model/config.json ]; then
+    huggingface-cli download Qwen/Qwen3-8B --local-dir work/model
+fi
+
+# Start the Reef training stack; stop it when the demo loop exits.
+python3 -m reef serve -c "$PWD/serve.yaml" > "$CORAL_TTT_STATE_DIR/reef.log" 2>&1 &
+reef_pid=$!
+cleanup() {
+    kill "$reef_pid" 2>/dev/null || true
+    wait "$reef_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Ray + Slime/Megatron + SGLang take minutes to come up.
+ready_deadline=$((SECONDS + 3600))
+while ! curl -sf http://127.0.0.1:8900/healthz > /dev/null; do
+    if ! kill -0 "$reef_pid" 2>/dev/null || (( SECONDS >= ready_deadline )); then
+        tail -n 100 "$CORAL_TTT_STATE_DIR/reef.log" >&2
+        echo "run.sh: the Reef stack did not become ready" >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+# CORAL gateway + demo agents + reporting; writes work/coral-demo/bundle.json.
+python3 run.py --work "$CORAL_TTT_STATE_DIR"

--- a/recipes/coral/examples/coral_demo/serve.yaml
+++ b/recipes/coral/examples/coral_demo/serve.yaml
@@ -1,0 +1,93 @@
+# Colocated Qwen3-8B LoRA stack for the CORAL test-time-training example.
+# Every value is literal except the two run.sh computes: CORAL_TTT_STATE_DIR
+# (the absolute root all durable state hangs off) and REEF_INFERENCE_HOST
+# (this machine's IP, which Slime binds the training engines' router to).
+
+run_dir: ${CORAL_TTT_STATE_DIR}/stack
+ready_timeout: 3600
+
+execution:
+  training: ray
+  rollout: ray
+
+reef:
+  host: 127.0.0.1
+  model_path: work/model
+  port: 8900
+  recipe: recipes.coral.recipe:CoralRecipe
+  token: reef-local
+  group_size: 2            # two scored siblings release a training group
+  checkpoint_every_n_versions: 1
+  ray_namespace: reef
+  ray_actor_name: reef-train-bridge
+  inference_timeout_s: 7200
+  train_timeout_s: 7200
+  inference_backend_factory: reef.train.slime_backend.reef_adapters.sglang.chat.SGLangChatTrainingInferenceBackend
+  artifact_repository: ${CORAL_TTT_STATE_DIR}/artifacts.git
+  artifact_work_dir: ${CORAL_TTT_STATE_DIR}/artifact-work
+  artifact_cache_dir: ${CORAL_TTT_STATE_DIR}/artifact-cache
+  agent_record_dir: ${CORAL_TTT_STATE_DIR}/agent-record
+
+observability:
+  wandb:
+    enabled: false
+    project: reef
+    directory: ${CORAL_TTT_STATE_DIR}/wandb
+
+training:
+  num_gpus: 2
+  steps: 4
+  max_new_tokens: 8192
+  cuda_visible_devices: "0,1"
+  checkpoint_dir: ${CORAL_TTT_STATE_DIR}/checkpoints
+  checkpoint_retention:
+    max_storage_fraction: 0.8
+    min_free_space_fraction: 0.1
+    policy: latest
+
+services:
+  - name: ray-head
+    command: >-
+      ray start --head --node-ip-address=127.0.0.1 --port=6379
+      --include-dashboard=false --num-cpus=32
+      --num-gpus=${training.num_gpus} --disable-usage-stats --block
+    ready: ray health-check --address=127.0.0.1:6379
+    cuda: ${training.cuda_visible_devices}
+
+  - name: slime-driver
+    command: >-
+      "${REEF_PYTHON}" -m reef.train.slime_backend.reef_adapters.driver
+      --hf-checkpoint=${reef.model_path}
+      --load=${training.checkpoint_dir}/megatron
+      --ref-load=${reef.model_path}
+      --save=${training.checkpoint_dir}/megatron
+      --save-hf=${training.checkpoint_dir}/hf/{rollout_id}
+      --save-interval=${reef.checkpoint_every_n_versions}
+      --reef-checkpoint-max-storage-fraction=${training.checkpoint_retention.max_storage_fraction}
+      --reef-checkpoint-min-free-space-fraction=${training.checkpoint_retention.min_free_space_fraction}
+      --reef-checkpoint-policy=${training.checkpoint_retention.policy}
+      --num-rollout=${training.steps}
+      --rollout-batch-size=2
+      --n-samples-per-prompt=${reef.group_size}
+      --global-batch-size=4
+      --actor-num-gpus-per-node=${training.num_gpus}
+      --rollout-num-gpus=${training.num_gpus}
+      --rollout-num-gpus-per-engine=1
+      --num-gpus-per-node=${training.num_gpus}
+      --megatron-lora-rank=32
+      --megatron-lora-alpha=32
+      --megatron-lora-target-modules linear_qkv linear_proj
+      --optimizer=adam --lr=4e-5 --lr-decay-style=constant
+      --loss-type=custom_loss --use-rollout-logprobs
+      --kl-coef=0.1
+      --rollout-temperature=1
+      --rollout-max-response-len=4096
+      --seq-length=16384
+      --max-tokens-per-gpu=16384
+      --log-probs-chunk-size=512
+    ready_file: ${CORAL_TTT_STATE_DIR}/stack/bridge.ready
+    cuda: ${training.cuda_visible_devices}
+
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz

--- a/recipes/coral/gateway_launcher.py
+++ b/recipes/coral/gateway_launcher.py
@@ -1,0 +1,81 @@
+"""Wire the adapter into a CORAL gateway (optional CORAL dependency).
+
+CORAL's ``GatewayManager.start()`` builds ``CoralGatewayMiddleware`` around
+LiteLLM's app and hands the result to uvicorn. This module splices the reef
+layer into that middleware's inner ``app`` reference:
+
+    uvicorn -> CoralGatewayMiddleware -> ReefGatewayMiddleware -> LiteLLM
+
+CORAL stamps ``x-coral-agent-id``/``x-coral-session-id`` first, then the
+reef layer translates them to reef headers, so the adapter never needs
+CORAL's key registry. The outer middleware object is left in place —
+``GatewayManager.register_agent`` type-checks it, so replacing it would
+break agent registration. Requires only that reef is one of the LiteLLM
+upstreams (an ``api_base`` pointing at ``reef serve``).
+
+Written against CORAL commit a69cbc2; the touched surface is the documented
+middleware's ``app`` attribute only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from recipes.coral.journal import CallJournal
+from recipes.coral.middleware import ReefGatewayMiddleware
+
+
+def attach_reef_adapter(
+    gateway_manager: Any,
+    *,
+    scenario: str,
+    journal_path: Path,
+    extra_tags: Mapping[str, str] | None = None,
+) -> CallJournal:
+    """Arrange for the reef layer to sit under a CORAL gateway.
+
+    Call between ``GatewayManager(...)`` construction and ``start()``: it
+    wraps the manager's ``start`` so the reef layer is spliced in right
+    after CORAL builds its middleware. Returns the journal for the
+    reporter side.
+    """
+    journal = CallJournal(journal_path)
+    original_start = gateway_manager.start
+
+    def start_with_adapter() -> None:
+        original_start()
+        insert_reef_layer(
+            gateway_manager._middleware,
+            scenario=scenario,
+            journal=journal,
+            extra_tags=extra_tags,
+        )
+
+    gateway_manager.start = start_with_adapter
+    return journal
+
+
+def insert_reef_layer(
+    coral_middleware: Any,
+    *,
+    scenario: str,
+    journal: CallJournal,
+    extra_tags: Mapping[str, str] | None = None,
+) -> None:
+    """Splice :class:`ReefGatewayMiddleware` under an existing CORAL middleware.
+
+    Idempotent: a middleware whose ``app`` is already the reef layer is left
+    alone, so a retried launcher does not stack two layers.
+    """
+    if coral_middleware is None or not hasattr(coral_middleware, "app"):
+        raise TypeError("expected a started CoralGatewayMiddleware with an `app` attribute")
+    if isinstance(coral_middleware.app, ReefGatewayMiddleware):
+        return
+    coral_middleware.app = ReefGatewayMiddleware(
+        coral_middleware.app,
+        scenario=scenario,
+        journal=journal,
+        extra_tags=extra_tags,
+    )

--- a/recipes/coral/journal.py
+++ b/recipes/coral/journal.py
@@ -1,0 +1,123 @@
+"""Append-only JSONL journal: which Reef records belong to which CORAL attempt.
+
+A crash loses at most the in-flight request; torn lines are skipped on read.
+When a receipt did not survive the proxy hop, the tags Reef stored with the
+INFERENCE record remain the correlation key.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CallRecord:
+    """One provider call as the gateway saw it."""
+
+    request_id: str
+    timestamp: str
+    scenario: str
+    agent_id: str
+    commit_hash: str
+    path: str
+    status_code: int
+    agent_record_id: str | None = None
+    #: ``x-reef-release-id`` from the response: which serving revision answered.
+    release_id: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, line: str) -> CallRecord:
+        data = json.loads(line)
+        return cls(**data)
+
+
+class CallJournal:
+    """Append-only JSONL journal, safe for concurrent agents behind one gateway."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, record: CallRecord) -> None:
+        line = record.to_json() + "\n"
+        with self._lock, open(self._path, "a", encoding="utf-8") as f:
+            f.write(line)
+
+    def records(self) -> list[CallRecord]:
+        if not self._path.exists():
+            return []
+        out: list[CallRecord] = []
+        with open(self._path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(CallRecord.from_json(line))
+                except (json.JSONDecodeError, TypeError):
+                    continue  # torn write from a crash — skip, never fail reads
+        return out
+
+    def size(self) -> int:
+        """Current record count — a cursor for :meth:`record_ids_since`.
+
+        Two sibling attempts run from the same worktree state, so their calls
+        share the (agent, commit) coordinate; a caller that snapshots the
+        cursor before an attempt's calls and resolves with it afterwards gets
+        exactly that attempt's records.
+        """
+        return len(self.records())
+
+    def record_ids_since(self, cursor: int, agent_id: str, commit_hash: str) -> list[str]:
+        """Captured record ids for one attempt, starting at ``cursor``."""
+        seen: dict[str, None] = {}
+        for record in self.records()[cursor:]:
+            if (
+                record.agent_id == agent_id
+                and record.commit_hash == commit_hash
+                and record.agent_record_id
+                and record.agent_record_id not in seen
+            ):
+                seen[record.agent_record_id] = None
+        return list(seen)
+
+    def record_ids_for_attempt(self, agent_id: str, commit_hash: str) -> list[str]:
+        """The captured Reef record ids for an attempt, in call order, deduplicated.
+
+        A retried provider call produces two journal lines with two distinct
+        record ids — both belong to the attempt (both hit the model); dedup
+        only collapses the same receipt seen twice.
+        """
+        seen: dict[str, None] = {}
+        for record in self.for_attempt(agent_id, commit_hash):
+            if record.agent_record_id and record.agent_record_id not in seen:
+                seen[record.agent_record_id] = None
+        return list(seen)
+
+
+def deterministic_report_id(scenario: str, agent_id: str, commit_hash: str) -> str:
+    """Client-supplied ``agent_record_id`` for the attempt's report.
+
+    Reef dedups identical resends of the same client-supplied id, so a
+    reporter that crashes after POST and runs again does not double-count
+    the attempt (and a changed payload under the same id is rejected loudly
+    rather than silently duplicated).
+    """
+    import hashlib
+
+    digest = hashlib.sha256(f"{scenario}\x00{agent_id}\x00{commit_hash}".encode()).hexdigest()
+    return f"coral-report-{digest[:24]}"

--- a/recipes/coral/middleware.py
+++ b/recipes/coral/middleware.py
@@ -1,0 +1,288 @@
+"""ASGI middleware stamping Reef correlation headers onto CORAL gateway traffic.
+
+Maps CORAL identity headers to ``x-reef-scenario`` + ``x-reef-tag-*`` (headers
+only; provider-native bodies are mirrored into ``extra_headers`` for proxy
+hops), captures Reef receipts from the response, and journals one
+:class:`CallRecord` per call. One discovery problem = one scenario; agent and
+worktree identity stay in tags.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from recipes.coral.journal import CallJournal, CallRecord
+
+logger = logging.getLogger(__name__)
+
+SCENARIO_HEADER = b"x-reef-scenario"
+RECORD_ID_RESPONSE_HEADER = b"x-reef-agent-record-id"
+RELEASE_ID_RESPONSE_HEADER = b"x-reef-release-id"
+
+#: CORAL identity headers (stamped upstream by CoralGatewayMiddleware) and the
+#: reef tag names they map to. Tag values are opaque to reef; these names are
+#: this example's contract with its reporter.
+CORAL_TO_REEF_TAGS: dict[bytes, str] = {
+    b"x-coral-agent-id": "coral-agent",
+    b"x-coral-session-id": "coral-commit",
+}
+
+_API_PREFIXES = (
+    "/v1/messages",
+    "/v1/chat/completions",
+    "/chat/completions",
+    "/v1/completions",
+    "/completions",
+)
+
+
+def _is_api_path(path: str) -> bool:
+    return any(path.startswith(p) for p in _API_PREFIXES)
+
+
+class AsgiApp(Protocol):
+    """The downstream ASGI application (LiteLLM, or another middleware)."""
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> Any: ...
+
+
+class ReefGatewayMiddleware:
+    """See module docstring.
+
+    ``extra_tags`` lets the launcher attach run-level parent links (e.g.
+    ``{"coral-run": run_id}``) once, instead of per request.
+    """
+
+    def __init__(
+        self,
+        app: AsgiApp,
+        *,
+        scenario: str,
+        journal: CallJournal,
+        extra_tags: Mapping[str, str] | None = None,
+        body_extra_headers: bool = True,
+    ) -> None:
+        if not scenario or not scenario.strip():
+            raise ValueError("scenario must be a non-empty string")
+        self.app = app
+        self.scenario = scenario.strip()
+        self.journal = journal
+        self.extra_tags = dict(extra_tags or {})
+        #: Also mirror the stamped headers into the JSON body's
+        #: ``extra_headers`` — LiteLLM's own per-request mechanism for
+        #: carrying headers to the upstream. A proxy hop builds a fresh
+        #: upstream request and drops inbound headers, so headers alone
+        #: only reach reef on direct deployments.
+        self.body_extra_headers = body_extra_headers
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> Any:
+        if scope.get("type") != "http" or not _is_api_path(scope.get("path", "")):
+            return await self.app(scope, receive, send)
+
+        request_id = uuid.uuid4().hex[:12]
+
+        # -- request side: read CORAL identity, stamp reef headers ----------
+        coral: dict[str, str] = {}
+        new_headers: list[tuple[bytes, bytes]] = []
+        for raw_name, raw_value in scope.get("headers", []):
+            name = bytes(raw_name).lower()
+            tag = CORAL_TO_REEF_TAGS.get(name)
+            if tag is not None:
+                coral[tag] = bytes(raw_value).decode("latin-1")
+            # Drop any inbound reef headers: the adapter owns this channel,
+            # and a client must not be able to redirect its own scenario.
+            if name == SCENARIO_HEADER or name.startswith(b"x-reef-tag-"):
+                continue
+            new_headers.append((raw_name, raw_value))
+
+        tags = {**self.extra_tags, **coral}
+        new_headers.append((SCENARIO_HEADER, self.scenario.encode("latin-1")))
+        for tag_name, tag_value in tags.items():
+            new_headers.append((b"x-reef-tag-" + tag_name.encode("latin-1"), tag_value.encode("latin-1")))
+        scope = dict(scope)
+        scope["headers"] = new_headers
+
+        reef_headers = {SCENARIO_HEADER.decode("latin-1"): self.scenario}
+        for tag_name, tag_value in tags.items():
+            reef_headers[f"x-reef-tag-{tag_name}"] = tag_value
+        if self.body_extra_headers:
+            receive = _extra_headers_receive(receive, reef_headers, scope)
+
+        # -- response side: capture the reef receipt ------------------------
+        status_code = 0
+        record_id: str | None = None
+        release_id: str | None = None
+        body_tail = bytearray()  # receipt + usage extraction after the stream ends
+
+        async def send_wrapper(message: dict) -> None:
+            nonlocal status_code, record_id, release_id
+            if message.get("type") == "http.response.start":
+                status_code = message.get("status", 0)
+                for raw_name, raw_value in message.get("headers", []):
+                    lowered = bytes(raw_name).lower()
+                    # Suffix match: a proxy hop that does forward provider
+                    # headers usually prefixes them (e.g. LiteLLM's
+                    # llm_provider-x-reef-agent-record-id).
+                    if lowered.endswith(RECORD_ID_RESPONSE_HEADER):
+                        record_id = bytes(raw_value).decode("latin-1")
+                    elif lowered.endswith(RELEASE_ID_RESPONSE_HEADER):
+                        release_id = bytes(raw_value).decode("latin-1")
+            elif message.get("type") == "http.response.body":
+                body_tail.extend(message.get("body", b""))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            body = bytes(body_tail)
+            if record_id is None:
+                record_id = _receipt_from_body(body)
+            usage = _usage_from_body(body)
+            entry = CallRecord(
+                request_id=request_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                scenario=self.scenario,
+                agent_id=coral.get("coral-agent", "unknown"),
+                commit_hash=coral.get("coral-commit", "unknown"),
+                path=scope.get("path", ""),
+                status_code=status_code,
+                agent_record_id=record_id,
+                release_id=release_id,
+                prompt_tokens=usage.get("prompt_tokens"),
+                completion_tokens=usage.get("completion_tokens"),
+                tags=tags,
+            )
+            try:
+                self.journal.append(entry)
+            except OSError as exc:  # never take the data path down with us
+                logger.warning("call journal append failed: %s", exc)
+
+
+def _receipt_from_body(body: bytes) -> str | None:
+    """Extract ``agent_record_id`` from a response body, if reef's receipt survived.
+
+    Handles the streaming shape (an SSE frame whose JSON payload carries a
+    top-level ``"reef"`` object) and the JSON-body shape. Returns ``None``
+    when the provider hop stripped the receipt — correlation then rests on
+    the tags reef stored with the INFERENCE record.
+    """
+    if not body:
+        return None
+    text = body.decode("utf-8", errors="replace")
+    if text.lstrip().startswith("{"):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        reef = payload.get("reef") if isinstance(payload, dict) else None
+        if isinstance(reef, dict) and isinstance(reef.get("agent_record_id"), str):
+            return reef["agent_record_id"]
+        return None
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if data == "[DONE]":
+            continue
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        reef = payload.get("reef")
+        if isinstance(reef, dict) and isinstance(reef.get("agent_record_id"), str):
+            return reef["agent_record_id"]
+    return None
+
+
+def _usage_from_body(body: bytes) -> dict:
+    """Token accounting from a JSON body or the last SSE usage chunk.
+
+    OpenAI-shaped ``usage`` objects only ({prompt,completion}_tokens ints);
+    anything else yields {} — accounting is best-effort by design.
+    """
+    if not body:
+        return {}
+    text = body.decode("utf-8", errors="replace")
+    candidates = []
+    if text.lstrip().startswith("{"):
+        candidates.append(text)
+    else:
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:") and line[5:].strip() != "[DONE]":
+                candidates.append(line[5:].strip())
+    usage: dict = {}
+    for raw in candidates:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and isinstance(payload.get("usage"), dict):
+            found = payload["usage"]
+            cleaned = {
+                key: value
+                for key, value in found.items()
+                if key in ("prompt_tokens", "completion_tokens") and isinstance(value, int)
+            }
+            if cleaned:
+                usage = cleaned  # last usage wins (final SSE chunk is authoritative)
+    return usage
+
+
+def _extra_headers_receive(receive: Any, reef_headers: Mapping[str, str], scope: dict) -> Any:
+    """Wrap ``receive`` so the JSON body carries ``extra_headers``.
+
+    Buffers the request body, merges the reef headers into the body's
+    ``extra_headers`` (caller-provided entries win nothing — the adapter
+    owns this channel, same rule as the header path), and replays it as a
+    single message with a corrected ``content-length``. Non-JSON bodies
+    pass through untouched.
+    """
+
+    async def buffered() -> dict:
+        parts: list[bytes] = []
+        while True:
+            message = await receive()
+            if message.get("type") != "http.request":
+                return {"body": b"".join(parts), "passthrough": message}
+            parts.append(message.get("body", b""))
+            if not message.get("more_body"):
+                return {"body": b"".join(parts), "passthrough": None}
+
+    state = {"done": False}
+
+    async def replay() -> dict:
+        if state["done"]:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        result = await buffered()
+        state["done"] = True
+        if result["passthrough"] is not None:
+            return result["passthrough"]
+        body = result["body"]
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            payload = None
+        if isinstance(payload, dict):
+            merged = dict(payload.get("extra_headers") or {})
+            merged.update(reef_headers)
+            payload["extra_headers"] = merged
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            new_headers = []
+            for raw_name, raw_value in scope.get("headers", []):
+                if bytes(raw_name).lower() == b"content-length":
+                    new_headers.append((raw_name, str(len(body)).encode("latin-1")))
+                else:
+                    new_headers.append((raw_name, raw_value))
+            scope["headers"] = new_headers
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return replay

--- a/recipes/coral/processor.py
+++ b/recipes/coral/processor.py
@@ -1,0 +1,168 @@
+"""CORAL attempts -> grouped policy batches (the training-semantics piece).
+
+CORAL's attempt tree already has the shape reef's grouped relative-reward
+training wants: every attempt names its ``parent_hash``, so the siblings of
+one parent form one comparison group — attempts that started from the same
+code and diverged. This processor groups reports by parent commit and
+releases a group as one training unit once ``group_size`` scored siblings
+accrued.
+
+The reports it consumes are exactly what :mod:`reef_coral.reporter` emits:
+``score``, ordered inference ``references``, and ``metadata.coral`` with
+``agent_id``/``commit_hash``/``parent_hash``. Root attempts (no parent)
+compare against each other under a sentinel group — they all diverged from
+the task seed.
+
+Token/loss-mask/logprob materialization is reef's ``SampleAssembly`` over the
+referenced INFERENCE records; a CORAL attempt is a multi-call trajectory, so
+multi-turn assembly is on by default.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Hashable, Mapping
+from typing import Any
+
+from reef.train.processors.reported import (
+    BatchUnit,
+    GroupDecision,
+    ReportContext,
+    ReportDecision,
+    ReportedFeedbackProcessor,
+    SampleAssembly,
+)
+from reef.train.types import GroupedPolicyBatch, ProcessorContext, policy_row_violation
+
+logger = logging.getLogger(__name__)
+
+#: Group key for attempts without a parent commit: first-generation attempts
+#: all diverged from the task seed, so they are each other's siblings.
+ROOT_GROUP = "__coral_root__"
+
+
+class CoralProcessor(ReportedFeedbackProcessor):
+    """One CORAL sibling group = one grouped relative-reward training unit.
+
+    Config:
+
+    - ``group_size`` (default 4, min 2): scored siblings required before a
+      parent's group trains. CORAL sibling counts are dynamic, so this is a
+      recipe-level barrier, not a CORAL invariant; parents that never accrue
+      enough scored children simply never train.
+    """
+
+    output_schema = GroupedPolicyBatch
+    exclusive_sources = True
+    ordered_groups = False  # sibling groups close in whatever order grading lands
+
+    def __init__(self, context: ProcessorContext) -> None:
+        config = dict(context.config)
+        self.group_size = int(config.get("group_size", 4))
+        if self.group_size < 2:
+            raise ValueError("group_size must be at least two (relative rewards need contrast)")
+        config.setdefault("accept_multi_turn_policy_samples", True)
+        assembly_config = context.with_config(config)
+        self._assembly = SampleAssembly.from_config(assembly_config)
+        self._mixed_release_groups: dict[str, tuple[str, ...]] = {}
+        super().__init__(context.with_config({**config, "batch_size": 1}))
+
+    @staticmethod
+    def _coral_metadata(context: ReportContext) -> Mapping[str, Any] | None:
+        metadata = context.report.payload.get("metadata")
+        if not isinstance(metadata, Mapping):
+            return None
+        coral = metadata.get("coral")
+        if not isinstance(coral, Mapping):
+            return None
+        if not isinstance(coral.get("commit_hash"), str) or not coral["commit_hash"]:
+            return None
+        return coral
+
+    def judge(self, context: ReportContext) -> ReportDecision:
+        coral = self._coral_metadata(context)
+        if coral is None:
+            return ReportDecision.never("CoralProcessor requires metadata.coral with a commit_hash")
+        if (gate := context.eligibility()) is not None:
+            return gate
+        score = context.score
+        if score is None or context.inferences is None:
+            raise RuntimeError("eligible CORAL report is not fully resolved")
+        try:
+            sample = self._assembly.build(context, score)
+        except (TypeError, ValueError) as error:
+            return ReportDecision.never(f"sample assembly failed: {error}")
+        if sample is None or policy_row_violation(sample.tokens, sample.loss_mask, sample.rollout_log_probs):
+            return ReportDecision.never("policy tensor contract violation")
+        release_ids = {
+            inference.artifact_ref.release_id for inference in context.inferences if inference.artifact_ref is not None
+        }
+        if len(release_ids) > 1:
+            # One attempt spanning a weight update cannot carry one coherent
+            # set of rollout log probs.
+            return ReportDecision.never(f"attempt {coral['commit_hash'][:12]} spans releases {sorted(release_ids)}")
+        parent = coral.get("parent_hash")
+        group_key = parent if isinstance(parent, str) and parent else ROOT_GROUP
+        return ReportDecision.train(
+            _CoralRow(sample, next(iter(release_ids), None)),
+            group_key=group_key,
+            slot=coral["commit_hash"],  # one attempt = one commit; regrade retries collapse
+        )
+
+    def decide_group(self, key: Hashable, candidates: tuple[Any, ...]) -> GroupDecision:
+        if len(candidates) < self.group_size:
+            return GroupDecision.INCOMPLETE
+        versions = {candidate.value.release_id for candidate in candidates if candidate.value.release_id is not None}
+        if len(versions) <= 1:
+            return GroupDecision.READY
+        ordered = tuple(sorted(versions))
+        self._mixed_release_groups[str(key)] = ordered
+        logger.error(
+            "CORAL sibling group %s discarded: %d attempts span releases %s",
+            key,
+            len(candidates),
+            list(ordered),
+        )
+        return GroupDecision.DISCARD
+
+    def status(self) -> Mapping[str, Any]:
+        return {
+            "discarded_groups": [
+                {"parent": parent, "reason": "mixed_release_ids", "release_ids": list(versions)}
+                for parent, versions in sorted(self._mixed_release_groups.items())
+            ],
+            # Why reports did not train — the first thing to look at when a
+            # group never releases on a live deployment.
+            "never_reasons": dict(self.never_reasons),
+        }
+
+    def make_batch(self, units: tuple[BatchUnit, ...], batch_number: int) -> GroupedPolicyBatch:
+        if len(units) != 1:
+            raise RuntimeError("CoralProcessor batches exactly one sibling group per step")
+        unit = units[0]
+        group = tuple(candidate.value.sample for candidate in unit.candidates)
+        rewards = tuple(sample.reward for sample in group)
+        if all(reward == rewards[0] for reward in rewards[1:]):
+            # Constant-reward group: keep it for a well-defined zero-gradient
+            # step rather than starving the barrier (mirrors TTTD's fallback).
+            logger.info("CORAL group %s has constant reward %s", unit.group_key, rewards[0])
+        self.experiment_logger.log(
+            {
+                "parent": unit.group_key,
+                "siblings": len(group),
+                "reward_min": min(rewards),
+                "reward_max": max(rewards),
+            },
+            namespace="coral",
+        )
+        return GroupedPolicyBatch(f"{self.scenario}:coral:{unit.group_key}:{batch_number}", (group,))
+
+
+class _CoralRow:
+    """One accepted attempt: its assembled sample plus producing release."""
+
+    __slots__ = ("release_id", "sample")
+
+    def __init__(self, sample: Any, release_id: str | None) -> None:
+        self.sample = sample
+        self.release_id = release_id

--- a/recipes/coral/recipe.py
+++ b/recipes/coral/recipe.py
@@ -1,0 +1,43 @@
+"""The CORAL weight-training recipe: what a deployment names in ``serve.yaml``.
+
+Binds :class:`~reef_coral.processor.CoralProcessor` to the grouped
+relative-reward training machinery. CORAL sibling groups have the same shape
+as TTT-Discover steps — comparison sets of scored rollouts from one shared
+starting point — so the recipe reuses the ``tttd`` step preparer (grouped
+adaptive-entropic leave-one-out advantages) and the ``tttd`` Slime loss
+family rather than duplicating either. The recipe's own configuration is the
+group barrier.
+
+Deployment reference: ``recipes.coral.recipe:CoralRecipe`` (after
+``pip install -e recipes/coral`` alongside the repository cookbook, which
+provides the ``tttd`` registrations this recipe reuses).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The tttd step preparer and loss-family reference live in the repository
+# cookbook; importing them is what registers both names this recipe binds.
+import recipes.tttd  # noqa: F401  (registration side effect)
+from recipes.coral.processor import CoralProcessor
+from reef.recipe.base import WeightTrainingRecipe, WeightTrainingSpec
+from reef.recipe.config_fields import config_field
+
+
+@dataclass(frozen=True, kw_only=True)
+class CoralRecipe(WeightTrainingRecipe):
+    name: str = "coral"
+    #: Scored siblings of one parent commit required before their group trains.
+    group_size: int = config_field(4, env="REEF_CORAL_GROUP_SIZE")
+
+    @classmethod
+    def training_spec(cls) -> WeightTrainingSpec:
+        return WeightTrainingSpec(step_preparer="tttd", loss_family="tttd", processor=CoralProcessor)
+
+    def __post_init__(self) -> None:
+        # Validate our own field first: the group barrier is checkable
+        # without a fully constructed training runtime.
+        if self.group_size < 2:
+            raise ValueError("group_size must be at least two (relative rewards need contrast)")
+        super().__post_init__()

--- a/recipes/coral/reporter.py
+++ b/recipes/coral/reporter.py
@@ -1,0 +1,87 @@
+"""Report finalized CORAL attempts to Reef as training signal.
+
+One ``POST /reef/report`` per attempt: the grader score, the attempt's
+captured inference references, the CORAL coordinates in metadata, and a
+deterministic client-supplied id so grader re-runs dedup server-side.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from recipes.coral.journal import deterministic_report_id
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AttemptReport:
+    """The reef-facing projection of one finalized CORAL attempt."""
+
+    scenario: str
+    agent_id: str
+    commit_hash: str
+    score: float | None
+    status: str
+    parent_hash: str | None = None
+    run_id: str | None = None
+    feedback: str | Mapping[str, Any] | None = None
+    references: tuple[str, ...] = ()
+    extra_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def payload(self) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "coral": {
+                "agent_id": self.agent_id,
+                "commit_hash": self.commit_hash,
+                "status": self.status,
+                "parent_hash": self.parent_hash,
+                "run_id": self.run_id,
+            },
+            **dict(self.extra_metadata),
+        }
+        body: dict[str, Any] = {
+            "agent_record_id": deterministic_report_id(self.scenario, self.agent_id, self.commit_hash),
+            "metadata": metadata,
+        }
+        if self.score is not None:
+            body["score"] = float(self.score)
+        if self.feedback is not None:
+            body["feedback"] = self.feedback if isinstance(self.feedback, str) else dict(self.feedback)
+        if self.references:
+            body["references"] = list(self.references)
+        return body
+
+
+def report_attempt(
+    reef_url: str,
+    report: AttemptReport,
+    *,
+    token: str | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """POST one report; returns reef's acknowledgement.
+
+    Raises ``urllib.error.HTTPError`` on rejection — a conflicting resend
+    (same client id, different payload) is a bug worth failing loudly on.
+    """
+    body = report.payload()
+    headers = {
+        "Content-Type": "application/json",
+        "x-reef-scenario": report.scenario,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        reef_url.rstrip("/") + "/reef/report",
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))

--- a/tests/reef_service/test_coral_processor.py
+++ b/tests/reef_service/test_coral_processor.py
@@ -1,0 +1,156 @@
+"""CoralProcessor: CORAL sibling groups -> grouped policy batches.
+
+Requires the reef package (and its train stack) importable; skipped
+otherwise so the adapter suite stays standalone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+reef_types = pytest.importorskip("reef.train.types", reason="requires a reef checkout")
+
+from recipes.coral.processor import ROOT_GROUP, CoralProcessor
+
+from reef.core import AgentRecord, RequestType
+from reef.train.types import GroupedPolicyBatch, ProcessorContext
+
+SCENARIO = "coral-demo"
+
+
+def _processor(group_size=2):
+    return CoralProcessor(ProcessorContext(SCENARIO, {"group_size": group_size}))
+
+
+def _inference(record_id, tokens, loss_mask, log_probs):
+    return AgentRecord.create(
+        scenario=SCENARIO,
+        request_type=RequestType.INFERENCE,
+        agent_record_id=record_id,
+        payload={
+            "response": {
+                "training": {
+                    "tokens": tokens,
+                    "loss_mask": loss_mask,
+                    "rollout_log_probs": log_probs,
+                    "runtime_load_id": "wv-1",
+                }
+            }
+        },
+    )
+
+
+def _attempt_report(record_id, references, score, *, commit, parent=None, agent="agent-1"):
+    refs = (references,) if isinstance(references, str) else tuple(references)
+    return AgentRecord.create(
+        scenario=SCENARIO,
+        request_type=RequestType.REPORT,
+        agent_record_id=record_id,
+        references=refs,
+        payload={
+            "score": score,
+            "references": list(refs),
+            "metadata": {
+                "coral": {
+                    "agent_id": agent,
+                    "commit_hash": commit,
+                    "parent_hash": parent,
+                    "status": "improved",
+                    "run_id": "run-1",
+                }
+            },
+        },
+    )
+
+
+def test_sibling_group_trains_as_one_grouped_batch():
+    processor = _processor(group_size=2)
+    processor.ingest(_inference("i1", [1, 2], [1], [-0.1]))
+    processor.ingest(_inference("i2", [3, 4], [1], [-0.2]))
+    processor.ingest(_attempt_report("r1", "i1", 0.3, commit="c-a", parent="p0"))
+    assert not processor.ready()  # one sibling is not a comparison group
+
+    processor.ingest(_attempt_report("r2", "i2", 0.9, commit="c-b", parent="p0"))
+    assert processor.ready()
+
+    batch = processor.build_batch()
+    assert isinstance(batch, GroupedPolicyBatch)
+    (group,) = batch.comparison_sets
+    assert sorted(sample.reward for sample in group) == [0.3, 0.9]
+
+
+def test_root_attempts_group_together():
+    processor = _processor(group_size=2)
+    processor.ingest(_inference("i1", [1, 2], [1], [-0.1]))
+    processor.ingest(_inference("i2", [3, 4], [1], [-0.2]))
+    processor.ingest(_attempt_report("r1", "i1", 0.1, commit="c-a", parent=None))
+    processor.ingest(_attempt_report("r2", "i2", 0.2, commit="c-b", parent=None))
+    assert processor.ready()
+    batch = processor.build_batch()
+    assert ROOT_GROUP in batch.batch_id
+
+
+def test_groups_do_not_mix_across_parents():
+    processor = _processor(group_size=2)
+    processor.ingest(_inference("i1", [1, 2], [1], [-0.1]))
+    processor.ingest(_inference("i2", [3, 4], [1], [-0.2]))
+    processor.ingest(_attempt_report("r1", "i1", 0.5, commit="c-a", parent="p0"))
+    processor.ingest(_attempt_report("r2", "i2", 0.6, commit="c-b", parent="p1"))
+    # two half-full groups, no cross-parent comparison
+    assert not processor.ready()
+
+
+def test_regrade_retry_at_same_commit_is_terminal_not_double_counted():
+    processor = _processor(group_size=2)
+    processor.ingest(_inference("i1", [1, 2], [1], [-0.1]))
+    processor.ingest(_inference("i2", [3, 4], [1], [-0.2]))
+    processor.ingest(_attempt_report("r1", "i1", 0.5, commit="c-a", parent="p0"))
+    # duplicate grader run for the same attempt commit, different record id
+    processor.ingest(_attempt_report("r1b", "i1", 0.5, commit="c-a", parent="p0"))
+    assert not processor.ready()  # still one distinct sibling
+
+    processor.ingest(_attempt_report("r2", "i2", 0.7, commit="c-b", parent="p0"))
+    assert processor.ready()
+    (group,) = processor.build_batch().comparison_sets
+    assert len(group) == 2
+
+
+def test_multi_call_attempt_assembles_multi_turn():
+    processor = _processor(group_size=2)
+    processor.ingest(_inference("i1", [1, 2], [1], [-0.1]))
+    processor.ingest(_inference("i2", [1, 2, 3, 4], [1], [-0.2]))  # extends i1
+    processor.ingest(_inference("i3", [5, 6], [1], [-0.3]))
+    processor.ingest(_attempt_report("r1", ("i1", "i2"), 0.5, commit="c-a", parent="p0"))
+    processor.ingest(_attempt_report("r2", "i3", 0.8, commit="c-b", parent="p0"))
+    assert processor.ready()
+    (group,) = processor.build_batch().comparison_sets
+    multi = next(s for s in group if s.reward == 0.5)
+    assert multi.is_multi_turn and multi.turn_count == 2
+
+
+def test_report_without_coral_metadata_is_named_never():
+    processor = _processor()
+    processor.ingest(_inference("i1", [1, 2], [1], [-0.1]))
+    processor.ingest(
+        AgentRecord.create(
+            scenario=SCENARIO,
+            request_type=RequestType.REPORT,
+            agent_record_id="r-bare",
+            references=("i1",),
+            payload={"score": 1.0, "references": ["i1"]},
+        )
+    )
+    assert any("metadata.coral" in reason for reason in processor.never_reasons)
+
+
+def test_group_size_floor():
+    with pytest.raises(ValueError, match="at least two"):
+        _processor(group_size=1)
+
+
+def test_status_is_a_mapping_even_before_any_discard():
+    """Regression: a private-name collision with the base class made
+    status() call .items() on the base's discard set."""
+    processor = _processor()
+    status = processor.status()
+    assert status == {"discarded_groups": [], "never_reasons": {}}

--- a/tests/reef_service/test_coral_recipe.py
+++ b/tests/reef_service/test_coral_recipe.py
@@ -1,0 +1,43 @@
+"""CoralRecipe: deployment wiring for the CORAL example.
+
+Requires the reef checkout (recipe base + cookbook registrations); skipped
+otherwise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+reef_recipe = pytest.importorskip("reef.recipe.base", reason="requires a reef checkout")
+
+from reef.train.algos import base as algos_base
+
+
+def _recipe_cls():
+    from recipes.coral.recipe import CoralRecipe
+
+    return CoralRecipe
+
+
+def test_training_spec_binds_processor_and_grouped_machinery():
+    recipe_cls = _recipe_cls()
+    spec = recipe_cls.training_spec()
+    from recipes.coral.processor import CoralProcessor
+
+    assert spec.processor is CoralProcessor
+    assert spec.step_preparer == "tttd"
+    assert spec.loss_family == "tttd"
+
+
+def test_importing_the_recipe_registers_the_reused_preparer():
+    _recipe_cls()
+    assert "tttd" in algos_base._decorated_preparers
+
+
+def test_group_size_floor():
+    recipe_cls = _recipe_cls()
+    from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
+
+    runtime = InferenceProxyRuntime(model_path="demo-model", base_url="http://localhost:8000")
+    with pytest.raises(ValueError, match="at least two"):
+        recipe_cls(runtime=runtime, group_size=1)

--- a/tests/reef_service/test_coral_service_integration.py
+++ b/tests/reef_service/test_coral_service_integration.py
@@ -1,0 +1,154 @@
+"""End-to-end: adapter -> real reef service -> receipt -> journal -> report.
+
+The reef service is real (``reef.service.app.create_app`` with a stub
+inference backend, exactly as reef's own service tests build it); the
+middleware forwards to it over real HTTP. What LiteLLM would contribute in
+production — an opaque proxy hop — is the pass-through the shim reproduces.
+
+Requires the reef package importable (run from a reef checkout); skipped
+otherwise so the adapter's own suite stays standalone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+reef_service = pytest.importorskip("reef.service.app", reason="requires a reef checkout")
+
+from aiohttp.test_utils import TestClient, TestServer
+from recipes.coral.journal import CallJournal
+from recipes.coral.middleware import ReefGatewayMiddleware
+from recipes.coral.reporter import AttemptReport
+
+from reef.dispatcher import build_default_dispatcher
+from reef.runtime.inference import InferenceBackend
+
+
+class _EchoBackend(InferenceBackend):
+    async def inference(self, artifact, path, payload):
+        del artifact, path, payload
+        return {"choices": [{"message": {"content": "a proposed config"}}]}
+
+
+class _HttpForwarder:
+    """ASGI app that forwards to the reef test client — the LiteLLM stand-in."""
+
+    def __init__(self, client: TestClient) -> None:
+        self.client = client
+
+    async def __call__(self, scope, receive, send):
+        headers = {bytes(k).decode("latin-1"): bytes(v).decode("latin-1") for k, v in scope["headers"]}
+        body = bytearray()
+        while True:
+            message = await receive()
+            body.extend(message.get("body", b""))
+            if not message.get("more_body"):
+                break
+        upstream = await self.client.post(scope["path"], data=bytes(body), headers=headers)
+        payload = await upstream.read()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": upstream.status,
+                "headers": [(k.encode(), v.encode()) for k, v in upstream.headers.items()],
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+
+def _coral_scope():
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"authorization", b"Bearer sk-coral-agent-1-deadbeef"),
+            (b"x-coral-agent-id", b"agent-1"),
+            (b"x-coral-session-id", b"commit-a"),
+        ],
+    }
+
+
+async def _post_through(mw, scope, body: bytes):
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+    status = next(m["status"] for m in sent if m["type"] == "http.response.start")
+    payload = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    return status, payload
+
+
+@pytest.mark.unit
+def test_full_loop_against_real_reef_service(tmp_path):
+    async def run():
+        reef_client = TestClient(
+            TestServer(reef_service.create_app(build_default_dispatcher(), inference_backend=_EchoBackend()))
+        )
+        await reef_client.start_server()
+        try:
+            journal = CallJournal(tmp_path / "calls.jsonl")
+            mw = ReefGatewayMiddleware(
+                _HttpForwarder(reef_client),
+                scenario="coral-demo",
+                journal=journal,
+                extra_tags={"coral-run": "run-1"},
+            )
+
+            # inference through the adapter: reef must accept (scenario header
+            # stamped by us, not by CORAL) and hand back a receipt
+            status, payload = await _post_through(
+                mw, _coral_scope(), json.dumps({"messages": [{"role": "user", "content": "hi"}]}).encode()
+            )
+            assert status == 200
+            assert json.loads(payload)["choices"][0]["message"]["content"] == "a proposed config"
+
+            (record,) = journal.records()
+            assert record.agent_record_id, "reef receipt must be captured"
+            assert record.agent_id == "agent-1"
+
+            # grader finalizes later: report with exact references
+            report = AttemptReport(
+                scenario="coral-demo",
+                agent_id="agent-1",
+                commit_hash="commit-a",
+                score=0.9,
+                status="improved",
+                run_id="run-1",
+                references=tuple(journal.record_ids_since(0, "agent-1", "commit-a")),
+            )
+            assert report.references == (record.agent_record_id,)
+
+            first = await reef_client.post(
+                "/reef/report", json=report.payload(), headers={"x-reef-scenario": "coral-demo"}
+            )
+            assert first.status == 200
+            echoed = (await first.json())["agent_record_id"]
+
+            # duplicate grader run: identical resend dedups, no double count
+            retry = await reef_client.post(
+                "/reef/report", json=report.payload(), headers={"x-reef-scenario": "coral-demo"}
+            )
+            assert retry.status == 200
+            assert (await retry.json())["agent_record_id"] == echoed
+
+            # conflicting resend (same id, different score) must be rejected
+            conflicting = dict(report.payload())
+            conflicting["score"] = 0.1
+            conflict = await reef_client.post(
+                "/reef/report", json=conflicting, headers={"x-reef-scenario": "coral-demo"}
+            )
+            assert conflict.status == 409
+        finally:
+            await reef_client.close()
+
+    asyncio.run(run())

--- a/tests/reef_service/test_sao_configs.py
+++ b/tests/reef_service/test_sao_configs.py
@@ -344,6 +344,7 @@ def test_user_facing_example_deployments_are_discovered() -> None:
     paths = {_config_id(path) for path in EXAMPLE_DEPLOYMENTS}
     assert paths == {
         "recipes/basic/external-provider.yaml",
+        "recipes/coral/examples/coral_demo/serve.yaml",
         "recipes/basic/local-sglang.yaml",
         "recipes/openclawrl/examples/openclawrl/serve.yaml",
         "recipes/tttd/examples/guidance_ttt/serve.yaml",

--- a/tests/test_coral_adapter.py
+++ b/tests/test_coral_adapter.py
@@ -1,0 +1,337 @@
+"""Adapter and correlation tests for the CORAL example (issue #3 acceptance list).
+
+Covers: parallel agents, retries, late grading, duplicate reports, and
+missing inference references — plus the header-stamping contract itself.
+The fake downstream app plays LiteLLM+provider+reef in one: it asserts the
+reef headers arrived and answers with a configurable receipt shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from recipes.coral.journal import CallJournal, CallRecord, deterministic_report_id
+from recipes.coral.middleware import ReefGatewayMiddleware
+from recipes.coral.reporter import AttemptReport
+
+
+def _scope(path="/v1/chat/completions", headers=None):
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": list(headers or []),
+    }
+
+
+def _coral_headers(agent="agent-1", commit="abc123def456"):
+    return [
+        (b"authorization", b"Bearer sk-coral-agent-1-deadbeef"),
+        (b"x-coral-agent-id", agent.encode()),
+        (b"x-coral-session-id", commit.encode()),
+    ]
+
+
+class FakeDownstream:
+    """The app behind the adapter: records what it saw, replies with a receipt."""
+
+    def __init__(self, record_id="rec-001", mode="header", status=200):
+        self.record_id = record_id
+        self.mode = mode  # "header" | "sse" | "json-body" | "none"
+        self.status = status
+        self.seen_scopes = []
+
+    async def __call__(self, scope, receive, send):
+        self.seen_scopes.append(scope)
+        headers = [(b"content-type", b"application/json")]
+        body = b'{"choices": []}'
+        if self.mode == "header":
+            headers.append((b"x-reef-agent-record-id", self.record_id.encode()))
+        elif self.mode == "sse":
+            headers = [(b"content-type", b"text/event-stream")]
+            receipt = json.dumps(
+                {"object": "chat.completion.chunk", "choices": [], "reef": {"agent_record_id": self.record_id}}
+            )
+            body = f"data: {json.dumps({'choices': [{'delta': {'content': 'hi'}}]})}\n\ndata: {receipt}\n\ndata: [DONE]\n\n".encode()
+        elif self.mode == "json-body":
+            body = json.dumps({"choices": [], "reef": {"agent_record_id": self.record_id}}).encode()
+        await send({"type": "http.response.start", "status": self.status, "headers": headers})
+        await send({"type": "http.response.body", "body": body})
+
+
+async def _call(mw, scope):
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+    return sent
+
+
+def _mw(tmp_path, downstream, scenario="coral-demo", extra_tags=None):
+    journal = CallJournal(tmp_path / "calls.jsonl")
+    return (
+        ReefGatewayMiddleware(downstream, scenario=scenario, journal=journal, extra_tags=extra_tags),
+        journal,
+    )
+
+
+# --------------------------------------------------------------------------
+# Header stamping: reef sees scenario+tags, provider body untouched
+# --------------------------------------------------------------------------
+
+
+def test_stamps_scenario_and_tags_without_touching_body(tmp_path):
+    downstream = FakeDownstream()
+    mw, journal = _mw(tmp_path, downstream, extra_tags={"coral-run": "run-7"})
+    asyncio.run(_call(mw, _scope(headers=_coral_headers())))
+
+    (scope,) = downstream.seen_scopes
+    headers = {bytes(k).decode(): bytes(v).decode() for k, v in scope["headers"]}
+    assert headers["x-reef-scenario"] == "coral-demo"
+    assert headers["x-reef-tag-coral-agent"] == "agent-1"
+    assert headers["x-reef-tag-coral-commit"] == "abc123def456"
+    assert headers["x-reef-tag-coral-run"] == "run-7"
+    # provider-native parts pass through untouched
+    assert headers["authorization"] == "Bearer sk-coral-agent-1-deadbeef"
+
+    (record,) = journal.records()
+    assert record.agent_record_id == "rec-001"
+    assert record.agent_id == "agent-1"
+    assert record.commit_hash == "abc123def456"
+
+
+def test_client_cannot_smuggle_reef_headers(tmp_path):
+    downstream = FakeDownstream()
+    mw, _ = _mw(tmp_path, downstream)
+    smuggled = [
+        *_coral_headers(),
+        (b"x-reef-scenario", b"evil-scenario"),
+        (b"x-reef-tag-coral-agent", b"spoofed"),
+    ]
+    asyncio.run(_call(mw, _scope(headers=smuggled)))
+    (scope,) = downstream.seen_scopes
+    values = [(bytes(k).decode(), bytes(v).decode()) for k, v in scope["headers"]]
+    scenarios = [v for k, v in values if k == "x-reef-scenario"]
+    agents = [v for k, v in values if k == "x-reef-tag-coral-agent"]
+    assert scenarios == ["coral-demo"]
+    assert agents == ["agent-1"]
+
+
+def test_non_api_paths_pass_through_unjournaled(tmp_path):
+    downstream = FakeDownstream()
+    mw, journal = _mw(tmp_path, downstream)
+    asyncio.run(_call(mw, _scope(path="/health", headers=_coral_headers())))
+    assert journal.records() == []
+
+
+# --------------------------------------------------------------------------
+# Receipt capture across response shapes
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["header", "sse", "json-body"])
+def test_receipt_capture(tmp_path, mode):
+    downstream = FakeDownstream(record_id=f"rec-{mode}", mode=mode)
+    mw, journal = _mw(tmp_path, downstream)
+    asyncio.run(_call(mw, _scope(headers=_coral_headers())))
+    (record,) = journal.records()
+    assert record.agent_record_id == f"rec-{mode}"
+
+
+def test_missing_receipt_still_journals_with_tags(tmp_path):
+    """Missing inference reference: degraded mode, tags remain the key."""
+    downstream = FakeDownstream(mode="none")
+    mw, journal = _mw(tmp_path, downstream)
+    asyncio.run(_call(mw, _scope(headers=_coral_headers())))
+    (record,) = journal.records()
+    assert record.agent_record_id is None
+    assert record.tags["coral-agent"] == "agent-1"
+    assert record.tags["coral-commit"] == "abc123def456"
+
+
+# --------------------------------------------------------------------------
+# Parallel agents and retries
+# --------------------------------------------------------------------------
+
+
+def test_parallel_agents_attribute_to_themselves(tmp_path):
+    """Concurrent calls from different agents never cross-attribute."""
+    journal = CallJournal(tmp_path / "calls.jsonl")
+
+    async def run_all():
+        tasks = []
+        for i in range(8):
+            agent = f"agent-{i % 4}"
+            downstream = FakeDownstream(record_id=f"rec-{agent}-{i}")
+            mw = ReefGatewayMiddleware(downstream, scenario="coral-demo", journal=journal)
+            tasks.append(_call(mw, _scope(headers=_coral_headers(agent=agent, commit=f"c-{agent}"))))
+        await asyncio.gather(*tasks)
+
+    asyncio.run(run_all())
+    records = journal.records()
+    assert len(records) == 8
+    for record in records:
+        assert record.agent_record_id.startswith(f"rec-{record.agent_id}-")
+    # per-attempt view: each agent's two calls, nothing from the others
+    ids = journal.record_ids_since(0, "agent-2", "c-agent-2")
+    assert len(ids) == 2
+    assert all("agent-2" in record_id for record_id in ids)
+
+
+def test_retry_produces_two_references_dedup_only_collapses_same_receipt(tmp_path):
+    journal = CallJournal(tmp_path / "calls.jsonl")
+
+    async def run():
+        for record_id in ("rec-try1", "rec-try2", "rec-try2"):  # retry + duplicate receipt
+            downstream = FakeDownstream(record_id=record_id)
+            mw = ReefGatewayMiddleware(downstream, scenario="s", journal=journal)
+            await _call(mw, _scope(headers=_coral_headers()))
+
+    asyncio.run(run())
+    ids = journal.record_ids_since(0, "agent-1", "abc123def456")
+    assert ids == ["rec-try1", "rec-try2"]
+
+
+def test_journal_concurrent_appends_from_threads(tmp_path):
+    """The gateway serves agents from multiple worker threads."""
+    journal = CallJournal(tmp_path / "calls.jsonl")
+
+    def append_many(agent):
+        for i in range(50):
+            journal.append(
+                CallRecord(
+                    request_id=f"{agent}-{i}",
+                    timestamp="t",
+                    scenario="s",
+                    agent_id=agent,
+                    commit_hash="c",
+                    path="/v1/chat/completions",
+                    status_code=200,
+                    agent_record_id=f"rec-{agent}-{i}",
+                )
+            )
+
+    threads = [threading.Thread(target=append_many, args=(f"a{n}",)) for n in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    records = journal.records()
+    assert len(records) == 200  # no torn/interleaved lines
+
+
+# --------------------------------------------------------------------------
+# Reporting: late grading, duplicates, missing references
+# --------------------------------------------------------------------------
+
+
+def test_late_grading_builds_report_from_journal(tmp_path):
+    """The grader finalizes long after inference; the journal still resolves."""
+    journal = CallJournal(tmp_path / "calls.jsonl")
+
+    async def run():
+        downstream = FakeDownstream(record_id="rec-late")
+        mw = ReefGatewayMiddleware(downstream, scenario="coral-demo", journal=journal)
+        await _call(mw, _scope(headers=_coral_headers(commit="late-commit")))
+
+    asyncio.run(run())
+
+    report = AttemptReport(
+        scenario="coral-demo",
+        agent_id="agent-1",
+        commit_hash="late-commit",
+        score=0.75,
+        status="improved",
+        parent_hash="parent-1",
+        run_id="run-7",
+        references=tuple(journal.record_ids_since(0, "agent-1", "late-commit")),
+    )
+    payload = report.payload()
+    assert payload["score"] == 0.75
+    assert payload["references"] == ["rec-late"]
+    assert payload["metadata"]["coral"]["parent_hash"] == "parent-1"
+    assert payload["metadata"]["coral"]["run_id"] == "run-7"
+
+
+def test_duplicate_reports_share_a_deterministic_id():
+    kwargs = {"scenario": "s", "agent_id": "a", "commit_hash": "c", "score": 1.0, "status": "improved"}
+    first = AttemptReport(**kwargs).payload()
+    second = AttemptReport(**kwargs).payload()
+    assert first["agent_record_id"] == second["agent_record_id"]
+    assert first == second  # identical resend -> reef dedups instead of double-counting
+    # and the id is attempt-scoped, not global
+    other = deterministic_report_id("s", "a", "c2")
+    assert other != first["agent_record_id"]
+
+
+def test_report_with_missing_references_still_carries_parent_links():
+    report = AttemptReport(  # no references: receipts lost
+        scenario="s",
+        agent_id="a",
+        commit_hash="c",
+        score=None,
+        status="crashed",
+    )
+    payload = report.payload()
+    assert "references" not in payload
+    assert "score" not in payload
+    assert payload["metadata"]["coral"]["status"] == "crashed"
+
+
+def test_torn_journal_line_is_skipped_not_fatal(tmp_path):
+    journal = CallJournal(tmp_path / "calls.jsonl")
+    journal.append(
+        CallRecord(
+            request_id="r1",
+            timestamp="t",
+            scenario="s",
+            agent_id="a",
+            commit_hash="c",
+            path="/v1/chat/completions",
+            status_code=200,
+            agent_record_id="rec-1",
+        )
+    )
+    with open(journal.path, "a", encoding="utf-8") as f:
+        f.write('{"request_id": "r2", "timest')  # crash mid-write
+    assert [r.request_id for r in journal.records()] == ["r1"]
+
+
+def test_cursor_separates_sibling_attempts_at_the_same_base(tmp_path):
+    """Two siblings run from one worktree state; the cursor gives each
+    report exactly its own calls."""
+    journal = CallJournal(tmp_path / "j.jsonl")
+
+    def call(record_id):
+        journal.append(
+            CallRecord(
+                request_id=record_id,
+                timestamp="t",
+                scenario="s",
+                agent_id="a",
+                commit_hash="base",
+                path="/v1/chat/completions",
+                status_code=200,
+                agent_record_id=record_id,
+            )
+        )
+
+    cursor_0 = journal.size()
+    call("rec-sib0")
+    refs_0 = journal.record_ids_since(cursor_0, "a", "base")
+    cursor_1 = journal.size()
+    call("rec-sib1")
+    refs_1 = journal.record_ids_since(cursor_1, "a", "base")
+    assert refs_0 == ["rec-sib0"]
+    assert refs_1 == ["rec-sib1"]
+    # cursor 0 gives the coordinate-wide view
+    assert journal.record_ids_since(0, "a", "base") == ["rec-sib0", "rec-sib1"]

--- a/tests/test_coral_body_headers.py
+++ b/tests/test_coral_body_headers.py
@@ -1,0 +1,104 @@
+"""Body ``extra_headers`` mirroring: how the stamp survives a LiteLLM hop."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from recipes.coral.journal import CallJournal
+from recipes.coral.middleware import ReefGatewayMiddleware
+
+
+class CaptureDownstream:
+    def __init__(self):
+        self.body = None
+        self.content_length = None
+
+    async def __call__(self, scope, receive, send):
+        parts = []
+        while True:
+            message = await receive()
+            parts.append(message.get("body", b""))
+            if not message.get("more_body"):
+                break
+        self.body = b"".join(parts)
+        for name, value in scope["headers"]:
+            if bytes(name).lower() == b"content-length":
+                self.content_length = int(value)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}"})
+
+
+def _run(mw, body: bytes, headers):
+    async def go():
+        messages = [{"type": "http.request", "body": body, "more_body": False}]
+
+        async def receive():
+            return messages.pop(0) if messages else {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            pass
+
+        await mw(
+            {"type": "http", "method": "POST", "path": "/v1/chat/completions", "headers": list(headers)},
+            receive,
+            send,
+        )
+
+    asyncio.run(go())
+
+
+CORAL_HEADERS = [
+    (b"content-type", b"application/json"),
+    (b"content-length", b"2"),
+    (b"x-coral-agent-id", b"agent-1"),
+    (b"x-coral-session-id", b"commit-a"),
+]
+
+
+def test_body_carries_extra_headers_for_the_proxy_hop(tmp_path):
+    downstream = CaptureDownstream()
+    mw = ReefGatewayMiddleware(
+        downstream,
+        scenario="coral-demo",
+        journal=CallJournal(tmp_path / "j.jsonl"),
+        extra_tags={"coral-run": "run-7"},
+    )
+    _run(mw, json.dumps({"messages": []}).encode(), CORAL_HEADERS)
+
+    payload = json.loads(downstream.body)
+    extra = payload["extra_headers"]
+    assert extra["x-reef-scenario"] == "coral-demo"
+    assert extra["x-reef-tag-coral-agent"] == "agent-1"
+    assert extra["x-reef-tag-coral-commit"] == "commit-a"
+    assert extra["x-reef-tag-coral-run"] == "run-7"
+    assert downstream.content_length == len(downstream.body)
+
+
+def test_client_supplied_extra_headers_cannot_override(tmp_path):
+    downstream = CaptureDownstream()
+    mw = ReefGatewayMiddleware(downstream, scenario="coral-demo", journal=CallJournal(tmp_path / "j.jsonl"))
+    smuggle = {"messages": [], "extra_headers": {"x-reef-scenario": "evil", "x-other": "kept"}}
+    _run(mw, json.dumps(smuggle).encode(), CORAL_HEADERS)
+    extra = json.loads(downstream.body)["extra_headers"]
+    assert extra["x-reef-scenario"] == "coral-demo"
+    assert extra["x-other"] == "kept"
+
+
+def test_non_json_body_passes_through_untouched(tmp_path):
+    downstream = CaptureDownstream()
+    mw = ReefGatewayMiddleware(downstream, scenario="coral-demo", journal=CallJournal(tmp_path / "j.jsonl"))
+    _run(mw, b"not-json", CORAL_HEADERS)
+    assert downstream.body == b"not-json"
+
+
+def test_body_mirroring_can_be_disabled(tmp_path):
+    downstream = CaptureDownstream()
+    mw = ReefGatewayMiddleware(
+        downstream,
+        scenario="coral-demo",
+        journal=CallJournal(tmp_path / "j.jsonl"),
+        body_extra_headers=False,
+    )
+    _run(mw, json.dumps({"messages": []}).encode(), CORAL_HEADERS)
+    assert "extra_headers" not in json.loads(downstream.body)

--- a/tests/test_coral_bundle.py
+++ b/tests/test_coral_bundle.py
@@ -1,0 +1,169 @@
+"""Result bundle and release/usage capture (issue #3: result bundle Done-when)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from recipes.coral.bundle import build_result_bundle
+from recipes.coral.journal import CallJournal, CallRecord
+from recipes.coral.middleware import ReefGatewayMiddleware
+from recipes.coral.reporter import AttemptReport
+
+
+def _record(agent, commit, record_id, *, release=None, prompt=0, completion=0, run="run-1"):
+    return CallRecord(
+        request_id=f"{agent}-{commit}-{record_id}",
+        timestamp="t",
+        scenario="s",
+        agent_id=agent,
+        commit_hash=commit,
+        path="/v1/chat/completions",
+        status_code=200,
+        agent_record_id=record_id,
+        release_id=release,
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        tags={"coral-run": run, "coral-agent": agent, "coral-commit": commit},
+    )
+
+
+def _report(agent, commit, score, *, status="improved", parent=None):
+    return AttemptReport(
+        scenario="s", agent_id=agent, commit_hash=commit, score=score, status=status, parent_hash=parent
+    )
+
+
+def test_bundle_scores_best_revisions_and_tokens(tmp_path):
+    journal = CallJournal(tmp_path / "journal.jsonl")
+    journal.append(_record("a1", "c1", "r1", release="rel-0", prompt=100, completion=50))
+    journal.append(_record("a1", "c1", "r2", release="rel-0", prompt=10, completion=5))
+    journal.append(_record("a1", "c2", "r3", release="rel-1", prompt=20, completion=9))
+    reports = [_report("a1", "c1", 0.4), _report("a1", "c2", 0.9, parent="c1")]
+
+    bundle = build_result_bundle(journal, reports, run_id="run-1")
+
+    assert [s["score"] for s in bundle["score_over_time"]] == [0.4, 0.9]
+    assert bundle["best_attempt"]["commit_hash"] == "c2"
+    assert bundle["model_revisions_served"] == ["rel-0", "rel-1"]
+    assert bundle["token_accounting"] == {
+        "inference_calls": 3,
+        "prompt_tokens": 130,
+        "completion_tokens": 64,
+    }
+    first, second = bundle["attempts"]
+    assert first["inference_calls"] == 2 and first["prompt_tokens"] == 110
+    assert second["release_ids"] == ["rel-1"]
+    # the revision check the issue asks for: later attempt on a newer release
+    assert [(a["commit_hash"], a["release_ids"]) for a in bundle["attempts"]] == [
+        ("c1", ["rel-0"]),
+        ("c2", ["rel-1"]),
+    ]
+
+
+def test_bundle_filters_by_run_and_tolerates_unscored(tmp_path):
+    journal = CallJournal(tmp_path / "journal.jsonl")
+    journal.append(_record("a1", "c1", "r1", run="run-1"))
+    journal.append(_record("a1", "c1", "r9", run="run-OTHER"))
+    reports = [_report("a1", "c1", None, status="crashed")]
+
+    bundle = build_result_bundle(journal, reports, run_id="run-1")
+    assert bundle["best_attempt"] is None
+    assert bundle["attempts"][0]["inference_calls"] == 1  # run-OTHER excluded
+
+
+def test_middleware_captures_release_and_usage(tmp_path):
+    class Downstream:
+        async def __call__(self, scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"x-reef-agent-record-id", b"rec-1"),
+                        (b"x-reef-release-id", b"rel-42"),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": json.dumps(
+                        {"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 3}}
+                    ).encode(),
+                }
+            )
+
+    journal = CallJournal(tmp_path / "journal.jsonl")
+    mw = ReefGatewayMiddleware(Downstream(), scenario="s", journal=journal)
+
+    async def run():
+        async def receive():
+            return {"type": "http.request", "body": b"{}", "more_body": False}
+
+        async def send(message):
+            pass
+
+        await mw(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/v1/chat/completions",
+                "headers": [(b"x-coral-agent-id", b"a1"), (b"x-coral-session-id", b"c1")],
+            },
+            receive,
+            send,
+        )
+
+    asyncio.run(run())
+    (record,) = journal.records()
+    assert record.release_id == "rel-42"
+    assert record.prompt_tokens == 7
+    assert record.completion_tokens == 3
+
+
+def test_middleware_usage_from_final_sse_chunk(tmp_path):
+    class Downstream:
+        async def __call__(self, scope, receive, send):
+            frames = (
+                'data: {"choices": [{"delta": {"content": "x"}}]}\n\n'
+                'data: {"choices": [], "reef": {"agent_record_id": "rec-s"}, '
+                '"usage": {"prompt_tokens": 11, "completion_tokens": 4}}\n\n'
+                "data: [DONE]\n\n"
+            )
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/event-stream")],
+                }
+            )
+            await send({"type": "http.response.body", "body": frames.encode()})
+
+    journal = CallJournal(tmp_path / "journal.jsonl")
+    mw = ReefGatewayMiddleware(Downstream(), scenario="s", journal=journal)
+
+    async def run():
+        async def receive():
+            return {"type": "http.request", "body": b"{}", "more_body": False}
+
+        async def send(message):
+            pass
+
+        await mw(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/v1/chat/completions",
+                "headers": [(b"x-coral-agent-id", b"a1"), (b"x-coral-session-id", b"c1")],
+            },
+            receive,
+            send,
+        )
+
+    asyncio.run(run())
+    (record,) = journal.records()
+    assert record.agent_record_id == "rec-s"
+    assert record.prompt_tokens == 11
+    assert record.completion_tokens == 4

--- a/tests/test_coral_gateway_launcher.py
+++ b/tests/test_coral_gateway_launcher.py
@@ -1,0 +1,70 @@
+"""Launcher splice: the reef layer goes under CORAL's middleware, not around it."""
+
+from __future__ import annotations
+
+import pytest
+
+from recipes.coral.gateway_launcher import attach_reef_adapter, insert_reef_layer
+from recipes.coral.middleware import ReefGatewayMiddleware
+
+
+class FakeCoralMiddleware:
+    """Shape-compatible stand-in: has .app and a register_agent contract."""
+
+    def __init__(self, app):
+        self.app = app
+        self.registered = []
+
+    def register_agent(self, agent_id, worktree_path, proxy_key):
+        self.registered.append((agent_id, str(worktree_path), proxy_key))
+
+
+class FakeManager:
+    def __init__(self):
+        self._middleware = None
+        self.started = False
+
+    def start(self):
+        self._middleware = FakeCoralMiddleware(app=object())
+        self.started = True
+
+    def register_agent(self, agent_id, worktree_path):
+        if not isinstance(self._middleware, FakeCoralMiddleware):
+            raise RuntimeError("gateway middleware is not initialized")
+        self._middleware.register_agent(agent_id, worktree_path, "sk-key")
+        return "sk-key"
+
+
+def test_attach_splices_under_coral_and_keeps_register_agent_working(tmp_path):
+    manager = FakeManager()
+    journal = attach_reef_adapter(manager, scenario="s", journal_path=tmp_path / "j.jsonl")
+    manager.start()
+
+    assert manager.started
+    # the outer object is still CORAL's middleware (type checks keep passing)
+    assert isinstance(manager._middleware, FakeCoralMiddleware)
+    # the reef layer sits underneath
+    assert isinstance(manager._middleware.app, ReefGatewayMiddleware)
+    assert manager._middleware.app.journal is journal
+    # and registration is untouched
+    assert manager.register_agent("agent-1", tmp_path) == "sk-key"
+    assert manager._middleware.registered[0][0] == "agent-1"
+
+
+def test_insert_is_idempotent(tmp_path):
+    from recipes.coral.journal import CallJournal
+
+    journal = CallJournal(tmp_path / "j.jsonl")
+    middleware = FakeCoralMiddleware(app=object())
+    insert_reef_layer(middleware, scenario="s", journal=journal)
+    first = middleware.app
+    insert_reef_layer(middleware, scenario="s", journal=journal)
+    assert middleware.app is first
+
+
+def test_insert_requires_a_started_middleware(tmp_path):
+    from recipes.coral.journal import CallJournal
+
+    journal = CallJournal(tmp_path / "j.jsonl")
+    with pytest.raises(TypeError, match="started CoralGatewayMiddleware"):
+        insert_reef_layer(None, scenario="s", journal=journal)


### PR DESCRIPTION
Implements #3: run a CORAL discovery task through Reef so that multi-agent attempts share one scenario, every inference is attributable, evaluator scores become training data, weights update, and later attempts serve from the new revision.

## Layout

`recipes/coral/` is a method package (same shape as `recipes/tttd/`), importable as `recipes.coral`. It has no CORAL dependency — the splice into CORAL's gateway is duck-typed, so the package tests standalone and the repo CI needs nothing new. The runnable example lives in `recipes/coral/examples/coral_demo/`; its `run.py` is the one module that imports CORAL (an optional dependency pinned to the commit the GPU runs used).

Three commits:

1. **Gateway adapter** (`middleware.py`, `journal.py`, `reporter.py`, `gateway_launcher.py`). The middleware sits under CORAL's gateway and translates its identity headers into `x-reef-scenario` plus `x-reef-tag-coral-{run,agent,commit}`; provider-native bodies are untouched, and the scenario and tags are mirrored into the body's `extra_headers` because LiteLLM builds a fresh upstream request and drops inbound headers. It captures Reef's receipt (record id), the serving revision, and token usage into an append-only journal; receipt headers are matched by suffix since a forwarding proxy prefixes them. The reporter posts finalized attempts to `/reef/report` with exact record references and a deterministic client-supplied id, so grader re-runs dedup server-side. One discovery problem is one scenario; agent and worktree identity stay in tags.
2. **Training semantics** (`processor.py`, `recipe.py`). CORAL's attempt tree already has the grouped relative-reward shape: siblings of one parent commit form one comparison group, released as a `GroupedPolicyBatch` after `group_size` scored siblings. Root attempts group under a sentinel, a regraded attempt occupies its commit's slot terminally, attempts spanning a weight update are rejected, and mixed-release groups are discarded whole. `CoralRecipe` binds the processor to the `tttd` step preparer and Slime loss family — the shapes match, so nothing is duplicated.
3. **Result bundle and the runnable example** (`bundle.py`, `examples/coral_demo/`). The bundle derives score-over-time, best attempt, serving revisions per attempt, token accounting, and replay pointers from the journal plus reports. `pip install -e .[coral] && ./run.sh` boots the stack (serve.yaml, `CoralRecipe`, Qwen3-8B LoRA on 2 GPUs) and drives two demo agents whose graded attempts train the served model.

## Validation

- 57 tests in the repo suite (`tests/test_coral_*.py`, `tests/reef_service/test_coral_*.py`), covering the issue's list — parallel agents, retries, late grading, duplicate reports, missing references — plus header smuggling, torn journal lines, thread safety, and an end-to-end test against a real in-process reef service (receipt → journal → report → retry dedup → conflict rejected with 409).
- One-agent GPU run: real CORAL gateway → LiteLLM → reef → SGLang (Qwen3-8B LoRA) on 2x8-GPU nodes. Receipts journaled, reports resolved their references, a sibling group released, slime/Megatron committed the step, and the LoRA weights reached the serving engines in 14.3s; the next attempt served the new revision.
- Multi-agent GPU run: two agents, separate worktrees and proxy keys, calls interleaved through one gateway. No record attributed to the wrong agent, no reference shared between the agents' reports, one scenario throughout, two training steps committed. This run motivated the journal cursor (`size()`/`record_ids_since()`): siblings execute from the same worktree state, so coordinate-based resolution had handed the second report the first sibling's records.
- Frozen-provider comparison: both arms ran the same multi-agent task under an exactly equal budget (4 attempts, 2144 completion tokens each); the frozen arm graded but never reported for training. Budget accounting verified end to end.

## Issue #3 Done-when

- [x] Adapter and attribution tests cover parallel agents, retries, late grading, duplicate reports, and missing inference references.
- [x] A one-agent GPU smoke run completes inference → grade → Reef batch → Slime train → serving update.
- [x] A multi-agent run completes without cross-agent attribution errors or scenario isolation violations.
- [x] The result bundle includes score-over-time, best artifact, model versions, token accounting, and replay metadata.
- [x] A clean-checkout guide documents CORAL setup, Reef/Slime topology, exact commands, and known limitations (`recipes/coral/README.md`).

## Follow-ups

- CORAL's gateway `header_provider` hook (merged into CORAL dev) will replace the middleware splice once released; the README notes this.
- The demo grader and scripted agents are placeholders by design — swapping in CORAL's real task and runtimes changes no wiring.
