### PR TITLE
fix(runtime): harden executor cleanup and local Ray startup

### DIFF
--- a/reef/runtime/executor/ray_runtime.py
+++ b/reef/runtime/executor/ray_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import threading
 from typing import Any
 
@@ -11,6 +12,33 @@ def _require_ray() -> Any:
     import ray
 
     return ray
+
+
+def _validate_local_ray_temp_path() -> None:
+    """Fail before Ray constructs a local Unix socket whose path is too long."""
+    if sys.platform == "win32":
+        return
+
+    temp_root = os.environ.get("RAY_TMPDIR")
+    source = "RAY_TMPDIR"
+    if temp_root is None and sys.platform.startswith("linux"):
+        temp_root = os.environ.get("TMPDIR")
+        source = "TMPDIR"
+    if temp_root is None:
+        temp_root = "/tmp"
+        source = "Ray's default temp directory"
+
+    # Ray uses a fixed-width timestamp plus the current PID in each session
+    # name. The plasma-store socket is the longer of its two local sockets.
+    session_name = f"session_0000-00-00_00-00-00_000000_{os.getpid()}"
+    socket_path = os.path.join(temp_root, "ray", session_name, "sockets", "plasma_store")
+    max_bytes = 103 if sys.platform.startswith("darwin") else 107
+    path_bytes = len(os.fsencode(socket_path))
+    if path_bytes > max_bytes:
+        raise RuntimeError(
+            f"{source} is too long for Ray's local Unix socket "
+            f"({path_bytes} bytes; limit {max_bytes}). Set RAY_TMPDIR to a shorter directory, such as /tmp."
+        )
 
 
 class RayRuntimeLease:
@@ -47,6 +75,8 @@ class _RayRuntime:
                     # (including 'auto') must connect, never fall back locally.
                     target = os.environ.get("RAY_ADDRESS") or address or "local"
                     try:
+                        if target == "local":
+                            _validate_local_ray_temp_path()
                         ray.init(address=target)
                     except BaseException:
                         ray.shutdown()

--- a/reef/train/slime_backend/reef_adapters/bridge.py
+++ b/reef/train/slime_backend/reef_adapters/bridge.py
@@ -623,7 +623,7 @@ class TrainBridgeActorImpl:
             for group in (self._critic_group, self._group):
                 if group is not None:
                     try:
-                        group.release_train()
+                        group.release()
                     except Exception as exc:
                         errors.append(exc)
             try:
@@ -1223,7 +1223,7 @@ def start_bridge(
         for group in (critic_group, actor_group):
             if group is not None:
                 with suppress(Exception):
-                    group.release_train()
+                    group.release()
         if rollout_manager is not None:
             with suppress(Exception):
                 RayExecutor.from_workers([rollout_manager]).rpc(0, "dispose", timeout=60)

--- a/tests/reef_service/test_shared_ray_runtime.py
+++ b/tests/reef_service/test_shared_ray_runtime.py
@@ -36,6 +36,8 @@ class FakeRay:
 def runtime(monkeypatch):
     fake = FakeRay()
     monkeypatch.delenv("RAY_ADDRESS", raising=False)
+    monkeypatch.delenv("RAY_TMPDIR", raising=False)
+    monkeypatch.delenv("TMPDIR", raising=False)
     monkeypatch.setattr(ray_runtime, "_require_ray", lambda: fake)
     return ray_runtime._RayRuntime(), fake
 
@@ -68,6 +70,22 @@ def test_environment_address_takes_precedence(runtime, monkeypatch):
     monkeypatch.setenv("RAY_ADDRESS", "10.0.0.2:12345")
     manager.acquire("10.0.0.1:12345").close()
     assert ray.init_calls == [{"address": "10.0.0.2:12345"}]
+
+
+def test_local_runtime_rejects_temp_path_that_cannot_fit_ray_socket(runtime, monkeypatch):
+    manager, ray = runtime
+    monkeypatch.setenv("RAY_TMPDIR", f"/tmp/{'nested-' * 20}")
+    with pytest.raises(RuntimeError, match=r"RAY_TMPDIR is too long.*Set RAY_TMPDIR"):
+        manager.acquire()
+    assert ray.init_calls == []
+    assert manager._users == 0
+
+
+def test_external_runtime_ignores_local_temp_path_limit(runtime, monkeypatch):
+    manager, ray = runtime
+    monkeypatch.setenv("RAY_TMPDIR", f"/tmp/{'nested-' * 20}")
+    manager.acquire("10.0.0.1:12345").close()
+    assert ray.init_calls == [{"address": "10.0.0.1:12345"}]
 
 
 def test_initialized_runtime_is_borrowed(runtime):

--- a/tests/reef_service/test_slime_bridge.py
+++ b/tests/reef_service/test_slime_bridge.py
@@ -34,16 +34,23 @@ def _local_ray_get(monkeypatch):
 def test_bridge_shutdown_attempts_both_training_groups_and_rollout_even_on_failure(monkeypatch):
     from threading import Lock
 
+    from reef.train.slime_backend.reef_adapters.train_groups import SlimeTrainGroup
+
     events = []
 
-    class Group:
+    class Executor:
         def __init__(self, name):
             self.name = name
 
-        def release_train(self):
+        def shutdown(self):
             events.append(self.name)
             if self.name == "critic":
                 raise RuntimeError("critic unavailable")
+
+    def group(name):
+        train_group = object.__new__(SlimeTrainGroup)
+        train_group._executor = Executor(name)
+        return train_group
 
     class Dispose:
         def remote(self):
@@ -53,8 +60,8 @@ def test_bridge_shutdown_attempts_both_training_groups_and_rollout_even_on_failu
     actor = object.__new__(bridge.TrainBridgeActorImpl)
     actor._closed = False
     actor._operation_lock = Lock()
-    actor._critic_group = Group("critic")
-    actor._group = Group("actor")
+    actor._critic_group = group("critic")
+    actor._group = group("actor")
     actor._rollout_manager = manager
     actor._manager_executor = bridge.RayExecutor.from_workers([manager])
     monkeypatch.setattr(bridge.ray, "kill", lambda target, **kwargs: events.append("rollout-kill"))
@@ -68,7 +75,24 @@ def test_bridge_shutdown_attempts_both_training_groups_and_rollout_even_on_failu
 def test_bridge_startup_failure_releases_rollout_and_owned_shared_reservation(tmp_path, monkeypatch):
     import importlib
 
+    from reef.train.slime_backend.reef_adapters.train_groups import SlimeTrainGroup
+
     events = []
+
+    class Executor:
+        def __init__(self, name):
+            self.name = name
+
+        def shutdown(self):
+            events.append(self.name)
+
+    def group(name):
+        train_group = object.__new__(SlimeTrainGroup)
+        train_group._executor = Executor(name)
+        return train_group
+
+    actor_group = group("actor")
+    critic_group = group("critic")
 
     class Dispose:
         def remote(self):
@@ -84,15 +108,22 @@ def test_bridge_startup_failure_releases_rollout_and_owned_shared_reservation(tm
         bridge, "create_placement_groups", lambda args: {"actor": (pg, [], []), "rollout": (pg, [], [])}
     )
     monkeypatch.setattr(bridge, "create_rollout_manager", lambda args, pg: manager)
-    monkeypatch.setattr(
-        bridge, "create_train_groups", lambda *args: (_ for _ in ()).throw(RuntimeError("training failed"))
-    )
+    monkeypatch.setattr(bridge, "create_train_groups", lambda *args: (actor_group, critic_group))
+
+    class FailingBridgeActor:
+        @staticmethod
+        def options(**kwargs):
+            return SimpleNamespace(
+                remote=lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("bridge creation failed"))
+            )
+
+    monkeypatch.setattr(bridge, "TrainBridgeActor", FailingBridgeActor)
     monkeypatch.setattr(
         bridge.CheckpointStorage, "validate_capacity", lambda self, **kwargs: {"blocked": False, "reasons": []}
     )
-    with pytest.raises(RuntimeError, match="training failed"):
+    with pytest.raises(RuntimeError, match="bridge creation failed"):
         bridge.start_bridge(_bridge_args(save_hf=str(tmp_path / "hf/{rollout_id}"), save=str(tmp_path / "megatron")))
-    assert events == ["dispose", "kill", "remove-pg"]
+    assert events == ["critic", "actor", "dispose", "kill", "remove-pg"]
 
 
 def _row(


### PR DESCRIPTION
This is a focused follow-up to #279.

## Summary

- release Slime actor and critic groups through the supported `SlimeTrainGroup.release()` interface during normal shutdown and startup rollback
- validate the projected local Ray Unix-socket path before `ray.init`, with an actionable `RAY_TMPDIR` error when the path cannot fit
- keep external and already-initialized Ray runtimes outside the local-path check
- exercise cleanup with real `SlimeTrainGroup` instances so a future interface mismatch cannot be hidden by test doubles

## Tests

- `python -m pytest -q tests/reef_service/test_shared_ray_runtime.py tests/reef_service/test_slime_bridge.py` (114 passed)
- repository pre-commit suite on all four changed files (passed)