### PR TITLE
fix(recipes): append repo root to PYTHONPATH instead of replacing it

### DIFF
--- a/recipes/sao/examples/sao/README.md
+++ b/recipes/sao/examples/sao/README.md
@@ -122,6 +122,23 @@ pip install -e .
 hf download Qwen/Qwen2.5-1.5B-Instruct --local-dir ~/models/Qwen2.5-1.5B-Instruct
 ```
 
+`run.py` also needs `docker`: Harbor runs each task's verifier in its own
+container. The `docker run` line in Evolve your model does not provide that,
+so when the stack itself runs inside the reef image, extend it:
+
+```bash
+docker run --gpus all --network host --ipc host --shm-size 32g -it \
+  -v ~/models:/root/models \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$REPO":"$REPO" -w "$REPO" \
+  reef bash
+# inside: apt-get update && apt-get install -y docker.io
+```
+
+Mount the repo at its host path (`-v "$REPO":"$REPO"`, not `/workspace/Reef`):
+Harbor's sibling containers bind-mount trial directories by path, and those
+paths must mean the same thing to the host docker daemon.
+
 ## Run
 
 ```bash

--- a/recipes/sao/examples/sao/run.sh
+++ b/recipes/sao/examples/sao/run.sh
@@ -9,7 +9,7 @@ export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1}
 mkdir -p work
 
 # Start the Reef training stack, stop it again when this script exits.
-PYTHONPATH=../../../.. python3 -m reef serve -c "$PWD/serve.yaml" > work/reef.log 2>&1 &
+PYTHONPATH="$(cd ../../../.. && pwd)${PYTHONPATH:+:$PYTHONPATH}" python3 -m reef serve -c "$PWD/serve.yaml" > work/reef.log 2>&1 &
 trap 'kill %1' EXIT
 
 # Ray + Slime/Megatron + SGLang take minutes to come up.

--- a/recipes/tttd/examples/guidance_ttt/run.sh
+++ b/recipes/tttd/examples/guidance_ttt/run.sh
@@ -25,7 +25,7 @@ export NO_PROXY=$REEF_INFERENCE_HOST
 
 # Start the Reef training stack. The Harbor controller waits for the final
 # durable training commit before this script exits and stops the stack.
-PYTHONPATH=../../../.. python3 -m reef serve -c "$PWD/serve.yaml" > work/polyomino_packing/reef.log 2>&1 &
+PYTHONPATH="$(cd ../../../.. && pwd)${PYTHONPATH:+:$PYTHONPATH}" python3 -m reef serve -c "$PWD/serve.yaml" > work/polyomino_packing/reef.log 2>&1 &
 reef_pid=$!
 cleanup() {
     kill "$reef_pid" 2>/dev/null || true


### PR DESCRIPTION
## Motivation

Tested `refactor/unified-worker-executors` with the SAO example and a real model, per the branch's call for testing. The executor stack itself came up and trained; two environment problems in the example scripts blocked the documented path and are fixed here.

## Changes

- `recipes/sao/examples/sao/run.sh`, `recipes/tttd/examples/guidance_ttt/run.sh`: append the repo root to `PYTHONPATH` instead of replacing it. Inside the reef image, `PYTHONPATH` carries `/opt/sglang/python` and `/root/Megatron-LM`; the replacement form drops both and the slime driver exits before ready with `No module named 'megatron.training'`. This is the same form `recipes/tttd/examples/tttd/run.sh` already uses. (Pre-existing on `main`, but it blocks the smoke path this branch asks people to run.)
- `recipes/sao/examples/sao/README.md`: document that `run.py` needs the host docker socket in the container (Harbor runs each verifier in a sibling container) and the repo mounted at its host path so the sibling bind mounts resolve. Without it all trials fail with `[Errno 2] No such file or directory: 'docker'` and rewards come back empty.

## Compatibility and operational impact

None. Shell-script and README changes in two examples; no library code.

## Verification

On p5en (2x H200 visible, `CUDA_VISIBLE_DEVICES=0,1`), image built from `docker/Dockerfile.reef` at 66be298, `pip install -e .` of this branch inside, Qwen2.5-1.5B-Instruct local:

- Before the fix: stock `./run.sh` fails at stack boot — `service 'slime-driver' exited before ready`, driver log shows `No module named 'megatron.training'`.
- After the fix: stock `./run.sh` exits 0. All three IMO tasks ran 6 rollouts each through SGLang, every report trained (Megatron checkpoint saves advancing, `work/checkpoints/hf/{0,1,2}` exported), rewards recorded (`{'reward': 0.0}` — expected at 1.5B per the README).
- Executor selection observed in logs: `slime-driver: executor=uni`, `training: executor=ray`, `rollout: executor=ray`; no executor-related errors in `reef.log`, the driver log, or the service logs.

## AI assistance

Written and tested by an AI agent operated by @Xuan-1998, who is responsible for the result.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior. (Shell/README only; verified by running the example end to end.)
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass. (No Python changes.)
- [x] Non-trivial AI assistance is disclosed above, or none was used.
