### PR TITLE
feat(train): commit a job the backend published before a restart interrupted its commit

### DIFF
--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -598,11 +598,26 @@ class Dispatcher:
         backend = current.trainer.training_backend
         if backend is None or not backend.dispatched:
             raise RuntimeContractError(f"training scenario {current.name!r} has no dispatched training backend")
-        backend.recover_pending_step(
+        recovered = backend.recover_pending_step(
             current.scenario_step,
             committed_training_job_id=current.committed_training_job_id,
             committed_training_without_job_id=current.committed_training_without_job_id,
         )
+        if recovered is not None:
+            # The backend published this job's weights and the restart came
+            # before Reef's commit. Commit it first: the serving engines and
+            # the checkpoint on disk already are that step.
+            training_job_id = recovered.result.training_job_id
+            logger.warning(
+                "scenario %r: committing training job %s, published before the restart",
+                current.name,
+                training_job_id,
+            )
+            current.reserve_recovered_step(recovered)
+            self._commit_result(current.name, recovered.result)
+            if training_job_id is not None:
+                backend.acknowledge_commit(current.scenario_step, training_job_id)
+            return True
         if (batch := current.reserve_training_batch()) is None:
             return False
         execution = current.execute_reserved_training_step()

--- a/reef/runtime/adapters/executor_runtime.py
+++ b/reef/runtime/adapters/executor_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from typing import Any
@@ -13,7 +14,9 @@ from reef.runtime.inference import InferenceBackend, InferenceBackendFactory, bu
 from reef.runtime.registry import RuntimeConfigError, RuntimeFactory, register_runtime_kind
 from reef.runtime.training_group import ExecutorTrainGroupHandle, TrainingGroupHandle, TrainingRuntimeError
 from reef.train.evaluation.contracts import SelectionDecision
-from reef.train.types import TrainingBatch, policy_samples
+from reef.train.types import RecoveredTrainingStep, TrainingBatch, TrainStepResult, policy_samples
+
+logger = logging.getLogger(__name__)
 
 
 class ExecutorTrainingRuntime(TrainingRuntime):
@@ -176,6 +179,19 @@ class ExecutorTrainingRuntime(TrainingRuntime):
                 raise TrainingRuntimeError("token staleness admission requires a verified serving runtime load ID")
             payload["max_staleness"] = self._max_staleness
             payload["producing_runtime_load_ids"] = list(versions)
+        # Reef's side of the commit, kept by the backend with the job's
+        # durable marker: a restart between the backend publishing the job's
+        # weights and Reef committing it cannot rebuild this batch (see
+        # reconcile_training_job), so the job comes back with what its
+        # commit needs. Record ids only: a processor's own bookkeeping (the
+        # reports paired with these samples, say) is released by retention
+        # once the samples are gone.
+        payload["reef_commit_context"] = {
+            "agent_record_ids": list(dict.fromkeys(sample.source_agent_record_id for sample in samples)),
+            "next_algorithm_state": dict(prepared.next_algorithm_state),
+            "metrics": dict(prepared.metrics),
+            "source_runtime_load_id": self.current_runtime_load_id(),
+        }
         # The scenario step crosses into the backend job as ``rollout_id`` —
         # the training backend's own (wire) name for the same integer.
         payload.update(rollout_id=scenario_step, expected_runtime_load_id=expected_runtime_load_id)
@@ -289,7 +305,7 @@ class ExecutorTrainingRuntime(TrainingRuntime):
         committed_training_job_id: str | None = None,
         committed_training_without_job_id: bool = False,
         scenario: str | None = None,
-    ) -> None:
+    ) -> RecoveredTrainingStep | None:
         if committed_training_job_id is not None and (
             not isinstance(committed_training_job_id, str) or not committed_training_job_id
         ):
@@ -299,22 +315,22 @@ class ExecutorTrainingRuntime(TrainingRuntime):
         training_job = self._training_job_status()
         status = training_job["status"]
         if self._sync_inference_admission(training_job):
-            return
+            return None
         job_scenario = training_job.get("scenario")
         if scenario is not None and isinstance(job_scenario, str) and job_scenario != scenario:
             # The pending job belongs to another scenario sharing this
             # runtime; admission is engine-global and already synced above,
             # but its commit handshake is that scenario's to finish.
-            return
+            return None
         if status == "REJECTING":
             training_job_id = training_job.get("training_job_id")
             if not isinstance(training_job_id, str) or not training_job_id:
                 raise TrainingRuntimeError("rejecting training job is missing its durable identity")
             self._train_group_handle.reject_training_candidate(training_job_id)
             self._inference_admission.open()
-            return
+            return None
         if status not in {"UPDATING_WEIGHTS", "READY_TO_COMMIT", "HEAD_COMMITTED", "COMPLETE"}:
-            return
+            return None
         rollout_id = training_job.get("rollout_id")
         training_job_id = training_job.get("training_job_id")
         if (
@@ -324,6 +340,10 @@ class ExecutorTrainingRuntime(TrainingRuntime):
             or not training_job_id
         ):
             raise TrainingRuntimeError("training-job status is missing its durable identity")
+        if status == "READY_TO_COMMIT" and scenario_step == rollout_id:
+            # Published and paused, with no commit for it: the restart fell
+            # between the backend's weight update and Reef's commit.
+            return self._recover_uncommitted_job(training_job, training_job_id)
         if status == "UPDATING_WEIGHTS":
             recovered = self._validated_result(self._train_group_handle.update_serving_weights(training_job_id))
             if recovered.outcome != "complete" or recovered.training_job_id != training_job_id:
@@ -340,9 +360,69 @@ class ExecutorTrainingRuntime(TrainingRuntime):
             # next-step training record is the strongest durable migration
             # proof available; rollback/non-training commits are excluded.
             self._finish_committed_training_job(training_job_id)
-            return
+            return None
         if scenario_step > rollout_id and committed_training_job_id == training_job_id:
             self._finish_committed_training_job(training_job_id)
+        return None
+
+    def _recover_uncommitted_job(
+        self, training_job: Mapping[str, Any], training_job_id: str
+    ) -> RecoveredTrainingStep | None:
+        """The step to commit for a job that published before Reef committed it.
+
+        The backend answers the same idempotent weight-update call the
+        settlement path makes with the job's recorded result; the commit
+        context Reef attached at preparation supplies the rest. Requests stay
+        held until the commit is acknowledged. Without a context (a marker an
+        older bridge wrote) the job is left to the operator, as before.
+        """
+        context = training_job.get("commit_context")
+        if not isinstance(context, Mapping):
+            logger.warning(
+                "training job %s published its weights before Reef committed it, and the backend kept no "
+                "commit context for it: Reef can neither commit nor replay it. Stop the stack and start the "
+                "training state over.",
+                training_job_id,
+            )
+            return None
+        state = context.get("next_algorithm_state")
+        record_ids = context.get("agent_record_ids")
+        source = context.get("source_runtime_load_id")
+        metrics = context.get("metrics")
+        if (
+            not isinstance(state, Mapping)
+            or not isinstance(record_ids, list)
+            or any(not isinstance(value, str) or not value for value in record_ids)
+            or (source is not None and (not isinstance(source, str) or not source))
+            or (metrics is not None and not isinstance(metrics, Mapping))
+        ):
+            raise TrainingRuntimeError(f"training job {training_job_id} carries a malformed commit context")
+        published = self._validated_result(self._train_group_handle.update_serving_weights(training_job_id))
+        if (
+            published.outcome != "complete"
+            or published.training_job_id != training_job_id
+            or published.runtime_load_id is None
+            or published.checkpoint_path is None
+        ):
+            raise TrainingRuntimeError("recovered training job returned an invalid completed result")
+        logger.warning(
+            "training job %s published its weights before Reef committed it; committing it now",
+            training_job_id,
+        )
+        result = TrainStepResult(
+            state=dict(state),
+            metrics={
+                **dict(published.metrics or {}),
+                **(dict(metrics) if metrics is not None else {}),
+                "selected": True,
+                "recovered_training_job": True,
+            },
+            runtime_load_id=published.runtime_load_id,
+            checkpoint_path=published.checkpoint_path,
+            training_job_id=training_job_id,
+            source_runtime_load_id=source,
+        )
+        return RecoveredTrainingStep(result, frozenset(record_ids))
 
     def _finish_committed_training_job(self, training_job_id: str) -> None:
         self._train_group_handle.acknowledge_training_commit(training_job_id)

--- a/reef/runtime/base.py
+++ b/reef/runtime/base.py
@@ -15,7 +15,7 @@ from reef.core.errors import ReefError
 from reef.runtime.candidates import ActivatedModel, ModelCandidate
 from reef.runtime.inference import InferenceBackend
 from reef.train.evaluation.contracts import SelectionDecision
-from reef.train.types import TrainingBatch
+from reef.train.types import RecoveredTrainingStep, TrainingBatch
 
 
 class RuntimeContractError(ReefError):
@@ -308,13 +308,18 @@ class TrainingRuntime(InferenceRuntime, ABC):
         committed_training_job_id: str | None = None,
         committed_training_without_job_id: bool = False,
         scenario: str | None = None,
-    ) -> None:
+    ) -> RecoveredTrainingStep | None:
         """Reconcile a backend training job against Reef's durable commit.
+
+        Returns the step to commit when the backend holds a job that published
+        its weights before Reef committed it (a restart fell between the two);
+        ``None`` when nothing is left for the caller to do.
 
         ``scenario`` is passed only by a backend bound to a runtime that
         trains several scenarios at once (see
         :attr:`concurrent_training_scenarios`).
         """
+        return None
 
     @abstractmethod
     def prepare_training_step(

--- a/reef/scenario/scenario.py
+++ b/reef/scenario/scenario.py
@@ -20,7 +20,7 @@ from reef.scenario.snapshot import SCENARIO_SNAPSHOT_METADATA_KEY, snapshot_meta
 from reef.surface.base import Surface
 from reef.train.backend import StepExecution
 from reef.train.trainer import Trainer
-from reef.train.types import TrainingBatch, TrainStepResult
+from reef.train.types import RecoveredTrainingStep, TrainingBatch, TrainStepResult
 
 
 class Scenario:
@@ -132,6 +132,11 @@ class Scenario:
         """Drop the reserved batch and durably compact whatever it released."""
         with self._commit_protocol.lock:
             self._trainer.reject_pending(metrics)
+
+    def reserve_recovered_step(self, recovered: RecoveredTrainingStep) -> None:
+        """Reserve a step the backend settled before a restart, excluding rollback and commit."""
+        with self._commit_protocol.lock:
+            self._trainer.reserve_recovered_step(recovered)
 
     def reingest(self, *, up_to_sequence: int, consumed_ids: frozenset[str]) -> None:
         """Rebuild processor memory from retained rows behind a recovered watermark."""

--- a/reef/train/backend.py
+++ b/reef/train/backend.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from reef.train.evaluation.contracts import CandidateEvaluator, EvaluationResult, SelectionDecision, UpdateCandidate
-from reef.train.types import TrainingBatch, TrainStepResult
+from reef.train.types import RecoveredTrainingStep, TrainingBatch, TrainStepResult
 
 
 @dataclass(frozen=True)
@@ -125,9 +125,14 @@ class TrainingBackend(CandidateEvaluator, ABC):
         *,
         committed_training_job_id: str | None,
         committed_training_without_job_id: bool,
-    ) -> None:
-        """Finish or roll back backend work left pending across a restart."""
-        return
+    ) -> RecoveredTrainingStep | None:
+        """Finish or roll back backend work left pending across a restart.
+
+        Returns the step to commit when the backend published a job's weights
+        before Reef committed it; the dispatcher commits it before it reserves
+        another batch. ``None`` when nothing is pending.
+        """
+        return None
 
     def acknowledge_commit(self, scenario_step: int, training_job_id: str) -> None:
         """Acknowledge that Reef durably committed a backend training job."""
@@ -169,4 +174,4 @@ class TrainingBackend(CandidateEvaluator, ABC):
         """Restore backend-local state after evaluation or settlement fails."""
 
 
-__all__ = ["PreparedStep", "StepExecution", "TrainingBackend"]
+__all__ = ["PreparedStep", "RecoveredTrainingStep", "StepExecution", "TrainingBackend"]

--- a/reef/train/slime_backend/backend.py
+++ b/reef/train/slime_backend/backend.py
@@ -9,7 +9,7 @@ from reef.runtime.base import RuntimeContractError, TrainingRuntime
 from reef.runtime.candidates import CandidateTrainingDeferred, ModelCandidate, StaleCandidate
 from reef.train.backend import PreparedStep, TrainingBackend
 from reef.train.evaluation.contracts import EvaluationResult, SelectionDecision, UpdateCandidate
-from reef.train.types import TrainingBatch, TrainStepResult
+from reef.train.types import RecoveredTrainingStep, TrainingBatch, TrainStepResult
 
 
 class SlimeTrainingBackend(TrainingBackend):
@@ -58,16 +58,15 @@ class SlimeTrainingBackend(TrainingBackend):
         *,
         committed_training_job_id: str | None = None,
         committed_training_without_job_id: bool = False,
-    ) -> None:
+    ) -> RecoveredTrainingStep | None:
         scenario = self._runtime_scenario()
         if scenario is None:
-            self._runtime.reconcile_training_job(
+            return self._runtime.reconcile_training_job(
                 scenario_step,
                 committed_training_job_id=committed_training_job_id,
                 committed_training_without_job_id=committed_training_without_job_id,
             )
-            return
-        self._runtime.reconcile_training_job(
+        return self._runtime.reconcile_training_job(
             scenario_step,
             committed_training_job_id=committed_training_job_id,
             committed_training_without_job_id=committed_training_without_job_id,

--- a/reef/train/slime_backend/reef_adapters/bridge.py
+++ b/reef/train/slime_backend/reef_adapters/bridge.py
@@ -653,6 +653,8 @@ class TrainBridgeActorImpl:
             )
             if "scenario" in marker:
                 training_job["scenario"] = marker["scenario"]
+            if isinstance(marker.get("commit_context"), Mapping):
+                training_job["commit_context"] = dict(marker["commit_context"])
         ok = self._phase not in {"training_failed", "checkpoint_failed", "weight_sync_failed", "stopped"}
         return {
             "ok": ok,
@@ -986,6 +988,12 @@ class TrainBridgeActorImpl:
             }
             if scenario is not None:
                 marker.update(scenario=scenario, scenario_step=scenario_step)
+            commit_context = payload.get("reef_commit_context")
+            if isinstance(commit_context, Mapping):
+                # Reef's side of the commit, kept with the job: a restart
+                # between publication and Reef's commit hands it back through
+                # health() so Reef can still commit the job.
+                marker["commit_context"] = dict(commit_context)
             write_marker(self._marker_path(), marker)
             try:
                 if self._colocate:

--- a/reef/train/trainer.py
+++ b/reef/train/trainer.py
@@ -26,7 +26,14 @@ from reef.train.backend import PreparedStep, StepExecution, TrainingBackend
 from reef.train.evaluation.contracts import CandidateEvaluationPlugin, SelectionDecision, UpdateCandidate
 from reef.train.evaluation.evaluators import DefaultCandidateEvaluationPlugin
 from reef.train.processors.base import DataProcessor
-from reef.train.types import PreparedCommit, ProcessorContext, TrainingBatch, TrainStepResult
+from reef.train.types import (
+    PolicyBatch,
+    PreparedCommit,
+    ProcessorContext,
+    RecoveredTrainingStep,
+    TrainingBatch,
+    TrainStepResult,
+)
 
 
 @dataclass
@@ -42,6 +49,9 @@ class _PendingStep:
     prepared_commit: PreparedCommit | None = None
     # Set once the processor has the batch back and the step consumed these ids on its own, so no acknowledgement.
     consumed_ids: frozenset[str] | None = None
+    # A step the backend settled before a restart: the processor never held
+    # its batch, so its rows are compacted with the commit instead of released.
+    recovered: bool = False
 
     @property
     def batch_id(self) -> str:
@@ -339,6 +349,27 @@ class Trainer:
             self._pending = _PendingStep(batch=batch, result=None)
             return batch
 
+    def reserve_recovered_step(self, recovered: RecoveredTrainingStep) -> None:
+        """Reserve a step the backend settled before a restart, so it commits like any other.
+
+        The batch it trained on is gone with the process, and the processor
+        may hold its rows again after re-ingestion; the reservation carries
+        the rows as consumed so the commit records and compacts them.
+        """
+        result = recovered.result
+        if result.training_job_id is None:
+            raise ValueError("a recovered training step must name its training job")
+        with self._lock:
+            if self._pending is not None:
+                raise RuntimeError("cannot reserve a recovered training step while a batch is reserved")
+            batch = PolicyBatch(f"{self.scenario}:recovered:{result.training_job_id}", ())
+            self._pending = _PendingStep(
+                batch=batch,
+                result=result,
+                consumed_ids=recovered.consumed_agent_record_ids,
+                recovered=True,
+            )
+
     def execute_reserved_step(self, scenario_step: int) -> StepExecution:
         """Run the dispatched backend for the currently reserved batch."""
         with self._lock:
@@ -388,6 +419,10 @@ class Trainer:
                 consumed = self._processor.acknowledge(batch_id)
             retention = self._processor.retention_decision()
             compacted = retention.releasable_agent_record_ids - retention.protected_agent_record_ids
+            if self._pending.recovered:
+                # Trained before the restart, re-ingested after it: gone with
+                # this commit, whatever the processor makes of them now.
+                compacted = frozenset(compacted) | consumed
             metrics = dict(result.metrics)
             request = self._pending.batch.request
             if request is not None:

--- a/reef/train/types/__init__.py
+++ b/reef/train/types/__init__.py
@@ -15,6 +15,7 @@ from reef.train.types.results import (
     DurableWeightsPublication,
     LiveWeightPublication,
     NoArtifactPublication,
+    RecoveredTrainingStep,
     SavedArtifactPublication,
     TrainStepResult,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "PolicySample",
     "PreparedCommit",
     "ProcessorContext",
+    "RecoveredTrainingStep",
     "RuntimeLoadSpan",
     "SavedArtifactPublication",
     "TraceBatch",

--- a/reef/train/types/results.py
+++ b/reef/train/types/results.py
@@ -110,3 +110,25 @@ class TrainStepResult:
                 return DurableWeightsPublication(self.checkpoint_path, self.runtime_load_id)
             return LiveWeightPublication(self.runtime_load_id)
         return NoArtifactPublication()
+
+
+@dataclass(frozen=True)
+class RecoveredTrainingStep:
+    """A backend step that published its weights before Reef could commit it.
+
+    A restart in that window leaves the backend serving, and paused on, a
+    job Reef has no commit for. Rebuilding the same batch is not possible in
+    general (a processor may judge with sampling, and new records may have
+    arrived since), so the runtime hands the step back with the commit
+    context it kept for Reef, and the dispatcher commits it like any settled
+    step. ``consumed_agent_record_ids`` are the records the job trained on;
+    the commit records them consumed and compacts them so they never train
+    twice.
+    """
+
+    result: TrainStepResult
+    consumed_agent_record_ids: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        if self.result.training_job_id is None or self.result.runtime_load_id is None:
+            raise ValueError("a recovered training step must carry its training job id and runtime load id")

--- a/tests/reef_service/test_ray_runtime.py
+++ b/tests/reef_service/test_ray_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import pickle
 from collections.abc import Mapping
 from typing import Any
@@ -27,7 +28,7 @@ from reef.surface import RuntimeLoadMismatch, create_weight_surface
 from reef.train.algos import StepScheduling, StepSignal
 from reef.train.evaluation import EvaluationResult, SelectionDecision
 from reef.train.slime_backend.reef_adapters.preparation import prepare_slime_step as slime_prepare_step
-from reef.train.types import GroupedPolicyBatch, PolicyBatch, PolicySample
+from reef.train.types import GroupedPolicyBatch, PolicyBatch, PolicySample, RecoveredTrainingStep
 
 from ._grouped_pg import GROUPED_PG_PREPARER as _TEST_GROUPED_PREPARER
 
@@ -1107,6 +1108,92 @@ def test_recovery_acknowledges_a_training_job_after_the_scenario_commit() -> Non
 
     assert handle.calls == ["acknowledge"]
     assert runtime.inference_admission_status == {"open": True, "active": 0}
+
+
+@pytest.mark.unit
+def test_recovery_commits_forward_a_job_published_before_reef_committed() -> None:
+    context = {
+        "agent_record_ids": ["i1", "i2"],
+        "next_algorithm_state": {"steps": 4},
+        "metrics": {"samples": 2},
+        "source_runtime_load_id": "engine:0",
+    }
+
+    class PublishedHandle(DeferredWeightUpdateTrainGroupHandle):
+        def health(self) -> Mapping[str, Any]:
+            health = dict(super().health())
+            health["training_job"] = {**health["training_job"], "commit_context": context}
+            return health
+
+        def update_serving_weights(self, training_job_id: str) -> TrainingJobResult:
+            # The idempotent replay of a published job: its recorded result.
+            self.calls.append("replay")
+            return TrainingJobResult(
+                outcome="complete",
+                runtime_load_id="engine:1",
+                checkpoint_path="/checkpoint",
+                metrics={"train/loss": 0.5},
+                training_job_id=training_job_id,
+            )
+
+    handle = PublishedHandle(status="READY_TO_COMMIT", rollout_id=3)
+    runtime = RayRuntime(train_group_handle=handle, inference_url="http://router")
+
+    # Reef's head is step 3, the job's commit never happened: the restart
+    # fell between the weight update and the commit.
+    recovered = runtime.reconcile_training_job(scenario_step=3, committed_training_job_id="job-2")
+
+    assert isinstance(recovered, RecoveredTrainingStep)
+    assert recovered.consumed_agent_record_ids == frozenset({"i1", "i2"})
+    result = recovered.result
+    assert (result.training_job_id, result.runtime_load_id, result.checkpoint_path) == (
+        handle.training_job_id,
+        "engine:1",
+        "/checkpoint",
+    )
+    assert result.state == {"steps": 4}
+    assert result.source_runtime_load_id == "engine:0"
+    assert result.metrics["train/loss"] == 0.5
+    assert result.metrics["samples"] == 2
+    assert result.metrics["selected"] is True
+    assert result.metrics["recovered_training_job"] is True
+    assert handle.calls == ["replay"]
+    # Requests stay held until Reef commits the step and acknowledges it.
+    assert runtime.inference_admission_status == {"open": False, "active": 0}
+
+    runtime.reconcile_training_job(scenario_step=4, committed_training_job_id=handle.training_job_id)
+
+    assert handle.calls == ["replay", "acknowledge"]
+    assert runtime.inference_admission_status == {"open": True, "active": 0}
+
+
+@pytest.mark.unit
+def test_recovery_leaves_a_published_job_without_commit_context_to_the_operator(caplog) -> None:
+    handle = DeferredWeightUpdateTrainGroupHandle(status="READY_TO_COMMIT", rollout_id=3)
+    runtime = RayRuntime(train_group_handle=handle, inference_url="http://router")
+
+    with caplog.at_level(logging.WARNING):
+        recovered = runtime.reconcile_training_job(scenario_step=3, committed_training_job_id="job-2")
+
+    assert recovered is None
+    assert handle.calls == []
+    assert runtime.inference_admission_status == {"open": False, "active": 0}
+    assert "kept no commit context" in caplog.text
+
+
+@pytest.mark.unit
+def test_prepared_training_step_carries_the_commit_context_for_recovery() -> None:
+    handle = DeferredWeightUpdateTrainGroupHandle()
+    runtime = RayRuntime(train_group_handle=handle, inference_url="http://router")
+
+    prepared = runtime.prepare_training_step(policy_batch(), "sft", {"steps": 3}, 3)
+
+    assert prepared.payload is not None
+    context = prepared.payload["reef_commit_context"]
+    assert context["agent_record_ids"] == [sample.source_agent_record_id for sample in policy_batch().samples]
+    assert context["next_algorithm_state"] == dict(prepared.next_algorithm_state)
+    assert context["metrics"] == dict(prepared.metrics)
+    assert context["source_runtime_load_id"] == runtime.current_runtime_load_id()
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_recovered_training_step.py
+++ b/tests/reef_service/test_recovered_training_step.py
@@ -1,0 +1,125 @@
+"""A job the backend published before a restart is committed before any new batch."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reef.artifact.memory import InMemoryRepositoryBackend
+from reef.dispatcher import Dispatcher
+from reef.recipe import Recipe
+from reef.runtime.adapters.executor_runtime import ExecutorTrainingRuntime
+from reef.train.backend import TrainingBackend
+from reef.train.types import RecoveredTrainingStep, TrainStepResult
+
+from .test_ray_runtime import DeferredWeightUpdateTrainGroupHandle
+
+pytestmark = pytest.mark.unit
+
+
+def _dispatcher() -> Dispatcher:
+    root = Path(tempfile.mkdtemp(prefix="reef-artifacts-"))
+    initial = root / "initial"
+    initial.mkdir()
+    return Dispatcher(Recipe(), InMemoryRepositoryBackend.factory(initial, root=root / "repository"))
+
+
+class _RecoveringBackend(TrainingBackend):
+    """A dispatched backend whose recovery hands back one published job."""
+
+    def __init__(self, recovered: RecoveredTrainingStep | None) -> None:
+        self.recovered = recovered
+        self.calls: list[tuple] = []
+
+    @property
+    def dispatched(self) -> bool:
+        return True
+
+    def initial_state(self):
+        return {}
+
+    def recover_pending_step(self, scenario_step, *, committed_training_job_id, committed_training_without_job_id):
+        self.calls.append(("recover", scenario_step, committed_training_job_id))
+        return self.recovered
+
+    def acknowledge_commit(self, scenario_step, training_job_id):
+        self.calls.append(("acknowledge", scenario_step, training_job_id))
+
+    def prepare_step(self, batch, state, scenario_step):
+        raise AssertionError("no batch is prepared while a recovered job waits for its commit")
+
+    def evaluate(self, candidate):
+        raise AssertionError("not used")
+
+    def settle_step(self, prepared, decision):
+        raise AssertionError("not used")
+
+    def abort_step(self, prepared):
+        raise AssertionError("not used")
+
+
+def _scenario(backend: TrainingBackend, reserved: list, *, batch_reserved: list) -> SimpleNamespace:
+    handle = DeferredWeightUpdateTrainGroupHandle(status="READY_TO_COMMIT", rollout_id=1)
+    runtime = ExecutorTrainingRuntime(train_group_handle=handle, inference_url="http://router")
+
+    def reserve_training_batch():
+        batch_reserved.append(True)
+
+    return SimpleNamespace(
+        name="s",
+        runtime=runtime,
+        scenario_step=1,
+        committed_training_job_id="job-0",
+        committed_training_without_job_id=False,
+        trainer=SimpleNamespace(training_backend=backend),
+        reserve_recovered_step=reserved.append,
+        reserve_training_batch=reserve_training_batch,
+    )
+
+
+def test_dispatcher_commits_a_recovered_job_before_reserving_a_batch(monkeypatch) -> None:
+    result = TrainStepResult(
+        {"steps": 2},
+        {"selected": True},
+        runtime_load_id="engine:2",
+        checkpoint_path="/checkpoint",
+        training_job_id="job-1",
+    )
+    recovered = RecoveredTrainingStep(result, frozenset({"i1"}))
+    backend = _RecoveringBackend(recovered)
+    reserved: list = []
+    batch_reserved: list = []
+    committed: list = []
+    dispatcher = _dispatcher()
+    scenario = _scenario(backend, reserved, batch_reserved=batch_reserved)
+    dispatcher._registry = SimpleNamespace(get_optional=lambda name: scenario if name == "s" else None)
+    monkeypatch.setattr(dispatcher, "_commit_result", lambda name, value: committed.append((name, value)))
+    monkeypatch.setattr(dispatcher, "_record_training_error", lambda name, value: None)
+
+    progressed = dispatcher._process_training_scenario("s")
+
+    # The published job is reserved, committed and acknowledged in that order,
+    # and this turn ends there: no batch is reserved behind it.
+    assert progressed is True
+    assert reserved == [recovered]
+    assert committed == [("s", result)]
+    assert backend.calls == [("recover", 1, "job-0"), ("acknowledge", 1, "job-1")]
+    assert batch_reserved == []
+
+
+def test_dispatcher_reserves_a_batch_when_nothing_was_left_pending(monkeypatch) -> None:
+    backend = _RecoveringBackend(None)
+    reserved: list = []
+    batch_reserved: list = []
+    dispatcher = _dispatcher()
+    scenario = _scenario(backend, reserved, batch_reserved=batch_reserved)
+    dispatcher._registry = SimpleNamespace(get_optional=lambda name: scenario if name == "s" else None)
+    monkeypatch.setattr(dispatcher, "_record_training_error", lambda name, value: None)
+
+    assert dispatcher._process_training_scenario("s") is False
+    assert reserved == []
+    assert batch_reserved == [True]
+    assert backend.calls == [("recover", 1, "job-0")]

--- a/tests/reef_service/test_slime_bridge.py
+++ b/tests/reef_service/test_slime_bridge.py
@@ -764,6 +764,31 @@ def test_bridge_defers_resume_until_reef_acknowledges_the_commit(tmp_path) -> No
 
 
 @pytest.mark.unit
+def test_bridge_keeps_reef_commit_context_with_the_job_marker(tmp_path) -> None:
+    template = str(tmp_path / "checkpoint-{rollout_id}")
+    group = _DurableGroup(template)
+    manager = _FakeRolloutManager(["packed"])
+    actor = bridge.TrainBridgeActorImpl(group, manager, save_hf_template=template)
+    context = {"agent_record_ids": ["a", "b", "c"], "next_algorithm_state": {"steps": 1}, "metrics": {"samples": 3}}
+    payload = _payload(loss="sft")
+    payload.update(rollout_id=0, expected_runtime_load_id="v1", reef_commit_context=context)
+
+    result = _execute_and_update_weights(actor, payload)
+
+    # Published and waiting for Reef's commit: the context rides the marker
+    # and health hands it back, so a restart here can still commit the job.
+    marker = read_marker(tmp_path / ".reef-latest-job.json")
+    assert result.outcome == "complete"
+    assert marker["status"] == "READY_TO_COMMIT"
+    assert marker["commit_context"] == context
+    assert actor.health()["training_job"]["commit_context"] == context
+
+    actor.acknowledge_training_commit(result.training_job_id)
+
+    assert read_marker(tmp_path / ".reef-latest-job.json")["commit_context"] == context
+
+
+@pytest.mark.unit
 def test_pause_barrier_failure_leaves_checkpoint_replayable(tmp_path) -> None:
     template = str(tmp_path / "checkpoint-{rollout_id}")
     group = _DurableGroup(template)

--- a/tests/reef_service/test_trainer.py
+++ b/tests/reef_service/test_trainer.py
@@ -24,7 +24,7 @@ from reef.train.evaluation import (
 from reef.train.processors import DataProcessor
 from reef.train.slime_backend.backend import SlimeTrainingBackend
 from reef.train.slime_backend.reef_adapters.preparation import prepare_slime_step
-from reef.train.types import PolicyBatch, PolicySample, TrainStepResult
+from reef.train.types import PolicyBatch, PolicySample, RecoveredTrainingStep, TrainStepResult
 
 from ._grouped_pg import GROUPED_PG_PREPARER as _GROUPED_PG_PREPARER
 from ._grouped_pg import GroupedPolicyProcessor
@@ -463,6 +463,43 @@ def test_trainer_reserves_batch_and_commits_backend_preparation() -> None:
     trainer.commit(prepared)
     trainer.apply_compaction(prepared.compacted_ids)
     assert trainer.state == {"steps": 1}
+
+
+@pytest.mark.unit
+def test_trainer_commits_a_recovered_step_and_compacts_the_rows_it_trained() -> None:
+    records = RecordStore()
+    records.append(inference("i1"))
+    records.append(report("r1", "i1", 1.0))
+    trainer = Trainer.build(
+        "math",
+        records,
+        processor_factory=lambda context: ThresholdProcessor(ProcessorContext(context.scenario, {"batch_size": 1})),
+        training_backend=_PreparingBackend(),
+    )
+    result = TrainStepResult(
+        {"steps": 7},
+        {"selected": True},
+        runtime_load_id="engine:1",
+        checkpoint_path="/checkpoint",
+        training_job_id="job-6",
+    )
+
+    trainer.reserve_recovered_step(RecoveredTrainingStep(result, frozenset({"i1"})))
+    with pytest.raises(RuntimeError, match="while a batch is reserved"):
+        trainer.reserve_recovered_step(RecoveredTrainingStep(result, frozenset()))
+    prepared = trainer.prepare_commit(result)
+
+    # The commit records what the job trained on and compacts it, whatever
+    # the re-ingested processor has made of those rows since.
+    assert prepared.training_job_id == "job-6"
+    assert prepared.consumed_ids == frozenset({"i1"})
+    assert "i1" in prepared.compacted_ids
+    assert prepared.algorithm_state == {"steps": 7}
+    trainer.commit(prepared)
+    trainer.apply_compaction(prepared.compacted_ids)
+    assert trainer.state == {"steps": 7}
+    assert trainer.pending_batch is None
+    assert records.get("math", "i1") is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
A restart between the bridge's weight update (marker `READY_TO_COMMIT`, engines paused on the new version) and Reef's durable commit wedged the stack: Reef had no record of the job, rebuilt a batch, and the bridge refused it as a conflict ("training marker is READY_TO_COMMIT; operator recovery required") on every cycle, with inference admission closed. The existing recovery assumes Reef rebuilds the identical job and replays it, which a processor that judges with sampling (openclawrl's PRM votes) never does.

- Reef attaches what its commit needs to the training payload (`reef_commit_context`: the batch's record ids, next algorithm state, preparer metrics, source version); the bridge keeps it in the job marker and reports it in `health()`.
- `reconcile_training_job` returns such a job as a `RecoveredTrainingStep`; the dispatcher reserves and commits it before reserving any new batch, and the commit records the job's rows consumed and compacts them, so nothing trains twice.
- A marker without the context (older bridge) is left to the operator with a warning that says so.

**Contract changes to review**: `TrainingRuntime.reconcile_training_job` and `TrainingBackend.recover_pending_step` now return `RecoveredTrainingStep | None`; the marker gains an opaque `commit_context`; `Trainer.reserve_recovered_step` reserves a step the processor never held.

**Verified**: unit tests for the runtime, trainer, bridge and dispatcher paths; mypy clean. Live on the openclawrl stack: the container was killed the moment a step reached `READY_TO_COMMIT`; after the restart Reef logged "committing training job …, published before the restart", committed it as the next step (`recovered_training_job: true` in its metrics), served its version with admission open, compacted the job's 16 records, and trained the following step normally.

**Not covered**: a kill during training itself (marker `RUNNING`) still needs the operator (discard the uncommitted `iter_N`/`hf/N`, point `latest_checkpointed_iteration.txt` back, rebuild a `COMPLETE` marker); the openclawrl README's "one window is not recoverable" note should be updated to describe that case once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
