### PR TITLE
feat(serve): resolve a dotted recipe's package beside the config

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -146,6 +146,16 @@ A recipe is selected three ways:
 There is no recipe-implementation registry. A bare name other than ``recipe``
 is always a preset name; it never imports a learning method implicitly.
 
+A dotted class does not have to be pip-installed. ``reef serve`` looks for
+its top-level package beside the config, walking up from the config file's
+directory to the nearest ancestor that holds ``<package>/__init__.py``, and
+appends that directory to ``PYTHONPATH`` for every service it starts. This is
+how ``recipes.sao.recipe:SAORecipe`` resolves from a source checkout: the
+``recipes/`` cookbook sits next to the example's ``serve.yaml``, so the
+launcher does not export ``PYTHONPATH`` itself. Entries already in
+``PYTHONPATH`` keep their precedence, and a service's ``env`` map can still
+set the variable outright.
+
 ``REEF_RECIPE_CONFIG_DIR`` is the directory preset YAML is read from, and it has
 **no default**: a bare recipe name resolves to a preset only when it is set.
 

--- a/recipes/AGENTS.md
+++ b/recipes/AGENTS.md
@@ -129,6 +129,8 @@ training stack under the same `reef:` section.
 1. Set environment variables (port, token, scenario, work dir); select the
    deployment recipe in YAML.
 2. Start `reef serve -c <yaml>` in the background; wait for `/healthz`.
+   `reef serve` finds the `recipes/` package beside the YAML and puts it on
+   every service's `PYTHONPATH`; the script does not set it.
 3. Run reef-eval with `--with-editable "$PWD"` (installs `harness/`) and
    `--with reef-client` (installs the SDK from PyPI).
 4. reef-eval resolves `--agent harness:HarborAgent` and runs the Harbor task.

--- a/recipes/sao/examples/sao/run.sh
+++ b/recipes/sao/examples/sao/run.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 mkdir -p work
 
 # Start the Reef training stack, stop it again when this script exits.
-PYTHONPATH=../../../.. python3 -m reef serve -c "$PWD/serve.yaml" > work/reef.log 2>&1 &
+python3 -m reef serve -c "$PWD/serve.yaml" > work/reef.log 2>&1 &
 trap 'kill %1' EXIT
 
 # Ray + Slime/Megatron + SGLang take minutes to come up.

--- a/recipes/tttd/examples/guidance_ttt/run.sh
+++ b/recipes/tttd/examples/guidance_ttt/run.sh
@@ -21,7 +21,7 @@ export NO_PROXY=$REEF_INFERENCE_HOST
 
 # Start the Reef training stack. The Harbor controller waits for the final
 # durable training commit before this script exits and stops the stack.
-PYTHONPATH=../../../.. python3 -m reef serve -c "$PWD/serve.yaml" > work/polyomino_packing/reef.log 2>&1 &
+python3 -m reef serve -c "$PWD/serve.yaml" > work/polyomino_packing/reef.log 2>&1 &
 reef_pid=$!
 cleanup() {
     kill "$reef_pid" 2>/dev/null || true

--- a/recipes/tttd/examples/tttd/run.sh
+++ b/recipes/tttd/examples/tttd/run.sh
@@ -36,7 +36,7 @@ fi
 
 # Start the Reef training stack. The Harbor controller waits for the final
 # durable training commit before this script exits and stops the stack.
-PYTHONPATH="$(cd ../../../.. && pwd)${PYTHONPATH:+:$PYTHONPATH}" python3 -m reef serve -c "$PWD/serve.yaml" > "$TTTD_STATE_DIR/reef.log" 2>&1 &
+python3 -m reef serve -c "$PWD/serve.yaml" > "$TTTD_STATE_DIR/reef.log" 2>&1 &
 reef_pid=$!
 cleanup() {
     kill "$reef_pid" 2>/dev/null || true

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -97,6 +97,32 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
     return _deep_interp_env(config, environ)
 
 
+def recipe_source_root(config: Mapping[str, Any], config_path: str | Path) -> Path | None:
+    """The directory a dotted ``reef.recipe`` class imports from, found beside the config.
+
+    A dotted reference such as ``recipes.sao.recipe:SAORecipe`` names a
+    package that is not pip-installed: the ``recipes/`` cookbook ships with
+    the source checkout, next to the ``serve.yaml`` that selects it. Walk up
+    from the config file to the nearest directory holding that top-level
+    package and return it, so ``reef serve`` can put it on the import path
+    of every service instead of each launcher exporting ``PYTHONPATH`` by
+    hand. ``None`` when the recipe is a bare name (core or preset) or when no
+    ancestor of the config holds the package; the import then fails in the
+    service exactly as it does today.
+    """
+    reference = config_value(config, "reef", "recipe")
+    if not isinstance(reference, str) or ":" not in reference:
+        return None
+    top_level = reference.partition(":")[0].partition(".")[0]
+    if not top_level:
+        return None
+    config_dir = Path(config_path).resolve().parent
+    for ancestor in (config_dir, *config_dir.parents):
+        if (ancestor / top_level / "__init__.py").is_file():
+            return ancestor
+    return None
+
+
 def validate_services(config: Mapping[str, Any], config_path: str | Path) -> list[dict[str, Any]]:
     """Services with valid commands and unique names, checked before any process starts."""
     services = config.get("services")

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -30,6 +30,7 @@ from reef.service.deploy.config import (
     config_value,
     interpolate_config,
     load_config,
+    recipe_source_root,
     resolve_model_paths,
     validate_services,
 )
@@ -49,6 +50,14 @@ def _command_argv(config: Mapping[str, Any], command: str | Sequence[str]) -> li
     if isinstance(command, str):
         return shlex.split(interpolate_config(config, command))
     return [interpolate_config(config, argument) for argument in command]
+
+
+def _with_path_entry(current: str | None, entry: Path) -> str:
+    """``current`` with ``entry`` appended once, in ``os.pathsep`` form."""
+    entries = [item for item in (current or "").split(os.pathsep) if item]
+    if str(entry) not in entries:
+        entries.append(str(entry))
+    return os.pathsep.join(entries)
 
 
 class InvalidOverrideError(ValueError):
@@ -192,12 +201,16 @@ class _Stack:
         run_dir: Path,
         ready_timeout_default: int,
         config_path: str | Path,
+        source_root: Path | None = None,
     ) -> None:
         self.config = config
         self.services = services
         self.run_dir = run_dir
         self.ready_timeout_default = ready_timeout_default
         self.config_path = Path(config_path)
+        # Where the deployment's dotted recipe package lives (see
+        # ``recipe_source_root``); every service gets it on ``PYTHONPATH``.
+        self.source_root = source_root
         self._procs: dict[str, subprocess.Popen[bytes]] = {}
         # Every POSIX service starts a fresh session, so its process-group ID
         # is the leader PID. Keep that identity after the leader exits:
@@ -226,10 +239,17 @@ class _Stack:
         The bridge driver's readiness marker lives under ``run_dir`` with the
         stack's pid and log files, so two stacks on one machine never share
         one; the driver reads the path from ``REEF_BRIDGE_READY_FILE``.
+
+        The recipe's source root is appended to ``PYTHONPATH`` rather than
+        prepended, so an inherited entry such as the reef image's Megatron
+        checkout keeps its precedence. A service's own ``env`` map is applied
+        last and can still replace the whole variable.
         """
         env = dict(os.environ)
         env["REEF_CONFIG"] = str(self.config_path)
         env["REEF_BRIDGE_READY_FILE"] = str(self.run_dir / "bridge.ready")
+        if self.source_root is not None:
+            env["PYTHONPATH"] = _with_path_entry(env.get("PYTHONPATH"), self.source_root)
         for k, v in (svc.get("env") or {}).items():
             env[k] = interpolate_config(self.config, str(v))
         cuda = svc.get("cuda")
@@ -467,6 +487,13 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
         config = _apply_overrides(config, overrides)
     # Structure first, so a bad stack fails before a model download, a run dir, or a child process.
     services = validate_services(config, resolved_config_path)
+    # Resolved against the operator's config, before any override copy
+    # relocates the path the services read.
+    source_root = recipe_source_root(config, resolved_config_path)
+    if source_root is not None:
+        _log(f"recipe package resolves from {source_root}")
+        if str(source_root) not in sys.path:
+            sys.path.append(str(source_root))
     paths_changed = resolve_model_paths(config)
     temp_config_path: Path | None = None
     if overrides or paths_changed:
@@ -482,6 +509,7 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
         run_dir,
         ready_timeout_default,
         resolved_config_path,
+        source_root=source_root,
     )
     try:
         stack.start()

--- a/tests/reef_service/test_deploy_config_validation.py
+++ b/tests/reef_service/test_deploy_config_validation.py
@@ -145,7 +145,7 @@ def test_orchestrator_uses_exactly_the_declared_services(tmp_path: Path, monkeyp
     class StackStub:
         exit_code = 0
 
-        def __init__(self, config, services, run_dir, ready_timeout_default, config_path):
+        def __init__(self, config, services, run_dir, ready_timeout_default, config_path, source_root=None):
             captured["services"] = services
 
         def start(self):

--- a/tests/reef_service/test_recipe_source_root.py
+++ b/tests/reef_service/test_recipe_source_root.py
@@ -1,0 +1,137 @@
+"""``reef serve`` puts a dotted recipe's package on every service's import path.
+
+A cookbook recipe such as ``recipes.sao.recipe:SAORecipe`` is not
+pip-installed; it lives beside the ``serve.yaml`` that selects it. The
+orchestrator resolves that directory from the config file and exports it,
+so example launchers no longer hand-roll ``PYTHONPATH``.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from pathlib import Path
+
+import pytest
+
+from reef.service.deploy.config import recipe_source_root
+from reef.service.deploy.orchestrator import _run_orchestrator, _Stack
+
+
+def _checkout(tmp_path: Path, package: str = "recipes") -> tuple[Path, Path]:
+    """A fake source checkout: ``<root>/<package>/`` and a config three levels down."""
+    root = tmp_path / "checkout"
+    (root / package).mkdir(parents=True)
+    (root / package / "__init__.py").write_text("")
+    config_path = root / package / "sao" / "examples" / "sao" / "serve.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("")
+    return root, config_path
+
+
+@pytest.mark.unit
+def test_dotted_recipe_resolves_to_the_nearest_ancestor_holding_its_package(tmp_path: Path) -> None:
+    root, config_path = _checkout(tmp_path)
+
+    assert recipe_source_root({"reef": {"recipe": "recipes.sao.recipe:SAORecipe"}}, config_path) == root
+
+
+@pytest.mark.unit
+def test_bare_recipe_names_have_no_source_root(tmp_path: Path) -> None:
+    _, config_path = _checkout(tmp_path)
+
+    assert recipe_source_root({"reef": {"recipe": "recipe"}}, config_path) is None
+    assert recipe_source_root({"reef": {"recipe": "my-preset"}}, config_path) is None
+    assert recipe_source_root({}, config_path) is None
+
+
+@pytest.mark.unit
+def test_missing_package_leaves_the_import_to_the_service(tmp_path: Path) -> None:
+    _, config_path = _checkout(tmp_path)
+
+    assert recipe_source_root({"reef": {"recipe": "other_pkg.method:Recipe"}}, config_path) is None
+
+
+@pytest.mark.unit
+def test_a_directory_without_init_is_not_the_package(tmp_path: Path) -> None:
+    root, config_path = _checkout(tmp_path)
+    (root / "recipes" / "__init__.py").unlink()
+
+    assert recipe_source_root({"reef": {"recipe": "recipes.sao.recipe:SAORecipe"}}, config_path) is None
+
+
+@pytest.mark.unit
+def test_source_root_is_appended_to_pythonpath_once(tmp_path: Path, monkeypatch) -> None:
+    root, config_path = _checkout(tmp_path)
+    monkeypatch.setenv("PYTHONPATH", "/opt/sglang/python:/root/Megatron-LM")
+    stack = _Stack({}, [{"name": "reef"}], tmp_path / "stack", 60, config_path, source_root=root)
+
+    env = stack._service_env({"name": "reef"})
+
+    assert env["PYTHONPATH"].split(os.pathsep) == ["/opt/sglang/python", "/root/Megatron-LM", str(root)]
+
+    monkeypatch.setenv("PYTHONPATH", env["PYTHONPATH"])
+    assert stack._service_env({"name": "reef"})["PYTHONPATH"] == env["PYTHONPATH"]
+
+
+@pytest.mark.unit
+def test_source_root_starts_pythonpath_when_unset(tmp_path: Path, monkeypatch) -> None:
+    root, config_path = _checkout(tmp_path)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    stack = _Stack({}, [{"name": "reef"}], tmp_path / "stack", 60, config_path, source_root=root)
+
+    assert stack._service_env({"name": "reef"})["PYTHONPATH"] == str(root)
+
+
+@pytest.mark.unit
+def test_service_env_map_still_owns_pythonpath(tmp_path: Path, monkeypatch) -> None:
+    root, config_path = _checkout(tmp_path)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    stack = _Stack({}, [{"name": "reef"}], tmp_path / "stack", 60, config_path, source_root=root)
+
+    env = stack._service_env({"name": "reef", "env": {"PYTHONPATH": "/explicit"}})
+
+    assert env["PYTHONPATH"] == "/explicit"
+
+
+@pytest.mark.unit
+def test_without_a_source_root_pythonpath_is_untouched(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    stack = _Stack({}, [{"name": "reef"}], tmp_path / "stack", 60, tmp_path / "serve.yaml")
+
+    assert "PYTHONPATH" not in stack._service_env({"name": "reef"})
+
+
+@pytest.mark.integration
+def test_a_service_imports_the_recipe_package_beside_the_config(tmp_path: Path, monkeypatch) -> None:
+    """End to end: a service started from an example directory imports the
+    cookbook package without the launcher exporting ``PYTHONPATH``."""
+    root, config_path = _checkout(tmp_path, package="probe_recipes")
+    (root / "probe_recipes" / "method.py").write_text("class Recipe: ...\n")
+    marker = tmp_path / "imported_from.txt"
+    probe = "import probe_recipes.method as m, pathlib, sys; pathlib.Path(sys.argv[1]).write_text(m.__file__)"
+    config_path.write_text(
+        "reef:\n"
+        "  recipe: probe_recipes.method:Recipe\n"
+        f"run_dir: {tmp_path / 'run'}\n"
+        "services:\n"
+        "  - name: probe\n"
+        f'    command: ["${{REEF_PYTHON}}", "-c", {probe!r}, "{marker}"]\n'
+    )
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    monkeypatch.delenv("REEF_PYTHON", raising=False)
+    monkeypatch.chdir(config_path.parent)
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    handlers = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
+    try:
+        # The probe exits as soon as it has written the marker, which the
+        # watchdog reports as an unexpected exit: exit code 1 is the
+        # expected outcome here, not a failure of the import.
+        assert _run_orchestrator(str(config_path)) == 1
+    finally:
+        for sig, handler in handlers.items():
+            signal.signal(sig, handler)
+
+    assert Path(marker.read_text()).resolve() == (root / "probe_recipes" / "method.py").resolve()
+    assert str(root) in sys.path


### PR DESCRIPTION
## Motivation

A dotted `reef.recipe` such as `recipes.sao.recipe:SAORecipe` names the `recipes/` cookbook, which is deliberately not pip-installed (`pyproject.toml` ships `reef` only). Until now every example `run.sh` had to put the repository root on `PYTHONPATH` by hand. The short `PYTHONPATH=../../../..` form used by two of them replaced the reef image's `/opt/sglang/python:/root/Megatron-LM`, so the slime driver exited before ready with `No module named 'megatron.training'`. #318 patched the two scripts to the append form that `tttd/run.sh` already used, leaving three copies of a shell idiom and nothing to stop the next example from pasting the broken one.

The import path for the recipe is the orchestrator's concern, not each launcher's. This moves it there.

## Changes

- `reef/service/deploy/config.py`: `recipe_source_root(config, config_path)` returns the nearest ancestor of the config file that holds `<top-level package>/__init__.py` for a dotted `reef.recipe`, or `None` for a bare name (core recipe or preset) or when no ancestor holds the package. In the latter case the import fails in the service exactly as it does today.
- `reef/service/deploy/orchestrator.py`: `_run_orchestrator` resolves the source root against the operator's config (before an override copy relocates `REEF_CONFIG`), logs it, and adds it to its own `sys.path`. `_Stack` takes an optional `source_root` and `_service_env` appends it to `PYTHONPATH` once. Inherited entries keep precedence, and a service's own `env` map is applied afterwards and can still set the variable outright.
- `recipes/sao/examples/sao/run.sh`, `recipes/tttd/examples/guidance_ttt/run.sh`, `recipes/tttd/examples/tttd/run.sh`: drop the hand-rolled `PYTHONPATH`; the line is now `python3 -m reef serve -c "$PWD/serve.yaml"`. The example `run.py` scripts import only `reef_eval`, so nothing else in these launchers needs the cookbook on the path.
- `docs/reference/configuration.rst`, `recipes/AGENTS.md`: document the resolution.
- Tests: `tests/reef_service/test_recipe_source_root.py` (unit tests for the walk-up, the `PYTHONPATH` composition, precedence, and the `env` override; one integration test that runs `_run_orchestrator` end to end and asserts a real child process imports the package from beside the config with `PYTHONPATH` unset). The `_Stack` stub in `test_deploy_config_validation.py` gains the new keyword.

## Compatibility and operational impact

- Configuration: no new keys. Behaviour changes only for a dotted `reef.recipe` whose top-level package exists beside the config: that directory is now appended to every service's `PYTHONPATH`. Deployments that already export it (openclawrl's compose file, the harness-evolution tutorial's `services[].env`) see the same entry once; nothing is prepended, so an image's Megatron/SGLang entries keep their precedence.
- A service `env` map that sets `PYTHONPATH` still wins, as before.
- The same caveat the Dockerfile already documents applies unchanged: the cookbook root also contains `reef/`, so a config living inside an image's baked-in checkout while a different checkout is `pip install -e`'d would shadow the editable install. The old `run.sh` lines had the identical effect; this PR does not widen it.
- Related: #318 landed on `refactor/unified-worker-executors`; when that branch merges, its two `run.sh` lines conflict trivially with the ones removed here (take this side).

## Verification

Local, Python 3.14 venv with `pip install -e .[dev]` and `third_party/reef-client` (no `ray`/`torch`, so `test_sao_bridge.py` and `test_slime_bridge.py` fail to collect; unrelated):

```
pytest tests/reef_service tests/test_cli_usage.py tests/test_cli_version.py --continue-on-collection-errors
1801 passed, 14 skipped, 2 errors (collection: ray)
python -m mypy
Success: no issues found in 210 source files
pre-commit run --files <changed files>
all hooks passed
```

The new integration test starts a real service from a config three directories below a fake `probe_recipes/` package, with `PYTHONPATH` unset and cwd set to the config's directory, and asserts the child imported the package from that checkout.

Not run: the GPU examples end to end. The launcher change is the removal of one environment prefix per script; the orchestrator supplies the same directory, appended instead of replaced.

## AI assistance

Written by Claude (Fable 5.1) operated by @zephyroszhou, who is responsible for the result.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC. (No new config key or wire contract; the orchestrator supplies an environment entry the launchers already exported.)
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
