### PR TITLE
fix(openclawrl): resume hermes sessions across turns and restart the stack after training

### DIFF
--- a/recipes/openclawrl/examples/openclawrl/README.md
+++ b/recipes/openclawrl/examples/openclawrl/README.md
@@ -57,8 +57,12 @@ pyproject.toml                   makes harness/ importable
 ## The ordinary agent
 
 The agent is a stock `hermes-agent` install inside each task container. It
-is driven through its command line, one `hermes -z` turn per student
-message, with its home directory on the stream's state mount. Hermes reads
+is driven through its command line, one quiet `hermes chat -q` turn per
+student message (`--resume latest` after the first, so the model keeps its
+own earlier replies in context), with its home directory on the stream's
+state mount. The one-shot `hermes -z` cannot be used for this: it accepts
+`--resume` but ignores it, so every turn would start a fresh conversation.
+Hermes reads
 its model endpoint from its own config and sends OpenAI-compatible chat
 requests; it knows nothing about Reef, scenarios, or training.
 
@@ -105,8 +109,9 @@ position. Around the unmodified agent it makes three changes:
 2. It mints a Reef scenario id at position 0 and writes it to
    `$REEF_EVAL_STATE_DIR`. One stream is one scenario, which is one chain of
    runtime load IDs in Reef.
-3. It writes the hermes config on first use with context compression turned
-   off.
+3. It writes the hermes config at the start of every position, with context
+   compression, reasoning display and the tirith scanner turned off (the
+   reply on stdout must be the answer alone).
 
 The runtime flow is:
 
@@ -196,6 +201,23 @@ stream name, or a fresh run directory, at a stack that has already trained is
 rejected with "training is already bound to scenario ...". Stop the stack
 with `docker compose down` in this directory before switching streams or
 starting a variant.
+
+A stopped stack restarts from `$RUN_DIR`: the actor resumes its Megatron
+checkpoint, the teacher is reloaded from the base HF weights, and the
+committed head is republished. Two cases need a hand:
+
+- A stop while Reef is committing a step (after the bridge has published its
+  weights) leaves the bridge waiting for that commit, and every later batch
+  is refused with "training marker is READY_TO_COMMIT; operator recovery
+  required". The batch cannot be replayed (the judges sample), so start the
+  training state over: stop the stack and move `checkpoints`,
+  `artifacts.git`, `artifact-work`, `artifact-cache`, `agent-record` and
+  `prm-records.jsonl` out of `$RUN_DIR`. The lab and stream state stay, and
+  a re-run continues at the next position.
+- A run killed mid-session leaves root-owned files in
+  `$RUN_DIR/lab/streams/<stream>/state` (Harbor only hands the mount back to
+  your user on a normal trial end), and reef-eval then fails to reset it with
+  `Permission denied`. Chown the directory to your user and re-run.
 
 ### Reading a run
 

--- a/recipes/openclawrl/examples/openclawrl/docker-compose.yaml
+++ b/recipes/openclawrl/examples/openclawrl/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
       # Optional external cluster; empty means Reef owns a local runtime.
       RAY_ADDRESS: ${RAY_ADDRESS:-}
       REEF_TOKEN: ${REEF_TOKEN}
-      REEF_INFERENCE_HOST: ${HOST_IP}
       PYTHONPATH: /workspace/Reef:/root/Megatron-LM
       WANDB_API_KEY: ${WANDB_API_KEY:-}
     healthcheck:

--- a/recipes/openclawrl/examples/openclawrl/harness/agent.py
+++ b/recipes/openclawrl/examples/openclawrl/harness/agent.py
@@ -11,14 +11,17 @@ reef-eval invokes this once per stream position. It owns the whole session:
   fresh variant starts fresh;
 * **hermes itself**, run inside the task container (the environment image
   installs it) with its home on the state mount, so optional agent memory
-  rides reef-eval's one cross-position channel. The config is written on first
-  use; compression stays off to match the recorded experiment, while the
-  session tag means correlation does not require an extending transcript;
+  rides reef-eval's one cross-position channel. The config is written at the
+  start of every position; compression stays off to match the recorded
+  experiment, and the session tag keeps correlation independent of what
+  hermes resends;
 * the **conversation loop** with the judge sidecar: student message from
-  ``$JUDGE_URL/state`` → one ``hermes -z`` turn (``--resume latest`` after
-  the first) → the reply to ``/reply`` — until the student is done or
-  ``MAX_TURNS``. A failed hermes turn ends the session, not the trial: the
-  verifier scores whatever the judge saw.
+  ``$JUDGE_URL/state`` → one quiet ``hermes chat -q`` turn (``--resume
+  latest`` after the first, so the turn continues the position's session and
+  the model sees its own earlier replies; see ``_hermes_turn`` for why the
+  one-shot ``hermes -z`` cannot do this) → the reply to ``/reply`` — until
+  the student is done or ``MAX_TURNS``. A failed hermes turn ends the
+  session, not the trial: the verifier scores whatever the judge saw.
 
 Agent configuration (``--agent-arg``): ``reef_url`` (required; reef as
 reachable from inside a container, e.g. ``http://172.17.0.1:28900`` — and
@@ -99,6 +102,18 @@ platform_toolsets:
 
 compression:
   enabled: false
+
+# The turn command is quiet single-query chat mode (see _hermes_turn). Its
+# stdout is the final reply alone only while reasoning display is off;
+# otherwise the model's thinking is printed ahead of the reply and would be
+# posted to the student as part of the answer. The tirith command scanner is
+# off for the same reason: the image does not ship the binary, and chat mode
+# prints a warning about that ahead of the reply on every turn.
+display:
+  show_reasoning: false
+
+security:
+  tirith_enabled: false
 """
 
 
@@ -184,11 +199,11 @@ class HermesStreamAgent(BaseAgent):
         # (dummy) Authorization header, and the stream's scenario id is
         # authoritative — nothing the agent sends may replace either.
         #
-        # The session tag carries cross-turn feedback in this example. The
-        # first request of each resumed Hermes turn starts from ``[system,
-        # user]`` instead of extending the preceding turn's final request, so
-        # reef's header-free correlation can bind tool steps inside a turn but
-        # never the student reply that carries the whole reward signal.
+        # The session tag carries cross-turn feedback in this example: it
+        # names the conversation outright, so binding a turn to the student
+        # reply that follows it never depends on hermes resending an
+        # extending transcript (a resumed turn does today, but hermes owns
+        # that history and may compact or rewrite it).
         headers = {
             "x-reef-scenario": scenario,
             "x-reef-tag-session": session,
@@ -206,8 +221,8 @@ class HermesStreamAgent(BaseAgent):
         return server
 
     async def _prepare(self, environment: BaseEnvironment, problem: dict) -> None:
-        # The homework lands under HERMES_HOME, not /workspace: hermes pins its
-        # working directory to HOME (``--in`` does not survive), so that is
+        # The homework lands under HERMES_HOME, not /workspace: the turn runs
+        # hermes with ``--in HERMES_HOME``, so that is the working directory
         # where the judge's relative ``homework/N.txt`` resolves for the agent.
         # The directory is wiped first because HOME rides the state mount —
         # left alone, every past session's solved homework would stay readable
@@ -226,11 +241,13 @@ class HermesStreamAgent(BaseAgent):
             model=MODEL,
             memory="true" if self._hermes_memory else "false",
         )
-        # Position 0 writes the config; later positions keep it (and memory).
+        # Every position writes the config: it is a constant, and a state
+        # directory carried over from an earlier harness must not keep a stale
+        # one. Memory and sessions live elsewhere under HERMES_HOME, untouched.
         await self._exec(
             environment,
-            f"[ -f {HERMES_HOME}/.hermes/config.yaml ] || (mkdir -p {HERMES_HOME}/.hermes && "
-            f"printf %s {shlex.quote(hermes_config)} > {HERMES_HOME}/.hermes/config.yaml)",
+            f"mkdir -p {HERMES_HOME}/.hermes && "
+            f"printf %s {shlex.quote(hermes_config)} > {HERMES_HOME}/.hermes/config.yaml",
         )
 
     async def _session_loop(self, environment: BaseEnvironment) -> tuple[int, str]:
@@ -305,9 +322,27 @@ class HermesStreamAgent(BaseAgent):
         return state
 
     async def _hermes_turn(self, environment: BaseEnvironment, message: str, *, resume: bool) -> str:
+        """Run one hermes turn; its stdout is the reply.
+
+        Quiet single-query chat mode (``hermes chat -Q -q``), not the one-shot
+        ``hermes -z``: one-shot bypasses hermes's session handling and
+        silently accepts ``--resume`` without acting on it, so every turn
+        after the first would be a fresh conversation in which the model
+        never sees the reply the student is reacting to (observed: each turn
+        opened its own session, and the recorded requests were ``[system,
+        user]`` throughout). Chat mode resumes the position's session
+        (``--resume latest``, scoped to ``--in``), prints only the final reply
+        on stdout while ``display.show_reasoning`` is off, and reports the
+        session id and the resume notice on stderr. stderr is discarded in
+        the container: the exec transport folds it into stdout, where those
+        lines would reach the student as part of the reply.
+
+        ``--in`` is HERMES_HOME, where ``_prepare`` put the homework, so the
+        judge's relative ``homework/N.txt`` resolves for the agent.
+        """
         resume_flag = " --resume latest" if resume else ""
         command = (
-            f"cd /workspace && HOME={HERMES_HOME} timeout {TURN_TIMEOUT_S} "
-            f"hermes -z {shlex.quote(message)} --in /workspace{resume_flag}"
+            f"HOME={HERMES_HOME} timeout {TURN_TIMEOUT_S} "
+            f"hermes chat -Q -q {shlex.quote(message)} --in {HERMES_HOME}{resume_flag} 2>/dev/null"
         )
         return (await self._exec(environment, command)).strip()

--- a/recipes/openclawrl/examples/openclawrl/run.sh
+++ b/recipes/openclawrl/examples/openclawrl/run.sh
@@ -41,7 +41,7 @@ echo "==> [1/2] the reef stack at $REEF_URL (a cold boot takes ~6 minutes on B20
 # compose reads these from the environment; the subshell keeps the token out of
 # everything that runs after it.
 (
-    export REEF_IMAGE REEF_CONFIG MODEL_DIR RUN_DIR REEF_ROOT HOST_IP REEF_TOKEN
+    export REEF_IMAGE REEF_CONFIG MODEL_DIR RUN_DIR REEF_ROOT REEF_TOKEN
     docker compose up -d --wait
 ) || { echo "run.sh: the stack never became healthy; docker compose logs" >&2; exit 1; }
 

--- a/recipes/openclawrl/sessions.py
+++ b/recipes/openclawrl/sessions.py
@@ -109,10 +109,11 @@ class SessionIndex:
     A harness that stamps ``x-reef-tag-session`` skips all of that: the tag
     names the conversation outright, so turns bind in arrival order within it
     and nothing depends on the client resending its transcript. That matters
-    for agents that keep history locally — Hermes restarts each turn from
-    ``[system, user]``, so no cross-turn request ever extends the previous
-    one and the header-free path binds only within a turn, never across the
-    user reply that carries the method's whole signal.
+    for agents that keep history locally or run each turn as a fresh process
+    — a Hermes one-shot turn starts from ``[system, user]``, so no cross-turn
+    request extends the previous one and the header-free path binds only
+    within a turn, never across the user reply that carries the method's
+    whole signal.
 
     Header-free matching has documented limits: ties between canonically
     identical transcripts go to the most recently active session; a client

--- a/recipes/openclawrl/slime/objective.py
+++ b/recipes/openclawrl/slime/objective.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import logging
 from argparse import Namespace
 from collections.abc import Callable
 from typing import Any
@@ -29,6 +30,8 @@ from slime.backends.megatron_utils.loss import get_log_probs_and_entropy, get_re
 from slime.utils.ppo_utils import compute_approx_kl, compute_policy_loss
 
 from reef.train.slime_backend.algorithm import objective
+
+logger = logging.getLogger(__name__)
 
 _NEG_INF = float("-inf")
 # verl-style numerical guard on the log-ratio before exp(). Prevents
@@ -833,25 +836,53 @@ def openclawrl_loss(
 
 @objective("reef_actor_init_hook_path")
 def openclawrl_actor_init(actor: Any) -> None:
-    """Back up the freshly loaded actor weights as the frozen Megatron teacher.
+    """Back up the frozen base weights as the Megatron teacher.
 
     The topk-select objective requires the frozen-base Megatron teacher
-    (upstream forces OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron). Fresh init
-    just bridge-loaded exactly those weights, so the backup IS the frozen PRM.
-    A resumed Megatron checkpoint holds trained weights instead — backing
-    those up would silently swap the teacher for the student, so it is
-    refused outright. Fresh-vs-resumed is the loader's own dispatch (the
-    bridge path reports iteration 0, so the returned rollout id cannot tell).
+    (upstream forces OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron). A fresh
+    init just bridge-loaded exactly those weights, so the backup IS the
+    frozen PRM. A resumed Megatron checkpoint holds trained weights instead —
+    backing those up would silently swap the teacher for the student — so a
+    resume bridge-loads the base HF weights (``--hf-checkpoint``) into the
+    model, backs them up as the teacher, and puts the trained weights back
+    from the actor backup init took. Without this a stack could never be
+    restarted once it had trained. Fresh-vs-resumed is the loader's own
+    dispatch (the bridge path reports iteration 0, so the returned rollout
+    id cannot tell).
     """
     from slime.backends.megatron_utils.checkpoint import _is_megatron_checkpoint
 
-    if actor.args.load and _is_megatron_checkpoint(actor.args.load):
+    if not (actor.args.load and _is_megatron_checkpoint(actor.args.load)):
+        actor.weights_backuper.backup("openclaw_teacher")
+        return
+    base = getattr(actor.args, "hf_checkpoint", None)
+    if not base:
         raise RuntimeError(
-            "openclawrl resumed from a Megatron checkpoint, so the current weights are "
-            "not the frozen base and cannot serve as its teacher. Start from a fresh run "
-            "directory (a base-weight reload on resume is not implemented)."
+            "openclawrl resumed from a Megatron checkpoint, so the current weights are not the "
+            "frozen base; reloading the base as the teacher needs --hf-checkpoint"
         )
-    actor.weights_backuper.backup("openclaw_teacher")
+    # slime's tagged loader: load ``base`` into the model, back it up under
+    # the tag and leave it active. The actor backup init took still holds the
+    # trained weights, so switching back restores them.
+    actor.load_other_checkpoint("openclaw_teacher", base)
+    actor._switch_model("actor")
+    if _same_weights(actor.weights_backuper, "openclaw_teacher", "actor"):
+        logger.warning(
+            "openclawrl: the frozen-base teacher reloaded from %s equals the actor resumed from %s",
+            base,
+            actor.args.load,
+        )
+    else:
+        logger.info("openclawrl: resumed from %s; frozen-base teacher reloaded from %s", actor.args.load, base)
+
+
+def _same_weights(backuper: Any, left: str, right: str) -> bool:
+    """Whether two weight backups hold identical tensors (stops at the first difference)."""
+    left_weights = backuper.get(left)
+    right_weights = backuper.get(right)
+    if set(left_weights) != set(right_weights):
+        return False
+    return all(torch.equal(left_weights[name], right_weights[name]) for name in left_weights)
 
 
 @objective("reef_actor_pre_train_hook_path")

--- a/tests/test_openclawrl.py
+++ b/tests/test_openclawrl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -87,6 +88,97 @@ def _sample(reward: float, cands: tuple | None = None, n: int = 3) -> PolicySamp
         topk_log_probs=tuple((-0.5, -1.0, -1.5, -2.0) for _ in range(n)),
         extras={"teacher_cands": cands},
     )
+
+
+class _FakeBackuper:
+    """slime's TensorBackuper surface, over dicts of CPU tensors."""
+
+    def __init__(self, live):
+        self.live = live
+        self.backups: dict[str, dict] = {}
+
+    @property
+    def backup_tags(self):
+        return list(self.backups)
+
+    def get(self, tag):
+        return self.backups[tag]
+
+    def backup(self, tag):
+        self.backups[tag] = {name: tensor.clone() for name, tensor in self.live.items()}
+
+    def restore(self, tag):
+        for name, tensor in self.backups[tag].items():
+            self.live[name].copy_(tensor)
+
+
+class _FakeActor:
+    """The two slime actor calls the init hook makes, over a fake model."""
+
+    def __init__(self, load, hf_checkpoint, base, trained):
+        torch = pytest.importorskip("torch")
+        self.args = SimpleNamespace(load=load, hf_checkpoint=hf_checkpoint)
+        self._base = base
+        self.live = {"w": torch.tensor(trained)}
+        self.weights_backuper = _FakeBackuper(self.live)
+        self.weights_backuper.backup("actor")  # what init leaves behind
+        self.calls: list = []
+
+    def load_other_checkpoint(self, tag, path):
+        torch = pytest.importorskip("torch")
+        self.calls.append(("load", tag, path))
+        self.live["w"].copy_(torch.tensor(self._base))
+        self.weights_backuper.backup(tag)
+
+    def _switch_model(self, tag):
+        self.calls.append(("switch", tag))
+        self.weights_backuper.restore(tag)
+
+
+@pytest.fixture
+def megatron_checkpoint_probe(monkeypatch):
+    """The one slime checkpoint helper the init hook imports, without Megatron."""
+    checkpoint = ModuleType("slime.backends.megatron_utils.checkpoint")
+    checkpoint._is_megatron_checkpoint = lambda path: (Path(path) / "latest_checkpointed_iteration.txt").is_file()
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.checkpoint", checkpoint)
+
+
+def test_actor_init_backs_up_the_fresh_load_as_the_teacher(
+    tmp_path, topk_objective, megatron_checkpoint_probe
+) -> None:
+    torch = pytest.importorskip("torch")
+    actor = _FakeActor(str(tmp_path / "megatron"), str(tmp_path / "hf"), base=[1.0, 2.0], trained=[1.0, 2.0])
+
+    topk_objective.openclawrl_actor_init(actor)
+
+    assert actor.calls == []  # a fresh bridge load IS the base: no reload
+    assert torch.equal(actor.weights_backuper.get("openclaw_teacher")["w"], torch.tensor([1.0, 2.0]))
+
+
+def test_actor_init_reloads_the_base_teacher_on_resume(tmp_path, topk_objective, megatron_checkpoint_probe) -> None:
+    torch = pytest.importorskip("torch")
+    load = tmp_path / "megatron"
+    load.mkdir()
+    (load / "latest_checkpointed_iteration.txt").write_text("1")
+    actor = _FakeActor(str(load), str(tmp_path / "hf"), base=[1.0, 2.0], trained=[1.5, 2.5])
+
+    topk_objective.openclawrl_actor_init(actor)
+
+    # The base HF weights become the teacher; the trained weights stay the actor.
+    assert actor.calls == [("load", "openclaw_teacher", str(tmp_path / "hf")), ("switch", "actor")]
+    assert torch.equal(actor.weights_backuper.get("openclaw_teacher")["w"], torch.tensor([1.0, 2.0]))
+    assert torch.equal(actor.live["w"], torch.tensor([1.5, 2.5]))
+
+
+def test_actor_init_on_resume_needs_the_base_checkpoint(tmp_path, topk_objective, megatron_checkpoint_probe) -> None:
+    load = tmp_path / "megatron"
+    load.mkdir()
+    (load / "latest_checkpointed_iteration.txt").write_text("1")
+    actor = _FakeActor(str(load), None, base=[1.0], trained=[2.0])
+
+    with pytest.raises(RuntimeError, match="--hf-checkpoint"):
+        topk_objective.openclawrl_actor_init(actor)
+    assert actor.calls == []
 
 
 def test_topk_preserves_external_advantages_through_slime_hook(topk_objective) -> None:

--- a/tests/test_openclawrl_stream.py
+++ b/tests/test_openclawrl_stream.py
@@ -261,7 +261,8 @@ class TestHarness:
         states = iter(
             [
                 {"message": "hey, do my homework", "done": False, "turn": 0},
-                {"message": "HOMEWORK_DONE", "done": True, "turn": 1},
+                {"message": "too robotic, redo it", "done": False, "turn": 1, "ready": True},
+                {"message": "HOMEWORK_DONE", "done": True, "turn": 2},
             ]
         )
 
@@ -277,9 +278,13 @@ class TestHarness:
                     return SimpleNamespace(return_code=0, stdout="", stderr="")
                 if "$JUDGE_URL/state" in command or "$JUDGE_URL/reply" in command:
                     return SimpleNamespace(return_code=0, stdout=json.dumps(next(states)), stderr="")
-                if "hermes -z" in command:
+                if "hermes chat" in command:
+                    # Quiet single-query mode: the reply alone on stdout, the
+                    # session id (and, on a resumed turn, the notice) on stderr.
                     return SimpleNamespace(
-                        return_code=0, stdout="<think>hm</think>we add 2 plus 2 equals 4, so 4", stderr=""
+                        return_code=0,
+                        stdout="we add 2 plus 2 equals 4, so 4\n",
+                        stderr="\nsession_id: 20260907_140709_77ea97\n",
                     )
                 return SimpleNamespace(return_code=0, stdout="", stderr="")
 
@@ -292,7 +297,7 @@ class TestHarness:
             def server_close(self):
                 pass
 
-        health = iter([(0, ""), (1, "")])
+        health = iter([(0, ""), (1, ""), (1, ""), (2, "")])
         stamped: list[str] = []
         monkeypatch.setattr(agent, "_start_shim", lambda _scenario, session: (stamped.append(session), FakeShim())[1])
         monkeypatch.setattr(agent, "_upstream_health", lambda: next(health))
@@ -300,17 +305,30 @@ class TestHarness:
         context = SimpleNamespace(metadata=None)
         asyncio.run(agent.run("ignored", environment, context))
 
-        assert context.metadata["openclawrl"]["turns"] == 1
+        assert context.metadata["openclawrl"]["turns"] == 2
         assert context.metadata["openclawrl"]["failure"] is None
         assert context.metadata["openclawrl"]["scenario"].startswith("openclawrl-stream-")
         # One position, one tagged conversation: the processor correlates on
-        # this instead of on a transcript hermes never resends.
+        # this rather than on whatever transcript hermes resends.
         assert stamped == [f"{context.metadata['openclawrl']['scenario']}-s0"]
-        hermes_calls = [c for c in environment.commands if "hermes -z" in c]
-        assert len(hermes_calls) == 1
+        hermes_calls = [c for c in environment.commands if "hermes chat" in c]
+        assert len(hermes_calls) == 2
+        # Quiet single-query chat mode, never the one-shot ``hermes -z``: that
+        # path ignores ``--resume``, so the second turn would forget the first.
+        # The working directory is the hermes home, where the homework lands;
+        # stderr is dropped because the exec transport folds it into stdout.
+        assert all(
+            "hermes chat -Q -q " in c and "--in /reef_eval/state/hermes" in c and c.endswith(" 2>/dev/null")
+            for c in hermes_calls
+        )
         assert "--resume" not in hermes_calls[0]  # first turn starts fresh
+        assert "--resume latest 2>/dev/null" in hermes_calls[1]  # later turns continue the session
+        assert "hermes -z" not in " ".join(environment.commands)
         config_writes = [c for c in environment.commands if ".hermes/config.yaml" in c]
         assert config_writes and "enabled: false" in config_writes[0]  # compression off
+        assert "show_reasoning: false" in config_writes[0]  # stdout is the reply alone
+        assert "tirith_enabled: false" in config_writes[0]  # no scanner warning ahead of the reply
+        assert "[ -f" not in config_writes[0]  # rewritten every position, never kept stale
 
 
 def test_reply_returns_before_the_reaction_exists(student_server):


### PR DESCRIPTION
Re-ran `recipes/openclawrl/examples/openclawrl/run.sh`. The stack boots, judges, trains and hot-swaps weights; the bugs were in the example's harness and in restarting the stack.

- **Harness**: `hermes -z` ignores `--resume`, so every turn after the first in a session was a fresh conversation (its own hermes session, a `[system, user]` request, the model never saw the reply the student was reacting to). Turns now run as `hermes chat -Q -q --in $HERMES_HOME`, which resumes the session and prints only the reply; reasoning display and the tirith warning are off, stderr is dropped because the exec transport folds it into the reply, and `--in` makes the relative homework path resolve on the first turn.
- **Restart**: with a Megatron checkpoint present the actor init hook refused to start, so the stack could not come back after its first training step. On resume it now bridge-loads the base HF weights as the frozen teacher and restores the trained weights.
- Drop the unread `REEF_INFERENCE_HOST` from the compose file; README notes on restarting.

Verified on the run: resumed turns carry the transcript (2→6→8→12 messages, sessions finish in 3-4 turns); a stack stopped after step 1 resumed, served the committed version and trained step 2. Documented but not fixed (Reef/reef-eval side): a stop during a commit leaves a `READY_TO_COMMIT` marker the recipe cannot replay, and a killed run leaves root-owned live state that reef-eval cannot reset.

