### PR TITLE
fix(dispatcher): log checkpoint-storage block transitions with reasons

### DIFF
--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -666,7 +666,16 @@ class Dispatcher:
 
     def _set_training_storage_status(self, value: Mapping[str, Any] | None) -> None:
         with self._training.lock:
+            was_blocked = self._training.storage_status is not None
             self._training.storage_status = value
+        if value is not None and not was_blocked:
+            logger.warning(
+                "training is blocked on checkpoint storage: %s; retrying every %.0f seconds until it clears",
+                "; ".join(str(reason) for reason in value.get("reasons", ())) or "no reason reported",
+                self.storage_retry_seconds,
+            )
+        elif value is None and was_blocked:
+            logger.info("checkpoint storage block cleared; training resumes")
 
     @property
     def storage_status(self) -> Mapping[str, Any] | None:

--- a/tests/reef_service/test_training_wait.py
+++ b/tests/reef_service/test_training_wait.py
@@ -267,10 +267,6 @@ def test_a_freshly_drained_ready_batch_does_not_warn(caplog) -> None:
 
 
 def test_a_storage_block_logs_its_reasons_once_per_stall(caplog) -> None:
-    # The other stall signature: the backend returns retry with a storage
-    # status, and the thread retries forever. Until now the reasons were
-    # visible only on the authenticated status endpoint; a run could sit
-    # for hours with idle GPUs and nothing in the logs saying why.
     dispatcher = _dispatcher()
     blocked = {"blocked": True, "reasons": ["checkpoint reservation would violate the filesystem free-space floor"]}
     with caplog.at_level(logging.INFO, logger="reef.dispatcher"):

--- a/tests/reef_service/test_training_wait.py
+++ b/tests/reef_service/test_training_wait.py
@@ -264,3 +264,37 @@ def test_a_freshly_drained_ready_batch_does_not_warn(caplog) -> None:
     with caplog.at_level(logging.WARNING, logger="reef.dispatcher"):
         assert dispatcher.build_training_status()["scenarios"]["s"]["batch_ready"] is True
     assert not caplog.records
+
+
+def test_a_storage_block_logs_its_reasons_once_per_stall(caplog) -> None:
+    # The other stall signature: the backend returns retry with a storage
+    # status, and the thread retries forever. Until now the reasons were
+    # visible only on the authenticated status endpoint; a run could sit
+    # for hours with idle GPUs and nothing in the logs saying why.
+    dispatcher = _dispatcher()
+    blocked = {"blocked": True, "reasons": ["checkpoint reservation would violate the filesystem free-space floor"]}
+    with caplog.at_level(logging.INFO, logger="reef.dispatcher"):
+        for _ in range(3):
+            dispatcher._set_training_storage_status(dict(blocked))
+    warnings = [r for r in caplog.records if "blocked on checkpoint storage" in r.message]
+    assert len(warnings) == 1
+    assert "free-space floor" in warnings[0].getMessage()
+
+
+def test_a_cleared_storage_block_logs_the_recovery_once(caplog) -> None:
+    dispatcher = _dispatcher()
+    dispatcher._set_training_storage_status({"blocked": True, "reasons": ["x"]})
+    with caplog.at_level(logging.INFO, logger="reef.dispatcher"):
+        for _ in range(2):
+            dispatcher._set_training_storage_status(None)
+    cleared = [r for r in caplog.records if "storage block cleared" in r.message]
+    assert len(cleared) == 1
+
+
+def test_an_unblocked_commit_does_not_log_storage_noise(caplog) -> None:
+    # Every successful step clears the (already clear) status; that must
+    # stay silent.
+    dispatcher = _dispatcher()
+    with caplog.at_level(logging.INFO, logger="reef.dispatcher"):
+        dispatcher._set_training_storage_status(None)
+    assert not caplog.records


### PR DESCRIPTION
## Problem

When the training backend returns `retry` with a storage status (for example: the next checkpoint reservation would violate the filesystem free-space floor), the dispatcher retries every `storage_retry_seconds` forever. That is the right policy — the block can clear when disk frees up — but the run produces no log evidence of it. The only line a stalled run emits is the generic one-shot "ready training batch undrained" warning, and the actual block reasons are visible only on the authenticated `/reef/status` endpoint.

In practice this means a multi-node training run can sit for hours with every GPU idle, and an operator tailing the logs has nothing that says why. We hit this repeatedly on large-model runs where a single distcp save is large enough to consume the remaining headroom: step N commits, the save lands, and the next step blocks silently.

## Fix

`_set_training_storage_status` now logs on transitions:

- block starts: a warning with the joined `reasons` from the storage status and the retry cadence
- block clears: an info line

Both fire once per transition. Repeated `retry` outcomes while blocked stay silent (the status is re-set on every retry), and the routine `None` clear on every committed step logs nothing.

## Testing

- 3 new regression tests in `test_training_wait.py` (same caplog pattern as the undrained-warning tests): block logs reasons once per stall, clear logs once, unblocked commits stay silent. The two transition tests fail on unpatched `dispatcher.py` and pass patched.
- `tests/reef_service/`: 2140 passed, 31 skipped (2 files skipped for a missing `ray` in the local venv only).
- `pre-commit run --files ...`: all hooks pass.
