### PR TITLE
fix(runtime): keep serving alive when adapter capacity refuses a publication

### DIFF
--- a/reef/runtime/adapter_residency.py
+++ b/reef/runtime/adapter_residency.py
@@ -38,7 +38,22 @@ class AdapterResidencyError(ReefError):
 
 
 class AdapterCapacityExhausted(AdapterResidencyError):
-    """Every loaded adapter is protected, so nothing can be evicted for a new one."""
+    """Every loaded adapter is protected, so nothing can be evicted for a new one.
+
+    Raised before anything is unloaded, so the engine still holds exactly what
+    it held and every scenario keeps serving: the publication was refused, not
+    half-applied.
+    """
+
+
+class AdapterEvictionFailed(AdapterCapacityExhausted):
+    """The engine refused to release the slot chosen for eviction.
+
+    Still a capacity failure for the caller, but a different one: a plain
+    :class:`AdapterCapacityExhausted` proves the engine is fine, while this
+    says it would not let go and may be wedged. Callers that recover engines
+    must branch on this subclass *before* the base class.
+    """
 
 
 class AdapterNotActive(AdapterResidencyError):
@@ -381,9 +396,16 @@ class AdapterResidencyManager:
             if victim is None:
                 self._counters["capacity_rejections"] += 1
                 protected = sorted(slot.name for slot in self._slots.values())
+                # Name the remedy: the usual cause is a capacity sized for one
+                # scenario on an engine that several now share, and the
+                # operator cannot infer the needed slot count from the names.
+                sharing = {slot.scenario for slot in self._slots.values()} | {scenario}
                 raise AdapterCapacityExhausted(
                     f"engine adapter capacity {self._capacity} is exhausted and every resident adapter is "
-                    f"protected (current, pinned, or in flight): {protected}; scenario {scenario!r} cannot activate"
+                    f"protected (current, pinned, or in flight): {protected}; scenario {scenario!r} cannot "
+                    f"activate. {len(sharing)} scenarios share this engine and each keeps its current "
+                    f"revision resident, so it needs at least {len(sharing) + 1} slots: raise "
+                    f"--max-loaded-loras. Nothing was unloaded; every scenario keeps serving."
                 )
             if (unload_error := self._unload(victim, engine)) is not None:
                 # The engine refused to let go; the slot stays occupied and
@@ -391,7 +413,7 @@ class AdapterResidencyManager:
                 # The unload failure rides along: "capacity exhausted" alone
                 # would hide that the real event may be a dead engine.
                 self._counters["capacity_rejections"] += 1
-                raise AdapterCapacityExhausted(
+                raise AdapterEvictionFailed(
                     f"engine adapter capacity {self._capacity} is exhausted and evicting {victim.name!r} "
                     f"failed ({unload_error}); scenario {scenario!r} cannot activate until the leaked slot "
                     f"is reclaimed"
@@ -528,6 +550,7 @@ def _require_runtime_load_id(runtime_load_id: str) -> None:
 __all__ = [
     "AdapterCapacityExhausted",
     "AdapterEngine",
+    "AdapterEvictionFailed",
     "AdapterLease",
     "AdapterNotActive",
     "AdapterResidencyError",

--- a/reef/train/slime_backend/reef_adapters/bridge.py
+++ b/reef/train/slime_backend/reef_adapters/bridge.py
@@ -32,7 +32,7 @@ from typing import Any, Literal
 import ray
 
 from reef.core.artifact_ref import parse_runtime_load_spans
-from reef.runtime.adapter_residency import AdapterResidencyManager
+from reef.runtime.adapter_residency import AdapterCapacityExhausted, AdapterEvictionFailed, AdapterResidencyManager
 from reef.runtime.base import PreparedTrainingStep, TrainingJobResult
 from reef.runtime.executor import resolve
 from reef.runtime.executor.ray import RayExecutor
@@ -803,6 +803,15 @@ class TrainBridgeActorImpl:
                     runtime_load_id=published,
                 )
                 self._phase = "awaiting_commit"
+            except AdapterCapacityExhausted:
+                # Capacity failures are classified in _update_serving, which
+                # terminates the engines only for the eviction one an engine
+                # refused (#61). A plain refusal published nothing and touched
+                # no engine, so escalating here would terminate engines it
+                # never involved and then fail identically on the next
+                # attempt; only more slots resolve it (#65).
+                traceback.print_exc(file=sys.stderr)
+                raise
             except BaseException:
                 self._phase = "weight_sync_failed"
                 with suppress(Exception):
@@ -1073,6 +1082,13 @@ class TrainBridgeActorImpl:
         the publishing scenario's own current revision when nothing else
         fits: generation is paused, so no request observes the gap) and
         records the published revision afterwards.
+
+        Admission runs before any weight leaves the trainer. A capacity
+        rejection therefore means nothing was published and every engine still
+        serves what it served, so it must not terminate them — that took down
+        scenarios which were never part of the publication (#65). An eviction
+        the engine refused is the opposite: its state is uncertain, so the
+        terminate-and-recover path stays (#61).
         """
         residency = self._residency if scenario is not None else None
         try:
@@ -1093,6 +1109,15 @@ class TrainBridgeActorImpl:
                 raise RuntimeError(f"serving engines disagree after update: {observed!r}")
             if residency is not None and scenario is not None:
                 residency.register(scenario, raw_version)
+        except AdapterEvictionFailed:
+            self._phase = "weight_sync_failed"
+            with suppress(Exception):
+                self._manager_call("terminate_updatable_engines")
+            raise
+        except AdapterCapacityExhausted:
+            # Admission was refused before any weight left the trainer.
+            self._phase = "serving"
+            raise
         except BaseException:
             self._phase = "weight_sync_failed"
             with suppress(Exception):

--- a/reef/train/slime_backend/reef_adapters/megatron/lora.py
+++ b/reef/train/slime_backend/reef_adapters/megatron/lora.py
@@ -67,8 +67,14 @@ def lora_engine_slots(args: Namespace) -> int:
     of scenarios plus one. With fewer slots the residency manager evicts the
     publishing scenario's own current revision first (generation is paused,
     so no request observes the gap); with exactly one slot that is the only
-    option, which is fine for one scenario but leaves a second scenario's
-    adapter unloaded whenever the other publishes.
+    option, which is fine for one scenario.
+
+    Sizing below the scenario count does NOT degrade gracefully: a peer's
+    current revision is never evicted, so the second scenario's publication is
+    refused with ``AdapterCapacityExhausted`` naming the slot count to set
+    here. That refusal is deliberate — evicting a serving peer would route its
+    next request to an adapter the engine no longer holds, and nothing reloads
+    it on demand.
     """
 
     value = getattr(args, "max_loaded_loras", None)

--- a/tests/reef_service/test_adapter_residency.py
+++ b/tests/reef_service/test_adapter_residency.py
@@ -8,6 +8,7 @@ import pytest
 
 from reef.runtime.adapter_residency import (
     AdapterCapacityExhausted,
+    AdapterEvictionFailed,
     AdapterNotActive,
     AdapterResidencyError,
     AdapterResidencyManager,
@@ -377,3 +378,36 @@ def test_recent_actions_are_bounded(engine: FakeEngine) -> None:
         manager.activate("a", f"v{index}", engine)
     actions = manager.status()["recent_actions"]
     assert len(actions) == 32 and all(entry["action"] == "evicted" for entry in actions)
+
+
+def test_capacity_rejection_names_the_slot_count_the_engine_needs(engine: FakeEngine) -> None:
+    """#65: the operator cannot infer the fix from a list of adapter names."""
+    manager = AdapterResidencyManager(capacity=1)
+    manager.activate("a", "a1", engine)
+    with pytest.raises(AdapterCapacityExhausted) as raised:
+        manager.activate("b", "b1", engine)
+    message = str(raised.value)
+    assert "2 scenarios share this engine" in message
+    assert "at least 3 slots" in message
+    assert "--max-loaded-loras" in message
+    # Nothing was touched, so the claim the message makes is true.
+    assert engine.unloaded == []
+    assert manager.current("a").runtime_load_id == "a1"
+
+
+def test_a_refused_eviction_is_distinguishable_from_a_plain_rejection(engine: FakeEngine) -> None:
+    """Only one of the two means the engine may be wedged; callers branch on it."""
+    manager = AdapterResidencyManager(capacity=2)
+    manager.activate("a", "a1", engine)
+    manager.activate("a", "a2", engine)
+    engine.fail_unload.add(adapter_name("a", "a1"))
+    with pytest.raises(AdapterEvictionFailed, match="engine keeps"):
+        manager.activate("b", "b1", engine)
+
+    # A plain rejection is the base class only, so `except AdapterEvictionFailed`
+    # cannot swallow it and `except AdapterCapacityExhausted` still catches both.
+    full = AdapterResidencyManager(capacity=1)
+    full.activate("a", "a1", FakeEngine())
+    with pytest.raises(AdapterCapacityExhausted) as raised:
+        full.activate("b", "b1", FakeEngine())
+    assert not isinstance(raised.value, AdapterEvictionFailed)

--- a/tests/reef_service/test_multi_scenario_bridge.py
+++ b/tests/reef_service/test_multi_scenario_bridge.py
@@ -10,7 +10,7 @@ pytest.importorskip("ray")
 
 from reef_service.test_sao_bridge import _RecordingGroup
 
-from reef.runtime.adapter_residency import AdapterCapacityExhausted
+from reef.runtime.adapter_residency import AdapterCapacityExhausted, AdapterEvictionFailed
 from reef.train.slime_backend.reef_adapters import bridge
 from reef.train.slime_backend.reef_adapters.megatron.lora import scenario_adapter_name
 from reef.train.slime_backend.reef_adapters.training_job.scenarios import ScenarioLedger, ledger_path
@@ -306,11 +306,30 @@ def test_a_full_engine_refuses_to_evict_another_scenarios_current_revision(tmp_p
     _run(actor, _job("a", 0, "inc:0"))
     result = actor.execute_training_job(_job("b", 0, "inc:1"))
     assert result.outcome == "checkpoint"
+    with pytest.raises(AdapterCapacityExhausted, match="max-loaded-loras") as raised:
+        actor.update_serving_weights(result.training_job_id)
+    # A refusal, not a wedged engine: the eviction never even ran.
+    assert not isinstance(raised.value, AdapterEvictionFailed)
+    assert manager.engine.unloaded == []
+    assert actor.health()["adapter_residency"]["counters"]["capacity_rejections"] == 1
+
+
+@pytest.mark.unit
+def test_a_rejected_publication_leaves_every_scenario_serving(tmp_path, _local_ray_get) -> None:
+    # Issue #65: the capacity check runs before update_weights touches an
+    # engine, so a rejection means nothing was published and nothing is
+    # inconsistent. Terminating the engines for it took down the innocent
+    # scenario's serving too, and cost a full stack restart.
+    version = _EngineVersion(0)
+    actor, _, manager, _ = _actor(tmp_path, version, adapter_capacity=1)
+    _run(actor, _job("a", 0, "inc:0"))
+    result = actor.execute_training_job(_job("b", 0, "inc:1"))
     with pytest.raises(AdapterCapacityExhausted, match="exhausted"):
         actor.update_serving_weights(result.training_job_id)
-    assert manager.engine.unloaded == []
-    assert actor.health()["phase"] == "weight_sync_failed"
-    assert actor.health()["adapter_residency"]["counters"]["capacity_rejections"] == 1
+    health = actor.health()
+    assert health["phase"] != "weight_sync_failed"
+    assert manager.recovered == 0, "engines were terminated for a publication that never started"
+    assert health["adapter_residency"]["scenarios"]["a"]["resident"] == ["inc:1"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes #65.

## What

- Split the two capacity failures the residency manager conflated: `AdapterEvictionFailed` (an engine refused to release a slot — it may be wedged) now subclasses `AdapterCapacityExhausted` (admission refused, nothing touched).
- `_update_serving` branches on them: the eviction failure keeps the terminate-and-recover path (#61); a plain refusal leaves every engine serving. The outer handler in `update_serving_weights` stops re-escalating what was already classified.
- The refusal message names the remedy — how many scenarios share the engine, how many slots that needs, and which flag sets it.
- `lora_engine_slots`' docstring described a graceful degradation no code path could deliver; it now describes the refusal and why it is deliberate.

## Why

The capacity check runs at `bridge.py:1083`, before `update_weights` touches an engine. A refusal there means the publication never started — yet it fell into the blanket `except BaseException` that sets `weight_sync_failed` and calls `terminate_updatable_engines`. The scenario that merely happened to be serving on the same engine lost its serving too, and the deployment needed a full stack restart plus marker recovery.

Terminating also cannot help: the engines were healthy, and the next attempt fails identically until someone raises `--max-loaded-loras`. So the escalation converted a configuration error into an outage.

The reproduction is the first commit's failing test:

```
bridge.py:1083   residency.make_room(scenario, self._adapter_engine, supersede=True)
adapter_residency.py:384   raise AdapterCapacityExhausted
→ except BaseException → phase="weight_sync_failed" → terminate_updatable_engines
```

## The direction chosen, and why

#65 offered two: make the code degrade as documented, or make the docs match the code and surface the misconfiguration usefully. This PR takes the second.

Evicting a peer's current revision cannot be made safe today. Nothing reloads an adapter on demand, so the peer's next request would name an adapter the engine no longer holds — trading a loud failure for the publishing scenario against a silent one for a bystander that was serving correctly. Under-capacity should refuse, and say what to change. If reload-on-demand lands (#26), the first option becomes available and this refusal is the right place to revisit.

`test_a_full_engine_refuses_to_evict_another_scenarios_current_revision` asserted `phase == "weight_sync_failed"`, so it encoded the defect; it now asserts the refusal is not an eviction failure and that the message names the fix. The surviving-serving behaviour is a separate test.

## Verified

Clean checkout of `origin/main` @ `016b4670`, CI's dependency set (`--group runtime`, CPU torch, the reef-client submodule).

```
$ python -m pytest tests -q
16 failed, 2756 passed, 59 skipped in 510.93s
```

All 16 failures reproduce on unmodified `origin/main` (`git stash`, same selection: 17 failed there, the extra one being the flaky `test_storage_lock_serializes_processes`). Diffing the two lists, **no test fails that passes without this change**. They are git-lfs, git-backend, harness-recipe, and native-serve timeout failures unrelated to this area.

```
$ python -m pytest tests/reef_service/test_multi_scenario_bridge.py tests/reef_service/test_adapter_residency.py -q
38 passed

$ python -m mypy
Success: no issues found in 236 source files

$ pre-commit run --files <changed>
all hooks Passed
```

## One note for reviewers

`_recover_scenario_adapters` at `bridge.py:782` is a second source of `AdapterCapacityExhausted`, and the simplified handler covers it. I could not build a test that reaches it: construction-time recovery (`bridge.py:493`) replays the same ledger first and raises outside any terminating handler, so a restart into too-small a capacity fails there before `update_serving_weights` ever runs. The handler is written to not overclaim — it states only what the tests prove.
