### PR TITLE
feat: resolve harness evolve models per scenario with BYOK

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -31,6 +31,11 @@ can be overridden in the environment. Use it when a service must share Reef's
 Python environment. A literal ``python`` keeps its normal meaning and is
 resolved from that service's ``PATH``; Reef never rewrites command names.
 
+For scenario-specific harness evolve providers, set ``REEF_BYOK_RESOLVER_URL``
+and ``REEF_BYOK_RESOLVER_TOKEN`` in the service environment. See
+`Harness BYOK <../user-guide/harness-byok.rst>`__ for the platform contract and
+rollout. Leaving them unset preserves deployment-wide model configuration.
+
 Start from a cookbook stack
 ---------------------------
 

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -66,6 +66,8 @@ Routes
 +-------------------------------------------------+---------------------------------------------------+
 | ``GET /reef/status``                            | training, serving, and storage state              |
 +-------------------------------------------------+---------------------------------------------------+
+| ``GET /reef/providers/capabilities``            | scenario provider support and resolver URL        |
++-------------------------------------------------+---------------------------------------------------+
 
 Headers
 -------
@@ -91,6 +93,19 @@ Headers
 |                                   | on the record under ``metadata.tags``, for a processor  |
 |                                   | to correlate on. Reef never reads a value.              |
 +-----------------------------------+---------------------------------------------------------+
+
+Scenario model providers
+------------------------
+
+``GET /reef/providers/capabilities`` returns ``{}`` unless a harness evolve
+provider resolver is configured. Enabled deployments return
+``{"harness_evolve_byok_v1": true, "resolver_url": "..."}``. The route uses
+normal service authentication. Platform inference requests may include
+``x-reef-provider-version`` to require that exact scenario configuration;
+a stale version is rejected before a provider call.
+
+See `Harness BYOK <../user-guide/harness-byok.rst>`__ for the resolver setup,
+scoped credentials and model bindings used throughout evolution.
 
 Manual training
 ---------------

--- a/docs/site/lib/docs.ts
+++ b/docs/site/lib/docs.ts
@@ -59,6 +59,7 @@ const navigationSources: ReadonlyArray<{ title: string; files: ReadonlyArray<str
     files: [
       "user-guide/recipes.rst",
       "user-guide/evolve-your-harness.rst",
+      "user-guide/harness-byok.rst",
       "user-guide/evolve-your-model.rst",
       "user-guide/recipes/sao.rst",
       "user-guide/recipes/tttd.rst",

--- a/docs/site/scripts/check-doc-contracts.mjs
+++ b/docs/site/scripts/check-doc-contracts.mjs
@@ -191,6 +191,14 @@ const preservedModelPrompts = new Map([
 ]);
 
 function terminologySource(path, source) {
+  // The naming policy must list the words it restricts; keep the rest of the
+  // instructions checked, including wording outside this explicit example list.
+  if (path === "AGENTS.md" || path === "CLAUDE.md") {
+    source = source.replace(
+      /(^In particular, avoid terms such as:\n\n)((?:- [^\n]+\n)+)/gm,
+      (_, prefix, examples) => prefix + examples.replace(/[^\n]/g, " "),
+    );
+  }
   const prompt = preservedModelPrompts.get(path);
   if (!prompt) return source;
   // Keep newlines so failures below still point to the original source lines.

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -747,3 +747,8 @@ the model calls. The bundled descriptors cover these agents:
 
 `Harness adapters <../developer-guide/harness-adapters.rst>`__ is the descriptor reference and
 how to connect an agent that has no adapter yet.
+
+.. seealso::
+
+   `Harness BYOK <harness-byok.rst>`__ explains scenario-specific custom providers for the entire
+   harness evolve model pipeline through Reef API Platform.

--- a/docs/user-guide/harness-byok.rst
+++ b/docs/user-guide/harness-byok.rst
@@ -1,0 +1,79 @@
+Harness evolve with a custom model provider
+==========================================
+
+A ``harness_evolve`` deployment can resolve each scenario's model provider
+through Reef API Platform. BYOK covers inference, proposer and named auxiliary
+models, model-based judges, evaluation episodes, and gate calls. The platform
+holds the encrypted provider credential and forwards model calls with the
+user's key. Reef receives a revocable scenario/version-scoped proxy credential.
+
+Operator setup
+--------------
+
+Deploy the platform's BYOK API and this runtime together. Configure the Reef
+service with the platform deployment ID and its registered service token::
+
+    REEF_BYOK_RESOLVER_URL=https://api.reefinfra.ai/api/internal/deployments/<id>/provider
+    REEF_BYOK_RESOLVER_TOKEN=<registered Reef service token>
+
+The recipe must be a ``CordisRecipe`` named ``harness_evolve``. Without these
+environment settings, existing deployment-wide model behavior is unchanged.
+The authenticated ``GET /reef/providers/capabilities`` endpoint advertises
+``harness_evolve_byok_v1`` and the configured resolver URL. The platform verifies
+both before accepting user settings.
+
+Allow the service and episode sandbox to reach the platform origin. User
+providers are contacted by the platform, which validates the URL and DNS
+addresses, pins the connection address and refuses redirects. Provider secrets
+stay out of the published harness and algorithm state. Both episode executors
+use the existing minimal inherited environment, without platform model keys.
+
+Method integration
+------------------
+
+Proposers already receive ``models``. BYOK replaces ``models.served`` and every
+named binding with the same user-selected endpoint, protocol and default model.
+Use these bindings for every model call; do not construct a separate client
+from environment credentials.
+
+A callable model-based judge can declare the ``models`` keyword::
+
+    def evaluate(task, result, *, models):
+        verdict = models["judge"].chat([
+            {"role": "user", "content": "Evaluate the episode: " + str(result.trajectory)}
+        ])
+        return float(verdict.strip() == "pass")
+
+An ``EpisodeScorer`` subclass overrides ``score_with_models(task, result,
+models)``. Existing deterministic scorers with ``evaluate(task, result)``
+continue to work. The ``models`` argument is the same configuration used for
+that step's proposer and episodes. Methods that make model calls outside this
+contract must be migrated before deploying BYOK.
+
+Configuration lifetime
+----------------------
+
+Each inference request and evolution step resolves a configuration snapshot.
+All stages of a step use that snapshot. Platform inference requests include
+``x-reef-provider-version``; the resolver rejects a mismatch before any model
+call. Configuration failures never fall back to the managed runtime.
+
+Replacing or clearing a binding revokes its proxy credential. An HTTP call
+already in progress can complete; later calls from a step with the old binding
+fail instead of changing credentials mid-step. New steps, including queued or
+recovered work, resolve the user's current settings when they start. Explicitly
+switching back to managed models therefore applies to those new steps.
+
+Supported BYOK protocols are OpenAI Chat Completions and Anthropic Messages,
+including token counting. The platform supplies matching native bindings to
+backend model clients and evaluation episodes. Reinstall the client harness
+after changing protocol or default model so its local model settings match.
+
+Verification
+------------
+
+``tests/reef_service/test_scenario_provider.py`` uses real HTTP requests and a
+subprocess episode runner to cover both protocols, proposer and judge calls,
+baseline/candidate evaluation, tenant-independent scenario bindings, key
+rotation, fail-closed behavior and credential-free publications. It also
+checks the service capability, request-version and installation contracts.

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -262,6 +262,9 @@ class Dispatcher:
     def recipe_has_files(self) -> bool:
         return self._registry.recipe_has_files()
 
+    def provider_capabilities(self) -> Mapping[str, Any]:
+        return self._recipe.provider_capabilities()
+
     def list_releases(self, scenario: str) -> tuple[dict[str, Any], ...]:
         with self._registry.lock_for(scenario):
             return self._registry.require(scenario).releases()

--- a/reef/harness/episodes/model_binding.py
+++ b/reef/harness/episodes/model_binding.py
@@ -23,7 +23,7 @@ import urllib.error
 import urllib.request
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
 
 from reef.core.errors import ReefError
 from reef.harness.adapters.descriptor import AdapterDescriptor
@@ -315,6 +315,7 @@ class ModelBindings(Mapping[str, ModelBinding]):
 
     served: ModelBinding
     named: Mapping[str, ModelBinding] = field(default_factory=dict)
+    byok: bool = False
 
     def __post_init__(self) -> None:
         if "served" in self.named:
@@ -335,6 +336,12 @@ class ModelBindings(Mapping[str, ModelBinding]):
 
     def __len__(self) -> int:
         return 1 + len(self.named)
+
+
+class ModelBindingsResolver(Protocol):
+    """Freeze the model configuration once for an entire evolution step."""
+
+    def resolve(self) -> ModelBindings: ...
 
 
 def _mentions_model(value: Any) -> bool:

--- a/reef/recipe/base.py
+++ b/reef/recipe/base.py
@@ -56,6 +56,14 @@ class Recipe:
         if self.training_mode not in ("auto", "manual", "hybrid"):
             raise ValueError("training_mode must be 'auto', 'manual' or 'hybrid'")
 
+    def for_scenario(self, scenario: str) -> Recipe:
+        """Bind scenario-specific resources without mutating the deployment recipe."""
+        return self
+
+    def provider_capabilities(self) -> Mapping[str, Any]:
+        """Provider configuration contracts supported by this deployment."""
+        return {}
+
     @classmethod
     def from_environment(
         cls,

--- a/reef/runtime/inference.py
+++ b/reef/runtime/inference.py
@@ -145,7 +145,7 @@ def provider_request_headers(api_key: str) -> RequestHeadersFactory:
 
     def headers_for(artifact: Artifact, path: str) -> Mapping[str, str]:
         headers = content_identity_headers(artifact)
-        if path == "/v1/messages":
+        if path in ("/v1/messages", "/v1/messages/count_tokens"):
             headers["x-api-key"] = api_key
             headers["anthropic-version"] = "2023-06-01"
         else:

--- a/reef/runtime/scenario_provider.py
+++ b/reef/runtime/scenario_provider.py
@@ -1,0 +1,125 @@
+"""Resolve a harness scenario's model configuration through its trusted platform.
+
+The platform returns a version-scoped proxy credential, not the user's provider
+key. A failed resolution is never treated as permission to use managed models.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+from reef.artifact.artifact import Artifact
+from reef.core.errors import ReefError
+from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
+from reef.runtime.base import InferenceRuntime
+from reef.runtime.inference import InferenceBackend, InferenceStream
+
+
+class ProviderResolutionError(ReefError):
+    """The configured platform could not authorize a model binding."""
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> None:
+        return None
+
+
+@dataclass(frozen=True)
+class ProviderSnapshot:
+    mode: str
+    version: str
+    runtime: InferenceRuntime
+
+
+@dataclass(frozen=True)
+class ScenarioProviderResolver:
+    """A deployment-scoped control-plane client configured by the operator."""
+
+    url: str
+    token: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        parsed = urlparse(self.url)
+        if parsed.scheme not in ("https", "http") or not parsed.netloc or parsed.username or parsed.password:
+            raise ValueError("REEF_BYOK_RESOLVER_URL must be an HTTP(S) URL without credentials")
+        if not self.token:
+            raise ValueError("REEF_BYOK_RESOLVER_TOKEN is required")
+
+    def resolve(self, scenario: str, managed: InferenceRuntime | None, version: str | None = None) -> ProviderSnapshot:
+        payload = {"scenario": scenario}
+        if version is not None:
+            payload["version"] = version
+        request = urllib.request.Request(
+            self.url,
+            data=json.dumps(payload).encode(),
+            headers={"content-type": "application/json", "authorization": f"Bearer {self.token}"},
+            method="POST",
+        )
+        try:
+            with urllib.request.build_opener(_NoRedirect()).open(request, timeout=15) as response:
+                answer = json.load(response)
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            raise ProviderResolutionError("Cannot resolve the scenario model provider; no managed fallback") from exc
+        if not isinstance(answer, Mapping) or not isinstance(answer.get("version"), str):
+            raise ProviderResolutionError("Invalid scenario provider response")
+        if version is not None and answer["version"] != version:
+            raise ProviderResolutionError("Scenario provider configuration changed")
+        if answer.get("mode") == "managed":
+            if managed is None:
+                raise ProviderResolutionError("No managed model is configured for this scenario")
+            return ProviderSnapshot("managed", answer["version"], managed)
+        if answer.get("mode") != "byok" or answer.get("api") not in ("openai", "anthropic"):
+            raise ProviderResolutionError("Invalid scenario provider mode or protocol")
+        for name in ("base_url", "api_key", "model"):
+            if not isinstance(answer.get(name), str) or not answer[name]:
+                raise ProviderResolutionError("Incomplete scenario provider binding")
+        # Only the trusted platform can receive the scoped credential.
+        base = urlparse(answer["base_url"])
+        origin = urlparse(self.url)
+        if (base.scheme, base.netloc) != (origin.scheme, origin.netloc) or base.username or base.password:
+            raise ProviderResolutionError("Provider proxy must use the resolver's origin")
+        runtime = InferenceProxyRuntime(
+            base_url=answer["base_url"], api_key=answer["api_key"], model_path=answer["model"], api=answer["api"]
+        )
+        return ProviderSnapshot("byok", answer["version"], runtime)
+
+
+class _ProviderInferenceBackend(InferenceBackend):
+    def __init__(self, runtime: ScenarioProviderRuntime) -> None:
+        self._runtime = runtime
+
+    async def inference(self, artifact: Artifact, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        backend = await asyncio.to_thread(self._runtime.request_backend)
+        return await backend.inference(artifact, path, payload)
+
+    async def inference_stream(self, artifact: Artifact, path: str, payload: dict[str, Any]) -> InferenceStream:
+        backend = await asyncio.to_thread(self._runtime.request_backend)
+        return await backend.inference_stream(artifact, path, payload)
+
+
+class ScenarioProviderRuntime(InferenceRuntime):
+    """One scenario's live configuration; each request or step freezes a snapshot."""
+
+    def __init__(self, resolver: ScenarioProviderResolver, scenario: str, managed: InferenceRuntime | None) -> None:
+        super().__init__(base_url=resolver.url)
+        self.resolver = resolver
+        self.scenario = scenario
+        self.managed = managed
+        self._backend = _ProviderInferenceBackend(self)
+
+    def snapshot(self, version: str | None = None) -> ProviderSnapshot:
+        return self.resolver.resolve(self.scenario, self.managed, version)
+
+    def request_backend(self, version: str | None = None) -> InferenceBackend:
+        return self.snapshot(version).runtime.inference_backend
+
+    @property
+    def inference_backend(self) -> InferenceBackend:
+        return self._backend

--- a/reef/scenario/factory.py
+++ b/reef/scenario/factory.py
@@ -215,7 +215,7 @@ class ScenarioFactory:
             backend,
             release_id,
         )
-        recipe_definition = self._recipe
+        recipe_definition = self._recipe.for_scenario(scenario)
         surface = recipe_definition.build_surface(scenario)
         runtime = recipe_definition.runtime
         checkpoint_head = backend.current()

--- a/reef/service/assembly.py
+++ b/reef/service/assembly.py
@@ -204,6 +204,19 @@ def build_dispatcher(
     recipe = _serving_recipe(selected_recipe, settings, env, connector)
     experiment_tracker = None
     try:
+        resolver_url = env.get("REEF_BYOK_RESOLVER_URL", "").strip()
+        if resolver_url:
+            from dataclasses import replace
+
+            from reef.runtime.scenario_provider import ScenarioProviderResolver
+            from reef.train.cordis_backend.recipe import CordisRecipe
+
+            if not isinstance(recipe, CordisRecipe) or recipe.name != "harness_evolve":
+                raise ValueError("BYOK is available only for harness_evolve")
+            recipe = replace(
+                recipe,
+                provider_resolver=ScenarioProviderResolver(resolver_url, env.get("REEF_BYOK_RESOLVER_TOKEN", "")),
+            )
         # A harness recipe's seed is the base artifact, so a fresh scenario serves a tree before any step.
         backend_factory = GitLFSRepositoryBackend.factory(
             _repository_location(settings.artifact_repository),

--- a/reef/service/request_service.py
+++ b/reef/service/request_service.py
@@ -28,6 +28,7 @@ from reef.recipe.errors import RecipeConfigError
 from reef.records import AgentRecord
 from reef.runtime.base import InferenceAdmissionHandle, TrainingRuntime
 from reef.runtime.inference import InferenceBackend, InferenceStream
+from reef.runtime.scenario_provider import ScenarioProviderRuntime
 from reef.scenario.scenario import Scenario
 from reef.service.install_script import TOKEN_PLACEHOLDER, render_install_script
 from reef.service.release_page import before_release_id, build_release_page
@@ -366,6 +367,11 @@ class RequestService:
         )
         if initial is None:
             raise UnknownScenario(f"unknown scenario {parsed.scenario!r}")
+        if isinstance(initial.runtime, ScenarioProviderRuntime):
+            normalized = {name.lower(): value for name, value in headers.items()}
+            backend = await asyncio.to_thread(
+                initial.runtime.request_backend, normalized.get("x-reef-provider-version")
+            )
         admission = await initial.runtime.acquire_inference() if initial.runtime is not None else None
         try:
             # Re-resolve after admission: a queued request must freeze the head
@@ -667,10 +673,18 @@ class RequestService:
         if not host or not model or not entries:
             return {}
         scheme = normalized.get("x-forwarded-proto") or "http"
-        binding = ModelBinding(base_url=f"{scheme}://{host}", model=model, api_key=TOKEN_PLACEHOLDER)
+        api = "openai"
+        client_models = () if info is None else info.client_models
+        if isinstance(scenario.runtime, ScenarioProviderRuntime):
+            snapshot = scenario.runtime.snapshot()
+            selected = ModelBinding.from_runtime(snapshot.runtime)
+            model, api = selected.model, selected.api
+            if snapshot.mode == "byok":
+                client_models = ()
+        binding = ModelBinding(base_url=f"{scheme}://{host}", model=model, api_key=TOKEN_PLACEHOLDER, api=api)
         nodes = [(str(entry["name"]), entry.get("config")) for entry in entries if not entry.get("disabled")]
         try:
-            bound = binding.compose_nodes(descriptor, models=() if info is None else info.client_models)
+            bound = binding.compose_nodes(descriptor, models=client_models)
             files = render_composition((*nodes, *bound), descriptor)
         except (ModelBindingError, RenderError, KeyError, TypeError):
             return {}

--- a/reef/service/routes/system.py
+++ b/reef/service/routes/system.py
@@ -50,6 +50,9 @@ def register_system_routes(app: web.Application, *, request_service: RequestServ
         value = await asyncio.to_thread(lambda: request_service.dispatcher.build_training_status())
         return web.json_response(value)
 
+    async def providers(request: web.Request) -> web.Response:
+        return web.json_response(request_service.dispatcher.provider_capabilities())
+
     async def adapters(request: web.Request) -> web.Response:
         names = await asyncio.to_thread(available_adapters)
         entries = []
@@ -82,6 +85,7 @@ def register_system_routes(app: web.Application, *, request_service: RequestServ
     app.router.add_post("/reef/harness/proposals", harness_proposals)
     app.router.add_get("/reef/harness/adapters", adapters)
     app.router.add_get("/reef/status", status)
+    app.router.add_get("/reef/providers/capabilities", providers)
 
 
 __all__ = ["register_system_routes"]

--- a/reef/train/cordis_backend/backend.py
+++ b/reef/train/cordis_backend/backend.py
@@ -25,7 +25,7 @@ from typing import Any
 from reef.artifact.artifact import Artifact
 from reef.harness.adapters.descriptor import AdapterDescriptor
 from reef.harness.episodes.executor import EPISODE_OWNER_LEASE, EpisodeExecutor, LocalExecutor, SandboxExecutor
-from reef.harness.episodes.model_binding import ModelBinding, ModelBindings, usage_of
+from reef.harness.episodes.model_binding import ModelBinding, ModelBindings, ModelBindingsResolver, usage_of
 from reef.harness.episodes.run import EpisodeError, EpisodeResult, TrajectoryKeepError, run_episode
 from reef.harness.episodes.trajectory import TrajectoryError
 from reef.harness.episodes.vendor_install import install_prefix, resolve_binary
@@ -80,20 +80,24 @@ class EpisodeEvaluationWorker:
     def __post_init__(self) -> None:
         self.executor.preflight()
 
-    def run(self, files: Mapping[str, str], task: str, keep_dir: Path | None = None) -> _ScoredEpisode:
+    def run(
+        self, files: Mapping[str, str], task: str, keep_dir: Path | None = None, models: ModelBindings | None = None
+    ) -> _ScoredEpisode:
         if keep_dir is None or not self.transfer_records:
-            return self._run_and_score(files, task, keep_dir)
+            return self._run_and_score(files, task, keep_dir, models)
         # Remote workers must not interpret the driver's path as a local path.
         # Keep the trajectory on the worker, then return it with the scored result.
         with tempfile.TemporaryDirectory(prefix="reef-worker-record-") as temporary:
             record_dir = Path(temporary) / "episode"
-            scored = self._run_and_score(files, task, record_dir)
+            scored = self._run_and_score(files, task, record_dir, models)
             buffer = BytesIO()
             with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
                 archive.add(record_dir, arcname=".")
             return replace(scored, record_archive=buffer.getvalue())
 
-    def _run_and_score(self, files: Mapping[str, str], task: str, keep_dir: Path | None) -> _ScoredEpisode:
+    def _run_and_score(
+        self, files: Mapping[str, str], task: str, keep_dir: Path | None, models: ModelBindings | None
+    ) -> _ScoredEpisode:
         """Score one side's episode; a ``None`` score marks an episode that
         could not run. The observation keeps what the exception handling
         would otherwise discard: the failure's stage and cause. A native turn
@@ -126,11 +130,11 @@ class EpisodeEvaluationWorker:
             return scored
         finally:
             EPISODE_OWNER_LEASE.reset(token)
-        scored = self._score_result(result, task)
+        scored = self._score_result(result, task, models)
         _write_episode_record(keep_dir, task, result, scored)
         return scored
 
-    def _score_result(self, result: EpisodeResult, task: str) -> _ScoredEpisode:
+    def _score_result(self, result: EpisodeResult, task: str, models: ModelBindings | None = None) -> _ScoredEpisode:
         """The score and the observations of an episode that ran."""
         residue = len(result.residue)
         agents = _agent_work(result.trajectory)
@@ -151,7 +155,9 @@ class EpisodeEvaluationWorker:
             # A loop turn walks no graph: the failure names the loop when the root's header does.
             stage = "loop" if _root_header(result.trajectory).get("loop") else "graph"
             return _ScoredEpisode(None, FailureObservation(task=task, stage=stage, cause=cause), residue, agents, path)
-        score = float(self.scorer(task, result))
+        score = float(
+            self.scorer(task, result) if models is None else self.scorer.score_with_models(task, result, models)
+        )
         if not math.isfinite(score):
             raise ValueError(f"episode scorer returned a non-finite score {score!r} for task {task!r}")
         if result.exit_code != 0:
@@ -413,7 +419,9 @@ def _budgeted_bindings(models: ModelBindings, cap: int, record: list[dict[str, A
         return _BudgetedBinding(binding, spent, cap, record)
 
     return ModelBindings(
-        served=wrap(models.served), named={name: wrap(models[name]) for name in models if name != "served"}
+        served=wrap(models.served),
+        named={name: wrap(models[name]) for name in models if name != "served"},
+        byok=models.byok,
     )
 
 
@@ -653,6 +661,7 @@ class CordisBackend(TrainingBackend):
         score_episode: EpisodeScorer,
         tasks: tuple[str, ...],
         models: ModelBindings | ModelBinding,
+        model_resolver: ModelBindingsResolver | None = None,
         binary: str | None = None,
         episode_timeout_s: float = 600.0,
         episode_repeats: int = 1,
@@ -692,6 +701,7 @@ class CordisBackend(TrainingBackend):
         self._score_episode = score_episode
         self._tasks = tasks
         self._models = models
+        self._model_resolver = model_resolver
         # The served binding renders into episodes only. It is resolved once
         # here so an adapter without a matching model_binding refuses boot,
         # not the first step.
@@ -842,6 +852,9 @@ class CordisBackend(TrainingBackend):
     ) -> PreparedStep:
         if not isinstance(batch, TraceBatch):
             raise TypeError(f"harness evolution requires TraceBatch, got {type(batch).__name__}")
+        if self._model_resolver is not None:
+            self._models = self._model_resolver.resolve()
+            self._binding_nodes = self._models.served.compose_nodes(self._descriptor)
         steps = int(state.get("steps", 0)) + 1
         entries = state.get("entries")
         if entries is not None:
@@ -1276,7 +1289,7 @@ class CordisBackend(TrainingBackend):
         return _agent_work(trajectory)
 
     def _evaluate_pairings(self, pairings):
-        scored = self._evaluation_pool.evaluate(pairings)
+        scored = self._evaluation_pool.evaluate(pairings, models=self._models)
         for pairing, result in zip(pairings, scored, strict=True):
             if result.record_archive is not None:
                 keep_dir = pairing[2]

--- a/reef/train/cordis_backend/execution.py
+++ b/reef/train/cordis_backend/execution.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import replace
 from threading import Lock
 
+from reef.harness.episodes.model_binding import ModelBindings
 from reef.runtime.executor import Executor, ExecutorConfig, WorkerSpec
 from reef.runtime.executor.config import (
     ExecutorSelection,
@@ -30,7 +31,7 @@ class EvaluationWorkerPool:
         self._lock = Lock()
         self._closed = False
 
-    def evaluate(self, pairings):
+    def evaluate(self, pairings, *, models: ModelBindings | None = None):
         # Drain a batch before admitting the next, including ordinary scorer errors.
         with self._lock:
             if self._closed:
@@ -50,7 +51,13 @@ class EvaluationWorkerPool:
             try:
                 for index, pairing in enumerate(pairings):
                     pending.append(
-                        self._executor.rpc(index % self._requirements.workers, "run", args=pairing, non_block=True)
+                        self._executor.rpc(
+                            index % self._requirements.workers,
+                            "run",
+                            args=pairing,
+                            kwargs={} if models is None else {"models": models},
+                            non_block=True,
+                        )
                     )
             except BaseException:
                 # Partial submission cannot be replayed safely. Retire the pool.

--- a/reef/train/cordis_backend/recipe.py
+++ b/reef/train/cordis_backend/recipe.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import importlib
 import warnings
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +33,7 @@ from reef.recipe.config_fields import config_field
 from reef.recipe.errors import RecipeConfigError
 from reef.records import RecordStore
 from reef.runtime.executor.config import ExecutorSettings, WorkerResources, executor_settings, role_executor_settings
+from reef.runtime.scenario_provider import ScenarioProviderResolver, ScenarioProviderRuntime
 from reef.surface.base import Surface
 from reef.surface.harnesses import create_harness_surface
 from reef.train.cordis_backend.backend import CordisBackend, ScoreComparisonSelector, tree_files
@@ -54,6 +55,22 @@ _CANDIDATE_SELECTORS: dict[str, CandidateSelector] = {
     "score_comparison": ScoreComparisonSelector(),
     "always": AlwaysSelect(),
 }
+
+
+@dataclass(frozen=True)
+class _ScenarioModels:
+    runtime: ScenarioProviderRuntime
+    model_name: str | None
+    named: Mapping[str, ModelBinding]
+
+    def resolve(self) -> ModelBindings:
+        snapshot = self.runtime.snapshot()
+        served = ModelBinding.from_runtime(
+            snapshot.runtime, model=None if snapshot.mode == "byok" else self.model_name
+        )
+        # Every auxiliary role uses the same user-selected endpoint, credential and default model.
+        named = dict.fromkeys(self.named, served) if snapshot.mode == "byok" else dict(self.named)
+        return ModelBindings(served=served, named=named, byok=snapshot.mode == "byok")
 
 
 def _resolve_callable(value: Any, what: str) -> Any:
@@ -213,6 +230,17 @@ class CordisRecipe(Recipe):
     max_score: float = config_field(0.0)
     batch_policy: str = config_field("reports")
     name: str = field(default="harness_evolve", kw_only=True)
+    provider_resolver: ScenarioProviderResolver | None = field(default=None, repr=False, kw_only=True)
+
+    def for_scenario(self, scenario: str) -> CordisRecipe:
+        if self.provider_resolver is None:
+            return self
+        return replace(self, runtime=ScenarioProviderRuntime(self.provider_resolver, scenario, self.runtime))
+
+    def provider_capabilities(self) -> Mapping[str, Any]:
+        if self.provider_resolver is None:
+            return {}
+        return {"harness_evolve_byok_v1": True, "resolver_url": self.provider_resolver.url}
 
     @property
     def report_type(self) -> type[ScoredRolloutReport]:
@@ -457,6 +485,11 @@ class CordisRecipe(Recipe):
 
     def model_binding(self) -> ModelBinding:
         """The served model's endpoint, derived from the recipe's runtime."""
+        if isinstance(self.runtime, ScenarioProviderRuntime):
+            snapshot = self.runtime.snapshot()
+            return ModelBinding.from_runtime(
+                snapshot.runtime, model=None if snapshot.mode == "byok" else self.model_name
+            )
         if self.runtime is None:
             raise RecipeConfigError(
                 "harness evolution requires an inference runtime: set reef.upstream_url (and reef.upstream_model) "
@@ -469,14 +502,22 @@ class CordisRecipe(Recipe):
 
     def model_bindings(self) -> ModelBindings:
         """What ``propose`` receives: the served model plus ``evolution.models``."""
+        if isinstance(self.runtime, ScenarioProviderRuntime):
+            return _ScenarioModels(self.runtime, self.model_name, self.models).resolve()
         return ModelBindings(served=self.model_binding(), named=dict(self.models))
 
     def build_surface(self, scenario: str) -> Surface:
         model = self.model_name or getattr(self.runtime, "model_path", None)
+        client_models = self.client_models
+        if isinstance(self.runtime, ScenarioProviderRuntime):
+            models = self.model_bindings()
+            model = models.served.model
+            if models.byok:
+                client_models = ()
         return create_harness_surface(
             seed_entries=tuple(dict(entry) for entry in self.seed),
             served_model=model if isinstance(model, str) and model else None,
-            client_models=self.client_models,
+            client_models=client_models,
         )
 
     def base_artifact_files(self) -> Mapping[str, str] | None:
@@ -507,6 +548,8 @@ class CordisRecipe(Recipe):
         experiment_logger: ExperimentLogger | None = None,
     ) -> Trainer:
         kwargs = self._backend_kwargs()
+        if isinstance(self.runtime, ScenarioProviderRuntime):
+            kwargs["model_resolver"] = _ScenarioModels(self.runtime, self.model_name, self.models)
         # One recipe serves many scenarios, so each scenario's steps record under their own directory; absolute,
         # so the path a commit record names resolves from any working directory.
         if kwargs["step_record_dir"] is not None:

--- a/reef/train/cordis_backend/strategies.py
+++ b/reef/train/cordis_backend/strategies.py
@@ -149,6 +149,10 @@ class EpisodeScorer(ABC):
         """
         return ExecutionRequirements()
 
+    def score_with_models(self, task: str, result: EpisodeResult, models: ModelBindings) -> float:
+        """Model-based judges override this method and use the supplied bindings."""
+        return self(task, result)
+
 
 def accepts_keyword(fn: Callable[..., Any], name: str) -> bool:
     """Whether ``fn`` names ``name`` or takes ``**kwargs``; a keyword is only passed to code that declared it."""
@@ -229,11 +233,16 @@ class _CallableProposer(Proposer):
 class _CallableEpisodeScorer(EpisodeScorer):
     """Adapter wrapping a plain callable as an episode scorer."""
 
-    def __init__(self, fn: Callable[[str, EpisodeResult], float]) -> None:
+    def __init__(self, fn: Callable[..., float]) -> None:
         self._fn = fn
 
     def __call__(self, task: str, result: EpisodeResult) -> float:
         return self._fn(task, result)
+
+    def score_with_models(self, task: str, result: EpisodeResult, models: ModelBindings) -> float:
+        if accepts_keyword(self._fn, "models"):
+            return self._fn(task, result, models=models)
+        return self(task, result)
 
 
 def resolve_proposer(value: object) -> Proposer:

--- a/tests/reef_service/test_scenario_provider.py
+++ b/tests/reef_service/test_scenario_provider.py
@@ -1,0 +1,294 @@
+"""A real HTTP provider, proposer, judge and subprocess episode share a BYOK binding."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+
+import pytest
+
+from reef.artifact import Artifact, InMemoryRepositoryBackend
+from reef.dispatcher import Dispatcher
+from reef.harness.episodes.model_binding import ModelBinding
+from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
+from reef.runtime.executor.config import ExecutorSettings
+from reef.runtime.scenario_provider import ProviderResolutionError, ScenarioProviderResolver, ScenarioProviderRuntime
+from reef.train.cordis_backend import CordisRecipe, Mutation, ScoreComparisonSelector
+from reef.train.cordis_backend.strategies import resolve_episode_scorer, resolve_proposer
+from reef.train.evaluation import DefaultCandidateEvaluationPlugin
+from reef.train.types import TraceBatch, TraceSample
+
+
+@pytest.fixture
+def platform():
+    state = {"calls": [], "configs": {}, "fail": False, "fail_models": False}
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["content-length"])))
+            if self.path == "/resolve":
+                if state["fail"] or self.headers.get("authorization") != "Bearer deployment-secret":
+                    self.send_error(503)
+                    return
+                config = state["configs"][body["scenario"]]
+                if "version" in body and body["version"] != config["version"]:
+                    self.send_error(409)
+                    return
+                answer = config
+            else:
+                state["calls"].append((self.path, dict(self.headers), body))
+                if state["fail_models"]:
+                    self.send_error(401)
+                    return
+                if self.path.endswith("/messages") or self.path.endswith("/count_tokens"):
+                    answer = {
+                        "content": [{"type": "text", "text": "OK"}],
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    }
+                else:
+                    answer = {
+                        "choices": [{"message": {"content": "OK"}}],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                    }
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(answer).encode())
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    state["url"] = f"http://127.0.0.1:{server.server_port}"
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def configure(platform, name, api, version="1"):
+    platform["configs"][name] = {
+        "mode": "byok",
+        "version": version,
+        "base_url": f"{platform['url']}/{name}/{version}",
+        "api_key": f"scoped-{name}-{version}",
+        "model": f"custom-{name}",
+        "api": api,
+    }
+
+
+FAKE_AGENT = """#!/usr/bin/env python3
+import json, os, urllib.request
+from pathlib import Path
+assert not os.environ.get("OPENAI_API_KEY")
+assert not os.environ.get("ANTHROPIC_API_KEY")
+root = Path(os.environ["PI_CODING_AGENT_DIR"])
+provider = next(iter(json.loads((root / "models.json").read_text())["providers"].values()))
+anthropic = provider["api"] == "anthropic-messages"
+url = provider["baseUrl"] + ("/v1/messages" if anthropic else "/chat/completions")
+headers = {"content-type": "application/json"}
+headers["x-api-key" if anthropic else "authorization"] = provider["apiKey"] if anthropic else "Bearer " + provider["apiKey"]
+if anthropic: headers["anthropic-version"] = "2023-06-01"
+body = {"model": provider["models"][0]["id"], "max_tokens": 10, "messages": [{"role": "user", "content": "episode"}]}
+with urllib.request.urlopen(urllib.request.Request(url, data=json.dumps(body).encode(), headers=headers)) as response:
+    json.load(response)
+sessions = Path(os.environ["PI_CODING_AGENT_SESSION_DIR"])
+sessions.mkdir(parents=True, exist_ok=True)
+rules = root / "AGENTS.md"
+(sessions / "session.jsonl").write_text(json.dumps({"type": "agent_end", "rules": rules.read_text() if rules.exists() else ""}) + "\\n")
+"""
+
+
+def judge(task, result, *, models):
+    assert models["judge"].chat([{"role": "user", "content": "judge"}]) == "OK"
+    return 1.0 if "marker" in result.trajectory[-1]["rules"] else 0.0
+
+
+def make_recipe(platform, tmp_path):
+    binary = tmp_path / "agent"
+    binary.write_text(FAKE_AGENT)
+    binary.chmod(0o755)
+
+    def propose(nodes, samples, models):
+        assert models.byok
+        assert models["teacher"].chat([{"role": "user", "content": "proposer"}]) == "OK"
+        return Mutation("create", "improvement", {"name": "rules", "config": {"text": "marker"}})
+
+    managed = ModelBinding(base_url=f"{platform['url']}/managed", api_key="platform-key", model="platform-model")
+    return CordisRecipe(
+        resolve_proposer(propose),
+        resolve_episode_scorer(judge),
+        ("test task",),
+        runtime=InferenceProxyRuntime(base_url=managed.base_url, api_key=managed.api_key, model_path=managed.model),
+        models={"teacher": managed, "judge": managed},
+        binary=str(binary),
+        client_models=("managed-alternative",),
+        provider_resolver=ScenarioProviderResolver(f"{platform['url']}/resolve", "deployment-secret"),
+        seed=({"id": "initial", "name": "skill", "config": {"name": "notes", "text": "notes"}},),
+        proposals_dir=str(tmp_path / "proposals"),
+    )
+
+
+@pytest.mark.parametrize("api", ["openai", "anthropic"])
+@pytest.mark.parametrize("executor", ["uni", "mp"])
+def test_full_evolution_uses_only_custom_binding(platform, tmp_path, monkeypatch, api, executor):
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-episodes")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "must-not-reach-episodes")
+    configure(platform, "alpha", api)
+    recipe = replace(make_recipe(platform, tmp_path), worker_executor=ExecutorSettings(backend=executor))
+    initial = tmp_path / "initial"
+    initial.mkdir()
+    dispatcher = Dispatcher(recipe, InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repo"))
+    try:
+        scenario = dispatcher.get_or_create_scenario("alpha")
+        artifact = Artifact(scenario.repository.require_current_artifact(), scenario.repository)
+        path = "/v1/messages" if api == "anthropic" else "/v1/chat/completions"
+        asyncio.run(scenario.inference_backend.inference(artifact, path, {"model": "custom-alpha", "messages": []}))
+        if api == "anthropic":
+            asyncio.run(
+                scenario.inference_backend.inference(
+                    artifact, "/v1/messages/count_tokens", {"model": "custom-alpha", "messages": []}
+                )
+            )
+        backend = scenario.trainer.training_backend
+        prepared = backend.prepare_step(
+            TraceBatch("batch", (TraceSample("record", {"messages": []}, 0.0),)), backend.initial_state(), 0
+        )
+        assert prepared.candidate is not None
+        plugin = DefaultCandidateEvaluationPlugin(backend, ScoreComparisonSelector())
+        evaluation = plugin.evaluate(prepared.candidate)
+        result = backend.settle_step(prepared, plugin.decide(prepared.candidate, evaluation))
+        assert result.metrics["selected"] is True
+        calls = platform["calls"]
+        assert len(calls) == (
+            7 if api == "anthropic" else 6
+        )  # inference, proposer, two episodes, two judges (+ count)
+        for path, raw_headers, body in calls:
+            headers = {k.lower(): v for k, v in raw_headers.items()}
+            assert path.startswith("/alpha/1/")
+            assert body["model"] == "custom-alpha"
+            if api == "anthropic":
+                assert headers["x-api-key"] == "scoped-alpha-1"
+                assert "authorization" not in headers
+            else:
+                assert headers["authorization"] == "Bearer scoped-alpha-1"
+            assert "platform-key" not in json.dumps(raw_headers)
+        assert "scoped-alpha" not in json.dumps(prepared.candidate.candidate_files)
+        assert "scoped-alpha" not in json.dumps(result.state)
+        result.publication.artifact.discard()
+    finally:
+        dispatcher.close()
+
+
+def test_concurrent_scenarios_rotation_and_fail_closed(platform, tmp_path):
+    configure(platform, "alpha", "openai")
+    configure(platform, "beta", "anthropic")
+    recipe = make_recipe(platform, tmp_path)
+    alpha = recipe.for_scenario("alpha")
+    beta = recipe.for_scenario("beta")
+    with ThreadPoolExecutor(2) as executor:
+        list(
+            executor.map(
+                lambda r: r.model_bindings().served.chat([{"role": "user", "content": "parallel"}]), (alpha, beta)
+            )
+        )
+    assert {path.split("/")[1] for path, _, _ in platform["calls"]} == {"alpha", "beta"}
+    first = alpha.model_bindings()
+    configure(platform, "alpha", "anthropic", "2")
+    second = alpha.model_bindings()
+    assert first.served.api_key == "scoped-alpha-1"
+    assert second.served.api_key == "scoped-alpha-2"
+    assert all(binding.api == "anthropic" for binding in second.values())
+    assert isinstance(alpha.runtime, ScenarioProviderRuntime)
+    with pytest.raises(ProviderResolutionError):
+        alpha.runtime.request_backend("1")
+    platform["fail"] = True
+    for bound in (alpha, beta):
+        with pytest.raises(ProviderResolutionError):
+            bound.model_bindings()
+    assert not any("/managed/" in path for path, _, _ in platform["calls"])
+
+
+def test_model_auth_failure_never_falls_back(platform, tmp_path):
+    configure(platform, "alpha", "openai")
+    recipe = make_recipe(platform, tmp_path).for_scenario("alpha")
+    bindings = recipe.model_bindings()
+    platform["fail_models"] = True
+    with pytest.raises(Exception, match="401"):
+        bindings["teacher"].chat([{"role": "user", "content": "proposer"}])
+    assert len(platform["calls"]) == 1
+    assert platform["calls"][0][0].startswith("/alpha/")
+
+
+def test_http_contract_checks_version_and_installs_selected_protocol(platform, tmp_path):
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from reef.harness.adapters import get_adapter
+    from reef.service.app import create_app
+    from reef.service.request_service import RequestService
+
+    configure(platform, "alpha", "openai")
+    recipe = make_recipe(platform, tmp_path)
+    initial = tmp_path / "initial"
+    initial.mkdir()
+    for path, content in recipe.base_artifact_files().items():
+        output = initial / path
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content)
+    dispatcher = Dispatcher(recipe, InMemoryRepositoryBackend.factory(initial, root=tmp_path / "repo"))
+
+    async def run():
+        client = TestClient(TestServer(create_app(dispatcher, tokens="deployment-secret")))
+        await client.start_server()
+        headers = {
+            "authorization": "Bearer deployment-secret",
+            "x-reef-scenario": "alpha",
+            "x-reef-provider-version": "1",
+        }
+        try:
+            capabilities = await client.get("/reef/providers/capabilities", headers=headers)
+            assert (await capabilities.json())["harness_evolve_byok_v1"] is True
+            response = await client.post(
+                "/v1/chat/completions", headers=headers, json={"model": "custom-alpha", "messages": []}
+            )
+            assert response.status == 200, await response.text()
+            assert response.headers["x-reef-agent-record-id"]
+            before = len(platform["calls"])
+            configure(platform, "alpha", "anthropic", "2")
+            stale = await client.post(
+                "/v1/chat/completions", headers=headers, json={"model": "custom-alpha", "messages": []}
+            )
+            assert stale.status == 400
+            assert len(platform["calls"]) == before
+            headers["x-reef-provider-version"] = "2"
+            fresh = await client.post("/v1/messages", headers=headers, json={"model": "custom-alpha", "messages": []})
+            assert fresh.status == 200, await fresh.text()
+            service = RequestService(dispatcher)
+            scenario = dispatcher.get_or_create_scenario("alpha")
+            # The live config takes precedence over the old release's model dialect.
+            binding = service._install_binding(
+                scenario,
+                {"release_id": scenario.repository.require_current_artifact().release_id},
+                get_adapter("pi"),
+                {"host": "platform.example", "x-forwarded-proto": "https"},
+            )
+            rendered = json.dumps(binding)
+            assert "anthropic-messages" in rendered
+            assert "https://platform.example" in rendered
+            assert "scoped-alpha" not in rendered
+            assert "managed-alternative" not in rendered
+        finally:
+            await client.close()
+
+    try:
+        asyncio.run(run())
+    finally:
+        dispatcher.close()


### PR DESCRIPTION
## Motivation

Harness evolve scenarios need to use their own OpenAI-compatible or Anthropic-compatible provider throughout inference, proposing, evaluation episodes and model-based judging. The matching platform UI and credential proxy are in https://github.com/Human-Agent-Society/reef_api/pull/50.

This is a maintainer-directed implementation with explicit authorization to merge from the development session. No separate RFC issue was opened.

## Changes

- Bind each scenario to a platform resolver and freeze model configuration per request or evolution step. Replace served and named model bindings in BYOK mode, and pass the same snapshot into evaluation workers and judges, including multiprocessing workers.
- Return only scenario/version-scoped proxy credentials from the platform, reject resolver failures and stale versions without managed fallback, and keep credentials out of published harnesses. Installed clients use the selected provider protocol and model.
- Add the authenticated provider capability endpoint, operator/API documentation, and real HTTP/subprocess tests for both protocols, rotation, scenario isolation and worker execution.
- Correct an existing documentation-check false positive on main: the naming-policy example list may name the words it restricts; other instruction text remains checked.

## Compatibility and operational impact

BYOK is opt-in via `REEF_BYOK_RESOLVER_URL` and `REEF_BYOK_RESOLVER_TOKEN`, and only supported for a `CordisRecipe` named `harness_evolve`. Without resolver configuration, deployment-wide model behavior is preserved. The platform and episode workers must be mutually reachable as documented.

Deterministic scorers keep their existing signature. Model-based scorers use `score_with_models` or a callable accepting `models`; methods using independent model clients must migrate to that contract. Replacing a binding invalidates later calls from an active step rather than changing its key mid-step.

## Verification

- Focused BYOK, evaluation-worker and harness-recipe suites: 114 passed, including OpenAI/Anthropic HTTP calls and single/multiprocess evaluation.
- `pre-commit run --all-files`: passed.
- Full `pytest tests/` with Git configuration isolated: 2,845 passed, 30 skipped (optional environments), 16 warnings.
- Documentation links/contracts, lint and production build: passed (one existing font lint warning). The terminology check also still rejects restricted terms outside its policy example list.
- Mypy on all 13 changed Python source files: passed. GitHub CI lint, including full mypy in the CI dependency environment, passed.
- Full mypy reports four existing PyTorch-related errors in unchanged `lora_transport.py` and `checkpoint.py`; reproduced identically on clean `a8c294e`. Changed sources add no errors. CI also runs mypy in its minimal dependency environment.

## AI assistance

Codex implemented the maintainer's requested behavior, reconciled the changes with current main, and ran local verification. The human contributor retains responsibility for this change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [ ] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

Merge requested explicitly by the maintainer after local verification. GitHub CI results are attached to this PR. See the repository maintenance model for the normal review workflow.
