### PR TITLE
feat(harness): Harness requests stage 4: a page per step and /reef-versions in reef-pi

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -539,6 +539,11 @@ captured receipts available for feedback, and registers nothing under
 ``skill`` ``reef-pi-extension-api`` (`reef/harness/adapters/pi/pi_extension_api.md
 <../../reef/harness/adapters/pi/pi_extension_api.md>`__, the pi extension
 API reference the service proposer reads before it writes an extension). The
+same extension's second command, ``/reef-versions [step]``, lists the release
+chain with each step's verdict and request, prints a step's page (``GET
+/reef/harness/releases/{step}/page``) and, for a pending release, the promote
+action and a trial install command, and ``/reef-versions <step> promote`` runs
+the promote after a confirmation. The
 agent only asks; the writing happens on the service, where the evolve step
 hands the request to the recipe's ``propose`` and the commit records it
 under ``training_request``, the merged ``requires`` list included.

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -53,6 +53,9 @@ Routes
 +-------------------------------------------------+---------------------------------------------------+
 | ``GET /reef/harness/releases``                  | the harness release catalog, oldest first         |
 +-------------------------------------------------+---------------------------------------------------+
+| ``GET /reef/harness/releases/{step}/page``      | one HTML page per catalog step: why, what         |
+|                                                 | changed, verdict, setup, chain                    |
++-------------------------------------------------+---------------------------------------------------+
 | ``POST /reef/harness/proposals``                | an agent's proposed tree change, admitted or not  |
 +-------------------------------------------------+---------------------------------------------------+
 | ``GET /reef/harness/install``                   | a shell script that installs the tree             |
@@ -559,6 +562,48 @@ the pending tree for a trial install. ``POST /reef/scenarios/{scenario}/promote`
 with ``{"release_id": "..."}`` serves it by the same republish path as
 rollback, so the promotion is itself a commit record with
 ``operation: promote`` and the promoted tree becomes a new release.
+
+Version page
+~~~~~~~~~~~~
+
+``GET /reef/harness/releases/{step}/page`` answers one self contained HTML
+page (``text/html``, no asset, its data inline) for one catalog row. ``step``
+is the row's position in ``GET /reef/harness/releases`` oldest first, the
+creation row being 0, which is the commit step: a rejected step publishes
+nothing and its row carries the head's release id, so the step is what names
+it. The page has five sections in this order: Why (the request the step read,
+else the claimed proposal's reason, else a failure in the batch), What changed
+(the step's mutations; an extension's file as text for a create, and for an
+update a line diff against the release the candidate ran on when that release
+is restorable, else the new text), Verdict (the verdict with ``selected``,
+``wins``, ``losses``, ``ties``, ``current_score``, ``candidate_score``,
+``episode_failures``, and the step record directory when
+``evolution.step_record_dir`` is set), Setup (the request's ``requires`` with
+name, kind and check, then the items the release carries from earlier steps
+in its chain, the same union the install script and ``reef-<adapter> setup``
+read; a rejected or skipped row lists only its own items, since its release
+id is the head's; nothing when both are empty) and Chain (the parent
+release, this release, and its children: the steps gated on it, won, lost or
+pending, and a promote or rollback made on it; a rejected or skipped step
+published nothing, so its Chain names the head it ran on and no children).
+The line under the title marks the served head as ``current``: the newest
+row that is neither pending nor a rejected or skipped step. A pending row
+that a later ``promote`` row names in ``rollback_target_release_id`` reads
+``promoted at step N``, where N is that later row's step. A step outside the
+catalog is HTTP 404 naming the range; a step that is not a number, or longer
+than nine digits, is HTTP 404 too. The row itself rides in a
+``<script type="application/json">`` block at the end of the page, every
+``<`` escaped.
+
+.. code:: bash
+
+   curl -sS -H "Authorization: Bearer $REEF_TOKEN" -H "x-reef-scenario: code-repair" \
+     "$REEF_URL/reef/harness/releases/3/page" > harness-step-3.html
+
+On pi, ``/reef-versions`` in a ``reef-pi`` session lists the chain, and
+``/reef-versions 3`` prints this URL with the promote command, the trial
+install (which replaces the installed tree) and the head's reinstall beside
+it when the release is pending; a promoted release gets none of them.
 
 Status
 ------

--- a/docs/site/scripts/check-doc-contracts.mjs
+++ b/docs/site/scripts/check-doc-contracts.mjs
@@ -63,8 +63,9 @@ if (!port) {
   throw new Error("Could not derive the Reef port from recipes/basic/local-sglang.yaml");
 }
 
-const routes = [...routeSource.matchAll(/app\.router\.add_(get|post)\("([^"]+)"/g)].map(
-  ([, method, path]) => ({ method: method.toUpperCase(), path }),
+// A raw string route with a matcher, {step:\d{1,9}}, is the docs row's {step}.
+const routes = [...routeSource.matchAll(/app\.router\.add_(get|post)\(r?"([^"]+)"/g)].map(
+  ([, method, path]) => ({ method: method.toUpperCase(), path: path.replace(/\{(\w+):(?:[^{}]|\{[^{}]*\})*\}/g, "{$1}") }),
 );
 if (!routes.length) throw new Error("Could not derive aiohttp routes from reef/service/routes");
 

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -522,6 +522,27 @@ notice prints the setup list instead of offering the install; a session
 that starts on a tree with an unmet item prints the list once and runs
 anyway. Nothing runs a check at install or at session start.
 
+See what a version is with ``/reef-versions`` in a ``reef-pi`` session: one
+line per catalog row, oldest first, with the step, the first eight characters
+of the release id, the verdict (``selected``, ``rejected``, ``skipped``,
+``pending``, ``promoted at step N`` once a later promote serves a pending
+release, else the row's operation: ``creation``, ``promote``, ``rollback`` or
+``recovery``), ``current`` on the served head and the request text the step
+answered. ``/reef-versions <step>`` prints the URL of that step's page,
+``GET /reef/harness/releases/<step>/page``, one self contained HTML page with
+five sections: Why (the request, else the proposal's reason, else a failure
+in the batch), What changed (the mutations; an extension update as a line
+diff against the release it ran on), Verdict (the gate's verdict and numbers,
+and the step record directory when ``evolution.step_record_dir`` is set),
+Setup (what the release needs from you: the step's own items, then those
+carried from earlier steps) and Chain (the parent, this release, and its
+children: the steps gated on it and any promote or rollback made on it; for
+a rejected or skipped step, the head it ran on). For a pending release the
+command also prints the promote curl, a trial install with ``?release_id=``
+that replaces the tree at your install root, and the head's reinstall to
+return to it; ``/reef-versions <step> promote`` runs the promote from the
+TUI after you confirm it.
+
 The native adapter's binary is ``reef-native``, which ships with reef, so
 the install route serves no script for it. Pull the tree with the client,
 name your Reef URL in its ``native/models.json``, and run the wrapper module

--- a/reef/harness/adapters/pi/requests.ts
+++ b/reef/harness/adapters/pi/requests.ts
@@ -1,11 +1,14 @@
-// Harness requests: the /reef-harness command for reef-pi. The person asks in plain
-// words; the request goes to reef with this session's id and the installed
-// release through native manual training; the service proposer writes the
-// change without requiring inference receipts or a feedback report. Nothing
-// here writes a mutation. Kept free of annotations on purpose: plain JavaScript
-// in a .ts file, so plain node can parse it in CI and pi's TS loader
-// accepts it unchanged. Gate episodes set PI_OFFLINE and this extension then
-// registers nothing, so the gate never sees the command.
+// Harness requests: the /reef-harness and /reef-versions commands for reef-pi. The
+// person asks in plain words; the request goes to reef with this session's id
+// and the installed release through native manual training; the service
+// proposer writes the change without requiring inference receipts or a
+// feedback report. /reef-versions lists the release chain with each step's
+// verdict and request, prints a step's page and, for a pending release, the
+// promote action and a trial install, and runs the promote after a
+// confirmation. Nothing here writes a mutation. Kept free of annotations on
+// purpose: plain JavaScript in a .ts file, so plain node can parse it in CI
+// and pi's TS loader accepts it unchanged. Gate episodes set PI_OFFLINE and
+// this extension then registers nothing, so the gate never sees the commands.
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -80,6 +83,165 @@ export default function requests(pi) {
       }
       const answer = await response.json();
       ctx.ui.notify(`Training request ${answer.agent_record_id} accepted.`, "info");
+    },
+  });
+
+  // The catalog oldest first; a step is a row's position in it, the creation row being 0, which is the commit
+  // step the service keys the page by (a rejected step publishes nothing, so only its position names it).
+  const releases = async () => {
+    let response;
+    try {
+      response = await fetch(`${serviceUrl}/reef/harness/releases`, { headers: reefHeaders() });
+    } catch (error) {
+      throw new Error(`reef unreachable at ${serviceUrl}: ${message(error)}`);
+    }
+    if (!response.ok) throw new Error(`reef refused the catalog read (HTTP ${response.status}): ${await response.text()}`);
+    const rows = (await response.json()).releases;
+    return Array.isArray(rows) ? rows : [];
+  };
+
+  // A promoted row stays pending in the catalog; the promote is a later row naming it, so with the rows given
+  // the pending row reads "promoted at step N".
+  const verdictOf = (row, rows = []) => {
+    if (row.pending) {
+      const promoted = rows.findIndex(
+        (other) => other.operation === "promote" && other.rollback_target_release_id === row.release_id,
+      );
+      return promoted >= 0 ? `promoted at step ${promoted}` : "pending";
+    }
+    const metrics = row.metrics && typeof row.metrics === "object" ? row.metrics : {};
+    if (typeof metrics.selected === "boolean") return metrics.selected ? "selected" : "rejected";
+    if (metrics.skipped) return "skipped";
+    return String(row.operation || "unknown");
+  };
+
+  // The served head: the newest row that is neither pending nor a rejected or skipped step, since those publish
+  // nothing and carry the head's id. The catalog's own current flag sits on the newest row, whatever it is.
+  const headStep = (rows) => {
+    for (let index = rows.length - 1; index >= 0; index--) {
+      if (!["pending", "rejected", "skipped"].includes(verdictOf(rows[index]))) return index;
+    }
+    return -1;
+  };
+
+  const requestText = (row) => {
+    const request = row.metrics && row.metrics.training_request;
+    const text = request && typeof request.text === "string" ? request.text.trim() : "";
+    if (!text) return "";
+    return `"${text.length > 60 ? `${text.slice(0, 57)}...` : text}"`;
+  };
+
+  const lineOf = (step, rows) =>
+    [
+      String(step),
+      String(rows[step].release_id || "").slice(0, 8),
+      verdictOf(rows[step], rows),
+      step === headStep(rows) ? "current" : "",
+      requestText(rows[step]),
+    ]
+      .filter(Boolean)
+      .join("  ");
+
+  const pageUrl = (step) => `${serviceUrl}/reef/harness/releases/${step}/page`;
+  // The token stays in the environment: the printed command names it as the variable, never its value.
+  const curl = () =>
+    `curl -fsS -H 'x-reef-scenario: ${scenario}' ` + (process.env.REEF_TOKEN ? '-H "Authorization: Bearer $REEF_TOKEN" ' : "");
+
+  const installLine = (releaseId) =>
+    `${curl()}'${serviceUrl}/reef/harness/install?adapter=pi&release_id=${encodeURIComponent(releaseId)}'` +
+    ` | bash -s -- '${destDir}'`;
+
+  const stepLines = (step, rows) => {
+    const row = rows[step];
+    const head = headStep(rows);
+    const verdict = verdictOf(row, rows);
+    const lines = [
+      `Harness step ${step}: ${row.release_id} (${verdict}${step === head ? ", current" : ""})`,
+      `page: ${pageUrl(step)}`,
+      `read it: ${curl()}'${pageUrl(step)}' > harness-step-${step}.html`,
+    ];
+    if (verdict === "pending") {
+      const body = JSON.stringify({ release_id: row.release_id });
+      lines.push(
+        `promote: ${curl()}-X POST -H 'content-type: application/json' -d '${body}' ` +
+          `'${serviceUrl}/reef/scenarios/${encodeURIComponent(scenario)}/promote'`,
+        `or from here: /reef-versions ${step} promote`,
+        `trial install (replaces the tree at ${destDir}): ${installLine(row.release_id)}`,
+      );
+      if (head >= 0) lines.push(`back to the head: ${installLine(rows[head].release_id)}`);
+    }
+    return lines;
+  };
+
+  pi.registerCommand("reef-versions", {
+    description: "List this harness's versions, or show one: /reef-versions [step] [promote]",
+    handler: async (args, ctx) => {
+      const words = (args || "").trim().split(/\s+/).filter(Boolean);
+      const promote = words[1] === "promote";
+      // Digits only before Number(): "1e1" and "0x3" are numbers to it and no step to the catalog.
+      const usable = words.length === 0 || (/^\d+$/.test(words[0]) && (words.length === 1 || (promote && words.length === 2)));
+      if (!usable) {
+        ctx.ui.notify("Usage: /reef-versions [step] [promote]", "warning");
+        return;
+      }
+      const step = words.length ? Number(words[0]) : null;
+      let rows;
+      try {
+        rows = await releases();
+      } catch (error) {
+        ctx.ui.notify(message(error), "error");
+        return;
+      }
+      if (step === null) {
+        ctx.ui.notify(rows.length ? rows.map((_, index) => lineOf(index, rows)).join("\n") : "no release on record", "info");
+        return;
+      }
+      const row = rows[step];
+      if (!row) {
+        ctx.ui.notify(`no step ${step}: the catalog holds steps 0 to ${rows.length - 1}`, "warning");
+        return;
+      }
+      if (!promote) {
+        ctx.ui.notify(stepLines(step, rows).join("\n"), "info");
+        return;
+      }
+      const verdict = verdictOf(row, rows);
+      if (verdict.startsWith("promoted")) {
+        ctx.ui.notify(`step ${step} is already ${verdict}; nothing to promote`, "warning");
+        return;
+      }
+      if (verdict !== "pending") {
+        ctx.ui.notify(`step ${step} is not pending (${verdict}); nothing to promote`, "warning");
+        return;
+      }
+      const confirmed = await ctx.ui.confirm(
+        `Promote harness step ${step}?`,
+        `Release ${row.release_id} then serves every session that installs the head. Read ${pageUrl(step)} first.`,
+      );
+      if (!confirmed) {
+        ctx.ui.notify(`step ${step} not promoted`, "info");
+        return;
+      }
+      let response;
+      try {
+        response = await fetch(`${serviceUrl}/reef/scenarios/${encodeURIComponent(scenario)}/promote`, {
+          method: "POST",
+          headers: { ...reefHeaders(), "content-type": "application/json" },
+          body: JSON.stringify({ release_id: row.release_id }),
+        });
+      } catch (error) {
+        ctx.ui.notify(`reef unreachable at ${serviceUrl}: ${message(error)}`, "error");
+        return;
+      }
+      if (!response.ok) {
+        ctx.ui.notify(`reef refused the promote (HTTP ${response.status}): ${await response.text()}`, "error");
+        return;
+      }
+      const answer = await response.json();
+      ctx.ui.notify(
+        `Promoted step ${step}: the head is now ${answer.release_id}; the update notice offers it at the next session start.`,
+        "info",
+      );
     },
   });
 }

--- a/reef/service/release_page.py
+++ b/reef/service/release_page.py
@@ -1,0 +1,384 @@
+"""One HTML page per catalog step: why the version exists, what it changed, the gate's verdict, its setup, its chain.
+
+``GET /reef/harness/releases/{step}/page`` builds it from the releases row
+plus, for an extension update, the file the release replaced. The page loads
+no asset and carries its data inline, so one curl with the scenario header is
+the whole read. The step is the row's position in the catalog oldest first,
+the creation row being 0: a rejected step publishes nothing and its row
+carries the head's release id, so only the step names it.
+"""
+
+from __future__ import annotations
+
+import difflib
+import html
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from reef.train.cordis_backend.requests import required_by
+
+#: The gate numbers the Verdict section lists, in this order, when the row carries them.
+VERDICT_FIELDS = ("selected", "wins", "losses", "ties", "current_score", "candidate_score", "episode_failures")
+
+#: Node kinds whose config carries the change as ``text``; the page shows that text instead of the config JSON.
+TEXT_KINDS = ("rules", "skill", "agent_command")
+
+STYLE = """
+:root{--bg:#f6f4ee;--ink:#1f2321;--mute:#6b6f6a;--line:#d9d5c9;--card:#fffdf8;--accent:#0a6f5c;--warn:#a1521a;--bad:#9b2c2c;--good:#2e7d4f;--code:#efece3}
+@media (prefers-color-scheme: dark){:root:not([data-theme="light"]){--bg:#15171a;--ink:#e8e6df;--mute:#9a9d97;--line:#2e3236;--card:#1c1f23;--accent:#4fc3a8;--warn:#e0a05a;--bad:#e07474;--good:#7fcf9a;--code:#22262b}}
+:root[data-theme="dark"]{--bg:#15171a;--ink:#e8e6df;--mute:#9a9d97;--line:#2e3236;--card:#1c1f23;--accent:#4fc3a8;--warn:#e0a05a;--bad:#e07474;--good:#7fcf9a;--code:#22262b}
+body{background:var(--bg);color:var(--ink);font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;margin:0;padding:0 0 4rem}
+main{max-width:960px;margin:0 auto;padding:1.5rem 1.25rem}
+h1{font-size:1.5rem;margin:0 0 .25rem}h2{font-size:1.05rem;margin:2rem 0 .75rem;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+h3{font-size:.95rem;margin:1rem 0 .5rem;font-weight:600}
+.sub{color:var(--mute);margin:0 0 1rem}.id{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.85rem}
+.tag{display:inline-block;font-size:.72rem;padding:0 .35rem;border:1px solid var(--line);border-radius:3px;margin-right:.25rem;color:var(--mute)}
+.selected,.promoted{color:var(--good)}.rejected{color:var(--bad)}.pending,.skipped{color:var(--warn)}
+pre{white-space:pre-wrap;word-break:break-word;background:var(--code);padding:.5rem;border-radius:4px;max-height:32rem;overflow:auto;font-size:.8rem}
+.add{color:var(--good)}.del{color:var(--bad)}.hunk{color:var(--mute)}
+table{border-collapse:collapse;width:100%;font-size:.85rem}th,td{text-align:left;padding:.3rem .5rem;border-bottom:1px solid var(--line);vertical-align:top}
+th{color:var(--mute);font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;white-space:nowrap}
+.empty{color:var(--mute);font-style:italic}
+"""
+
+
+def _esc(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def _short(release_id: Any) -> str:
+    return str(release_id)[:8] if release_id else "-"
+
+
+def mutations_of(metrics: Mapping[str, Any] | None) -> list[Mapping[str, Any]]:
+    """The step's mutations: ``mutation`` for one, ``mutations`` for a composite, none for a skip or a recheck."""
+    if not metrics:
+        return []
+    single = metrics.get("mutation")
+    if isinstance(single, Mapping):
+        return [single]
+    many = metrics.get("mutations")
+    if isinstance(many, Sequence) and not isinstance(many, str):
+        return [mutation for mutation in many if isinstance(mutation, Mapping)]
+    return []
+
+
+def verdict_of(row: Mapping[str, Any], rows: Sequence[Mapping[str, Any]] = ()) -> str:
+    """The row's verdict: pending, selected, rejected, skipped, else the operation (creation, promote, rollback).
+
+    A pending row stays pending in the catalog after a person promotes it;
+    the promote is a later row naming it in ``rollback_target_release_id``,
+    so with ``rows`` given such a row reads ``promoted at step N``."""
+    if row.get("pending"):
+        release_id = row.get("release_id")
+        for index, other in enumerate(rows):
+            if other.get("operation") == "promote" and other.get("rollback_target_release_id") == release_id:
+                return f"promoted at step {index}"
+        return "pending"
+    metrics = row.get("metrics")
+    if isinstance(metrics, Mapping):
+        if isinstance(metrics.get("selected"), bool):
+            return "selected" if metrics["selected"] else "rejected"
+        if metrics.get("skipped"):
+            return "skipped"
+    return str(row.get("operation") or "unknown")
+
+
+def _class(verdict: str) -> str:
+    return verdict.split(" ")[0]
+
+
+def _span(verdict: str) -> str:
+    return f'<span class="{_esc(_class(verdict))}">{_esc(verdict)}</span>'
+
+
+def served_step(rows: Sequence[Mapping[str, Any]]) -> int | None:
+    """The step whose release serves: the newest row that is neither pending nor a rejected or skipped step.
+
+    The catalog's own ``current`` flag sits on the newest row, which a
+    pending win or a lost gate makes the wrong one: those rows publish
+    nothing, and a rejected or skipped row carries the head's id."""
+    for index in range(len(rows) - 1, -1, -1):
+        if verdict_of(rows[index]) not in ("pending", "rejected", "skipped"):
+            return index
+    return None
+
+
+def before_release_id(row: Mapping[str, Any]) -> str | None:
+    """The release the step ran on: the parent of a release that won, the head a rejected or skipped step ran on.
+
+    A rejected or skipped step's row carries the head's own release id, so
+    its parent would be one release too far back."""
+    verdict = verdict_of(row)
+    if verdict in ("selected", "pending"):
+        parent = row.get("parent_release_id")
+        return str(parent) if parent else None
+    if verdict in ("rejected", "skipped"):
+        return str(row.get("release_id") or "") or None
+    return None
+
+
+def _why(row: Mapping[str, Any], metrics: Mapping[str, Any]) -> str:
+    operation = row.get("operation")
+    if operation != "training":
+        target = row.get("rollback_target_release_id")
+        words = {
+            "creation": "the tree this scenario started from; no step made it",
+            "promote": f"a person promoted release {target} after reading it",
+            "rollback": f"a person rolled the head back to release {target}",
+            "recovery": "the head this process recovered at boot",
+        }
+        return f"<p>{_esc(words.get(str(operation), f'a {operation} commit'))}</p>"
+    request = metrics.get("training_request")
+    if isinstance(request, Mapping) and request.get("text"):
+        return (
+            f"<p>{_esc(request['text'])}</p>"
+            f"<p class=\"sub\">request <span class=\"id\">{_esc(request.get('id'))}</span> from session "
+            f"<span class=\"id\">{_esc(request.get('session'))}</span> on release "
+            f"<span class=\"id\">{_esc(request.get('release_id'))}</span></p>"
+        )
+    proposal = metrics.get("proposal")
+    if isinstance(proposal, Mapping) and proposal.get("reason"):
+        return (
+            f"<p>{_esc(proposal['reason'])}</p>"
+            f"<p class=\"sub\">an agent's proposal <span class=\"id\">{_esc(proposal.get('id'))}</span> from session "
+            f"<span class=\"id\">{_esc(proposal.get('session'))}</span></p>"
+        )
+    return "<p>a failure in the batch</p>"
+
+
+def _diff_block(path: str, before: str, after: str, before_id: str | None, release_id: Any) -> str:
+    lines = difflib.unified_diff(
+        before.splitlines(),
+        after.splitlines(),
+        fromfile=f"{path} ({_short(before_id)})",
+        tofile=f"{path} ({_short(release_id)})",
+        lineterm="",
+    )
+    rendered = []
+    # By position, not prefix: the first two lines are the file headers, after which "++count;" is an addition.
+    for index, line in enumerate(lines):
+        if index < 2:
+            rendered.append(f'<span class="hunk">{_esc(line)}</span>')
+        elif line.startswith("+"):
+            rendered.append(f'<span class="add">{_esc(line)}</span>')
+        elif line.startswith("-"):
+            rendered.append(f'<span class="del">{_esc(line)}</span>')
+        elif line.startswith("@@"):
+            rendered.append(f'<span class="hunk">{_esc(line)}</span>')
+        else:
+            rendered.append(_esc(line))
+    if not rendered:
+        return f'<p class="empty">{_esc(path)} is unchanged</p>'
+    return "<pre>" + "\n".join(rendered) + "</pre>"
+
+
+def _mutation_block(
+    mutation: Mapping[str, Any],
+    row: Mapping[str, Any],
+    before_entries: Mapping[str, Mapping[str, Any]],
+    before_files: Mapping[str, str] | None,
+    node_paths: Mapping[str, str],
+) -> str:
+    op = str(mutation.get("op") or "?")
+    entry_id = str(mutation.get("id") or "?")
+    options = mutation.get("options")
+    options = options if isinstance(options, Mapping) else {}
+    previous = before_entries.get(entry_id, {})
+    kind = str(options.get("name") or previous.get("name") or "?")
+    head = f'<h3><span class="tag">{_esc(op)}</span>{_esc(entry_id)} <span class="tag">{_esc(kind)}</span></h3>'
+    if op == "remove":
+        return head
+    config = options.get("config")
+    config = config if isinstance(config, Mapping) else {}
+    if kind == "code_extension":
+        code = config.get("code")
+        if not isinstance(code, str):
+            return head + '<p class="empty">this mutation changes no code</p>'
+        previous_config = previous.get("config")
+        previous_config = previous_config if isinstance(previous_config, Mapping) else {}
+        name = config.get("name") or previous_config.get("name")
+        template = node_paths.get("code_extension")
+        if op == "update" and before_files is not None and template and name:
+            path = template.format(name=name)
+            before = before_files.get(path)
+            if before is not None:
+                return head + _diff_block(path, before, code, before_release_id(row), row.get("release_id"))
+        return head + f"<pre>{_esc(code)}</pre>"
+    if kind in TEXT_KINDS and isinstance(config.get("text"), str):
+        rest = {key: value for key, value in options.items() if key not in ("config", "name")}
+        rest.update({key: value for key, value in config.items() if key != "text"})
+        note = f'<p class="sub">{_esc(json.dumps(rest, sort_keys=True))}</p>' if rest else ""
+        return head + note + f"<pre>{_esc(config['text'])}</pre>"
+    return head + f"<pre>{_esc(json.dumps(options, indent=2, sort_keys=True))}</pre>"
+
+
+def _what_changed(
+    row: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    before_entries: Mapping[str, Mapping[str, Any]],
+    before_files: Mapping[str, str] | None,
+    node_paths: Mapping[str, str],
+) -> str:
+    mutations = mutations_of(metrics)
+    if mutations:
+        return "".join(_mutation_block(m, row, before_entries, before_files, node_paths) for m in mutations)
+    if metrics.get("skipped"):
+        return f'<p class="empty">nothing: the step skipped ({_esc(metrics["skipped"])})</p>'
+    if metrics.get("recheck"):
+        return '<p class="empty">nothing new: a recheck of the last good tree against the published one</p>'
+    if row.get("operation") == "training":
+        return '<p class="empty">no mutation on record</p>'
+    if row.get("operation") == "creation":
+        return '<p class="empty">nothing: the seed as the recipe rendered it</p>'
+    return '<p class="empty">no mutation: the head moved without a step</p>'
+
+
+def _verdict(row: Mapping[str, Any], metrics: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]) -> str:
+    verdict = verdict_of(row, rows)
+    notes = {
+        "pending": "won the gate; waits for a promote before any session installs it",
+        "selected": "won the gate and was published",
+        "rejected": "lost the gate; the head stayed",
+        "skipped": "no candidate reached the gate",
+    }
+    if _class(verdict) == "promoted":
+        notes[verdict] = f"won the gate and was {verdict}; the release that step published serves it"
+    lines = [f'<tr><th>verdict</th><td class="{_esc(_class(verdict))}">{_esc(verdict)}</td></tr>']
+    if verdict in notes:
+        lines.append(f"<tr><th>meaning</th><td>{_esc(notes[verdict])}</td></tr>")
+    if metrics.get("skipped"):
+        lines.append(f"<tr><th>skipped</th><td>{_esc(metrics['skipped'])}</td></tr>")
+    for field in VERDICT_FIELDS:
+        if field in metrics:
+            value = metrics[field]
+            shown = json.dumps(value) if isinstance(value, bool) else str(value)
+            lines.append(f"<tr><th>{_esc(field.replace('_', ' '))}</th><td>{_esc(shown)}</td></tr>")
+    selection = metrics.get("selection")
+    if isinstance(selection, Mapping) and selection.get("reason"):
+        lines.append(f"<tr><th>reason</th><td>{_esc(selection['reason'])}</td></tr>")
+    if metrics.get("step_record"):
+        lines.append(f'<tr><th>step record</th><td class="id">{_esc(metrics["step_record"])}</td></tr>')
+    return "<table><tbody>" + "".join(lines) + "</tbody></table>"
+
+
+def _requires_table(items: Sequence[Mapping[str, Any]]) -> str:
+    rows = "".join(
+        f"<tr><td>{_esc(item.get('name'))}</td><td>{_esc(item.get('kind'))}</td>"
+        f"<td class=\"id\">{_esc(item.get('check') or '')}</td></tr>"
+        for item in items
+    )
+    return f"<table><thead><tr><th>name</th><th>kind</th><th>check</th></tr></thead><tbody>{rows}</tbody></table>"
+
+
+def _setup(row: Mapping[str, Any], metrics: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]) -> str:
+    """The step's own ``training_request.requires`` items, then what its release carries from earlier steps.
+
+    The install script, ``reef-<adapter> setup`` and the update notice read
+    the union over the release's chain (``required_by``), so the page lists
+    the same items split by the step that named them. A rejected or skipped
+    row carries the head's id and published nothing, so only its own items
+    show."""
+    request = metrics.get("training_request")
+    requires = request.get("requires") if isinstance(request, Mapping) else None
+    own = [item for item in requires if isinstance(item, Mapping)] if isinstance(requires, Sequence) else []
+    carried: list[Mapping[str, Any]] = []
+    if verdict_of(row) not in ("rejected", "skipped"):
+        names = {item.get("name") for item in own}
+        carried = [item for item in required_by(rows, row.get("release_id")) if item.get("name") not in names]
+    if not own and not carried:
+        return '<p class="empty">this step names nothing to set up</p>'
+    parts = [_requires_table(own) if own else '<p class="empty">this step names nothing of its own</p>']
+    if carried:
+        parts.append(f"<h3>carried from earlier steps</h3>{_requires_table(carried)}")
+    parts.append('<p class="sub">reef-pi setup lists these and runs a check only after you confirm it</p>')
+    return "".join(parts)
+
+
+def _ran_on(other: Mapping[str, Any], release_id: Any) -> bool:
+    """Whether ``other`` is a child of ``release_id``: a step gated on it, or a promote or rollback made on it."""
+    if not release_id:
+        return False
+    if other.get("operation") in ("promote", "rollback"):
+        return other.get("parent_release_id") == release_id
+    # Not the parent: a rejected or skipped row copies the head's ref, so its parent is the grandparent.
+    return before_release_id(other) == release_id
+
+
+def _chain(step: int, row: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]) -> str:
+    release_id = row.get("release_id")
+    verdict = verdict_of(row)
+    if verdict in ("rejected", "skipped"):
+        # The row carries the head's id and published nothing, so the head's parent and children are not its own.
+        ran_on = _esc(before_release_id(row) or "-")
+        if verdict == "rejected":
+            ran_on += " (the head at this step; the candidate published nothing)"
+        else:
+            ran_on += " (the head at this step; nothing was gated)"
+        return (
+            "<table><tbody>"
+            f'<tr><th>ran on</th><td class="id">{ran_on}</td></tr>'
+            '<tr><th>children</th><td><span class="empty">none (the candidate published nothing)</span></td></tr>'
+            "</tbody></table>"
+        )
+    children = [
+        f'<li>step {index} <span class="id">{_esc(other.get("release_id"))}</span> {_span(verdict_of(other, rows))}</li>'
+        for index, other in enumerate(rows)
+        if index != step and _ran_on(other, release_id)
+    ]
+    listed = "<ul>" + "".join(children) + "</ul>" if children else '<span class="empty">none</span>'
+    return (
+        "<table><tbody>"
+        f'<tr><th>parent</th><td class="id">{_esc(row.get("parent_release_id") or "-")}</td></tr>'
+        f'<tr><th>this release</th><td class="id">{_esc(release_id)}</td></tr>'
+        f"<tr><th>children</th><td>{listed}</td></tr>"
+        "</tbody></table>"
+    )
+
+
+def build_release_page(
+    step: int,
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    before_entries: Sequence[Mapping[str, Any]] = (),
+    before_files: Mapping[str, str] | None = None,
+    node_paths: Mapping[str, str] | None = None,
+) -> str:
+    """The page for ``rows[step]``, the rows oldest first as ``GET /reef/harness/releases`` lists them.
+
+    ``before_entries`` and ``before_files`` describe the release an update is
+    read against (see ``before_release_id``); ``node_paths`` is the adapter's
+    render template per kind, which names an extension's file. Without them an
+    extension update shows its new text instead of a diff. Pure ASCII out:
+    other characters leave as numeric references.
+    """
+    row = rows[step]
+    metrics = row.get("metrics")
+    metrics = metrics if isinstance(metrics, Mapping) else {}
+    entries = {str(entry["id"]): entry for entry in before_entries if isinstance(entry, Mapping) and "id" in entry}
+    verdict = verdict_of(row, rows)
+    recorded = row.get("recorded_at")
+    title = f"Harness step {step}"
+    sub = f'release <span class="id">{_esc(row.get("release_id"))}</span> | {_span(verdict)}'
+    if served_step(rows) == step:
+        sub += " | current"
+    if isinstance(recorded, (int, float)):
+        sub += f" | recorded at {recorded:.0f}"
+    # Every "<" leaves the JSON as \u003c: a code text holding "</script>" would otherwise close the data block.
+    data = json.dumps(row, ensure_ascii=True, sort_keys=True).replace("<", "\\u003c")
+    page = (
+        f"<title>{title}</title>\n<style>{STYLE}</style>\n<main>\n"
+        f'<h1>{title}</h1>\n<p class="sub">{sub}</p>\n'
+        f"<h2>Why</h2>\n{_why(row, metrics)}\n"
+        f"<h2>What changed</h2>\n{_what_changed(row, metrics, entries, before_files, node_paths or {})}\n"
+        f"<h2>Verdict</h2>\n{_verdict(row, metrics, rows)}\n"
+        f"<h2>Setup</h2>\n{_setup(row, metrics, rows)}\n"
+        f"<h2>Chain</h2>\n{_chain(step, row, rows)}\n"
+        "</main>\n"
+        f'<script id="data" type="application/json">{data}</script>\n'
+    )
+    return page.encode("ascii", "xmlcharrefreplace").decode("ascii")
+
+
+__all__ = ["VERDICT_FIELDS", "before_release_id", "build_release_page", "mutations_of", "served_step", "verdict_of"]

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import Any, Protocol, runtime_checkable
 
-from reef.artifact.artifact import Artifact, ArtifactNotFound, ArtifactRef
+from reef.artifact.artifact import Artifact, ArtifactError, ArtifactNotFound, ArtifactRef
 from reef.core.errors import ReefError, UnknownScenario
 from reef.core.records_types import RequestType
 from reef.core.training_request import TrainingRequest
@@ -30,6 +30,7 @@ from reef.runtime.base import InferenceAdmissionHandle, TrainingRuntime
 from reef.runtime.inference import InferenceBackend, InferenceStream
 from reef.scenario.scenario import Scenario
 from reef.service.install_script import TOKEN_PLACEHOLDER, render_install_script
+from reef.service.release_page import before_release_id, build_release_page
 from reef.service.wire import SCENARIO_HEADER, ProposalPayload, ReportPayload, RequestHeaders, parse_request_headers
 from reef.surface.base import InferenceLease, LeasingInferenceHooks, Surface
 from reef.surface.weights import RuntimeLoadMismatch, reported_runtime_load_id, reported_runtime_load_spans
@@ -551,6 +552,46 @@ class RequestService:
             "scenario": scenario.name,
             "releases": list(reversed(scenario.releases())),
         }
+
+    def harness_release_page(self, headers: Mapping[str, str], step: int) -> str:
+        """One HTML page for the catalog row at ``step``, counted oldest first with the creation row as 0.
+
+        The rows are the ones ``harness_releases`` answers, so the step a
+        client counts there is the step this page names. The release the
+        step ran on (the parent of a win, the head a rejected or skipped
+        step ran on) comes through the artifact snapshot when it is
+        restorable, so an extension update shows as a diff, else as its new
+        text. An unknown step raises ArtifactNotFound naming the range.
+        """
+        scenario = self._file_scenario(headers)
+        rows = list(reversed(scenario.releases()))
+        if not 0 <= step < len(rows):
+            raise ArtifactNotFound(
+                f"scenario {scenario.name!r} has no step {step}: the catalog holds steps 0 to {len(rows) - 1}"
+            )
+        before = before_release_id(rows[step])
+        before_entries: Sequence[Mapping[str, Any]] = ()
+        before_files: Mapping[str, str] | None = None
+        if before is not None:
+            info = scenario.surface.harness
+            logged = scenario.entries_for_version(before)
+            if logged is None and info is not None:
+                logged = info.seed_entries
+            before_entries = logged or ()
+            tree = scenario.surface.files
+            try:
+                artifact, _ = scenario.artifact_snapshot(before)
+                before_files = None if tree is None else tree.read_files(artifact)
+            except ArtifactError:
+                before_files = None
+        descriptor = getattr(scenario.trainer.training_backend, "descriptor", None)
+        return build_release_page(
+            step,
+            rows,
+            before_entries=before_entries,
+            before_files=before_files,
+            node_paths=None if descriptor is None else descriptor.node_paths,
+        )
 
     def harness_install_script(
         self,

--- a/reef/service/routes/system.py
+++ b/reef/service/routes/system.py
@@ -36,6 +36,11 @@ def register_system_routes(app: web.Application, *, request_service: RequestServ
         catalog = await asyncio.to_thread(request_service.harness_releases, request.headers)
         return web.json_response(catalog)
 
+    async def harness_release_page(request: web.Request) -> web.Response:
+        step = int(request.match_info["step"])
+        page = await asyncio.to_thread(request_service.harness_release_page, request.headers, step)
+        return web.Response(text=page, content_type="text/html")
+
     async def harness_proposals(request: web.Request) -> web.Response:
         payload = await read_object(request)
         answer = await asyncio.to_thread(request_service.harness_propose, request.headers, payload)
@@ -72,6 +77,8 @@ def register_system_routes(app: web.Application, *, request_service: RequestServ
     app.router.add_get("/reef/harness", harness)
     app.router.add_get("/reef/harness/install", harness_install)
     app.router.add_get("/reef/harness/releases", harness_releases)
+    # One to nine digits: a step that is no number, or longer than any catalog, is no row; the router's own 404 answers it.
+    app.router.add_get(r"/reef/harness/releases/{step:\d{1,9}}/page", harness_release_page)
     app.router.add_post("/reef/harness/proposals", harness_proposals)
     app.router.add_get("/reef/harness/adapters", adapters)
     app.router.add_get("/reef/status", status)

--- a/tests/reef_service/test_http_api_docs.py
+++ b/tests/reef_service/test_http_api_docs.py
@@ -1,0 +1,37 @@
+"""The grid tables in docs/reference/http-api.rst stay aligned: the docs site drops a short row's cell and reports nothing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+HTTP_API = Path(__file__).parents[2] / "docs" / "reference" / "http-api.rst"
+
+
+def grid_tables(lines: list[str]) -> list[tuple[int, list[str]]]:
+    """Each run of consecutive grid table lines (the ones starting with + or |) with its first line number."""
+    tables: list[tuple[int, list[str]]] = []
+    block: list[str] = []
+    start = 0
+    for number, line in enumerate(lines, 1):
+        if line.startswith(("+", "|")):
+            if not block:
+                start = number
+            block.append(line)
+        elif block:
+            tables.append((start, block))
+            block = []
+    if block:
+        tables.append((start, block))
+    return tables
+
+
+def test_every_grid_table_line_has_its_bars_in_the_same_columns() -> None:
+    tables = grid_tables(HTTP_API.read_text(encoding="utf-8").splitlines())
+    assert any("/reef/harness/releases/{step}/page" in line for _, block in tables for line in block)
+    for start, block in tables:
+        columns = [index for index, char in enumerate(block[0]) if char == "+"]
+        assert len(columns) >= 2, f"docs/reference/http-api.rst:{start} does not open a grid table"
+        for offset, line in enumerate(block):
+            where = f"docs/reference/http-api.rst:{start + offset}"
+            assert len(line) == len(block[0]), f"{where} is {len(line)} characters wide; the table is {len(block[0])}"
+            assert all(line[column] in "+|" for column in columns), f"{where} has a bar off the table's columns"

--- a/tests/reef_service/test_release_page.py
+++ b/tests/reef_service/test_release_page.py
@@ -1,0 +1,559 @@
+"""The page per catalog step: why a version exists, what it changed, the gate's verdict, its setup and its chain.
+
+``GET /reef/harness/releases/{step}/page`` renders it from the releases row,
+the step being the row's position oldest first with the creation row as 0. The
+chain driven here runs in ``training_mode: hybrid``: one published win and one
+rejected candidate answering requests posted to ``POST /reef/train``, one
+rejected automatic step from a scored report with no request, and one pending
+extension update, again from a request, whose page diffs the file against the
+head.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from aiohttp.test_utils import TestClient, TestServer
+from reef_service.test_harness_recipe import SEED_MODELS, SEED_SETTINGS, make_binary, runtime
+from reef_service.test_harness_requests import _post, _request
+
+from reef.artifact import InMemoryRepositoryBackend
+from reef.core import AgentRecord, RequestType
+from reef.dispatcher import Dispatcher
+from reef.harness.episodes.run import EpisodeResult
+from reef.service.app import create_app
+from reef.service.release_page import before_release_id, build_release_page, served_step, verdict_of
+from reef.train.cordis_backend import CordisRecipe, Mutation
+from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
+
+MODULE = Path(__file__).parents[2] / "reef" / "service" / "release_page.py"
+
+OLD_CODE = "export default function hello(pi) {\n  if (1 < 2) return;\n}\n"
+NEW_CODE = 'export default function hello(pi) {\n  if (1 < 2) return;\n  pi.on("session_start", () => {});\n}\n'
+SEED_RULES = {"id": "r1", "name": "rules", "config": {"text": "Answer briefly."}}
+SEED_EXTENSION = {"id": "ext", "name": "code_extension", "config": {"name": "hello", "code": OLD_CODE}}
+SEED = (SEED_MODELS, SEED_SETTINGS, SEED_RULES, SEED_EXTENSION)
+
+MARKER = Mutation("update", "r1", {"config": {"text": "marker rules"}})
+PLAIN = Mutation("update", "r1", {"config": {"text": "Answer briefly, with care."}})
+TWO_MARKERS = Mutation("update", "r1", {"config": {"text": "marker marker rules"}})
+EXTENSION = Mutation("update", "ext", {"config": {"name": "hello", "code": NEW_CODE}})
+NOTES = Mutation("create", "s1", {"name": "skill", "config": {"name": "notes", "text": "# notes"}})
+
+FIRST = "run the tests before you answer"
+SECOND = "answer with more care"
+FOURTH = "log a note when a < b, before the turn ends"
+# What the proposer answers each request with; an automatic step, with no request, proposes NOTES from the failure.
+ANSWERS = {FIRST: MARKER, SECOND: PLAIN, FOURTH: (TWO_MARKERS, EXTENSION)}
+SCENARIO = "agents"
+
+
+def evaluate(task: str, result: EpisodeResult) -> float:
+    # Marker count, so a second marker still beats a head that carries one.
+    return float(result.trajectory[-1]["rules"].count("marker"))
+
+
+def _propose(nodes, samples, models, *, requests=()):
+    return ANSWERS[requests[0]["text"]] if requests else NOTES
+
+
+def _dispatcher(tmp_path: Path) -> Dispatcher:
+    recipe = CordisRecipe(
+        resolve_proposer(_propose),
+        resolve_episode_scorer(evaluate),
+        ("task one",),
+        binary=str(make_binary(tmp_path)),
+        seed=SEED,
+        runtime=runtime(),
+        proposals_dir=str(tmp_path / "inbox"),
+        review_kinds=("code_extension",),
+        training_mode="hybrid",
+    )
+    bootstrap = tmp_path / "bootstrap"
+    bootstrap.mkdir()
+    # What the service assembly does: the recipe's seed is the base artifact every scenario forks from.
+    for relative, text in (recipe.base_artifact_files() or {}).items():
+        target = bootstrap / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    factory = InMemoryRepositoryBackend.factory(bootstrap, root=tmp_path / "repository")
+    return Dispatcher(
+        recipe, factory, local_artifact_dir=tmp_path / "local", agent_record_dir=tmp_path / "agent-record"
+    )
+
+
+def _report(dispatcher: Dispatcher, suffix: str) -> None:
+    """One scored exchange through the dispatcher: what wakes an automatic step in ``hybrid`` mode."""
+    inference = AgentRecord.create(
+        scenario=SCENARIO,
+        request_type=RequestType.INFERENCE,
+        payload={"messages": [{"role": "user", "content": "q"}]},
+        agent_record_id=f"i{suffix}",
+    )
+    report = AgentRecord.create(
+        scenario=SCENARIO,
+        request_type=RequestType.REPORT,
+        payload={"score": 0.0, "references": [f"i{suffix}"]},
+        agent_record_id=f"r{suffix}",
+    )
+    dispatcher.accept_record(inference)
+    dispatcher.accept_record(report)
+
+
+async def _committed(scenario, count: int, seconds: float = 30.0) -> None:
+    """Returns once the catalog holds ``count`` rows; the dispatcher's worker runs the steps on its own thread."""
+    for _ in range(int(seconds / 0.05)):
+        if len(scenario.releases()) >= count:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"the catalog did not reach {count} rows in {seconds}s: {scenario.releases()}")
+
+
+def _chain(tmp_path: Path) -> Dispatcher:
+    """Steps 1 to 4 on one scenario: published, rejected, rejected without a request, pending extension."""
+    dispatcher = _dispatcher(tmp_path)
+    scenario = dispatcher.get_or_create_scenario(SCENARIO)
+    assert scenario is not None
+
+    async def run() -> None:
+        client = TestClient(TestServer(create_app(dispatcher)))
+        await client.start_server()
+        try:
+            # One step at a time, so the rows land in the order the pages are counted by.
+            for count, body in ((2, _request(FIRST)), (3, _request(SECOND, session="s2"))):
+                response = await _post(client, body, SCENARIO)
+                assert response.status == 200, await response.text()
+                await _committed(scenario, count)
+            _report(dispatcher, "3")
+            await _committed(scenario, 4)
+            response = await _post(client, _request(FOURTH, session="s4", release_id="rel-1"), SCENARIO)
+            assert response.status == 200, await response.text()
+            await _committed(scenario, 5)
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+    rows = list(reversed(scenario.releases()))
+    assert [verdict_of(row) for row in rows] == ["creation", "selected", "rejected", "rejected", "pending"]
+    assert ["training_request" in (row.get("metrics") or {}) for row in rows] == [False, True, True, False, True]
+    return dispatcher
+
+
+def _pages(dispatcher: Dispatcher, *paths: str) -> list[tuple[int, str, str]]:
+    async def run() -> list[tuple[int, str, str]]:
+        client = TestClient(TestServer(create_app(dispatcher)))
+        await client.start_server()
+        try:
+            answers = []
+            for path in paths:
+                response = await client.get(path, headers={"x-reef-scenario": SCENARIO})
+                answers.append((response.status, response.headers.get("content-type", ""), await response.text()))
+            return answers
+        finally:
+            await client.close()
+
+    return asyncio.run(run())
+
+
+def _page(dispatcher: Dispatcher, step: int) -> str:
+    ((status, content_type, page),) = _pages(dispatcher, f"/reef/harness/releases/{step}/page")
+    assert status == 200 and content_type.startswith("text/html")
+    page.encode("ascii")
+    return page
+
+
+def _sections(page: str) -> list[str]:
+    return [line[4:-5] for line in page.splitlines() if line.startswith("<h2>")]
+
+
+def _data(page: str) -> dict:
+    _, _, tail = page.partition('<script id="data" type="application/json">')
+    block, _, _ = tail.partition("</script>")
+    assert "<" not in block
+    return json.loads(block)
+
+
+def _section(page: str, name: str) -> str:
+    _, _, tail = page.partition(f"<h2>{name}</h2>")
+    body, _, _ = tail.partition("<h2>")
+    return body
+
+
+def _sub(page: str) -> str:
+    """The line under the title: the release id, the verdict, current on the served head, the commit time."""
+    return next(line for line in page.splitlines() if line.startswith('<p class="sub">'))
+
+
+def test_the_page_for_a_published_step_carries_the_request_the_verdict_and_the_chain(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        rows = list(reversed(dispatcher.get_or_create_scenario(SCENARIO).releases()))
+        page = _page(dispatcher, 1)
+        assert page.startswith("<title>Harness step 1</title>")
+        assert "<h1>Harness step 1</h1>" in page
+        assert _sections(page) == ["Why", "What changed", "Verdict", "Setup", "Chain"]
+        assert FIRST in _section(page, "Why") and "3f1c2a9d0b7e" in _section(page, "Why")
+        changed = _section(page, "What changed")
+        assert '<span class="tag">update</span>r1 <span class="tag">rules</span>' in changed
+        assert "<pre>marker rules</pre>" in changed
+        verdict = _section(page, "Verdict")
+        assert '<td class="selected">selected</td>' in verdict
+        assert "<th>wins</th><td>1</td>" in verdict and "<th>losses</th><td>0</td>" in verdict
+        assert "<th>candidate score</th><td>1.0</td>" in verdict and "<th>current score</th><td>0.0</td>" in verdict
+        assert "<th>episode failures</th><td>0</td>" in verdict
+        assert "nothing to set up" in _section(page, "Setup")
+        chain = _section(page, "Chain")
+        assert rows[0]["release_id"] in chain and rows[1]["release_id"] in chain
+        # The pending extension update was gated against this head, so it is this release's child.
+        assert f"<li>step 4 <span class=\"id\">{rows[4]['release_id']}</span>" in chain
+        data = _data(page)
+        assert data["release_id"] == rows[1]["release_id"] and data["metrics"]["training_request"]["text"] == FIRST
+        assert data["metrics"]["training_request"]["requires"] == []
+    finally:
+        dispatcher.close()
+
+
+def test_the_page_for_a_pending_extension_step_diffs_the_file_against_the_head(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        rows = list(reversed(dispatcher.get_or_create_scenario(SCENARIO).releases()))
+        page = _page(dispatcher, 4)
+        assert "<title>Harness step 4</title>" in page
+        assert FOURTH.replace("<", "&lt;") in _section(page, "Why")
+        changed = _section(page, "What changed")
+        assert '<span class="tag">update</span>ext <span class="tag">code_extension</span>' in changed
+        # A unified diff of the rendered file against the head's copy, the added line marked.
+        assert f"--- pi-agent/extensions/hello.ts ({rows[1]['release_id'][:8]})" in changed
+        assert f"+++ pi-agent/extensions/hello.ts ({rows[4]['release_id'][:8]})" in changed
+        assert '<span class="add">+  pi.on(&quot;session_start&quot;, () =&gt; {});</span>' in changed
+        assert "if (1 &lt; 2) return;" in changed
+        # The rules bump that made the composite win rides beside it.
+        assert "<pre>marker marker rules</pre>" in changed
+        verdict = _section(page, "Verdict")
+        assert '<td class="pending">pending</td>' in verdict and "waits for a promote" in verdict
+        chain = _section(page, "Chain")
+        assert f'<tr><th>parent</th><td class="id">{rows[1]["release_id"]}</td></tr>' in chain
+        assert rows[4]["release_id"] in chain and "<li>" not in chain
+        data = _data(page)
+        assert data["pending"] is True and data["metrics"]["mutations"][1]["options"]["config"]["code"] == NEW_CODE
+    finally:
+        dispatcher.close()
+
+
+def test_the_page_for_a_rejected_step_names_the_head_it_ran_on_and_the_candidate(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        rows = list(reversed(dispatcher.get_or_create_scenario(SCENARIO).releases()))
+        page = _page(dispatcher, 2)
+        assert SECOND in _section(page, "Why") and "s2" in _section(page, "Why")
+        assert "<pre>Answer briefly, with care.</pre>" in _section(page, "What changed")
+        verdict = _section(page, "Verdict")
+        assert '<td class="rejected">rejected</td>' in verdict and "the head stayed" in verdict
+        assert "<th>wins</th><td>0</td>" in verdict and "<th>losses</th><td>1</td>" in verdict
+        chain = _section(page, "Chain")
+        assert rows[2]["release_id"] == rows[1]["release_id"]
+        assert f'{rows[1]["release_id"]} (the head at this step; the candidate published nothing)' in chain
+        assert before_release_id(rows[2]) == rows[1]["release_id"]
+    finally:
+        dispatcher.close()
+
+
+def test_the_page_for_an_automatic_step_without_a_request_says_a_failure_in_the_batch(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        page = _page(dispatcher, 3)
+        assert "<p>a failure in the batch</p>" in _section(page, "Why")
+        changed = _section(page, "What changed")
+        assert '<span class="tag">create</span>s1 <span class="tag">skill</span>' in changed
+        assert "<pre># notes</pre>" in changed and "notes" in changed
+        assert '<td class="rejected">rejected</td>' in _section(page, "Verdict")
+        # The trainer writes training_request on every request step's row; an automatic step has none.
+        assert "training_request" not in _data(page)["metrics"]
+    finally:
+        dispatcher.close()
+
+
+def test_the_chain_lists_the_steps_gated_against_a_release_as_its_children(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        rows = list(reversed(dispatcher.get_or_create_scenario(SCENARIO).releases()))
+        page = _page(dispatcher, 0)
+        assert "<title>Harness step 0</title>" in page
+        assert "no step made it" in _section(page, "Why")
+        assert "the seed as the recipe rendered it" in _section(page, "What changed")
+        assert '<td class="creation">creation</td>' in _section(page, "Verdict")
+        chain = _section(page, "Chain")
+        # Only the win ran on the seed; the two rejected candidates ran on the win, whose id their rows carry.
+        assert chain.count("<li>step ") == 1
+        assert (
+            f'<li>step 1 <span class="id">{rows[1]["release_id"]}</span> <span class="selected">selected</span>'
+            in chain
+        )
+        assert '<span class="rejected">' not in chain
+        head = _section(_page(dispatcher, 1), "Chain")
+        assert head.count("<li>step ") == 3 and "<li>step 1 " not in head
+        for step in (2, 3):
+            assert f'<li>step {step} <span class="id">{rows[1]["release_id"]}</span> <span class="rejected">' in head
+        assert (
+            f'<li>step 4 <span class="id">{rows[4]["release_id"]}</span> <span class="pending">pending</span>' in head
+        )
+    finally:
+        dispatcher.close()
+
+
+def test_an_unknown_step_is_404_naming_the_range_and_a_non_number_is_404(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        (missing, letters, long, longer) = _pages(
+            dispatcher,
+            "/reef/harness/releases/9/page",
+            "/reef/harness/releases/x/page",
+            "/reef/harness/releases/9999999999/page",
+            f"/reef/harness/releases/{'9' * 5000}/page",
+        )
+        assert missing[0] == 404 and "has no step 9" in missing[2] and "steps 0 to 4" in missing[2]
+        assert letters[0] == 404
+        # Ten digits and more never match the route: no catalog is that long, and int() would balk past 4300.
+        assert long[0] == 404 and longer[0] == 404
+    finally:
+        dispatcher.close()
+
+
+def test_the_page_module_is_ascii_and_the_builder_escapes_every_angle_bracket() -> None:
+    MODULE.read_text(encoding="utf-8").encode("ascii")
+    creation = {"release_id": "rel-0", "parent_release_id": None, "operation": "creation", "current": False}
+    row = {
+        "release_id": "rel-1",
+        "parent_release_id": "rel-0",
+        "operation": "training",
+        "pending": False,
+        "current": True,
+        "recorded_at": 1756400000.0,
+        "metrics": {
+            "steps": 1,
+            "selected": True,
+            "wins": 2,
+            "losses": 0,
+            "ties": 1,
+            "current_score": 1.0,
+            "candidate_score": 3.0,
+            "episode_failures": 1,
+            "step_record": "/srv/reef/steps/agents/1",
+            "selection": {"reason": "candidate won 2 of 3"},
+            "mutation": {"op": "create", "id": "n1", "options": {"name": "rules", "config": {"text": "<b>bold</b>"}}},
+            "training_request": {
+                "id": "q-1",
+                "session": "s1",
+                "release_id": "rel-0",
+                "text": "caf\u00e9 <script>alert(1)</script>",
+                "requires": [
+                    {"name": "SLACK_WEBHOOK", "kind": "env", "check": "SLACK_WEBHOOK"},
+                    {"name": "notifications", "kind": "permission", "check": "osascript -e '1 < 2'"},
+                    {"name": "calendar", "kind": "service"},
+                ],
+            },
+        },
+    }
+    page = build_release_page(1, [creation, row])
+    page.encode("ascii")
+    assert "<script>alert" not in page and "&lt;script&gt;alert(1)&lt;/script&gt;" in page
+    assert "caf&#233;" in page
+    assert "<pre>&lt;b&gt;bold&lt;/b&gt;</pre>" in page
+    verdict = _section(page, "Verdict")
+    assert "<th>ties</th><td>1</td>" in verdict and "<th>episode failures</th><td>1</td>" in verdict
+    assert '<td class="id">/srv/reef/steps/agents/1</td>' in verdict and "candidate won 2 of 3" in verdict
+    setup = _section(page, "Setup")
+    assert '<tr><td>SLACK_WEBHOOK</td><td>env</td><td class="id">SLACK_WEBHOOK</td></tr>' in setup
+    assert (
+        '<tr><td>notifications</td><td>permission</td><td class="id">osascript -e &#x27;1 &lt; 2&#x27;</td></tr>'
+        in setup
+    )
+    assert '<tr><td>calendar</td><td>service</td><td class="id"></td></tr>' in setup
+    assert "reef-pi setup" in setup and "carried from earlier steps" not in setup
+    data = _data(page)
+    assert data["metrics"]["training_request"]["text"] == "caf\u00e9 <script>alert(1)</script>"
+    assert data["metrics"]["training_request"]["requires"][1]["check"] == "osascript -e '1 < 2'"
+    assert "recorded at 1756400000" in page
+
+
+def test_the_setup_section_splits_the_steps_own_items_from_what_the_chain_carries() -> None:
+    """The same union the install script reads (required_by), shown by the step that named each item."""
+    twilio = {"name": "TWILIO_SID", "kind": "env", "check": "TWILIO_SID"}
+    notify = {"name": "notify", "kind": "permission", "check": "test -d /"}
+    never = {"name": "never", "kind": "service"}
+    creation = {"release_id": "rel-0", "parent_release_id": None, "operation": "creation"}
+    first = {
+        "release_id": "rel-1",
+        "parent_release_id": "rel-0",
+        "operation": "training",
+        "metrics": {"selected": True, "training_request": {"id": "q-1", "text": "text me", "requires": [twilio]}},
+    }
+    # The rejected candidate's row carries the head's id; its own item never installed anywhere.
+    rejected = {
+        "release_id": "rel-1",
+        "parent_release_id": "rel-0",
+        "operation": "training",
+        "metrics": {"selected": False, "training_request": {"id": "q-2", "text": "more", "requires": [never]}},
+    }
+    second = {
+        "release_id": "rel-2",
+        "parent_release_id": "rel-1",
+        "operation": "training",
+        "pending": True,
+        "metrics": {"selected": True, "training_request": {"id": "q-3", "text": "notify", "requires": [notify]}},
+    }
+    promote = {
+        "release_id": "rel-3",
+        "parent_release_id": "rel-1",
+        "operation": "promote",
+        "rollback_target_release_id": "rel-2",
+    }
+    rows = [creation, first, rejected, second, promote]
+    twilio_row = '<tr><td>TWILIO_SID</td><td>env</td><td class="id">TWILIO_SID</td></tr>'
+    notify_row = '<tr><td>notify</td><td>permission</td><td class="id">test -d /</td></tr>'
+
+    assert "nothing to set up" in _section(build_release_page(0, rows), "Setup")
+    own_only = _section(build_release_page(1, rows), "Setup")
+    assert twilio_row in own_only and "carried from earlier steps" not in own_only
+    candidate = _section(build_release_page(2, rows), "Setup")
+    assert '<tr><td>never</td><td>service</td><td class="id"></td></tr>' in candidate
+    assert "TWILIO_SID" not in candidate and "carried from earlier steps" not in candidate
+    pending = _section(build_release_page(3, rows), "Setup")
+    own, _, carried = pending.partition("<h3>carried from earlier steps</h3>")
+    assert notify_row in own and twilio_row not in own
+    assert twilio_row in carried and notify_row not in carried
+    assert "reef-pi setup" in carried
+    # The promote row names nothing itself; through its target it carries the whole chain.
+    promoted = _section(build_release_page(4, rows), "Setup")
+    own, _, carried = promoted.partition("<h3>carried from earlier steps</h3>")
+    assert "nothing of its own" in own and twilio_row in carried and notify_row in carried
+    assert carried.index(twilio_row) < carried.index(notify_row)
+
+
+def test_an_extension_update_without_the_parents_file_shows_its_new_text() -> None:
+    creation = {"release_id": "rel-0", "parent_release_id": None, "operation": "creation"}
+    row = {
+        "release_id": "rel-1",
+        "parent_release_id": "rel-0",
+        "operation": "training",
+        "pending": True,
+        "metrics": {
+            "selected": True,
+            "mutation": {"op": "update", "id": "ext", "options": {"config": {"code": NEW_CODE}}},
+        },
+    }
+    without = build_release_page(1, [creation, row], before_entries=[SEED_EXTENSION])
+    assert "<pre>export default function hello(pi) {" in without and "+++ " not in without
+    assert '<span class="tag">update</span>ext <span class="tag">code_extension</span>' in without
+    files = {"pi-agent/extensions/hello.ts": OLD_CODE}
+    paths = {"code_extension": "pi-agent/extensions/{name}.ts"}
+    with_diff = build_release_page(
+        1, [creation, row], before_entries=[SEED_EXTENSION], before_files=files, node_paths=paths
+    )
+    assert "+++ pi-agent/extensions/hello.ts (rel-1)" in with_diff and '<span class="add">+  pi.on(' in with_diff
+    unchanged = {"pi-agent/extensions/hello.ts": NEW_CODE}
+    same = build_release_page(
+        1, [creation, row], before_entries=[SEED_EXTENSION], before_files=unchanged, node_paths=paths
+    )
+    assert "pi-agent/extensions/hello.ts is unchanged" in same
+
+
+def test_current_marks_the_served_head_and_not_the_pending_row(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        rows = list(reversed(dispatcher.get_or_create_scenario(SCENARIO).releases()))
+        # The catalog's own flag sits on the newest row, the pending one, which serves nothing.
+        assert rows[4]["current"] is True and rows[1]["current"] is False
+        assert served_step(rows) == 1
+        assert "| current" in _sub(_page(dispatcher, 1))
+        for step in (0, 2, 3, 4):
+            assert "current" not in _sub(_page(dispatcher, step))
+    finally:
+        dispatcher.close()
+
+
+def test_a_promoted_pending_step_reads_promoted_at_the_promote_step(tmp_path: Path) -> None:
+    dispatcher = _chain(tmp_path)
+    try:
+        scenario = dispatcher.get_or_create_scenario(SCENARIO)
+        pending_id = list(reversed(scenario.releases()))[4]["release_id"]
+        dispatcher.promote(SCENARIO, pending_id)
+        rows = list(reversed(scenario.releases()))
+        assert rows[5]["operation"] == "promote" and rows[5]["rollback_target_release_id"] == pending_id
+        assert rows[4]["pending"] is True and verdict_of(rows[4]) == "pending"
+        assert verdict_of(rows[4], rows) == "promoted at step 5"
+        assert served_step(rows) == 5
+        page = _page(dispatcher, 4)
+        sub = _sub(page)
+        assert '<span class="promoted">promoted at step 5</span>' in sub and "current" not in sub
+        verdict = _section(page, "Verdict")
+        assert '<td class="promoted">promoted at step 5</td>' in verdict
+        assert "won the gate and was promoted at step 5; the release that step published serves it" in verdict
+        assert "waits for a promote" not in verdict
+        # The step still diffs against the head it was gated on; the promote's own page names it as the target.
+        assert f"+++ pi-agent/extensions/hello.ts ({pending_id[:8]})" in _section(page, "What changed")
+        promoted = _page(dispatcher, 5)
+        assert "| current" in _sub(promoted)
+        assert f"a person promoted release {pending_id} after reading it" in _section(promoted, "Why")
+        head = _section(_page(dispatcher, 1), "Chain")
+        assert '<span class="promoted">promoted at step 5</span>' in head
+        # The promote was made on the head, so it is the head's child too.
+        assert (
+            f'<li>step 5 <span class="id">{rows[5]["release_id"]}</span> <span class="promote">promote</span>' in head
+        )
+    finally:
+        dispatcher.close()
+
+
+def test_a_step_that_published_nothing_chains_to_the_head_it_ran_on() -> None:
+    creation = {"release_id": "rel-0", "parent_release_id": None, "operation": "creation"}
+    head = {
+        "release_id": "rel-1",
+        "parent_release_id": "rel-0",
+        "operation": "training",
+        "metrics": {"selected": True},
+    }
+    skipped = {
+        "release_id": "rel-1",
+        "parent_release_id": "rel-0",
+        "operation": "training",
+        "metrics": {"skipped": "no proposal"},
+    }
+    rows = [creation, head, skipped]
+    assert before_release_id(skipped) == "rel-1" and served_step(rows) == 1
+    # Chain is the last section, so cut it before the data block, which carries the row's own parent id.
+    chain = _section(build_release_page(2, rows), "Chain").partition("</main>")[0]
+    assert '<tr><th>ran on</th><td class="id">rel-1 (the head at this step; nothing was gated)</td></tr>' in chain
+    assert "none (the candidate published nothing)" in chain
+    assert "<th>parent</th>" not in chain and "<th>this release</th>" not in chain and "rel-0" not in chain
+    published = _section(build_release_page(1, rows), "Chain").partition("</main>")[0]
+    assert '<tr><th>parent</th><td class="id">rel-0</td></tr>' in published
+    assert '<tr><th>this release</th><td class="id">rel-1</td></tr>' in published
+    # The skipped step ran on rel-1, so it is rel-1's child and not rel-0's, though its row names rel-0 as parent.
+    assert '<li>step 2 <span class="id">rel-1</span> <span class="skipped">skipped</span></li>' in published
+    seed = _section(build_release_page(0, rows), "Chain").partition("</main>")[0]
+    assert seed.count("<li>step ") == 1 and "<li>step 1 " in seed
+
+
+def test_the_diff_colours_lines_by_position_so_a_plus_plus_line_is_an_addition() -> None:
+    creation = {"release_id": "rel-0", "parent_release_id": None, "operation": "creation"}
+    row = {
+        "release_id": "rel-1",
+        "parent_release_id": "rel-0",
+        "operation": "training",
+        "metrics": {
+            "selected": True,
+            "mutation": {"op": "update", "id": "ext", "options": {"config": {"code": "let n = 0;\n++n;\n"}}},
+        },
+    }
+    files = {"pi-agent/extensions/hello.ts": "let n = 0;\n--n;\n"}
+    paths = {"code_extension": "pi-agent/extensions/{name}.ts"}
+    page = build_release_page(
+        1, [creation, row], before_entries=[SEED_EXTENSION], before_files=files, node_paths=paths
+    )
+    changed = _section(page, "What changed")
+    assert '<span class="hunk">--- pi-agent/extensions/hello.ts (rel-0)</span>' in changed
+    assert '<span class="hunk">+++ pi-agent/extensions/hello.ts (rel-1)</span>' in changed
+    assert '<span class="del">---n;</span>' in changed and '<span class="add">+++n;</span>' in changed

--- a/tests/reef_service/test_requests_extension.py
+++ b/tests/reef_service/test_requests_extension.py
@@ -1,8 +1,10 @@
-"""The harness requests extension: reef-pi's /reef-harness command, run under node with stubs.
+"""The harness requests extension: reef-pi's /reef-harness and /reef-versions commands, run under node with stubs.
 
 The asset registers nothing under ``PI_OFFLINE`` and no tools at all; the
-command posts the request with the session id and the sidecar's release,
-leaves inference receipts available for feedback, and reports durable acceptance.
+ask command posts the request with the session id and the sidecar's release,
+leaves inference receipts available for feedback, and reports durable
+acceptance; the versions command lists the chain, prints a step's page and
+promotes a pending release after a confirmation.
 """
 
 from __future__ import annotations
@@ -41,7 +43,7 @@ const ctx = {
   hasUI: true,
   isIdle: () => true,
   ui: {
-    confirm: async (title, message) => { events.push({ kind: "confirm", title, message }); return false; },
+    confirm: async (title, message) => { events.push({ kind: "confirm", title, message }); return process.env.TEST_CONFIRM === "1"; },
     notify: (message, type) => events.push({ kind: "notify", message, type }),
     select: async () => undefined,
   },
@@ -60,6 +62,8 @@ const out = { tools: Object.keys(tools), commands: Object.keys(commands), events
 try {
   if (process.env.TEST_STEP === "command") {
     await commands["reef-harness"].handler(process.env.TEST_ARGS || "", ctx);
+  } else if (process.env.TEST_STEP === "versions") {
+    await commands["reef-versions"].handler(process.env.TEST_ARGS || "", ctx);
   }
 } catch (error) {
   out.error = error.message;
@@ -91,7 +95,7 @@ def _run(tmp_path: Path, agent_dir: Path, **env: str) -> dict[str, Any]:
         "REEF_HARNESS_DEST": str(tmp_path),
         **env,
     }
-    for name in ("PI_OFFLINE", "REEF_TOKEN"):
+    for name in ("PI_OFFLINE", "REEF_TOKEN", "TEST_CONFIRM"):
         if name not in env:
             full_env.pop(name, None)
     completed = subprocess.run(["node", str(runner)], check=True, capture_output=True, text=True, env=full_env)
@@ -135,7 +139,9 @@ def test_the_extension_carries_no_tools_and_no_confirmation() -> None:
     text = ASSET.read_text(encoding="utf-8")
     assert "registerTool" not in text
     assert "typebox" not in text
-    assert "ui.confirm" not in text
+    # Asking confirms nothing; the one confirm guards the promote inside /reef-versions, registered after it.
+    asking, versions, _ = text.partition('pi.registerCommand("reef-versions"')
+    assert versions and "ui.confirm" not in asking
 
 
 def test_offline_registers_nothing(tmp_path: Path) -> None:
@@ -156,7 +162,7 @@ def test_a_missing_scenario_registers_nothing(tmp_path: Path) -> None:
 def test_registers_the_command_and_no_tool(tmp_path: Path) -> None:
     out = _run(tmp_path, _install_root(tmp_path))
     assert out["tools"] == []
-    assert out["commands"] == ["reef-harness"]
+    assert out["commands"] == ["reef-harness", "reef-versions"]
     assert out["events"] == []
 
 
@@ -239,3 +245,294 @@ def test_the_command_falls_back_to_the_sidecar_beside_the_agent_dir(tmp_path: Pa
     answers = {"POST /reef/train": {"status": 200, "body": ACCEPTED}}
     out = _ask(tmp_path, _install_root(tmp_path), answers, REEF_HARNESS_DEST="")
     assert _fetches(out)[0]["body"]["release_id"] == "v1"
+
+
+# The catalog /reef-versions reads, oldest first: the creation row, a published win with a request, a rejected
+# candidate whose row carries the head's id, a pending extension win, and a step the method skipped.
+LONG_TEXT = "text me when you are blocked, and say what you tried before you stopped"
+RELEASES = {
+    "scenario": "code-repair",
+    "releases": [
+        {"release_id": "rel-0000-creation", "parent_release_id": None, "operation": "creation", "pending": False},
+        {
+            "release_id": "rel-1111-selected",
+            "parent_release_id": "rel-0000-creation",
+            "operation": "training",
+            "pending": False,
+            "current": True,
+            "metrics": {"steps": 1, "selected": True, "training_request": {"id": "q-1", "text": LONG_TEXT}},
+        },
+        {
+            "release_id": "rel-1111-selected",
+            "parent_release_id": "rel-0000-creation",
+            "operation": "training",
+            "pending": False,
+            "current": False,
+            "metrics": {"steps": 2, "selected": False, "training_request": {"id": "q-2", "text": "answer with care"}},
+        },
+        {
+            "release_id": "rel-3333-pending",
+            "parent_release_id": "rel-1111-selected",
+            "operation": "training",
+            "pending": True,
+            "current": False,
+            "metrics": {"steps": 3, "selected": True, "training_request": {"id": "q-3", "text": "log when blocked"}},
+        },
+        {
+            "release_id": "rel-1111-selected",
+            "parent_release_id": "rel-0000-creation",
+            "operation": "training",
+            "pending": False,
+            "current": False,
+            "metrics": {"steps": 4, "skipped": "no proposal"},
+        },
+    ],
+}
+CATALOG = {"GET /reef/harness/releases": {"status": 200, "body": RELEASES}}
+PROMOTED = {"POST /reef/scenarios/code-repair/promote": {"status": 200, "body": {"release_id": "rel-4444-promote"}}}
+
+
+def _versions(tmp_path: Path, agent_dir: Path, answers: dict[str, Any], args: str = "", **env: str) -> dict[str, Any]:
+    return _run(tmp_path, agent_dir, TEST_STEP="versions", TEST_ARGS=args, TEST_ANSWERS=json.dumps(answers), **env)
+
+
+def test_versions_lists_the_chain_oldest_first_one_line_per_row(tmp_path: Path) -> None:
+    out = _versions(tmp_path, _install_root(tmp_path), CATALOG, REEF_TOKEN="tok")
+    assert out["error"] is None
+    (catalog,) = _fetches(out)
+    assert catalog["method"] == "GET" and catalog["url"] == "http://reef:8900/reef/harness/releases"
+    assert catalog["headers"] == {"x-reef-scenario": "code-repair", "authorization": "Bearer tok"}
+    (notice,) = _notices(out)
+    assert notice["type"] == "info"
+    assert notice["message"].splitlines() == [
+        "0  rel-0000  creation",
+        f'1  rel-1111  selected  current  "{LONG_TEXT[:57]}..."',
+        '2  rel-1111  rejected  "answer with care"',
+        '3  rel-3333  pending  "log when blocked"',
+        "4  rel-1111  skipped",
+    ]
+
+
+def test_versions_with_a_step_prints_the_page_url_and_for_a_pending_release_the_promote_and_the_trial_install(
+    tmp_path: Path,
+) -> None:
+    agent_dir = _install_root(tmp_path)
+    out = _versions(tmp_path, agent_dir, CATALOG, args="3", REEF_TOKEN="tok")
+    (notice,) = _notices(out)
+    lines = notice["message"].splitlines()
+    assert lines[0] == "Harness step 3: rel-3333-pending (pending)"
+    assert lines[1] == "page: http://reef:8900/reef/harness/releases/3/page"
+    auth = "-H 'x-reef-scenario: code-repair' -H \"Authorization: Bearer $REEF_TOKEN\" "
+    assert (
+        lines[2] == f"read it: curl -fsS {auth}'http://reef:8900/reef/harness/releases/3/page' > harness-step-3.html"
+    )
+    assert lines[3] == (
+        f"promote: curl -fsS {auth}-X POST -H 'content-type: application/json' "
+        "-d '{\"release_id\":\"rel-3333-pending\"}' 'http://reef:8900/reef/scenarios/code-repair/promote'"
+    )
+    assert lines[4] == "or from here: /reef-versions 3 promote"
+    assert lines[5] == (
+        f"trial install (replaces the tree at {tmp_path}): "
+        f"curl -fsS {auth}'http://reef:8900/reef/harness/install?adapter=pi&release_id=rel-3333-pending'"
+        f" | bash -s -- '{tmp_path}'"
+    )
+    # The way back rides beside the trial: the served head's own install, pinned by release id.
+    assert lines[6] == (
+        f"back to the head: curl -fsS {auth}'http://reef:8900/reef/harness/install?adapter=pi&release_id=rel-1111-selected'"
+        f" | bash -s -- '{tmp_path}'"
+    )
+    assert len(lines) == 7
+    # The token never leaves the environment: the printed commands name the variable, not the value.
+    assert "tok" not in notice["message"].replace("$REEF_TOKEN", "")
+
+    published = _versions(tmp_path, agent_dir, CATALOG, args="1")
+    (notice,) = _notices(published)
+    lines = notice["message"].splitlines()
+    assert lines[0] == "Harness step 1: rel-1111-selected (selected, current)"
+    assert (
+        lines[2]
+        == "read it: curl -fsS -H 'x-reef-scenario: code-repair' 'http://reef:8900/reef/harness/releases/1/page' > harness-step-1.html"
+    )
+    assert len(lines) == 3 and "promote" not in notice["message"]
+
+
+def test_versions_promotes_a_pending_release_after_the_confirm_and_not_without(tmp_path: Path) -> None:
+    agent_dir = _install_root(tmp_path)
+    confirmed = _versions(
+        tmp_path,
+        agent_dir,
+        {**CATALOG, **PROMOTED},
+        args="3 promote",
+        TEST_CONFIRM="1",
+        REEF_TOKEN="tok",
+    )
+    assert confirmed["error"] is None
+    assert [event["kind"] for event in confirmed["events"]] == ["fetch", "confirm", "fetch", "notify"]
+    prompt = confirmed["events"][1]
+    assert prompt["title"] == "Promote harness step 3?"
+    assert "rel-3333-pending" in prompt["message"] and "/reef/harness/releases/3/page" in prompt["message"]
+    promote = confirmed["events"][2]
+    assert promote["method"] == "POST" and promote["url"] == "http://reef:8900/reef/scenarios/code-repair/promote"
+    assert promote["headers"] == {
+        "x-reef-scenario": "code-repair",
+        "authorization": "Bearer tok",
+        "content-type": "application/json",
+    }
+    assert promote["body"] == {"release_id": "rel-3333-pending"}
+    assert confirmed["events"][3] == {
+        "kind": "notify",
+        "message": "Promoted step 3: the head is now rel-4444-promote; the update notice offers it at the next session start.",
+        "type": "info",
+    }
+
+    declined = _versions(tmp_path, agent_dir, {**CATALOG, **PROMOTED}, args="3 promote")
+    assert [event["kind"] for event in declined["events"]] == ["fetch", "confirm", "notify"]
+    assert declined["events"][2] == {"kind": "notify", "message": "step 3 not promoted", "type": "info"}
+
+    not_pending = _versions(tmp_path, agent_dir, {**CATALOG, **PROMOTED}, args="1 promote", TEST_CONFIRM="1")
+    assert [event["kind"] for event in not_pending["events"]] == ["fetch", "notify"]
+    assert not_pending["events"][1] == {
+        "kind": "notify",
+        "message": "step 1 is not pending (selected); nothing to promote",
+        "type": "warning",
+    }
+
+
+def test_versions_reports_an_unreachable_reef_as_one_notice(tmp_path: Path) -> None:
+    agent_dir = _install_root(tmp_path)
+    for args in ("", "3", "3 promote"):
+        out = _versions(tmp_path, agent_dir, {}, args=args)
+        assert out["error"] is None
+        assert len(_fetches(out)) == 1
+        (notice,) = _notices(out)
+        assert notice["type"] == "error"
+        assert notice["message"].startswith("reef unreachable at http://reef:8900: ")
+        assert [event["kind"] for event in out["events"]] == ["fetch", "notify"]
+
+
+def test_versions_refuses_a_missing_step_and_bad_arguments_with_a_notice(tmp_path: Path) -> None:
+    agent_dir = _install_root(tmp_path)
+    missing = _versions(tmp_path, agent_dir, CATALOG, args="9")
+    assert _notices(missing) == [
+        {"kind": "notify", "message": "no step 9: the catalog holds steps 0 to 4", "type": "warning"}
+    ]
+    for args in ("three", "-1", "3 publish", "3 promote now"):
+        out = _versions(tmp_path, agent_dir, CATALOG, args=args)
+        assert _fetches(out) == []
+        assert _notices(out) == [
+            {"kind": "notify", "message": "Usage: /reef-versions [step] [promote]", "type": "warning"}
+        ]
+    refused = _versions(
+        tmp_path,
+        agent_dir,
+        {"GET /reef/harness/releases": {"status": 404, "body": {"error": "unknown scenario"}}},
+    )
+    (notice,) = _notices(refused)
+    assert notice["type"] == "error" and notice["message"].startswith("reef refused the catalog read (HTTP 404)")
+
+
+# The catalog as the service reports it: its current flag sits on the newest row, here a pending win.
+NEWEST_PENDING = {
+    "scenario": "code-repair",
+    "releases": [
+        {"release_id": "rel-0000-creation", "parent_release_id": None, "operation": "creation", "pending": False},
+        {
+            "release_id": "rel-1111-selected",
+            "parent_release_id": "rel-0000-creation",
+            "operation": "training",
+            "pending": False,
+            "current": False,
+            "metrics": {"steps": 1, "selected": True, "training_request": {"id": "q-1", "text": "say when blocked"}},
+        },
+        {
+            "release_id": "rel-1111-selected",
+            "parent_release_id": "rel-0000-creation",
+            "operation": "training",
+            "pending": False,
+            "current": False,
+            "metrics": {"steps": 2, "selected": False},
+        },
+        {
+            "release_id": "rel-1111-selected",
+            "parent_release_id": "rel-0000-creation",
+            "operation": "training",
+            "pending": False,
+            "current": False,
+            "metrics": {"steps": 3, "selected": False},
+        },
+        {
+            "release_id": "rel-4444-pending",
+            "parent_release_id": "rel-1111-selected",
+            "operation": "training",
+            "pending": True,
+            "current": True,
+            "metrics": {"steps": 4, "selected": True},
+        },
+    ],
+}
+# The same catalog after a person promoted the pending win: the promote row names it as its target.
+PROMOTE_ROW = {
+    "release_id": "rel-5555-promote",
+    "parent_release_id": "rel-1111-selected",
+    "operation": "promote",
+    "pending": False,
+    "current": True,
+    "rollback_target_release_id": "rel-4444-pending",
+}
+AFTER_PROMOTE = {
+    "scenario": "code-repair",
+    "releases": [*NEWEST_PENDING["releases"][:4], {**NEWEST_PENDING["releases"][4], "current": False}, PROMOTE_ROW],
+}
+
+
+def test_versions_marks_the_served_head_current_and_never_the_pending_row(tmp_path: Path) -> None:
+    agent_dir = _install_root(tmp_path)
+    catalog = {"GET /reef/harness/releases": {"status": 200, "body": NEWEST_PENDING}}
+    listed = _versions(tmp_path, agent_dir, catalog)
+    (notice,) = _notices(listed)
+    assert notice["message"].splitlines() == [
+        "0  rel-0000  creation",
+        '1  rel-1111  selected  current  "say when blocked"',
+        "2  rel-1111  rejected",
+        "3  rel-1111  rejected",
+        "4  rel-4444  pending",
+    ]
+    head = _versions(tmp_path, agent_dir, catalog, args="1")
+    assert _notices(head)[0]["message"].splitlines()[0] == "Harness step 1: rel-1111-selected (selected, current)"
+    pending = _versions(tmp_path, agent_dir, catalog, args="4")
+    lines = _notices(pending)[0]["message"].splitlines()
+    assert lines[0] == "Harness step 4: rel-4444-pending (pending)"
+    assert lines[6].startswith("back to the head: ") and "release_id=rel-1111-selected'" in lines[6]
+
+
+def test_versions_reads_a_promoted_pending_row_as_promoted_and_offers_no_promote(tmp_path: Path) -> None:
+    agent_dir = _install_root(tmp_path)
+    catalog = {"GET /reef/harness/releases": {"status": 200, "body": AFTER_PROMOTE}}
+    listed = _versions(tmp_path, agent_dir, catalog)
+    (notice,) = _notices(listed)
+    assert notice["message"].splitlines()[4:] == ["4  rel-4444  promoted at step 5", "5  rel-5555  promote  current"]
+    shown = _versions(tmp_path, agent_dir, catalog, args="4")
+    lines = _notices(shown)[0]["message"].splitlines()
+    assert lines[0] == "Harness step 4: rel-4444-pending (promoted at step 5)"
+    assert len(lines) == 3 and "promote" not in "\n".join(lines[1:]) and "install" not in "\n".join(lines)
+    refused = _versions(tmp_path, agent_dir, {**catalog, **PROMOTED}, args="4 promote", TEST_CONFIRM="1")
+    assert [event["kind"] for event in refused["events"]] == ["fetch", "notify"]
+    assert refused["events"][1] == {
+        "kind": "notify",
+        "message": "step 4 is already promoted at step 5; nothing to promote",
+        "type": "warning",
+    }
+
+
+def test_versions_takes_only_a_run_of_digits_as_the_step(tmp_path: Path) -> None:
+    agent_dir = _install_root(tmp_path)
+    for args in ("1e0", "0x1", "1.0", "+1", "1 promote extra"):
+        out = _versions(tmp_path, agent_dir, CATALOG, args=args)
+        assert _fetches(out) == []
+        assert _notices(out) == [
+            {"kind": "notify", "message": "Usage: /reef-versions [step] [promote]", "type": "warning"}
+        ]
+    leading_zero = _versions(tmp_path, agent_dir, CATALOG, args="01")
+    assert (
+        _notices(leading_zero)[0]["message"].splitlines()[0] == "Harness step 1: rel-1111-selected (selected, current)"
+    )


### PR DESCRIPTION
## Motivation

A version of the harness is a row in `GET /reef/harness/releases` and a step record directory on the server. To learn why a version exists, what it changed, whether it won the gate and what installing it needs from me, I had to read the catalog JSON and the record files by hand; and a release the gate held for review could be promoted only with a curl against the scenario route. This stage gives every catalog step one self contained HTML page and gives reef-pi a `/reef-versions` command that lists the chain, prints a step's page and promotes a pending release after a confirmation. Refs #310, stage 4.

## Changes

- `GET /reef/harness/releases/{step}/page` answers one `text/html` page for the catalog row at `step` (oldest first, the creation row being 0), no asset and its data inline: Why (the request the step read, else the claimed proposal's reason, else a failure in the batch), What changed (the mutations; an extension update as a line diff against the release it ran on when that release is restorable, else the new text), Verdict (the verdict, the gate numbers and the step record directory), Setup (the step's own `requires`, then the items its release carries from earlier steps, the union the install script reads) and Chain (parent, this release, children; a rejected or skipped step names the head it ran on).
- The page marks the served head `current` (the newest row that is neither pending nor rejected nor skipped, since those publish nothing and the catalog's own flag sits on the newest row) and reads a pending row a later promote names as `promoted at step N`. Unknown steps are HTTP 404 naming the range; a non numeric step is HTTP 404 from the router.
- `/reef-versions` in reef-pi lists one line per row (step, release id, verdict, `current`, request text); `/reef-versions <step>` prints the page URL and, for a pending release, the promote curl, a trial install pinned by release id and the head's reinstall; `/reef-versions <step> promote` runs the promote after `ctx.ui.confirm`. The printed commands name `$REEF_TOKEN`, never its value.
- Docs: the route row, a Version page section in the HTTP API reference, a paragraph in the user guide, one sentence in the adapters guide. `test_http_api_docs.py` pins the grid tables' width.

## Compatibility and operational impact

One new GET route; no existing route or payload changes. The pi extension registers a second command and still no tool; under `PI_OFFLINE` it registers nothing. The page reads only the catalog rows and the artifact snapshots the service already holds. No configuration change, no persisted data change.

## Verification

- `pytest tests/reef_service/test_release_page.py tests/reef_service/test_requests_extension.py tests/reef_service/test_http_api_docs.py`: 37 passed. The page tests run the service in `training_mode: both`: three requests through `POST /reef/train` and one scored report, then read every step's page over HTTP, promote the pending release and read it again.
- `pytest tests/reef_service/test_harness_requests.py tests/reef_service/test_reef_contracts.py tests/reef_service/test_requests_requires.py`: 48 passed.
- Whole `tests/reef_service` suite (sao and slime bridges ignored): 1912 passed, 14 skipped, 1 warning in 222s, exit 0.
- mypy clean; pre-commit clean; `check-doc-contracts.mjs` and `check-doc-links.mjs` pass.

## AI assistance

Claude Code carried the old stage 4 commit onto the new transport and rewrote the chain test; I reviewed every line and ran the checks.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
