### PR TITLE
fix(harness): what a person's reef-pi run needs that an episode does not

### DIFF
--- a/reef/harness/adapters/descriptor.py
+++ b/reef/harness/adapters/descriptor.py
@@ -158,6 +158,14 @@ class AdapterDescriptor:
     #: Optional quirk that validates the executor against the rendered tree,
     #: replacing the blanket self_isolating restriction before launch.
     validate_execution: ExecutionValidator | None = None
+    #: Environment the ``reef-<adapter>`` wrapper adds when a person runs the
+    #: binary: what an interactive run needs that an episode's ``env`` (offline,
+    #: hermetic) must not carry, such as silencing the binary's self-updater
+    #: while reef pins its version.
+    client_env: Mapping[str, str] = field(default_factory=dict)
+    #: Commands the binary expects on PATH at first start and otherwise fetches
+    #: itself, as ``(command, package)``; the install script names the missing ones.
+    client_tools: tuple[tuple[str, str], ...] = ()
 
     def compose_relocation(self) -> tuple[str, str]:
         """The env var and the composition subdirectory it relocates: the deepest directory above the primary config target that an env entry names as ``{root}/<dir>``.
@@ -228,6 +236,12 @@ def load_descriptor(path: Path) -> AdapterDescriptor:
     self_isolating = data.get("self_isolating", False)
     if not isinstance(self_isolating, bool):
         raise DescriptorError(f"{where} 'self_isolating' must be a boolean")
+    client_env = data.get("client_env", {})
+    if not isinstance(client_env, Mapping) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in client_env.items()
+    ):
+        raise DescriptorError(f"{where} 'client_env' must map strings to strings")
+    client_tools = _parse_client_tools(data.get("client_tools"), where)
     finalize, quirk_whitelist, validate_execution = _load_quirks(data.get("quirks"), where)
     return AdapterDescriptor(
         name=name,
@@ -246,6 +260,8 @@ def load_descriptor(path: Path) -> AdapterDescriptor:
         model_binding=_parse_model_binding(data.get("model_binding"), config_targets, where),
         tree_path=_parse_tree_path(files, where),
         validate_execution=validate_execution,
+        client_env=dict(client_env),
+        client_tools=client_tools,
     )
 
 
@@ -353,6 +369,23 @@ def _parse_node_paths(files: Mapping[str, Any], where: str) -> dict[str, str]:
             raise DescriptorError(f"{where} files.{kind} template must contain {{name}}")
         node_paths[kind] = template
     return node_paths
+
+
+def _parse_client_tools(value: Any, where: str) -> tuple[tuple[str, str], ...]:
+    """``client_tools``: a list of ``{command, package}`` the binary wants on PATH."""
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise DescriptorError(f"{where} 'client_tools' must be a list")
+    tools: list[tuple[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, Mapping) or not isinstance(entry.get("command"), str) or not entry["command"]:
+            raise DescriptorError(f"{where} 'client_tools' entries need a non-empty 'command'")
+        package = entry.get("package", entry["command"])
+        if not isinstance(package, str) or not package:
+            raise DescriptorError(f"{where} 'client_tools' 'package' must be a non-empty string")
+        tools.append((entry["command"], package))
+    return tuple(tools)
 
 
 def _load_quirks(

--- a/reef/harness/adapters/pi/descriptor.yaml
+++ b/reef/harness/adapters/pi/descriptor.yaml
@@ -20,6 +20,17 @@ env:
   PI_CODING_AGENT_SESSION_DIR: "{root}/sessions"
   PI_OFFLINE: "1"
   PI_SKIP_VERSION_CHECK: "1"
+# An interactive run through reef-pi: online (it talks to reef), but reef pins
+# pi's version, so pi's own update notice would only mislead.
+client_env:
+  PI_SKIP_VERSION_CHECK: "1"
+# pi wants these on PATH at first start and otherwise downloads them from
+# GitHub releases, which rate-limits unauthenticated clients.
+client_tools:
+  - command: rg
+    package: ripgrep
+  - command: fd
+    package: fd
 files:
   config:
     primary:

--- a/reef/harness/adapters/pi/quirks.py
+++ b/reef/harness/adapters/pi/quirks.py
@@ -5,11 +5,39 @@ relocates its whole composition and it never mutates rendered files at boot -
 so the quirks reduce to the files it may create beside the composition:
 ``trust.json`` (trust decisions) and ``auth.json`` (provider auth caches) can
 appear in the agent directory even for an offline run.
+
+pi follows the Agent Skills spec: a ``SKILL.md`` needs ``name`` and
+``description`` frontmatter or the skill is reported as a conflict at startup
+and never offered. A skill node whose text carries none gets both, the
+description being the text's first line, the same synthesis codex and dsh do.
 """
 
 from __future__ import annotations
+
+from typing import Any
+
+import yaml
 
 cleanup_whitelist = (
     "pi-agent/trust.json",
     "pi-agent/auth.json",
 )
+
+_SKILLS = "pi-agent/skills/"
+
+
+def _with_frontmatter(path: str, text: str) -> str:
+    if text.startswith("---\n"):
+        return text
+    name = path.split("/")[-2]
+    first = next((line.strip().lstrip("#").strip() for line in text.splitlines() if line.strip()), "")
+    header: dict[str, Any] = {"name": name, "description": first[:200] or name}
+    return "---\n" + yaml.dump(header, sort_keys=False, default_flow_style=False, allow_unicode=True) + "---\n" + text
+
+
+def finalize_render(files: dict[str, str]) -> dict[str, str]:
+    """Give every skill the frontmatter pi requires when its text has none."""
+    for path, text in list(files.items()):
+        if path.startswith(_SKILLS) and path.endswith("/SKILL.md"):
+            files[path] = _with_frontmatter(path, text)
+    return files

--- a/reef/harness/client/wrapper.py
+++ b/reef/harness/client/wrapper.py
@@ -572,6 +572,9 @@ def run_agent(binary: str, compose_dir: str, scenario: str, adapter: str, env_va
     temp_dir = _create_temp_composition(adapter, compose_dir, proxy.port)
     env = os.environ.copy()
     env[env_var] = temp_dir
+    # What an interactive run needs beyond the episode env; the person's own setting wins.
+    for key, value in get_adapter(adapter).client_env.items():
+        env.setdefault(key, value)
     # The update notice extension needs the service address, the scenario,
     # and the true install root; the relocated temp copy carries none of them.
     env["REEF_SERVICE_URL"] = upstream

--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -220,6 +220,9 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
     return [
         f"# Ensure the pinned binary ({pin}) via the vendor's channel.",
         *prelude,
+        "vendor_install() {",
+        *[line.replace("        ", "    ", 1) for line in steps],
+        "}",
         'installed=""',
         f'if [ -x "$BINARY" ]{gate}; then',
         f'    installed="$({probe} --version 2>/dev/null || true)"',
@@ -229,10 +232,8 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
         f'        echo "reef: {descriptor.binary} {install.version} already installed"',
         "        ;;",
         "    *)",
-        # The vendor install is the slow step, a minute on a fresh machine; say so before it starts.
-        f'        echo "reef: installing {descriptor.binary} {install.version} ({pin}) into $PREFIX; this takes a minute"',
         '        mkdir -p "$PREFIX"',
-        *steps,
+        f'        spin "installing {descriptor.binary} {install.version} ({pin}) into $PREFIX, about a minute" vendor_install',
         f'        echo "reef: {descriptor.binary} {install.version} installed"',
         "        ;;",
         "esac",
@@ -246,7 +247,8 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
         # surfacing later as a bare ModuleNotFoundError from the launcher.
         (
             "python3 -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || "
-            'python3 -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" 2>/dev/null || true'
+            'spin "installing reef-client and reef-infra for python3" '
+            'python3 -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" || true'
         ),
         (
             "python3 -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || "
@@ -291,6 +293,46 @@ def _binding_lines(bindings: Mapping[str, str]) -> list[str]:
 #: The literal the model binding overlay carries where the client's own token goes; the script swaps in
 #: ``$REEF_TOKEN`` at install time, so the served script itself never holds a credential.
 TOKEN_PLACEHOLDER = "__REEF_TOKEN__"
+
+
+def _spinner_lines() -> list[str]:
+    """``spin LABEL CMD...``: run a slow step with a spinner on a terminal, or one static line elsewhere.
+
+    The step's output goes to a temporary log that is printed only on
+    failure, so npm and pip cannot smear the spinner; on a terminal the line
+    is erased once the step ends, so a successful install leaves the
+    announcements alone. ``set -e`` does not see the background job's exit
+    status, so it is read explicitly and returned.
+    """
+    return [
+        "# Run a slow step behind a spinner on a terminal (a static line elsewhere); its output shows only on failure.",
+        "spin() {",
+        '    label="$1"; shift',
+        '    log="$(mktemp)"',
+        "    if [ -t 1 ]; then",
+        '        "$@" >"$log" 2>&1 &',
+        "        pid=$!",
+        "        i=0",
+        '        while kill -0 "$pid" 2>/dev/null; do',
+        "            case $i in 0) c='|' ;; 1) c='/' ;; 2) c='-' ;; *) c='\\' ;; esac",
+        "            i=$(( (i + 1) % 4 ))",
+        '            printf \'\\r%s reef: %s\' "$c" "$label"',
+        "            sleep 0.2",
+        "        done",
+        '        wait "$pid" && status=0 || status=$?',
+        "        printf '\\r\\033[K'",
+        "    else",
+        '        echo "reef: $label"',
+        '        "$@" >"$log" 2>&1 && status=0 || status=$?',
+        "    fi",
+        '    if [ "$status" -ne 0 ]; then',
+        '        cat "$log" >&2',
+        '        rm -f "$log"',
+        '        return "$status"',
+        "    fi",
+        '    rm -f "$log"',
+        "}",
+    ]
 
 
 def _sidecar_tool_lines(wrapper_name: str) -> list[str]:
@@ -445,6 +487,8 @@ def render_install_script(
         "fi",
         "",
         *_sidecar_tool_lines(wrapper_name),
+        "",
+        *_spinner_lines(),
         "",
         f'echo "reef: harness release {release_id} for {descriptor.name}"',
         f"# The gate runs first of all: nothing is installed or written while an item is not checked off ({wrapper_name} setup).",

--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -255,6 +255,12 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
             'echo "reef: warning: reef-client and reef-infra are not importable by python3; '
             'install them into the environment that runs the wrapper" >&2'
         ),
+        *(
+            f'command -v {command} >/dev/null 2>&1 || echo "reef: warning: {descriptor.binary} wants {package} '
+            f"({command}) on PATH and otherwise downloads it from GitHub at first start, which GitHub rate-limits; "
+            f'install {package} with your package manager" >&2'
+            for command, package in descriptor.client_tools
+        ),
     ]
 
 

--- a/tests/reef_service/data/harness_goldens/pi/pi-agent/skills/notes/SKILL.md
+++ b/tests/reef_service/data/harness_goldens/pi/pi-agent/skills/notes/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: notes
+description: Notes skill
+---
 # Notes skill
 
 Keep short notes.

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -823,11 +823,42 @@ elif mode == "merge":
 REEF_SIDECAR_TOOL_EOF
 }
 
+# Run a slow step behind a spinner on a terminal (a static line elsewhere); its output shows only on failure.
+spin() {
+    label="$1"; shift
+    log="$(mktemp)"
+    if [ -t 1 ]; then
+        "$@" >"$log" 2>&1 &
+        pid=$!
+        i=0
+        while kill -0 "$pid" 2>/dev/null; do
+            case $i in 0) c='|' ;; 1) c='/' ;; 2) c='-' ;; *) c='\' ;; esac
+            i=$(( (i + 1) % 4 ))
+            printf '\r%s reef: %s' "$c" "$label"
+            sleep 0.2
+        done
+        wait "$pid" && status=0 || status=$?
+        printf '\r\033[K'
+    else
+        echo "reef: $label"
+        "$@" >"$log" 2>&1 && status=0 || status=$?
+    fi
+    if [ "$status" -ne 0 ]; then
+        cat "$log" >&2
+        rm -f "$log"
+        return "$status"
+    fi
+    rm -f "$log"
+}
+
 echo "reef: harness release v1 for pi"
 # The gate runs first of all: nothing is installed or written while an item is not checked off (reef-pi setup).
 [ "$REQUIRES" = "[]" ] || sidecar_tool gate "$DEST/.reef-harness-release" "$REQUIRES" "$FALLBACK" || exit 1
 
 # Ensure the pinned binary (@earendil-works/pi-coding-agent@0.84.2) via the vendor's channel.
+vendor_install() {
+    npm install --prefix "$PREFIX" '@earendil-works/pi-coding-agent@0.84.2'
+}
 installed=""
 if [ -x "$BINARY" ]; then
     installed="$(PI_OFFLINE='1' PI_SKIP_VERSION_CHECK='1' "$BINARY" --version 2>/dev/null || true)"
@@ -837,15 +868,14 @@ case " $installed " in
         echo "reef: pi 0.84.2 already installed"
         ;;
     *)
-        echo "reef: installing pi 0.84.2 (@earendil-works/pi-coding-agent@0.84.2) into $PREFIX; this takes a minute"
         mkdir -p "$PREFIX"
-        npm install --prefix "$PREFIX" '@earendil-works/pi-coding-agent@0.84.2'
+        spin "installing pi 0.84.2 (@earendil-works/pi-coding-agent@0.84.2) into $PREFIX, about a minute" vendor_install
         echo "reef: pi 0.84.2 installed"
         ;;
 esac
 
 # Ensure reef-client (capture proxy) and reef (harness wrapper) are installed.
-python3 -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || python3 -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" 2>/dev/null || true
+python3 -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || spin "installing reef-client and reef-infra for python3" python3 -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" || true
 python3 -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || echo "reef: warning: reef-client and reef-infra are not importable by python3; install them into the environment that runs the wrapper" >&2
 
 # The checksum stream, as baked into CHECKSUM: each sorted relative path,

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -877,6 +877,8 @@ esac
 # Ensure reef-client (capture proxy) and reef (harness wrapper) are installed.
 python3 -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || spin "installing reef-client and reef-infra for python3" python3 -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" || true
 python3 -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || echo "reef: warning: reef-client and reef-infra are not importable by python3; install them into the environment that runs the wrapper" >&2
+command -v rg >/dev/null 2>&1 || echo "reef: warning: pi wants ripgrep (rg) on PATH and otherwise downloads it from GitHub at first start, which GitHub rate-limits; install ripgrep with your package manager" >&2
+command -v fd >/dev/null 2>&1 || echo "reef: warning: pi wants fd (fd) on PATH and otherwise downloads it from GitHub at first start, which GitHub rate-limits; install fd with your package manager" >&2
 
 # The checksum stream, as baked into CHECKSUM: each sorted relative path,
 # its byte length, then its bytes, newline separated. The unquoted wc
@@ -1279,7 +1281,10 @@ def test_a_seeded_recipe_serves_and_installs_a_fresh_scenario_before_any_step(tm
             manifest = await client.get("/reef/harness", headers={"x-reef-scenario": "delivery"})
             assert manifest.status == 200
             files = (await manifest.json())["files"]
-            assert files["pi-agent/skills/answer-style/SKILL.md"] == "# seed skill\n"
+            # The seed skill's text plus the frontmatter pi requires, synthesized from its first line.
+            assert files["pi-agent/skills/answer-style/SKILL.md"] == (
+                "---\nname: answer-style\ndescription: seed skill\n---\n# seed skill\n"
+            )
             assert "pi-agent/models.json" in files and "reef" not in files["pi-agent/models.json"]
             response = await client.get(
                 "/reef/harness/install", params={"adapter": "pi"}, headers={"x-reef-scenario": "delivery"}

--- a/tests/reef_service/test_harness_render.py
+++ b/tests/reef_service/test_harness_render.py
@@ -387,3 +387,23 @@ def test_claude_quirk_rejects_reopened_hermetic_switches() -> None:
 
 def test_bundled_adapters_are_discoverable() -> None:
     assert set(available_adapters()) >= {"claude", "codex", "dsh", "opencode", "pi"}
+
+
+def test_pi_descriptor_declares_what_an_interactive_run_needs() -> None:
+    """The wrapper adds ``client_env`` to a person's run; the install script names ``client_tools`` missing from PATH."""
+    descriptor = get_adapter("pi")
+    assert descriptor.client_env == {"PI_SKIP_VERSION_CHECK": "1"}
+    assert "PI_OFFLINE" not in descriptor.client_env  # an interactive run talks to reef
+    assert descriptor.client_tools == (("rg", "ripgrep"), ("fd", "fd"))
+
+
+def test_pi_skill_without_frontmatter_gets_name_and_description() -> None:
+    files = render_composition(
+        [("skill", {"name": "notes", "text": "# Notes skill\n\nKeep short notes.\n"})], get_adapter("pi")
+    )
+    assert (
+        files["pi-agent/skills/notes/SKILL.md"]
+        == "---\nname: notes\ndescription: Notes skill\n---\n# Notes skill\n\nKeep short notes.\n"
+    )
+    own = ("skill", {"name": "own", "text": "---\nname: own\ndescription: mine\n---\nBody.\n"})
+    assert render_composition([own], get_adapter("pi"))["pi-agent/skills/own/SKILL.md"] == own[1]["text"]


### PR DESCRIPTION
## Summary
The first interactive `reef-pi` run through the platform showed three things at pi's startup banner:

1. **Skill conflicts: `description is required`.** pi follows the Agent Skills spec, so a `SKILL.md` without `name`/`description` frontmatter is never offered. The pi quirks now synthesize both from the text (first line as the description), the same way codex and dsh already do. Skills that carry their own frontmatter pass through untouched. The seed skill and every evolved skill were affected.
2. **pi's "Update Available 0.85.1"** while reef pins pi 0.84.2. The descriptor gains `client_env`: what a person's run needs beyond the episode `env` (which is offline and hermetic and must not leak into an interactive run). The wrapper adds it to the child with `setdefault`; pi's is `PI_SKIP_VERSION_CHECK=1`.
3. **`fd`/`ripgrep` download 403** from GitHub's API rate limit. The descriptor gains `client_tools` (`command`, `package`) and the install script warns for each one missing from PATH, naming the package to install.

Stacked on #348 (install script spinner); rebases cleanly once that merges.

## Test plan
- [x] pi golden tree (notes skill gains frontmatter), install script golden, seeded-recipe assertion updated
- [x] New: `test_pi_descriptor_declares_what_an_interactive_run_needs`, `test_pi_skill_without_frontmatter_gets_name_and_description`
- [x] render / channel / git-lfs / skillclaw / harness example / requests / version check: 186 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)