### PR TITLE
test: fix pid-marker read race in killed-worker executor test

### DIFF
--- a/tests/reef_service/test_multiproc_executor.py
+++ b/tests/reef_service/test_multiproc_executor.py
@@ -70,7 +70,8 @@ class EpisodeSleeper:
                     sys.executable,
                     "-c",
                     "import os,time; from pathlib import Path; "
-                    "Path('child.pid').write_text(str(os.getpid())); time.sleep(120)",
+                    "Path('child.pid.tmp').write_text(str(os.getpid())); "
+                    "os.replace('child.pid.tmp', 'child.pid'); time.sleep(120)",
                 ],
                 root=root,
                 workspace=root,
@@ -221,11 +222,14 @@ def test_killed_worker_does_not_leave_running_harness(tmp_path):
         pending = executor.rpc(0, "run", args=(str(tmp_path),), non_block=True)
         marker = tmp_path / "child.pid"
         deadline = time.monotonic() + 10
-        while not marker.exists():
+        while True:
+            content = marker.read_text() if marker.exists() else ""
+            if content:
+                break
             if time.monotonic() > deadline:
                 pytest.fail("harness failed to start")
             time.sleep(0.01)
-        pid = int(marker.read_text())
+        pid = int(content)
         executor._ranks[0].process.kill()
         with pytest.raises(RuntimeError):
             pending.result(timeout=5)


### PR DESCRIPTION
## Problem

`tests/reef_service/test_multiproc_executor.py::test_killed_worker_does_not_leave_running_harness` fails intermittently on CI with:

```
ValueError: invalid literal for int() with base 10: ''
```

Observed on a `package (3.11)` run (passed on 3.10/3.12 in the same workflow): https://github.com/Human-Agent-Society/reef/actions/runs/34152486130/job/101837460022

## Cause

The harness child writes the pid marker with `Path('child.pid').write_text(...)`, which creates the file before the pid text is written. The test polls `marker.exists()` and then calls `int(marker.read_text())`, so a read that lands between the create and the write sees an empty string.

## Fix

- The child writes `child.pid.tmp` and renames it into place with `os.replace`, so `child.pid` never exists without its content.
- The reader polls for non-empty content instead of bare existence, so the test is robust on its own even if the writer changes.

## Testing

- Full file: 9 passed.
- Target test run 30 consecutive times: 30/30 passed.
- `pre-commit run --files tests/reef_service/test_multiproc_executor.py`: all hooks pass.
