### PR TITLE
fix(train): size LoRA checkpoint reservations from the base model, not 8x

### DIFF
--- a/reef/train/slime_backend/reef_adapters/bridge.py
+++ b/reef/train/slime_backend/reef_adapters/bridge.py
@@ -451,6 +451,7 @@ class TrainBridgeActorImpl:
                 critic_root=self._critic_save_root,
                 source_hf=source_hf,
                 source_megatron=source_megatron,
+                lora=lora,
             )
             if storage_config is not None and save_hf_template is not None and megatron_save_root is not None
             else None

--- a/reef/train/slime_backend/reef_adapters/preflight.py
+++ b/reef/train/slime_backend/reef_adapters/preflight.py
@@ -167,6 +167,7 @@ def prepare_checkpoint_storage(args, retention: RetentionConfig) -> CheckpointSt
         critic_root=critic_root,
         source_hf=getattr(args, "hf_checkpoint", None),
         source_megatron=getattr(args, "load", None),
+        lora=bool(getattr(args, "megatron_lora_rank", 0)),
     )
     marker = read_marker(storage.marker_path)
     if marker is not None and marker["status"] == "RUNNING":

--- a/reef/train/slime_backend/reef_adapters/training_job/storage.py
+++ b/reef/train/slime_backend/reef_adapters/training_job/storage.py
@@ -366,12 +366,6 @@ class CheckpointStorage:
         # critic checkpoint (when configured) is a second full model plus
         # optimizer state of roughly the same footprint.
         if self._lora:
-            # LoRA freezes the base model: one checkpoint pair is the base
-            # weights in distcp form plus a marginal adapter and its optimizer
-            # state. Measured on a Qwen3-8B r32 run: 17G distcp pair for a 16G
-            # HF source (~1.06x); 1.2 leaves margin. Do not sum hf+megatron:
-            # slime rewrites an empty --load to the HF source, so both point
-            # at the same base model and the sum double-counts it.
             return int(1.2 * max(hf_bytes, megatron_bytes))
         training_state = 8 * hf_bytes * (2 if self.critic_root is not None else 1)
         return max(hf_bytes + megatron_bytes, training_state)

--- a/reef/train/slime_backend/reef_adapters/training_job/storage.py
+++ b/reef/train/slime_backend/reef_adapters/training_job/storage.py
@@ -83,8 +83,10 @@ class CheckpointStorage:
         source_megatron: str | Path | None = None,
         measure: Callable[[Path], int] | None = None,
         disk_usage: Callable[[Path], Any] = shutil.disk_usage,
+        lora: bool = False,
     ) -> None:
         self.config = config
+        self._lora = bool(lora)
         template = Path(hf_template).expanduser()
         if "{rollout_id}" not in template.name:
             raise ValueError("HF checkpoint template must contain {rollout_id} in its basename")
@@ -363,6 +365,14 @@ class CheckpointStorage:
         # HF export + model, FP32 master weights, and two Adam moments; the
         # critic checkpoint (when configured) is a second full model plus
         # optimizer state of roughly the same footprint.
+        if self._lora:
+            # LoRA freezes the base model: one checkpoint pair is the base
+            # weights in distcp form plus a marginal adapter and its optimizer
+            # state. Measured on a Qwen3-8B r32 run: 17G distcp pair for a 16G
+            # HF source (~1.06x); 1.2 leaves margin. Do not sum hf+megatron:
+            # slime rewrites an empty --load to the HF source, so both point
+            # at the same base model and the sum double-counts it.
+            return int(1.2 * max(hf_bytes, megatron_bytes))
         training_state = 8 * hf_bytes * (2 if self.critic_root is not None else 1)
         return max(hf_bytes + megatron_bytes, training_state)
 

--- a/tests/reef_service/test_checkpoint_storage.py
+++ b/tests/reef_service/test_checkpoint_storage.py
@@ -32,6 +32,7 @@ def _storage(
     cap: int = 1000,
     free: int = 1000,
     min_free: int = 0,
+    lora: bool = False,
 ) -> CheckpointStorage:
     root = tmp_path / "checkpoints"
     source_hf, source_megatron = tmp_path / "source-hf", tmp_path / "source-megatron"
@@ -46,6 +47,7 @@ def _storage(
         source_megatron=source_megatron,
         measure=_logical_bytes,
         disk_usage=lambda path: Usage(1000, 1000 - free, free),
+        lora=lora,
     )
 
 
@@ -83,6 +85,27 @@ class TestCheckpointStorage:
         storage = _storage(tmp_path)
         _write_bytes(storage._source_megatron_checkpoint, 10)
         assert storage.validate_capacity()["reservation_bytes"] == 80
+
+    def test_lora_estimate_reserves_base_weights_plus_adapter_margin(self, tmp_path: Path) -> None:
+        # LoRA freezes the base model, so one checkpoint pair is the base
+        # weights in distcp form plus a marginal adapter and its optimizer
+        # state — not the 8x full-training footprint of FP32 master weights
+        # and two Adam moments. Without the flag a 480B-class LoRA run
+        # reserves 8x the HF source and blocks forever on any filesystem
+        # smaller than that, while the rollout side keeps serving.
+        full = _storage(tmp_path).validate_capacity()["reservation_bytes"]
+        lora = _storage(tmp_path, lora=True).validate_capacity()["reservation_bytes"]
+        assert lora == int(1.2 * 90)  # 1.2 x max(hf, megatron source)
+        assert lora > 90  # still covers the base weights themselves
+        assert full == 100  # unchanged full-training estimate
+
+    def test_lora_estimate_does_not_double_count_the_base_model(self, tmp_path: Path) -> None:
+        # Slime rewrites an empty --load to the HF source, so source_hf and
+        # source_megatron can point at the same base model; the LoRA estimate
+        # must take the max, not the sum.
+        storage = _storage(tmp_path, lora=True)
+        _write_bytes(storage._source_megatron_checkpoint, 10)
+        assert storage.validate_capacity()["reservation_bytes"] == int(1.2 * 10)
 
     def test_cold_start_estimates_from_the_hf_source_alone(self, tmp_path: Path) -> None:
         # The first boot of a fresh deployment has saved nothing yet, and

--- a/tests/reef_service/test_checkpoint_storage.py
+++ b/tests/reef_service/test_checkpoint_storage.py
@@ -87,12 +87,6 @@ class TestCheckpointStorage:
         assert storage.validate_capacity()["reservation_bytes"] == 80
 
     def test_lora_estimate_reserves_base_weights_plus_adapter_margin(self, tmp_path: Path) -> None:
-        # LoRA freezes the base model, so one checkpoint pair is the base
-        # weights in distcp form plus a marginal adapter and its optimizer
-        # state — not the 8x full-training footprint of FP32 master weights
-        # and two Adam moments. Without the flag a 480B-class LoRA run
-        # reserves 8x the HF source and blocks forever on any filesystem
-        # smaller than that, while the rollout side keeps serving.
         full = _storage(tmp_path).validate_capacity()["reservation_bytes"]
         lora = _storage(tmp_path, lora=True).validate_capacity()["reservation_bytes"]
         assert lora == int(1.2 * 90)  # 1.2 x max(hf, megatron source)
@@ -100,9 +94,6 @@ class TestCheckpointStorage:
         assert full == 100  # unchanged full-training estimate
 
     def test_lora_estimate_does_not_double_count_the_base_model(self, tmp_path: Path) -> None:
-        # Slime rewrites an empty --load to the HF source, so source_hf and
-        # source_megatron can point at the same base model; the LoRA estimate
-        # must take the max, not the sum.
         storage = _storage(tmp_path, lora=True)
         _write_bytes(storage._source_megatron_checkpoint, 10)
         assert storage.validate_capacity()["reservation_bytes"] == int(1.2 * 10)


### PR DESCRIPTION
## Problem

`CheckpointStorage._source_estimate` sizes its one-pair reservation with the full-training formula — `8 x` the HF source, covering FP32 master weights plus two Adam moments. A LoRA run freezes the base model, so a real checkpoint pair is the base weights in distcp form plus a marginal adapter and its optimizer state (measured ~1.06x the HF source on a rank-32 run).

With the full formula, a LoRA run whose base model is large relative to free disk **deadlocks silently**:

- the bridge actor computes a reservation that can never fit (e.g. a ~1 TB MoE base reserves ~8 TB on a filesystem with a few TB free),
- the storage plan reports `blocked` with `checkpoint reservation would violate the filesystem free-space floor`,
- training never starts, but inference keeps serving, so nothing crashes — the training GPUs sit at 0% and a TTTD harness polls `/reef/status` until its train timeout (hours of idle nodes).

The status payload during the hang (LoRA run, ~961 GB base, 2.6 TB free):

```
"checkpoint_storage": {"blocked": true,
  "reasons": ["checkpoint reservation would violate the filesystem free-space floor"],
  "reservation_bytes": 7685757181952, ...}
```

`7,685,757,181,952 = 8 x` the HF source — the full-training estimate applied to a LoRA run.

Small bases never notice (8 x 16 GB always fits), which is why the example recipes don't hit this.

## Fix

- `CheckpointStorage` gains a `lora` flag; the LoRA estimate is `1.2 x max(hf, megatron)` — max, not sum, because slime rewrites an empty `--load` to the HF source, so both sources can point at the same base weights.
- Both call sites pass it: the driver preflight (`prepare_checkpoint_storage`) and the train bridge actor (`TrainBridgeActorImpl`), keyed off `megatron_lora_rank`. The actor site matters most: it recomputes its own plan at train time, so fixing only the preflight would leave the boot passing and the first train step blocked.

## Repro

Any LoRA run where `8 x base model size > filesystem free bytes`: boot the stack, complete one rollout batch, and watch `/reef/status` report `batch_ready: true` with `checkpoint_storage.blocked: true` forever.

## Tests

- `test_lora_estimate_reserves_base_weights_plus_adapter_margin` — LoRA reservation is `1.2 x` the base, full-training path unchanged.
- `test_lora_estimate_does_not_double_count_the_base_model` — max, not sum, when both sources exist.

Both fail on the unpatched code (`TypeError` / 8x estimate); 31/31 pass patched. `pre-commit` clean on all touched files.