### PR TITLE
fix(sao-example): block until each task's rollouts have trained

### DIFF
--- a/recipes/sao/examples/sao/run.py
+++ b/recipes/sao/examples/sao/run.py
@@ -9,19 +9,88 @@ For each task, in order:
              recipe trains on the rollouts, and the *next* task is served
              by the updated weights
 
-The ordering is the experiment: task N+1 measures what task N taught.
+The ordering is the experiment: task N+1 measures what task N taught. That
+only holds if task N's rollouts have actually trained before task N+1
+starts, so after each episode the loop blocks until the scenario's version
+chain carries one ``training`` release per scored rollout so far. Rollouts
+are quick at this model size while a train step also saves a checkpoint and
+publishes weights; without the barrier the episode loop finishes ahead of
+training and the process exit tears the stack down over a queue of
+never-trained rollouts.
 """
 
 import asyncio
+import json
+import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 from reef_eval import Lab
 
 MODEL = "reef"  # model name the agent sends; Reef's SGLang serves it
 
+#: The drain below reads the same deployment the agent talks to. Copied from
+#: harness/agent.py rather than imported, because the harness is installed on
+#: its own into reef-eval's environment while run.py stays host-side.
+SERVICE_URL = "http://127.0.0.1:8900"
+TOKEN = "reef-local"
+SCENARIO = "sao-smoke"
+ROLLOUTS = 6
+
 HERE = Path(__file__).resolve().parent
 TASKS = ["imo-4", "imo-8", "imo-12"]
 AGENT = {"name": "harness:HarborAgent", "model_name": MODEL}
+#: Ceiling on waiting for one task's six training steps (checkpoint saves
+#: and weight publishes included) before moving on with a warning.
+TRAIN_DRAIN_TIMEOUT_S = 1800
+
+#: The service is gone or rejecting requests; waiting cannot help.
+_SERVICE_GONE = -1
+
+
+def training_release_count() -> int | None:
+    """Training releases committed so far; ``None`` while the service is busy.
+
+    The scenario's registry lock serializes release reads with training, so
+    this request legitimately stalls for the length of an in-flight train
+    step (which includes a checkpoint save and a weight publish). A timeout
+    is "try again", not an error. A refused connection or an HTTP rejection
+    is terminal: the stack is gone or this loop is talking to something that
+    is not its deployment, and waiting cannot change either.
+    """
+    request = urllib.request.Request(
+        f"{SERVICE_URL}/reef/scenarios/{SCENARIO}/releases",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read())
+    except urllib.error.HTTPError:
+        return _SERVICE_GONE  # answered and rejected: not our deployment
+    except urllib.error.URLError as error:
+        if isinstance(getattr(error, "reason", None), ConnectionRefusedError):
+            return _SERVICE_GONE
+        return None  # stalled behind a train step — try again
+    except TimeoutError:
+        return None
+    return sum(1 for row in payload["releases"] if row.get("operation") == "training")
+
+
+def wait_for_training(expected: int) -> None:
+    """Block until ``expected`` rollouts have each committed a training release."""
+    deadline = time.time() + TRAIN_DRAIN_TIMEOUT_S
+    trained = None
+    while time.time() < deadline:
+        trained = training_release_count()
+        if trained == _SERVICE_GONE:
+            print("    WARNING: the Reef service is not reachable; skipping the training drain")
+            return
+        if trained is not None and trained >= expected:
+            print(f"    trained: {trained}/{expected} rollouts committed")
+            return
+        time.sleep(10)
+    print(f"    WARNING: only {trained}/{expected} rollouts trained within {TRAIN_DRAIN_TIMEOUT_S}s")
 
 
 async def main():
@@ -29,6 +98,7 @@ async def main():
     for position, name in enumerate(TASKS):
         row = await lab.run(str(HERE / "harbor" / name), AGENT, tags={"position": position})
         print(f"[{position}] {name}: reward {row.rewards}")
+        wait_for_training(expected=(position + 1) * ROLLOUTS)
 
 
 asyncio.run(main())


### PR DESCRIPTION
## Symptom

The SAO example's point is the ordering: task N+1 is served by the weights task N produced ("The ordering is the experiment"). On a fresh run that does not hold: rollouts at this model size take seconds while a train step also saves a checkpoint and publishes weights, so the episode loop finishes far ahead of training; `run.py` then exits and `run.sh`'s trap tears the stack down over a queue of never-trained rollouts. A fresh 2-GPU run committed **1 training step out of 18 scored rollouts**, and the release chain the README says to read stayed empty.

## Fix

After each episode, `run.py` polls the scenario's release chain (`GET /reef/scenarios/sao-smoke/releases`) until it carries one `training` release per scored rollout so far, then moves to the next task.

Poll semantics learned the hard way, from live runs:

- a request that stalls is *retry*: the scenario registry lock serializes release reads with training, so the endpoint legitimately blocks for the length of an in-flight train step (checkpoint save and weight publish included);
- a refused connection or an HTTP rejection is *terminal*: the stack is gone, or the loop is talking to something that is not its deployment — waiting cannot change either (this also keeps the host-side entrypoint contract test off the network and fast);
- a 30-minute per-task ceiling with a warning, so a legitimately rejected rollout cannot hang the run.

## Validation

Full example run on a GPU node (2x NVIDIA H200), Qwen2.5-1.5B-Instruct, on top of the driver PYTHONPATH fix (#337):

```
[0] imo-4: reward {'reward': 0.0}
    trained: 6/6 rollouts committed
[1] imo-8: reward {'reward': 0.0}
    trained: 12/12 rollouts committed
[2] imo-12: reward {'reward': 0.0}
    trained: 18/18 rollouts committed
```

18/18 scored rollouts each committed a training release (checkpoint iterations 0..17, `latest_checkpointed_iteration.txt` = 17), 114 `update_weights_from_distributed` syncs to the serving engines across the run, `pg_clipfrac` ~0.53-0.60 (the DIS mask actively gating), `critic/explained_variance` 0.0 — exact for this run's all-zero rewards. `tests/test_example_entrypoints.py` passes (0.07s; the drain stays off the network under the stubbed contract test).
