### PR TITLE
feat(artifact): give every published LoRA adapter auditable provenance

### DIFF
--- a/docs/user-guide/evolve-your-model.rst
+++ b/docs/user-guide/evolve-your-model.rst
@@ -181,6 +181,46 @@ is admitted the same way. It enters the release chain only if
 ``peft_type``, the weights are present, and its base model matches the one the
 engine holds.
 
+What a published adapter contains
+---------------------------------
+
+Every accepted update publishes an adapter-only directory, never a merged or
+full-model checkpoint. That is what makes durable-by-default affordable: a
+rank-32 adapter is megabytes where the base is gigabytes, so
+``checkpoint_every_n_versions`` stays at 1 and the release chain keeps every
+revision instead of sampling them.
+
+.. code:: text
+
+   adapter_config.json          standard PEFT config: peft_type, r, lora_alpha,
+                                target_modules, lora_dropout, base_model_name_or_path
+   adapter_model.safetensors    the adapter tensors, and only those
+   reef-adapter.json            Reef's provenance sidecar
+
+The first two files are a plain Hugging Face PEFT adapter, so a published
+revision loads outside Reef with nothing but ``transformers`` and ``peft``:
+
+.. code:: python
+
+   from peft import PeftModel
+   from transformers import AutoModelForCausalLM
+
+   base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-8B")
+   model = PeftModel.from_pretrained(base, "/path/to/checkpoint-4")
+
+``reef-adapter.json`` is what makes a revision auditable rather than merely
+loadable. It records the base model and the digests of its tokenizer and
+chat-template files, the PEFT settings the export claims to have written, the
+dtype of the tensors actually written, the scenario and step that produced it,
+and a SHA-256 for each PEFT file. PEFT loaders ignore files they do not
+recognize, so carrying it costs no portability.
+
+Reef checks the sidecar whenever one is present: a digest that no longer
+matches its file, a config the sidecar contradicts, or a covered file that is
+missing all refuse the artifact rather than serving weights nobody can account
+for. Adapters from elsewhere carry no sidecar and are admitted without one — a
+deployment that should serve only its own exports can require it.
+
 Connect your agent
 ------------------
 

--- a/reef/artifact/peft.py
+++ b/reef/artifact/peft.py
@@ -9,8 +9,9 @@ to weights it never saw.
 
 from __future__ import annotations
 
+import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,15 @@ from reef.core.errors import ReefError
 
 ADAPTER_CONFIG = "adapter_config.json"
 ADAPTER_WEIGHTS = ("adapter_model.safetensors", "adapter_model.bin")
+#: Reef's provenance sidecar. PEFT loaders ignore files they do not know, so
+#: an artifact carrying one still loads with plain ``transformers`` + ``peft``.
+ADAPTER_PROVENANCE = "reef-adapter.json"
+#: Bumped when a field changes meaning. A reader that does not know a schema
+#: refuses the artifact rather than validating it against the wrong rules.
+PROVENANCE_SCHEMA = 1
+#: The PEFT settings a provenance document restates, so a disagreement between
+#: the export and the config it claims to have written is caught at admission.
+DECLARED_PEFT_KEYS = ("peft_type", "r", "lora_alpha", "lora_dropout", "target_modules")
 
 
 class AdapterArtifactError(ReefError):
@@ -40,11 +50,63 @@ def read_peft_config(local_path: Path) -> Mapping[str, Any]:
     return config
 
 
+def _digest(path: Path) -> str:
+    """SHA-256 of one artifact file, read in chunks so a large adapter streams."""
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def read_provenance(local_path: Path) -> Mapping[str, Any] | None:
+    """Parse Reef's provenance sidecar, or ``None`` when the artifact has none.
+
+    Absence is not an error: an adapter from an offline SFT run or the Hub is
+    a legitimate artifact, it just cannot be audited back to a training step.
+    """
+    provenance_path = local_path / ADAPTER_PROVENANCE
+    if not provenance_path.is_file():
+        return None
+    try:
+        document = json.loads(provenance_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AdapterArtifactError(f"{ADAPTER_PROVENANCE} is not readable JSON: {exc}") from exc
+    if not isinstance(document, Mapping):
+        raise AdapterArtifactError(f"{ADAPTER_PROVENANCE} must contain a JSON object")
+    schema = document.get("schema")
+    if schema != PROVENANCE_SCHEMA:
+        raise AdapterArtifactError(
+            f"{ADAPTER_PROVENANCE} declares schema {schema!r}, but this Reef understands {PROVENANCE_SCHEMA}"
+        )
+    return document
+
+
+def _comparable(value: Any) -> Any:
+    """Normalize a declared PEFT value so JSON round-tripping cannot fail a match.
+
+    ``target_modules`` is a set in PEFT and a list on disk, and a dropout of
+    ``0`` and ``0.0`` are the same setting written by different writers.
+    """
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return sorted(_comparable(item) for item in value)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return value
+    return float(value)
+
+
 @dataclass(frozen=True)
 class PEFTValidator:
-    """Validate a PEFT artifact and its optional base-model binding."""
+    """Validate a PEFT artifact, its base-model binding, and its provenance.
+
+    ``require_provenance`` is for scenarios served only by Reef's own exports:
+    it refuses an adapter that cannot be audited back to the training step
+    that produced it. Leave it off where hand-built or Hub adapters are
+    legitimate — a sidecar that *is* present is always checked either way.
+    """
 
     base_model: str | None = None
+    require_provenance: bool = False
 
     def validate(self, artifact: Artifact) -> None:
         local_path = artifact.materialize().local_path
@@ -73,5 +135,70 @@ class PEFTValidator:
                 f"{self.base_model!r}; serving it would apply the adapter to weights it never saw"
             )
 
+        provenance = read_provenance(root)
+        if provenance is None:
+            if self.require_provenance:
+                raise AdapterArtifactError(
+                    f"adapter artifact has no {ADAPTER_PROVENANCE}; this scenario serves only adapters "
+                    "Reef exported, which carry the training step and checksums that make one auditable"
+                )
+            return
+        self._validate_provenance(root, config, provenance)
 
-__all__ = ["ADAPTER_CONFIG", "ADAPTER_WEIGHTS", "AdapterArtifactError", "PEFTValidator", "read_peft_config"]
+    def _validate_provenance(self, root: Path, config: Mapping[str, Any], provenance: Mapping[str, Any]) -> None:
+        """Check the sidecar against the bytes and the config it claims to describe."""
+        declared_base = _mapping(provenance, "base_model").get("name_or_path")
+        config_base = config.get("base_model_name_or_path")
+        if declared_base != config_base:
+            raise AdapterArtifactError(
+                f"{ADAPTER_PROVENANCE} records base model {declared_base!r} but {ADAPTER_CONFIG} says "
+                f"{config_base!r}; the export and the artifact disagree about what it was fit to"
+            )
+
+        declared_peft = _mapping(provenance, "peft")
+        for key in DECLARED_PEFT_KEYS:
+            if key not in declared_peft:
+                continue
+            if _comparable(declared_peft[key]) != _comparable(config.get(key)):
+                raise AdapterArtifactError(
+                    f"{ADAPTER_PROVENANCE} records {key}={declared_peft[key]!r} but {ADAPTER_CONFIG} says "
+                    f"{config.get(key)!r}; the exported tensors match only one of them"
+                )
+
+        files = _mapping(provenance, "files")
+        if not files:
+            raise AdapterArtifactError(f"{ADAPTER_PROVENANCE} records no file checksums, so it audits nothing")
+        for name, expected in sorted(files.items()):
+            if not isinstance(expected, str) or not expected:
+                raise AdapterArtifactError(f"{ADAPTER_PROVENANCE} checksum for {name!r} must be a non-empty string")
+            target = root / name
+            if not target.is_file():
+                raise AdapterArtifactError(
+                    f"{ADAPTER_PROVENANCE} covers {name!r}, which the artifact does not contain; "
+                    "the adapter is incomplete"
+                )
+            if (actual := _digest(target)) != expected:
+                raise AdapterArtifactError(
+                    f"{name!r} hashes to {actual} but {ADAPTER_PROVENANCE} recorded {expected}; "
+                    "the adapter was corrupted or modified after export"
+                )
+
+
+def _mapping(document: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    value = document.get(key, {})
+    if not isinstance(value, Mapping):
+        raise AdapterArtifactError(f"{ADAPTER_PROVENANCE} field {key!r} must be an object")
+    return value
+
+
+__all__ = [
+    "ADAPTER_CONFIG",
+    "ADAPTER_PROVENANCE",
+    "ADAPTER_WEIGHTS",
+    "DECLARED_PEFT_KEYS",
+    "PROVENANCE_SCHEMA",
+    "AdapterArtifactError",
+    "PEFTValidator",
+    "read_peft_config",
+    "read_provenance",
+]

--- a/reef/train/slime_backend/reef_adapters/megatron/lora_checkpoint.py
+++ b/reef/train/slime_backend/reef_adapters/megatron/lora_checkpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -12,15 +13,33 @@ from typing import Any
 import torch
 import torch.distributed as dist
 
+from reef.artifact.peft import ADAPTER_CONFIG, ADAPTER_PROVENANCE, PROVENANCE_SCHEMA
 from reef.train.slime_backend.reef_adapters.megatron.lora import build_sglang_lora_config, is_lora_weight_name
 
+ADAPTER_WEIGHTS_FILE = "adapter_model.safetensors"
+#: Files whose identity a tokenizer or chat template change would alter. The
+#: base checkpoint owns them; the adapter only records which ones it was fit
+#: against, so a later base swap is visible instead of silent.
+TOKENIZER_FILES = ("tokenizer_config.json", "tokenizer.json", "chat_template.jinja")
 
-def save_lora_adapter_to_path(args: Any, output_dir: str | Path, adapter_tensors) -> None:
+
+def save_lora_adapter_to_path(
+    args: Any,
+    output_dir: str | Path,
+    adapter_tensors,
+    *,
+    scenario: str | None = None,
+    scenario_step: int | None = None,
+) -> None:
     """Gather a replicated/sharded Bridge export and write one PEFT adapter.
 
     Bridge conversion runs on every Megatron rank because tensor-parallel
     exports may contain collectives. Duplicate tensors from data/tensor
     parallel replicas must agree exactly; pipeline-local tensors are merged.
+
+    The directory is a portable Hugging Face PEFT adapter plus Reef's
+    provenance sidecar, so it loads with plain ``transformers`` + ``peft`` and
+    still records which training step produced it.
     """
 
     local_tensors: list[tuple[str, torch.Tensor]] = [(name, _cpu_tensor(tensor)) for name, tensor in adapter_tensors]
@@ -43,7 +62,13 @@ def save_lora_adapter_to_path(args: Any, output_dir: str | Path, adapter_tensors
             if gathered is None:
                 raise RuntimeError("root rank did not allocate a LoRA tensor gather buffer")
             merged = _merge_adapter_tensors(gathered)
-            _write_adapter_checkpoint(args, Path(output_dir), merged)
+            _write_adapter_checkpoint(
+                args,
+                Path(output_dir),
+                merged,
+                scenario=scenario,
+                scenario_step=scenario_step,
+            )
         except Exception as exc:
             error = f"{type(exc).__name__}: {exc}"
 
@@ -78,23 +103,45 @@ def _peft_adapter_name(name: str) -> str:
     return f"base_model.model.{name}"
 
 
-def _write_adapter_checkpoint(args: Any, path: Path, tensors: dict[str, torch.Tensor]) -> None:
+def _write_adapter_checkpoint(
+    args: Any,
+    path: Path,
+    tensors: dict[str, torch.Tensor],
+    *,
+    scenario: str | None = None,
+    scenario_step: int | None = None,
+) -> None:
     from safetensors.torch import save_file
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    config = {
-        **build_sglang_lora_config(args),
-        "base_model_name_or_path": str(args.hf_checkpoint),
-        "inference_mode": True,
-    }
+    peft_config = build_sglang_lora_config(args)
+    base_model = str(args.hf_checkpoint)
+    config = {**peft_config, "base_model_name_or_path": base_model, "inference_mode": True}
     temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
     temporary.mkdir()
     try:
-        config_path = temporary / "adapter_config.json"
+        config_path = temporary / ADAPTER_CONFIG
         config_path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        weights_path = temporary / "adapter_model.safetensors"
+        weights_path = temporary / ADAPTER_WEIGHTS_FILE
         save_file(dict(sorted(tensors.items())), weights_path, metadata={"format": "pt"})
-        for checkpoint_file in (config_path, weights_path):
+        # Checksums cover the two PEFT files, so the sidecar is written last
+        # and never hashes itself.
+        provenance_path = temporary / ADAPTER_PROVENANCE
+        provenance = {
+            "schema": PROVENANCE_SCHEMA,
+            "base_model": {"name_or_path": base_model, "tokenizer": _tokenizer_identity(base_model)},
+            "peft": dict(peft_config),
+            # Reported from the tensors actually written, not from a training
+            # flag: the artifact's dtype is whatever a loader will find in it.
+            "dtype": _tensor_dtype(tensors),
+            "source": {"scenario": scenario, "scenario_step": scenario_step},
+            "files": {
+                ADAPTER_CONFIG: _digest(config_path),
+                ADAPTER_WEIGHTS_FILE: _digest(weights_path),
+            },
+        }
+        provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        for checkpoint_file in (config_path, weights_path, provenance_path):
             descriptor = os.open(checkpoint_file, os.O_RDONLY)
             try:
                 os.fsync(descriptor)
@@ -106,6 +153,44 @@ def _write_adapter_checkpoint(args: Any, path: Path, tensors: dict[str, torch.Te
     finally:
         if temporary.exists():
             shutil.rmtree(temporary)
+
+
+def _digest(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _tensor_dtype(tensors: dict[str, torch.Tensor]) -> str | None:
+    """The one dtype every adapter tensor shares, or ``None`` when they differ.
+
+    A mixed export is not rejected here — the tensors are already written and
+    a loader can still read them — but it must not be recorded as a single
+    dtype an auditor would then trust.
+    """
+    dtypes = {tensor.dtype for tensor in tensors.values()}
+    if len(dtypes) != 1:
+        return None
+    return str(dtypes.pop()).removeprefix("torch.")
+
+
+def _tokenizer_identity(base_model: str) -> dict[str, str]:
+    """Digest whichever tokenizer and chat-template files the base checkpoint has.
+
+    Recorded, never enforced here: the adapter cannot know which base a future
+    deployment will pair it with, only which one it was fit against.
+    """
+    root = Path(base_model)
+    identity: dict[str, str] = {}
+    if not root.is_dir():
+        return identity
+    for name in TOKENIZER_FILES:
+        candidate = root / name
+        if candidate.is_file():
+            identity[name] = _digest(candidate)
+    return identity
 
 
 def _validate_adapter_tensors(tensors) -> None:

--- a/reef/train/slime_backend/reef_adapters/megatron/train_actor.py
+++ b/reef/train/slime_backend/reef_adapters/megatron/train_actor.py
@@ -260,6 +260,7 @@ class ReefMegatronTrainRayActor(MegatronTrainRayActor):
             if force_sync and self.args.async_save:
                 maybe_finalize_async_save(blocking=True)
 
+            slots = self.adapter_slots
             if self.args.save_hf is not None and self.role == "actor":
                 output_dir = Path(self.args.save_hf.format(rollout_id=rollout_id))
                 context = torch_memory_saver.disable() if self.args.offload_train else nullcontext()
@@ -268,8 +269,9 @@ class ReefMegatronTrainRayActor(MegatronTrainRayActor):
                         self.args,
                         output_dir,
                         self.weight_updater.export_lora_adapter_tensors(),
+                        scenario=None if slots is None else slots.active,
+                        scenario_step=rollout_id,
                     )
-            slots = self.adapter_slots
             if slots is not None and slots.active is not None:
                 # The Megatron checkpoint above holds only the active slot;
                 # every scenario's state must survive a restart on its own.

--- a/tests/reef_service/test_peft_validator.py
+++ b/tests/reef_service/test_peft_validator.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from reef.artifact import AdapterArtifactError, Artifact, PEFTValidator, read_peft_config
+from reef.artifact.peft import ADAPTER_PROVENANCE, PROVENANCE_SCHEMA, read_provenance
+
+
+@contextmanager
+def fail_on(message: str):
+    """pytest.raises with the message treated as text, not a regex."""
+    with pytest.raises(AdapterArtifactError) as raised:
+        yield raised
+    assert message in str(raised.value)
+
 
 BASE_MODEL = "Qwen/Qwen3.6-27B"
 
@@ -83,3 +95,109 @@ def test_validate_rejects_an_adapter_fit_to_another_base_model(tmp_path: Path) -
 
 def test_validate_skips_the_base_model_check_when_unconfigured(tmp_path: Path) -> None:
     PEFTValidator().validate(adapter(tmp_path, base_model_name_or_path="other/base"))
+
+
+def provenance(root: Path, **overrides: Any) -> dict[str, Any]:
+    """Reef's sidecar for the adapter `adapter()` wrote, written into it."""
+    config_path = root / "adapter_config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    document: dict[str, Any] = {
+        "schema": PROVENANCE_SCHEMA,
+        "base_model": {"name_or_path": config["base_model_name_or_path"], "tokenizer": {}},
+        "peft": {key: config[key] for key in ("peft_type", "r", "lora_alpha", "target_modules")},
+        "dtype": "bfloat16",
+        "source": {"scenario": "math", "scenario_step": 7},
+        "files": {name: digest(root / name) for name in ("adapter_config.json", "adapter_model.safetensors")},
+    }
+    document.update(overrides)
+    (root / ADAPTER_PROVENANCE).write_text(json.dumps(document), encoding="utf-8")
+    return document
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_an_artifact_without_provenance_stays_admissible(tmp_path: Path) -> None:
+    """An offline SFT run or a Hub adapter is legitimate; it just cannot be audited."""
+    artifact = adapter(tmp_path)
+    assert read_provenance(Path(artifact.local_path)) is None
+    PEFTValidator(BASE_MODEL).validate(artifact)
+
+
+def test_requiring_provenance_refuses_an_unauditable_adapter(tmp_path: Path) -> None:
+    with pytest.raises(AdapterArtifactError, match="Reef exported"):
+        PEFTValidator(BASE_MODEL, require_provenance=True).validate(adapter(tmp_path))
+
+
+def test_a_reef_exported_adapter_validates_against_its_provenance(tmp_path: Path) -> None:
+    artifact = adapter(tmp_path)
+    document = provenance(Path(artifact.local_path))
+    PEFTValidator(BASE_MODEL, require_provenance=True).validate(artifact)
+    assert document["source"] == {"scenario": "math", "scenario_step": 7}
+
+
+def test_provenance_from_an_unknown_schema_is_refused(tmp_path: Path) -> None:
+    """A reader that does not know the rules must not validate against the wrong ones."""
+    artifact = adapter(tmp_path)
+    provenance(Path(artifact.local_path), schema=PROVENANCE_SCHEMA + 1)
+    with pytest.raises(AdapterArtifactError, match="understands"):
+        PEFTValidator(BASE_MODEL).validate(artifact)
+
+
+def test_modified_adapter_weights_fail_their_recorded_checksum(tmp_path: Path) -> None:
+    artifact = adapter(tmp_path)
+    root = Path(artifact.local_path)
+    provenance(root)
+    (root / "adapter_model.safetensors").write_bytes(b"\x01")
+    with pytest.raises(AdapterArtifactError, match="corrupted or modified after export"):
+        PEFTValidator(BASE_MODEL).validate(artifact)
+
+
+def test_a_file_the_provenance_covers_must_exist(tmp_path: Path) -> None:
+    """A shard listed at export and missing on disk is a truncated artifact."""
+    artifact = adapter(tmp_path)
+    root = Path(artifact.local_path)
+    document = provenance(root)
+    document["files"]["adapter_model-00002-of-00002.safetensors"] = "0" * 64
+    (root / ADAPTER_PROVENANCE).write_text(json.dumps(document), encoding="utf-8")
+    with fail_on("the adapter is incomplete"):
+        PEFTValidator(BASE_MODEL).validate(artifact)
+
+
+def test_provenance_disagreeing_with_the_config_is_refused(tmp_path: Path) -> None:
+    """The exported tensors match one rank; the artifact must not claim both."""
+    artifact = adapter(tmp_path)
+    root = Path(artifact.local_path)
+    document = provenance(root)
+    document["peft"]["r"] = 8
+    (root / ADAPTER_PROVENANCE).write_text(json.dumps(document), encoding="utf-8")
+    with fail_on("match only one of them"):
+        PEFTValidator(BASE_MODEL).validate(artifact)
+
+
+def test_provenance_naming_another_base_model_is_refused(tmp_path: Path) -> None:
+    artifact = adapter(tmp_path)
+    root = Path(artifact.local_path)
+    document = provenance(root, base_model={"name_or_path": "meta-llama/Llama-3-8B"})
+    assert document["base_model"]["name_or_path"] != BASE_MODEL
+    with fail_on("disagree about what it was fit to"):
+        PEFTValidator(BASE_MODEL).validate(artifact)
+
+
+def test_target_module_order_is_not_a_disagreement(tmp_path: Path) -> None:
+    """PEFT stores target_modules as a set, so its written order is arbitrary."""
+    artifact = adapter(tmp_path)
+    root = Path(artifact.local_path)
+    document = provenance(root)
+    document["peft"]["target_modules"] = ["v_proj", "q_proj"]
+    document["peft"]["lora_alpha"] = 16.0
+    (root / ADAPTER_PROVENANCE).write_text(json.dumps(document), encoding="utf-8")
+    PEFTValidator(BASE_MODEL).validate(artifact)
+
+
+def test_provenance_without_checksums_audits_nothing(tmp_path: Path) -> None:
+    artifact = adapter(tmp_path)
+    provenance(Path(artifact.local_path), files={})
+    with fail_on("audits nothing"):
+        PEFTValidator(BASE_MODEL).validate(artifact)

--- a/tests/reef_service/test_sao_bridge.py
+++ b/tests/reef_service/test_sao_bridge.py
@@ -449,6 +449,7 @@ def _install_slime_parser_stubs() -> None:
     ``test_sao_configs._install_slime_parser_stubs``); inside the full Slime
     image the real modules win.
     """
+    import importlib.machinery
     import sys
     import types
 
@@ -467,6 +468,11 @@ def _install_slime_parser_stubs() -> None:
             __import__(name)
         except ImportError:
             module = types.ModuleType(name)
+            # A bare ModuleType has __spec__ None, and these stubs outlive the
+            # test that installed them. Anything later asking the import system
+            # about the name -- accelerate probes wandb this way on its way in
+            # from peft -- then raises instead of answering.
+            module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
             for attr, value in attrs.items():
                 setattr(module, attr, value)
             sys.modules[name] = module

--- a/tests/reef_service/test_sao_configs.py
+++ b/tests/reef_service/test_sao_configs.py
@@ -39,6 +39,7 @@ Slime driver is therefore part of this contract automatically.
 from __future__ import annotations
 
 import argparse
+import importlib.machinery
 import os
 import shlex
 import sys
@@ -196,6 +197,11 @@ def _install_slime_parser_stubs() -> None:
             __import__(name)
         except ImportError:
             module = types.ModuleType(name)
+            # A bare ModuleType has __spec__ None, and these stubs outlive the
+            # test that installed them. Anything later asking the import system
+            # about the name -- accelerate probes wandb this way on its way in
+            # from peft -- then raises instead of answering.
+            module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
             for attr, value in attrs.items():
                 setattr(module, attr, value)
             sys.modules[name] = module

--- a/tests/slime_backend/test_megatron_lora.py
+++ b/tests/slime_backend/test_megatron_lora.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import sys
@@ -65,6 +66,79 @@ def test_lora_checkpoint_is_readable_by_peft_without_base_weights(tmp_path) -> N
     from peft.utils.save_and_load import load_peft_weights
 
     assert set(load_peft_weights(output, device="cpu")) == set(saved)
+
+
+def test_lora_checkpoint_records_auditable_provenance(tmp_path) -> None:
+    peft = pytest.importorskip("peft")
+    base = tmp_path / "Qwen3-8B"
+    base.mkdir()
+    (base / "tokenizer_config.json").write_text('{"chat_template": "x"}', encoding="utf-8")
+    output = tmp_path / "checkpoint-4"
+    tensors = [
+        ("model.layers.0.self_attn.q_proj.lora_A.weight", torch.ones(2, 4, dtype=torch.bfloat16)),
+        ("model.layers.0.self_attn.q_proj.lora_B.weight", torch.ones(4, 2, dtype=torch.bfloat16)),
+    ]
+
+    save_lora_adapter_to_path(
+        _args(megatron_lora_alpha=32, hf_checkpoint=str(base)),
+        output,
+        tensors,
+        scenario="math",
+        scenario_step=4,
+    )
+
+    document = json.loads((output / "reef-adapter.json").read_text(encoding="utf-8"))
+    assert document["schema"] == 1
+    assert document["source"] == {"scenario": "math", "scenario_step": 4}
+    assert document["dtype"] == "bfloat16"
+    assert document["peft"]["r"] == 32
+    assert document["base_model"]["name_or_path"] == str(base)
+    # The base checkpoint owns the tokenizer; the adapter records which one it
+    # was fit against so a later base swap is visible.
+    assert set(document["base_model"]["tokenizer"]) == {"tokenizer_config.json"}
+
+    config_bytes = (output / "adapter_config.json").read_bytes()
+    assert document["files"]["adapter_config.json"] == hashlib.sha256(config_bytes).hexdigest()
+    weight_bytes = (output / "adapter_model.safetensors").read_bytes()
+    assert document["files"]["adapter_model.safetensors"] == hashlib.sha256(weight_bytes).hexdigest()
+
+    # The sidecar must not cost portability: PEFT ignores files it does not know.
+    assert peft.PeftConfig.from_pretrained(output).r == 32
+
+
+def test_lora_checkpoint_provenance_passes_reefs_own_validator(tmp_path) -> None:
+    """Export and admission are one contract, so the writer must satisfy the reader."""
+    pytest.importorskip("safetensors.torch")
+    from reef.artifact import Artifact, PEFTValidator
+
+    base = tmp_path / "Qwen3-8B"
+    base.mkdir()
+    output = tmp_path / "checkpoint-0"
+    save_lora_adapter_to_path(
+        _args(megatron_lora_alpha=32, hf_checkpoint=str(base)),
+        output,
+        [("model.layers.0.self_attn.q_proj.lora_A.weight", torch.ones(2, 4))],
+        scenario="math",
+        scenario_step=0,
+    )
+
+    PEFTValidator(str(base), require_provenance=True).validate(Artifact.local(output))
+
+
+def test_lora_checkpoint_records_no_dtype_for_a_mixed_export(tmp_path) -> None:
+    """One recorded dtype would be a claim an auditor could not rely on."""
+    pytest.importorskip("safetensors.torch")
+    output = tmp_path / "checkpoint-0"
+    save_lora_adapter_to_path(
+        _args(megatron_lora_alpha=32),
+        output,
+        [
+            ("model.layers.0.self_attn.q_proj.lora_A.weight", torch.ones(2, 4, dtype=torch.float32)),
+            ("model.layers.0.self_attn.q_proj.lora_B.weight", torch.ones(4, 2, dtype=torch.bfloat16)),
+        ],
+    )
+
+    assert json.loads((output / "reef-adapter.json").read_text(encoding="utf-8"))["dtype"] is None
 
 
 def test_lora_checkpoint_rejects_base_tensors(tmp_path) -> None:


### PR DESCRIPTION
Refs #14.

## What

- The export writes `reef-adapter.json` beside `adapter_config.json` and `adapter_model.safetensors`, inside the same atomic directory swap: base model plus the digests of its tokenizer and chat-template files, the PEFT settings the export claims to have written, the dtype of the tensors actually written, the scenario and step that produced it, and a SHA-256 per PEFT file.
- `PEFTValidator` verifies the sidecar whenever one is present, and `require_provenance=True` refuses an adapter that has none.
- The user guide gains the artifact layout, the compatibility contract, the retention argument, and the standalone load command.

## Why

An exported adapter was loadable but not accountable. Nothing recorded which training step wrote it, which tokenizer it was fit against, or what its bytes should hash to — so a corrupted, truncated, or swapped adapter was indistinguishable from the one Reef published. #14 asks for exactly that: "checksums and enough provenance to audit the export".

Three choices worth reviewing:

- **A sidecar, not extra keys in `adapter_config.json`.** That file is PEFT's, and #14's word is *portable*. A separate file travels with the directory and loaders ignore what they do not recognize, so the revision still opens with plain `transformers` + `peft` — the test asserts that rather than assuming it.
- **Dtype is read back off the written tensors**, not off a training flag, because the artifact's dtype is whatever a loader will actually find. A mixed export records `null` rather than a single dtype an auditor would wrongly trust.
- **Absent provenance stays admissible.** An offline SFT run or a Hub adapter is a legitimate artifact; it just cannot be audited. `require_provenance` is the opt-in for deployments that serve only their own exports.

The reader lives in `reef/artifact/peft.py` with no torch or training imports, keeping #14's "base package free of eager GPU/training imports when validating or listing adapter artifacts".

## Already satisfied, so not in this PR

Checking #14's list against `main` first: adapter-only export, failing closed on base tensors or an empty export, and atomic publication already exist in `lora_checkpoint.py`. `checkpoint_every_n_versions` already defaults to 1, so adapter publication is already the default checkpoint for every accepted update, and `commit_protocol.py:286` already stages the exported directory through the scenario release chain. Numerical-fidelity and GPU-smoke boxes need a GPU (#27).

## A prerequisite fix, and why it is here

`tests/reef_service/test_sao_configs.py` and `test_sao_bridge.py` install stub modules — `wandb` among them — with `types.ModuleType`, which leaves `__spec__` as `None`, and never remove them. Anything later asking the import system about the name then raises rather than answering: `peft` → `transformers` → `accelerate` probes `wandb` exactly that way, so `importlib.util.find_spec` died with `ValueError: wandb.__spec__ is None`.

That already silently disabled the existing `test_lora_checkpoint_is_readable_by_peft_without_base_weights` in any full-suite run where `peft` is installed, and it would have done the same to the tests here. Giving each stub a real `ModuleSpec` fixes both. Minimal reproduction:

```
$ pytest tests/reef_service/test_sao_configs.py tests/slime_backend/test_megatron_lora.py -q
2 failed, 49 passed      # before
51 passed                # after
```

**This never fires in CI, because CI's test job installs neither `peft` nor `safetensors`** (they are `slime`-extra dependencies; the `package` job only asserts they are *declared*). So the PEFT-portability guarantee is currently unenforced there, and the tests in this PR will skip too. Adding `safetensors` alone to the test job is cheap — no `transformers` in its dependency tree — and would activate most of them; `peft` costs more. Left out deliberately: expanding CI's dependency set is a call for whoever owns that budget.

## Verified

Clean checkout of `origin/main` @ `9dff4b66`, CI's dependency set plus `peft` and `safetensors` so the adapter tests actually execute rather than skip.

```
$ python -m pytest tests -q
15 failed, 2808 passed, 58 skipped in 501.64s
```

Every failure reproduces on unmodified `origin/main`; diffing the lists, no test fails that passes without this change. They are git-lfs, git-backend, harness-recipe, and native-serve timeout failures unrelated to this area.

```
$ python -m pytest tests/reef_service/test_peft_validator.py tests/slime_backend/test_megatron_lora.py -q
47 passed

$ python -m mypy
Success: no issues found in 236 source files

$ pre-commit run --files <changed>
all hooks Passed
```
