### PR TITLE
feat(harness): bind the install script to the forwarded host behind a gateway

### DIFF
--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -406,8 +406,10 @@ Harness artifacts
 +--------------------------------+---------------------------------------------------------------+
 | ``GET /reef/harness/install``  | a self-contained POSIX shell script that installs the vendor  |
 |                                | binary, writes the tree, and writes the adapter's model       |
-|                                | binding at the Reef the request reached, the token filled     |
-|                                | from ``REEF_TOKEN`` when the script runs                      |
+|                                | binding at the address the request reached (a gateway in      |
+|                                | front names it in ``x-forwarded-host`` and                    |
+|                                | ``x-forwarded-proto``), the token filled from ``REEF_TOKEN``  |
+|                                | when the script runs                                          |
 +--------------------------------+---------------------------------------------------------------+
 | ``GET /reef/harness/adapters`` | ``{adapters}`` — every harness adapter this process resolves, |
 |                                | each with ``name``, ``binary``, ``trajectory_format``,        |

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -439,9 +439,11 @@ the install works before any step has run:
    reef-pi report --score 0 --feedback "missed the empty-token case"
 
 The script installs the pinned agent, writes the tree, writes the agent's
-model binding pointed at the Reef the script came from (the served tree
-itself carries no endpoint or credential; the binding takes its token from
-``REEF_TOKEN`` in your shell when the script runs), and puts a
+model binding pointed at the address the script came from, which behind a
+gateway is the gateway's (Reef reads ``x-forwarded-host`` and
+``x-forwarded-proto`` when a proxy sets them); the served tree itself carries
+no endpoint or credential, and the binding takes its token from
+``REEF_TOKEN`` in your shell when the script runs. It also puts a
 ``reef-<adapter>`` wrapper (here ``reef-pi``) on your PATH. The wrapper keeps
 the receipts from a run, so ``report`` only needs the result. Pinning,
 rollback, and the raw manifest routes are in `HTTP API

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -653,7 +653,9 @@ class RequestService:
         composition as before.
         """
         normalized = {key.lower(): value.strip() for key, value in headers.items()}
-        host = normalized.get("host")
+        # A gateway in front of Reef names the address the client reached in the forwarded
+        # headers; the binding goes there, so the installed harness calls back through it.
+        host = normalized.get("x-forwarded-host") or normalized.get("host")
         gate = manifest.get("gate") or {}
         model = (gate.get("gated_against") or {}).get("model") if isinstance(gate, Mapping) else None
         info = scenario.surface.harness

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -1263,6 +1263,36 @@ def test_a_seeded_recipe_serves_and_installs_a_fresh_scenario_before_any_step(tm
 
 
 @pytest.mark.unit
+def test_install_script_binds_to_the_forwarded_host_when_a_gateway_fronts_reef(tmp_path) -> None:
+    """Behind a gateway the client reached ``https://api.example.test``, not this process: the
+    binding takes the forwarded host and scheme, so reef-pi calls back through the gateway."""
+    seed = ({"id": "answer-style", "name": "skill", "config": {"name": "answer-style", "text": "# seed skill\n"}},)
+    dispatcher = _dispatcher(tmp_path, (), seed=seed)
+
+    async def run() -> None:
+        client = TestClient(TestServer(create_app(dispatcher, inference_backend=_EchoBackend())))
+        await client.start_server()
+        try:
+            response = await client.get(
+                "/reef/harness/install",
+                params={"adapter": "pi"},
+                headers={
+                    "x-reef-scenario": "delivery",
+                    "x-forwarded-host": "api.example.test",
+                    "x-forwarded-proto": "https",
+                },
+            )
+            assert response.status == 200
+            script = await response.text()
+            assert '"baseUrl": "https://api.example.test/v1"' in script
+            assert f"{client.host}:{client.port}" not in script
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.unit
 def test_install_route_serves_the_script_for_head_and_pinned_versions(tmp_path) -> None:
     async def run() -> None:
         client = TestClient(TestServer(create_app(_dispatcher(tmp_path, MUTATIONS), inference_backend=_EchoBackend())))


### PR DESCRIPTION
## Summary
- `GET /reef/harness/install` renders the model binding at `x-forwarded-host` when a proxy sets it, else `host` as before; the scheme already came from `x-forwarded-proto`.
- Needed by the reef_api platform: without it the install script points reef-pi at the deployment's own address instead of the gateway, and the upstream URL leaks to the customer.

## Test plan
- [x] New `test_install_script_binds_to_the_forwarded_host_when_a_gateway_fronts_reef`
- [x] `tests/reef_service/test_harness_channel.py` + `test_harness_requests.py`: 72 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)