### PR TITLE
fix(train): carry the driver's PYTHONPATH to the Ray actors its job creates

### DIFF
--- a/reef/train/slime_backend/reef_adapters/driver.py
+++ b/reef/train/slime_backend/reef_adapters/driver.py
@@ -273,6 +273,28 @@ def _healthcheck(ready_file: Path) -> int:
             ray.shutdown()
 
 
+def _job_runtime_env(environ: Mapping[str, str] | None = None) -> dict[str, Any] | None:
+    """Ray job ``runtime_env`` carrying the driver's ``PYTHONPATH`` to its actors.
+
+    The deploy layer appends the recipe source root to every *service*
+    process's ``PYTHONPATH``, but Ray actors are forked from the raylet,
+    whose environment predates the stack: with ``execution: training: ray``
+    the shared local cluster starts inside ``reef serve``, before any
+    service environment exists. Cookbook loss families
+    (``recipes.<method>.slime:...``) resolve inside the Megatron workers, so
+    without the driver's ``PYTHONPATH`` the first train actor dies with
+    ``No module named 'recipes'``. Setting the job-level ``runtime_env``
+    here covers every actor this driver creates — the bridge and the train
+    workers — on local and external clusters alike; Slime's per-actor
+    ``env_vars`` merge over the job-level mapping rather than replacing it.
+    """
+    source = os.environ if environ is None else environ
+    pythonpath = source.get("PYTHONPATH", "").strip()
+    if not pythonpath:
+        return None
+    return {"env_vars": {"PYTHONPATH": pythonpath}}
+
+
 def _serve(direct_args: Sequence[str], ready_file: Path) -> int:
     # Remove a stale marker before parsing or connecting. This also makes a
     # configuration error fail closed instead of advertising the previous job.
@@ -309,7 +331,7 @@ def _serve(direct_args: Sequence[str], ready_file: Path) -> int:
 
     bridge = None
     try:
-        ray.init(address=ray_address, namespace=namespace)
+        ray.init(address=ray_address, namespace=namespace, runtime_env=_job_runtime_env())
         # Importing the bridge initializes the Slime serving/training modules;
         # keep that work out of the lightweight healthcheck path.
         from reef.train.slime_backend.reef_adapters.bridge import start_bridge

--- a/tests/slime_backend/test_driver_runtime_env.py
+++ b/tests/slime_backend/test_driver_runtime_env.py
@@ -1,0 +1,33 @@
+"""The driver's job runtime_env: its PYTHONPATH must reach the actors it creates.
+
+Cookbook loss families (``recipes.<method>.slime:...``) are resolved inside
+Megatron workers. The deploy layer puts the recipe source root on the
+*driver's* PYTHONPATH, but Ray actors fork from the raylet — started before
+any service environment exists — so the driver must carry its PYTHONPATH
+across the job boundary itself.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from reef.train.slime_backend.reef_adapters.driver import _job_runtime_env, _serve
+
+
+def test_driver_pythonpath_becomes_the_job_runtime_env():
+    env = {"PYTHONPATH": "/repo:/opt/sglang/python", "OTHER": "x"}
+    assert _job_runtime_env(env) == {"env_vars": {"PYTHONPATH": "/repo:/opt/sglang/python"}}
+
+
+def test_empty_or_missing_pythonpath_means_no_runtime_env():
+    assert _job_runtime_env({}) is None
+    assert _job_runtime_env({"PYTHONPATH": "   "}) is None
+
+
+def test_serve_initializes_ray_with_the_job_runtime_env():
+    # The wiring is textual by necessity — _serve needs a live Ray cluster to
+    # run — but the contract it pins is real: the serve path must pass the
+    # job runtime_env, or workers on a cluster the driver did not start
+    # cannot import the cookbook loss family.
+    source = inspect.getsource(_serve)
+    assert "runtime_env=_job_runtime_env()" in source


### PR DESCRIPTION
## Symptom

On a clean checkout, the SAO example does not boot: the first Megatron train actor dies with

```
UnknownLossFamilyError: cannot import loss family 'recipes.sao.slime:SaoAlgorithm': No module named 'recipes'
```

and `reef serve` reports `service 'slime-driver' exited before ready`.

## Root cause

Cookbook loss families (`recipes.<method>.slime:...`) are resolved inside the Megatron workers. The deploy layer appends the recipe source root to every *service* process's `PYTHONPATH` (`ProcessWorker._service_env`), so the slime-driver itself imports fine — but Ray actors fork from the raylet, whose environment predates the stack: since the executor unification (#279), the shared local Ray cluster starts inside `reef serve`, before any service environment exists. Nothing carries the source root across the job boundary, so the driver's actors cannot import `recipes`.

The tttd and coral examples mask this by exporting `PYTHONPATH` in their `run.sh`; the SAO example's `run.sh` (correctly) does not, which is how it surfaced.

## Fix

Set the job-level `runtime_env` at the driver's `ray.init`: `_job_runtime_env()` carries the driver's full `PYTHONPATH` (image paths + the injected source root) to every actor the driver's job creates — the bridge and the train workers — on local and external clusters alike. Slime's per-actor `env_vars` merge over the job-level mapping rather than replacing it, so nothing the runtime sets is lost.

## Validation

- The SAO example (`recipes/sao/examples/sao/run.sh`) boots from a clean checkout with no `PYTHONPATH` export and runs its full loop on a GPU node (2x NVIDIA H200): 3 tasks x 6 scored rollouts, 18 single-rollout training steps committed (checkpoint iterations 0..17), weights synced to the serving engines after each step.
- Unit tests for the helper and a source-level pin that `_serve` passes the job runtime_env (`tests/slime_backend/test_driver_runtime_env.py`).
- Full local suite passes.
