### PR TITLE
feat(harness): evolution.client_models, the models an installed client may switch to

### DIFF
--- a/docs/developer-guide/harness-adapters.rst
+++ b/docs/developer-guide/harness-adapters.rst
@@ -523,6 +523,12 @@ To connect an agent that has no adapter yet:
 descriptor at load, and the bundled adapters under `reef/harness/adapters/
 <../../reef/harness/adapters>`__ are complete references. A third-party adapter
 registers on the ``reef.harness_adapters`` entry-point group.
+``evolution.client_models`` lists further model names the installed client
+may switch to: the install script repeats every ``model_binding`` template
+entry that names ``{model}`` (a mapping key, a list item) once per model,
+the served model first and still the default, so pi and opencode show them
+in their model pickers. Each call names the model it wants and the service
+proxies it as is.
 ``evolution.version_check: true`` in the recipe config writes an update
 prompt into the tree and ships for ``pi`` only. The
 prompt offers to run the update or skip in interactive mode and prints the

--- a/reef/harness/episodes/model_binding.py
+++ b/reef/harness/episodes/model_binding.py
@@ -277,8 +277,16 @@ class ModelBinding:
 
     # -- Episode-side rendering ----------------------------------------------
 
-    def compose_nodes(self, descriptor: AdapterDescriptor) -> tuple[tuple[str, Mapping[str, Any]], ...]:
-        """``config`` nodes that point ``descriptor``'s harness at this binding."""
+    def compose_nodes(
+        self, descriptor: AdapterDescriptor, *, models: Sequence[str] = ()
+    ) -> tuple[tuple[str, Mapping[str, Any]], ...]:
+        """``config`` nodes that point ``descriptor``'s harness at this binding.
+
+        ``models`` are further model names the harness may pick from: every
+        template entry that names ``{model}`` (a mapping key or a list item)
+        is repeated once per model, this binding's first, while a plain
+        ``{model}`` elsewhere, the default, stays this binding's.
+        """
 
         templates = descriptor.model_binding.get(self.api)
         if not templates:
@@ -288,7 +296,11 @@ class ModelBinding:
                 f"(declared: {known}); episodes cannot reach a model"
             )
         values = {"base_url": self.base_url, "api_key": self.api_key or NO_KEY_PLACEHOLDER, "model": self.model}
-        return tuple(("config", _substitute(node, values)) for node in templates)
+        choices = [self.model]
+        for name in models:
+            if isinstance(name, str) and name and name not in choices:
+                choices.append(name)
+        return tuple(("config", _substitute(node, values, choices)) for node in templates)
 
 
 @dataclass(frozen=True)
@@ -325,15 +337,40 @@ class ModelBindings(Mapping[str, ModelBinding]):
         return 1 + len(self.named)
 
 
-def _substitute(value: Any, values: Mapping[str, str]) -> Any:
+def _mentions_model(value: Any) -> bool:
+    if isinstance(value, str):
+        return "{model}" in value
+    if isinstance(value, Mapping):
+        return any(_mentions_model(key) or _mentions_model(item) for key, item in value.items())
+    if isinstance(value, list):
+        return any(_mentions_model(item) for item in value)
+    return False
+
+
+def _substitute(value: Any, values: Mapping[str, str], models: Sequence[str] = ()) -> Any:
+    """Fill ``{placeholders}``; with ``models``, a mapping key or list item naming ``{model}`` is repeated per model."""
     if isinstance(value, str):
         for key, replacement in values.items():
             value = value.replace("{" + key + "}", replacement)
         return value
     if isinstance(value, Mapping):
-        return {_substitute(key, values): _substitute(item, values) for key, item in value.items()}
+        out: dict[Any, Any] = {}
+        for key, item in value.items():
+            if len(models) > 1 and isinstance(key, str) and "{model}" in key:
+                for model in models:
+                    each = {**values, "model": model}
+                    out[_substitute(key, each)] = _substitute(item, each)
+            else:
+                out[_substitute(key, values, models)] = _substitute(item, values, models)
+        return out
     if isinstance(value, list):
-        return [_substitute(item, values) for item in value]
+        out_list: list[Any] = []
+        for item in value:
+            if len(models) > 1 and _mentions_model(item):
+                out_list.extend(_substitute(item, {**values, "model": model}) for model in models)
+            else:
+                out_list.append(_substitute(item, values, models))
+        return out_list
     return value
 
 

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -670,7 +670,7 @@ class RequestService:
         binding = ModelBinding(base_url=f"{scheme}://{host}", model=model, api_key=TOKEN_PLACEHOLDER)
         nodes = [(str(entry["name"]), entry.get("config")) for entry in entries if not entry.get("disabled")]
         try:
-            bound = binding.compose_nodes(descriptor)
+            bound = binding.compose_nodes(descriptor, models=() if info is None else info.client_models)
             files = render_composition((*nodes, *bound), descriptor)
         except (ModelBindingError, RenderError, KeyError, TypeError):
             return {}

--- a/reef/surface/base.py
+++ b/reef/surface/base.py
@@ -97,6 +97,8 @@ class HarnessInfo:
 
     seed_entries: tuple[Mapping[str, Any], ...] = ()
     served_model: str | None = None
+    #: Further models the installed client may pick from; the served one stays the default.
+    client_models: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/reef/surface/harnesses.py
+++ b/reef/surface/harnesses.py
@@ -10,7 +10,9 @@ from reef.surface.files import TextFileTree
 
 
 def create_harness_surface(
-    seed_entries: tuple[Mapping[str, Any], ...] = (), served_model: str | None = None
+    seed_entries: tuple[Mapping[str, Any], ...] = (),
+    served_model: str | None = None,
+    client_models: tuple[str, ...] = (),
 ) -> Surface:
     """Build a surface exposing every text file in a harness tree.
 
@@ -19,12 +21,15 @@ def create_harness_surface(
     commands, code extensions). The surface does not validate or
     transform; the client pulls the raw tree and applies it. ``harness``
     carries the recipe's seed, the composition behind the base release no
-    step published, and the model the recipe serves, which the install
-    route binds an installed tree with when a release has no gate of its own.
+    step published, the model the recipe serves, which the install
+    route binds an installed tree with when a release has no gate of its own,
+    and the further models an installed client may switch to.
     """
     return Surface(
         files=TextFileTree(),
-        harness=HarnessInfo(seed_entries=tuple(seed_entries), served_model=served_model),
+        harness=HarnessInfo(
+            seed_entries=tuple(seed_entries), served_model=served_model, client_models=tuple(client_models)
+        ),
     )
 
 

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -123,6 +123,9 @@ class CordisRecipe(Recipe):
     steps write the proposer's model calls, the parsed proposal and each gate
     episode's trajectory files, so the decision is reconstructible; off by
     default),
+    optional ``client_models`` (further model names the installed client
+    may switch to; the install script renders them into its config beside
+    the served model, which stays the default),
     and optional ``version_check``
     (``true`` appends the adapter's shipped update notice extension to the
     seed, so every pulled tree tells its user at startup when it is behind
@@ -193,6 +196,8 @@ class CordisRecipe(Recipe):
     min_win_margin: int = 0
     publish: str = "auto"
     review_kinds: tuple[str, ...] = ()
+    #: Models an installed client may switch to besides the served one, rendered into its config.
+    client_models: tuple[str, ...] = ()
     seed: tuple[Mapping[str, Any], ...] = ()
     model_name: str | None = None
     models: Mapping[str, ModelBinding] = field(default_factory=dict)
@@ -334,6 +339,11 @@ class CordisRecipe(Recipe):
             raise RecipeConfigError("evolution.review_kinds must be a list of node kind names")
         if not all(isinstance(kind, str) and kind for kind in review_kinds):
             raise RecipeConfigError("evolution.review_kinds must be a list of node kind names")
+        client_models = evolution.get("client_models", ())
+        if isinstance(client_models, str) or not isinstance(client_models, Sequence):
+            raise RecipeConfigError("evolution.client_models must be a list of model names")
+        if not all(isinstance(name, str) and name for name in client_models):
+            raise RecipeConfigError("evolution.client_models must be a list of model names")
         adapter = str(evolution.get("adapter", "pi"))
         version_check = evolution.get("version_check", False)
         if not isinstance(version_check, bool):
@@ -436,6 +446,7 @@ class CordisRecipe(Recipe):
             "max_promoted_per_client": per_client,
             "publish": publish,
             "review_kinds": tuple(review_kinds),
+            "client_models": tuple(client_models),
             "seed": tuple(seed),
             "model_name": model_name if isinstance(model_name, str) and model_name else None,
             "models": models,
@@ -465,6 +476,7 @@ class CordisRecipe(Recipe):
         return create_harness_surface(
             seed_entries=tuple(dict(entry) for entry in self.seed),
             served_model=model if isinstance(model, str) and model else None,
+            client_models=self.client_models,
         )
 
     def base_artifact_files(self) -> Mapping[str, str] | None:

--- a/tests/reef_service/test_model_binding.py
+++ b/tests/reef_service/test_model_binding.py
@@ -190,6 +190,51 @@ def test_the_budgeted_binding_records_each_calls_usage_for_the_step(monkeypatch)
     assert record[0]["usage"] == {"input_tokens": 9, "output_tokens": 2} and "usage" not in record[1]
 
 
+def test_compose_nodes_repeats_the_model_entries_for_every_client_model() -> None:
+    """With client models, the provider block lists them all, the served one first
+    and still the default; a template with no such list is unchanged."""
+    binding = ModelBinding("http://up", "served", api_key="k")
+    pi = binding.compose_nodes(get_adapter("pi"), models=("other/big", "served", "other/small"))
+    providers = next(data for _, data in pi if "providers" in data["data"])["data"]["providers"]["reef"]
+    assert [m["id"] for m in providers["models"]] == ["served", "other/big", "other/small"]
+    primary = next(data for _, data in pi if "defaultModel" in data["data"])["data"]
+    assert primary["defaultModel"] == "reef/served"
+    opencode = binding.compose_nodes(get_adapter("opencode"), models=("other/big",))
+    data = opencode[0][1]["data"]
+    assert list(data["provider"]["reef"]["models"]) == ["served", "other/big"] and data["model"] == "reef/served"
+    assert binding.compose_nodes(get_adapter("opencode")) == binding.compose_nodes(
+        get_adapter("opencode"), models=("served",)
+    )
+
+
+def test_recipe_reads_client_models_into_the_harness_surface(tmp_path) -> None:
+    module = tmp_path / "demo_client_models.py"
+    module.write_text(
+        "def propose(nodes, samples, models):\n    return None\n\ndef evaluate(task, result):\n    return 0.0\n"
+    )
+    import sys
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        config = {
+            "model": {"path": "small"},
+            "evolution": {
+                "propose": "demo_client_models:propose",
+                "evaluate": "demo_client_models:evaluate",
+                "tasks": ["t"],
+                "client_models": ["big/one", "big/two"],
+            },
+        }
+        runtime = InferenceProxyRuntime(model_path="small", base_url="http://up")
+        built = CordisRecipe.from_environment({}, config=config, runtime=runtime)
+        assert built.build_surface("s").harness.client_models == ("big/one", "big/two")
+        bad = {**config, "evolution": {**config["evolution"], "client_models": "big/one"}}
+        with pytest.raises(RecipeConfigError, match=r"evolution\.client_models"):
+            CordisRecipe.from_environment({}, config=bad, runtime=runtime)
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
 def test_unknown_api_is_refused() -> None:
     with pytest.raises(ValueError, match="api must be one of"):
         ModelBinding("http://up", "m", api="cohere")


### PR DESCRIPTION
## Summary
- New recipe option `evolution.client_models`: further model names an installed client may switch to.
- `ModelBinding.compose_nodes(descriptor, models=...)` repeats every template entry naming `{model}` (mapping key or list item) once per model, served first and still the default. pi's `models.json` and opencode's `provider.reef.models` list them all.
- The harness surface carries the list; the install route renders it.

## Test plan
- [x] `test_model_binding`: pi and opencode shapes with extra models, single-model output unchanged, recipe parsing and validation.
- [x] `test_harness_channel`, `test_harness_recipe`, `test_harness_render`, `test_harness_step_record`, `test_scenario_api`, `test_requests_extension` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)