### PR TITLE
fix(openclawrl): run the container side of a session as the host user

### DIFF
--- a/recipes/openclawrl/examples/openclawrl/README.md
+++ b/recipes/openclawrl/examples/openclawrl/README.md
@@ -214,10 +214,11 @@ committed head is republished. Two cases need a hand:
   `artifacts.git`, `artifact-work`, `artifact-cache`, `agent-record` and
   `prm-records.jsonl` out of `$RUN_DIR`. The lab and stream state stay, and
   a re-run continues at the next position.
-- A run killed mid-session leaves root-owned files in
-  `$RUN_DIR/lab/streams/<stream>/state` (Harbor only hands the mount back to
-  your user on a normal trial end), and reef-eval then fails to reset it with
-  `Permission denied`. Chown the directory to your user and re-run.
+- The harness runs every container command, hermes included, as your user
+  and hands the hermes home to you at the start of each position, so a
+  killed run leaves nothing root-owned in `$RUN_DIR/lab/streams/<stream>/state`
+  that reef-eval could not reset. A state directory written by an earlier
+  harness may still need a one-time chown to your user.
 
 ### Reading a run
 

--- a/recipes/openclawrl/examples/openclawrl/harness/agent.py
+++ b/recipes/openclawrl/examples/openclawrl/harness/agent.py
@@ -9,6 +9,12 @@ reef-eval invokes this once per stream position. It owns the whole session:
 * the **reef scenario id**, minted at position 0 and carried in
   ``$REEF_EVAL_STATE_DIR`` — one stream, one scenario, one weight chain; a
   fresh variant starts fresh;
+* **host ownership of the state mount**: every command in the container,
+  hermes included, runs as the user running reef-eval, and each position
+  first hands the hermes home back to that user. reef-eval resets the live
+  state directory between positions with ``rmtree``; files the container had
+  created as root would fail that on the next run after a kill (Harbor only
+  chowns the mount back when a trial ends normally);
 * **hermes itself**, run inside the task container (the environment image
   installs it) with its home on the state mount, so optional agent memory
   rides reef-eval's one cross-position channel. The config is written at the
@@ -126,6 +132,10 @@ class HermesStreamAgent(BaseAgent):
         if not self._reef_url:
             raise ValueError("the hermes stream harness requires --agent-arg reef_url=http://<host>:<port>")
         self._hermes_memory = str(kwargs.get("hermes_memory", "")).strip().lower() in ("1", "true", "yes")
+        # The container user for every command the harness runs: the host
+        # user, so the state mount never holds root-owned files. None (the
+        # image's default user) where the host has no POSIX ids.
+        self._container_user = f"{os.getuid()}:{os.getgid()}" if hasattr(os, "getuid") else None
         self._capture = CaptureStore()  # replaced per session by _start_shim
 
     @staticmethod
@@ -157,8 +167,15 @@ class HermesStreamAgent(BaseAgent):
 
     # ------------------------------------------------------------- plumbing
 
-    async def _exec(self, environment: BaseEnvironment, command: str, *, ok_codes: tuple[int, ...] = (0,)) -> str:
-        result = await environment.exec(command)
+    async def _exec(
+        self,
+        environment: BaseEnvironment,
+        command: str,
+        *,
+        ok_codes: tuple[int, ...] = (0,),
+        as_root: bool = False,
+    ) -> str:
+        result = await environment.exec(command, user=None if as_root else self._container_user)
         if result.return_code not in ok_codes:
             raise RuntimeError(
                 f"exec failed ({result.return_code}): {command[:120]} :: {(result.stderr or '')[-300:]}"
@@ -227,6 +244,17 @@ class HermesStreamAgent(BaseAgent):
         # The directory is wiped first because HOME rides the state mount —
         # left alone, every past session's solved homework would stay readable
         # and become a third adaptation channel behind weights and memory.
+        # Root does the wipe and hands the whole home to the host user: a
+        # state directory from an earlier harness, or from a killed run, may
+        # still hold root-owned files the host user could neither delete nor
+        # write into.
+        if self._container_user is not None:
+            await self._exec(
+                environment,
+                f"rm -rf {HERMES_HOME}/homework && mkdir -p {HERMES_HOME} && "
+                f"chown -R {self._container_user} {HERMES_HOME}",
+                as_root=True,
+            )
         homework = f"Problem:\n{problem['question']}\n\nSolution:\n"
         await self._exec(
             environment,

--- a/recipes/openclawrl/examples/openclawrl/harness/agent.py
+++ b/recipes/openclawrl/examples/openclawrl/harness/agent.py
@@ -333,16 +333,19 @@ class HermesStreamAgent(BaseAgent):
         user]`` throughout). Chat mode resumes the position's session
         (``--resume latest``, scoped to ``--in``), prints only the final reply
         on stdout while ``display.show_reasoning`` is off, and reports the
-        session id and the resume notice on stderr. stderr is discarded in
-        the container: the exec transport folds it into stdout, where those
-        lines would reach the student as part of the reply.
+        session id and the resume notice on stderr. stderr goes to a file in
+        the container, because the exec transport folds it into stdout, where
+        those lines would reach the student as part of the reply; a failed
+        turn replays it so the error reaches the trial's record.
 
         ``--in`` is HERMES_HOME, where ``_prepare`` put the homework, so the
         judge's relative ``homework/N.txt`` resolves for the agent.
         """
         resume_flag = " --resume latest" if resume else ""
+        stderr = f"{HERMES_HOME}/.hermes/turn.stderr"
         command = (
             f"HOME={HERMES_HOME} timeout {TURN_TIMEOUT_S} "
-            f"hermes chat -Q -q {shlex.quote(message)} --in {HERMES_HOME}{resume_flag} 2>/dev/null"
+            f"hermes chat -Q -q {shlex.quote(message)} --in {HERMES_HOME}{resume_flag} 2>{stderr} "
+            f"|| {{ rc=$?; cat {stderr} >&2; exit $rc; }}"
         )
         return (await self._exec(environment, command)).strip()

--- a/tests/test_openclawrl_stream.py
+++ b/tests/test_openclawrl_stream.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import importlib
 import json
+import os
 import sys
 import threading
 import time
@@ -269,9 +270,11 @@ class TestHarness:
         class FakeEnvironment:
             def __init__(self):
                 self.commands = []
+                self.users = []
 
-            async def exec(self, command):
+            async def exec(self, command, user=None):
                 self.commands.append(command)
+                self.users.append(user)
                 if "cat /agent/problem.json" in command:
                     return SimpleNamespace(return_code=0, stdout=json.dumps(problem), stderr="")
                 if "cat /reef_eval/state/scenario" in command:
@@ -325,6 +328,14 @@ class TestHarness:
         assert "--resume" not in hermes_calls[0]  # first turn starts fresh
         assert f"--resume latest {stderr}" in hermes_calls[1]  # later turns continue the session
         assert "hermes -z" not in " ".join(environment.commands)
+        # Every command runs as the host user, so nothing on the state mount
+        # ends up root-owned; only the wipe that hands the home over runs as root.
+        host_user = f"{os.getuid()}:{os.getgid()}"
+        root_commands = [c for c, u in zip(environment.commands, environment.users, strict=True) if u is None]
+        assert len(root_commands) == 1 and f"chown -R {host_user} /reef_eval/state/hermes" in root_commands[0]
+        assert all(
+            u == host_user for c, u in zip(environment.commands, environment.users, strict=True) if "hermes chat" in c
+        )
         config_writes = [c for c in environment.commands if ".hermes/config.yaml" in c]
         assert config_writes and "enabled: false" in config_writes[0]  # compression off
         assert "show_reasoning: false" in config_writes[0]  # stdout is the reply alone

--- a/tests/test_openclawrl_stream.py
+++ b/tests/test_openclawrl_stream.py
@@ -317,12 +317,13 @@ class TestHarness:
         # path ignores ``--resume``, so the second turn would forget the first.
         # The working directory is the hermes home, where the homework lands;
         # stderr is dropped because the exec transport folds it into stdout.
+        stderr = "2>/reef_eval/state/hermes/.hermes/turn.stderr || { rc=$?; cat /reef_eval/state/hermes/.hermes/turn.stderr >&2; exit $rc; }"
         assert all(
-            "hermes chat -Q -q " in c and "--in /reef_eval/state/hermes" in c and c.endswith(" 2>/dev/null")
+            "hermes chat -Q -q " in c and "--in /reef_eval/state/hermes" in c and c.endswith(stderr)
             for c in hermes_calls
         )
         assert "--resume" not in hermes_calls[0]  # first turn starts fresh
-        assert "--resume latest 2>/dev/null" in hermes_calls[1]  # later turns continue the session
+        assert f"--resume latest {stderr}" in hermes_calls[1]  # later turns continue the session
         assert "hermes -z" not in " ".join(environment.commands)
         config_writes = [c for c in environment.commands if ".hermes/config.yaml" in c]
         assert config_writes and "enabled: false" in config_writes[0]  # compression off


### PR DESCRIPTION
reef-eval resets a stream's live state directory with `rmtree` before each position. The task container ran the harness's commands and hermes as root, so the state mount filled with root-owned files; Harbor hands the mount back to the host user when a trial ends normally, not when the run is killed, and the next run then failed in that `rmtree` with `Permission denied`.

- Every command the harness execs, hermes included, runs as the user running reef-eval (`environment.exec(user=uid:gid)`); each position starts with one root command that wipes the homework and chowns the hermes home to that user, which also repairs a state directory an earlier harness left behind.
- hermes's stderr goes to a file and is replayed when a turn fails, so the trial record says why (it was dropped entirely before).

**Verified**: unit tests; live on the stack, sessions run and resume as the host user, and the live state holds nothing root-owned.
