### PR TITLE
feat: connect local Reef runtimes to the dashboard

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -55,27 +55,34 @@ and the Git-backed release chain, to the ``reef.*_dir`` paths in the config.
 Connect to the API platform
 --------------------------
 
-With Reef already serving, run this in another terminal:
+With Reef already serving, open another terminal in your Reef project directory.
+This example connects the runtime on port 9000 to a local API platform on port 3000:
 
 .. code:: bash
 
-   reef connect
+   uv run reef connect \
+     --url http://127.0.0.1:9000 \
+     --platform http://localhost:3000 \
+     --name workstation \
+     --no-browser --foreground
+
+Set ``--url`` to your running Reef service's address and ``--platform`` to
+your API platform's address. Replace both example addresses to match your setup.
+``--name`` sets the label shown in the console.
 
 Open the printed sign-in link, sign in, and paste the device code from your
 terminal into the page. The code is required and expires after ten minutes.
 The link does not contain the code, and the page never fills it in for you.
-The connector runs in the background after approval. Open **Local Reef** in
+With ``--no-browser``, open the link yourself; ``--foreground`` keeps the
+connector in this terminal, which must remain open. Omit ``--foreground``
+to run it in the background after approval. Open **Local Reef** in
 the API platform to view the runtime from another device. No inbound port,
 public endpoint, browser access to localhost, or ``console_origins`` setting
 is required for this connection.
 
-The default runtime URL is ``http://127.0.0.1:8900`` and the default platform
-is ``https://api.reefinfra.ai``. For a different runtime or platform:
-
-.. code:: bash
-
-   reef connect --url http://127.0.0.1:9000 --name workstation
-   reef connect --platform http://localhost:3000 --no-browser --foreground
+If omitted, ``--url`` defaults to ``http://127.0.0.1:8900`` and
+``--platform`` defaults to ``https://api.reefinfra.ai``. Each invocation
+uses its own arguments; it does not inherit addresses from a previous command.
 
 URLs must use HTTPS except for loopback HTTP. If the existing service requires
 a token, set ``REEF_TOKEN`` in the connector's environment; use
@@ -92,14 +99,9 @@ platform as commands. Inference continues to use your runtime URL directly.
 Lifecycle and local state
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: bash
-
-   reef connect --status
-   reef connect --stop
-   reef connect
-
-Use the same ``--url`` and ``--platform`` options when inspecting, stopping,
-or restarting a non-default connection. Stopping the connector leaves Reef
+Use the same ``--url`` and ``--platform`` options with ``--status`` to
+inspect the connector or ``--stop`` to stop it. Rerun the connection command
+above to restart it. Stopping the connector leaves Reef
 serving and retains authorization. **Revoke connection** in the console
 disables the credential; a revoked connector exits and requires a new login.
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -1,8 +1,9 @@
-Reef CLI: start a deployment
-============================
+Reef CLI: serve and connect
+==========================
 
-Reef has one command you run. It reads a deployment config and starts every
-process the config declares, in dependency order. (The wheel also installs
+``reef serve`` reads a deployment config and starts every
+process the config declares, in dependency order. ``reef connect`` optionally
+links an existing runtime to your API platform account. (The wheel also installs
 ``reef-native`` and ``reef-terminus``, the loop runners those two harness
 adapters launch per episode; nothing calls them by hand.)
 
@@ -50,3 +51,73 @@ Where it writes
 Each service gets a log and a PID file under ``run_dir``, which defaults to
 ``/tmp/reef-stack``. Reef writes its own state, including records, commit logs,
 and the Git-backed release chain, to the ``reef.*_dir`` paths in the config.
+
+Connect to the API platform
+--------------------------
+
+With Reef already serving, run this in another terminal:
+
+.. code:: bash
+
+   reef connect
+
+Open the printed sign-in link, sign in, and paste the device code from your
+terminal into the page. The code is required and expires after ten minutes.
+The link does not contain the code, and the page never fills it in for you.
+The connector runs in the background after approval. Open **Local Reef** in
+the API platform to view the runtime from another device. No inbound port,
+public endpoint, browser access to localhost, or ``console_origins`` setting
+is required for this connection.
+
+The default runtime URL is ``http://127.0.0.1:8900`` and the default platform
+is ``https://api.reefinfra.ai``. For a different runtime or platform:
+
+.. code:: bash
+
+   reef connect --url http://127.0.0.1:9000 --name workstation
+   reef connect --platform http://localhost:3000 --no-browser --foreground
+
+URLs must use HTTPS except for loopback HTTP. If the existing service requires
+a token, set ``REEF_TOKEN`` in the connector's environment; use
+``--reef-token-env VARIABLE`` to select a different environment variable.
+Do not put tokens in URLs or command-line arguments.
+
+The platform receives scenario names, serving release identifiers, training
+modes and selected numeric evaluation results. It can create a scenario,
+request training, change training mode, promote or roll back a release.
+Local provider credentials, artifact files, and recorded prompts are not
+uploaded. Instructions you submit through the dashboard are stored on the
+platform as commands. Inference continues to use your runtime URL directly.
+
+Lifecycle and local state
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+   reef connect --status
+   reef connect --stop
+   reef connect
+
+Use the same ``--url`` and ``--platform`` options when inspecting, stopping,
+or restarting a non-default connection. Stopping the connector leaves Reef
+serving and retains authorization. **Revoke connection** in the console
+disables the credential; a revoked connector exits and requires a new login.
+
+By default, each platform/runtime URL pair has a private directory under
+``~/.reef/connections/``. It stores an instance UUID, service and connector
+credentials, a SQLite command record, a process lock, and a background log.
+The directory is mode 0700 and credential files are mode 0600 on POSIX systems.
+``--state-dir PATH`` selects an explicit directory. Preserve it to keep the
+same identity; do not share or copy it between running machines.
+
+The connector reconnects after network failures. It does not install an OS
+startup service; use ``--foreground`` with your process supervisor for restart
+after a machine reboot. It reports heartbeats every three seconds and scenario
+summaries about every fifteen seconds. The console marks it offline after
+45 seconds without a heartbeat and retains its last scenario summary.
+
+Commands are delivered once. An interrupted operation is marked **unknown**,
+and is not replayed automatically. Check Reef before submitting it again.
+Completed results are saved locally until the platform acknowledges them;
+cloud command history is retained for 30 days. Closing a browser or revoking a
+connection cannot undo an operation already dispatched to Reef.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -26,6 +26,14 @@ a bare ``--model_path /models/demo`` targets the ``reef`` section, and a dotted
 ``--training.checkpoint_dir /tmp/ckpt`` targets any other. Each process writes a
 log under ``/tmp/reef-stack/``; set ``run_dir`` to move it.
 
+Use ``${VAR:?}`` for a required environment variable, for example
+``upstream_model: ${REEF_UPSTREAM_MODEL:?}``. If it is unset, empty, or only
+whitespace, Reef reports the missing variable names and their config fields
+before downloading models or starting processes. Command-line overrides are
+applied before this check, so ``--upstream_model <model-id>`` can supply the
+value instead. Plain ``${VAR}`` keeps resolving to an empty string when unset;
+use it for optional values such as an API key for a provider without authentication.
+
 ``REEF_PYTHON`` defaults to the interpreter that launched ``reef serve`` and
 can be overridden in the environment. Use it when a service must share Reef's
 Python environment. A literal ``python`` keeps its normal meaning and is
@@ -73,6 +81,7 @@ The ``reef`` section
    reef.recipe | the recipe this deployment serves. Required.
    reef.host | 0.0.0.0 | bind address
    reef.port | 8900 | bind port
+   reef.console_origins | [] | exact browser console origins allowed to access the HTTP service; disabled by default
    reef.token | the bearer token the service accepts. Use ``tokens: [...]`` to accept several while rotating.
    reef.model_path | a local HF model directory or a repo id, downloaded on start
    reef.upstream_url | the OpenAI-compatible provider, with no ``/v1`` suffix

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -723,3 +723,34 @@ Status codes
 Reef relays upstream 4xx failures with the provider's original message; the
 common client statuses (400, 401, 403, 404, 408, 409, 422, 429) keep their
 status code, and any other upstream 4xx comes back as 400.
+
+Browser consoles
+----------------
+
+The service can opt in to direct browser access with ``reef.console_origins``
+in the serve YAML. List each trusted console origin explicitly, with no path,
+trailing slash, credentials, or wildcard:
+
+.. code-block:: yaml
+
+   reef:
+     console_origins:
+       - "https://api.reefinfra.ai"
+       - "http://localhost:3000"
+
+Restart the service after changing the configuration. Without this option, Reef
+does not add CORS headers. With it, unlisted browser origins are rejected before
+a route runs. CORS preflight requests from listed origins do not need a service
+token; actual requests retain the configured Bearer authentication. Browser
+requests may use GET, POST or DELETE with Authorization, Content-Type and
+x-reef-scenario headers. Cookies are not enabled through CORS.
+
+CORS headers also cover errors and streamed responses, exposing
+``x-reef-agent-record-id``, ``x-reef-release-id`` and ``x-reef-artifact-version``
+to the browser. Clients without an Origin header keep their existing behavior.
+A browser may additionally require local network permission or HTTPS; allowing
+an origin in Reef does not override browser policy.
+
+A connected console acts with the service token's existing permissions. Its
+requests operate directly on this runtime's scenarios, without creating a
+cloud deployment or uploading history as part of the CORS connection.

--- a/reef/cli.py
+++ b/reef/cli.py
@@ -2,6 +2,7 @@
 
 Usage:
   reef serve -c path/to/stack.yaml             # start a configured stack
+  reef connect                               # link an existing runtime to the console
 
 `reef serve` reads a config's `services` list and starts every declared
 process in dependency order, including the internal Reef HTTP service.
@@ -16,7 +17,7 @@ from __future__ import annotations
 
 import sys
 
-_COMMANDS = {"serve"}
+_COMMANDS = {"serve", "connect"}
 
 
 def _help_text():
@@ -24,6 +25,7 @@ def _help_text():
 usage: reef <command> [options]
 
   serve  Start a stack from a config
+  connect  Connect an existing Reef runtime to the API platform
 
   -c CONFIG   Config file (default: reef.yaml or $REEF_CONFIG)
   --version   Print the installed reef version
@@ -31,6 +33,7 @@ usage: reef <command> [options]
 Examples:
   reef serve -c path/to/local-sglang.yaml
   reef serve -c path/to/external-provider.yaml
+  reef connect
 """
 
 
@@ -58,6 +61,12 @@ def main(argv=None):
         print(f"reef: unknown command '{cmd}'\n", file=sys.stderr)
         print(_help_text(), file=sys.stderr)
         sys.exit(2)
+
+    if cmd == "connect":
+        from reef.service.connector import main as _connect_main
+
+        _connect_main(rest)
+        return
 
     from reef.service.deploy import DeployConfigError
     from reef.service.deploy import main as _serve_main

--- a/reef/service/app.py
+++ b/reef/service/app.py
@@ -8,6 +8,7 @@ from aiohttp import web
 from reef.dispatcher import Dispatcher, build_default_dispatcher
 from reef.runtime.inference import InferenceBackend
 from reef.service.auth import create_authentication_middleware
+from reef.service.cors import configure_browser_access
 from reef.service.errors import translate_errors
 from reef.service.request_service import InferenceRetryPolicy, RequestService
 from reef.service.routes import register_routes
@@ -17,6 +18,7 @@ def create_app(
     dispatcher: Dispatcher | None = None,
     *,
     tokens: str | Iterable[str] | None = None,
+    console_origins: Iterable[str] = (),
     inference_backend: InferenceBackend | None = None,
     inference_retry_policy: InferenceRetryPolicy | None = None,
     close_dispatcher: bool = False,
@@ -27,6 +29,7 @@ def create_app(
     )
     request_service_key = web.AppKey("reef_request_service", RequestService)
     app = web.Application(middlewares=[create_authentication_middleware(tokens), translate_errors])
+    configure_browser_access(app, console_origins)
     app[request_service_key] = request_service
     register_routes(
         app,

--- a/reef/service/assembly.py
+++ b/reef/service/assembly.py
@@ -249,6 +249,7 @@ def build_app(settings: ServiceSettings, *, environ: Mapping[str, str] | None = 
         return create_app(
             dispatcher,
             tokens=settings.tokens,
+            console_origins=settings.console_origins,
             inference_retry_policy=retry_policy,
             close_dispatcher=True,
         )

--- a/reef/service/connector/__init__.py
+++ b/reef/service/connector/__init__.py
@@ -1,0 +1,292 @@
+"""Opt-in outbound connection from an existing Reef service to its owner's console."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import uuid
+import webbrowser
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import aiohttp
+
+from reef.service.connector.runtime import BODY_LIMIT, HTTPFailure, JSONClient, ReefRuntime, endpoint_url
+from reef.service.connector.state import ConnectorState
+
+logger = logging.getLogger(__name__)
+
+
+class Connector:
+    """Maintain heartbeats independently of one in-flight local operation."""
+
+    def __init__(self, platform: JSONClient, runtime: ReefRuntime, state: ConnectorState):
+        self.platform = platform
+        self.runtime = runtime
+        self.state = state
+
+    async def execute(self, command: dict[str, Any]) -> None:
+        command_id = str(uuid.UUID(command["id"]))
+        if not self.state.start(command_id):
+            return
+        try:
+            value = await self.runtime.execute(command)
+            result: dict[str, Any] = {"state": "succeeded", "value": value}
+            if command.get("action") != "releases":
+                result["snapshot"] = value if command.get("action") == "refresh" else await self.runtime.snapshot()
+            if len(json.dumps(result).encode()) > BODY_LIMIT:
+                result = {"state": "failed", "error": "The result exceeds the connector size limit"}
+        except asyncio.CancelledError:
+            self.state.finish(
+                command_id,
+                {"state": "unknown", "error": "Connector stopped during execution. Check Reef before retrying."},
+            )
+            raise
+        except HTTPFailure as exc:
+            result = {
+                "state": "failed" if 400 <= exc.status < 500 else "unknown",
+                "error": f"Reef returned HTTP {exc.status}. Check the runtime before retrying.",
+            }
+        except (aiohttp.ClientError, TimeoutError):
+            result = {
+                "state": "unknown",
+                "error": "Lost contact with Reef after dispatch. Check the runtime before retrying.",
+            }
+        except (ValueError, KeyError, TypeError):
+            result = {"state": "failed", "error": "Reef returned an unsupported response or command"}
+        self.state.finish(command_id, result)
+
+    async def flush_results(self) -> None:
+        for command_id, result in self.state.pending():
+            try:
+                await self.platform.request(f"/api/connector/commands/{command_id}/result", body=result)
+            except HTTPFailure as exc:
+                if exc.status not in (404, 409):
+                    raise
+                logger.warning("Result %s no longer accepts updates (HTTP %s)", command_id, exc.status)
+            self.state.acknowledge(command_id)
+
+    async def run(self, stop: asyncio.Event) -> None:
+        self.state.recover()
+        operation: asyncio.Task[None] | None = None
+        next_snapshot = 0.0
+        snapshot: dict[str, Any] | None = None
+        retry_seconds = 3.0
+        try:
+            while not stop.is_set():
+                try:
+                    if operation is not None and operation.done():
+                        await operation
+                        operation = None
+                        next_snapshot = 0
+                    await self.flush_results()
+                    if time.monotonic() >= next_snapshot:
+                        snapshot = await self.runtime.snapshot()
+                        next_snapshot = time.monotonic() + 15
+                    body: dict[str, Any] = {"protocol": 1, "ready": operation is None}
+                    if snapshot is not None:
+                        body["snapshot"] = snapshot
+                    response = await self.platform.request("/api/connector/poll", body=body)
+                    snapshot = None
+                    if response.get("protocol") != 1:
+                        raise RuntimeError("Platform requires a newer connector")
+                    command = response.get("command")
+                    if command:
+                        operation = asyncio.create_task(self.execute(command))
+                    retry_seconds = 3.0
+                except HTTPFailure as exc:
+                    if exc.status in (401, 403):
+                        raise RuntimeError("Connection was revoked. Run reef connect to authorize it again.") from exc
+                    logger.warning("Platform unavailable (HTTP %s); reconnecting", exc.status)
+                    retry_seconds = min(30, retry_seconds * 2)
+                except (aiohttp.ClientError, TimeoutError, ValueError):
+                    logger.warning("Platform connection interrupted; reconnecting")
+                    retry_seconds = min(30, retry_seconds * 2)
+                with suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(stop.wait(), timeout=retry_seconds)
+        finally:
+            if operation is not None:
+                operation.cancel()
+                with suppress(asyncio.CancelledError):
+                    await operation
+
+
+async def authorize(config: dict[str, Any], state: ConnectorState, *, no_browser: bool) -> dict[str, Any]:
+    async with aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar(), trust_env=True) as session:
+        platform = JSONClient(session, config["platform_url"], config.get("connector_token", ""))
+        if platform.token:
+            try:
+                await platform.request("/api/connector/poll", body={"protocol": 1, "ready": False})
+                return config
+            except HTTPFailure as exc:
+                if exc.status != 401:
+                    raise
+        platform.token = ""
+        pairing = await platform.request(
+            "/api/connector/pair",
+            body={
+                "protocol": 1,
+                "instance_id": config["instance_id"],
+                "name": config["name"],
+            },
+        )
+        verification = pairing["verification_uri"]
+        login_url, platform_url = urlsplit(endpoint_url(verification)), urlsplit(config["platform_url"])
+        if (login_url.scheme, login_url.netloc) != (platform_url.scheme, platform_url.netloc):
+            raise ValueError("Platform returned a login URL on a different origin")
+        platform.token = pairing["device_token"]
+        print(
+            f"Open {verification}\nDevice code: {pairing['user_code']}\nPaste this code into the page to connect {config['name']}.",
+            flush=True,
+        )
+        print(
+            "The platform can read scenario/version summaries and run training and version commands. Service credentials stay on this machine.",
+            flush=True,
+        )
+        if not no_browser:
+            webbrowser.open(verification)
+        deadline = time.monotonic() + min(float(pairing.get("expires_in", 600)), 600)
+        while time.monotonic() < deadline:
+            status = await platform.request("/api/connector/pair")
+            if status.get("status") == "approved":
+                config["connector_token"] = platform.token
+                config["runtime_id"] = status["runtime_id"]
+                state.save(config)
+                return config
+            await asyncio.sleep(3)
+        raise RuntimeError("Connection code expired; run reef connect again")
+
+
+async def run_connector(config: dict[str, Any], state: ConnectorState) -> None:
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(signum, stop.set)
+    async with (
+        aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar(), trust_env=True) as platform_session,
+        aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar()) as local_session,
+    ):
+        connector = Connector(
+            JSONClient(platform_session, config["platform_url"], config["connector_token"]),
+            ReefRuntime(JSONClient(local_session, config["reef_url"], config.get("reef_token", ""))),
+            state,
+        )
+        await connector.run(stop)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reef connect", description="Connect an existing Reef runtime to your API platform account."
+    )
+    parser.add_argument("--url", default="http://127.0.0.1:8900", help="Existing Reef service URL")
+    parser.add_argument("--platform", default="https://api.reefinfra.ai", help="API platform URL")
+    parser.add_argument("--name", help="Name shown in the console")
+    parser.add_argument(
+        "--reef-token-env", default="REEF_TOKEN", help="Environment variable holding the local service token"
+    )
+    parser.add_argument("--state-dir", type=Path, help="Private state directory for this connection")
+    parser.add_argument("--foreground", action="store_true", help="Stay in the foreground (for service supervisors)")
+    parser.add_argument("--no-browser", action="store_true", help="Print the login link without opening a browser")
+    parser.add_argument(
+        "--stop", action="store_true", help="Stop this connector, keeping its credentials for a later restart"
+    )
+    parser.add_argument(
+        "--status", action="store_true", help="Show this connector's local process and state directory"
+    )
+    parser.add_argument("--run", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def _running(state: ConnectorState) -> bool:
+    try:
+        with state.lock():
+            return False
+    except RuntimeError:
+        return True
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Authorize once, then maintain the connection independently of the browser."""
+    args = _parser().parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    try:
+        platform_url, reef_url = endpoint_url(args.platform), endpoint_url(args.url)
+        connection_key = hashlib.sha256(f"{platform_url}\n{reef_url}".encode()).hexdigest()[:16]
+        directory = args.state_dir or Path.home() / ".reef" / "connections" / connection_key
+        state = ConnectorState(directory)
+        try:
+            running = _running(state)
+            if args.status:
+                print(f"Connector {'running' if running else 'stopped'}\nState: {directory}")
+                return
+            if args.stop:
+                if running:
+                    os.kill(int((directory / "connector.pid").read_text()), signal.SIGTERM)
+                print(
+                    "Connector stopping. Reef continues serving; revoke access in the console to remove authorization."
+                )
+                return
+            if running:
+                raise RuntimeError("This connector is already running; use --status or --stop")
+            config = state.load()
+            if args.run:
+                if not config.get("connector_token"):
+                    raise RuntimeError("Run reef connect to authorize this instance first")
+                with state.lock():
+                    (directory / "connector.pid").write_text(str(os.getpid()))
+                    asyncio.run(run_connector(config, state))
+                return
+            if config and (config.get("platform_url") != platform_url or config.get("reef_url") != reef_url):
+                raise ValueError(
+                    "This state directory belongs to another endpoint; use its original --platform and --url"
+                )
+            config.update(
+                {
+                    "platform_url": platform_url,
+                    "reef_url": reef_url,
+                    "instance_id": config.get("instance_id") or str(uuid.uuid4()),
+                    "name": args.name or config.get("name") or socket.gethostname(),
+                    "reef_token": os.environ.get(args.reef_token_env, config.get("reef_token", "")),
+                }
+            )
+            # Save identity before authorization so interrupted logins cannot create new identities.
+            state.save(config)
+            config = asyncio.run(authorize(config, state, no_browser=args.no_browser))
+            if args.foreground:
+                with state.lock():
+                    (directory / "connector.pid").write_text(str(os.getpid()))
+                    asyncio.run(run_connector(config, state))
+            else:
+                log_path = directory / "connector.log"
+                descriptor = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+                with os.fdopen(descriptor, "a") as output:
+                    process = subprocess.Popen(
+                        [sys.executable, "-m", "reef.service.connector", "--run", "--state-dir", str(directory)],
+                        stdin=subprocess.DEVNULL,
+                        stdout=output,
+                        stderr=output,
+                        start_new_session=True,
+                    )
+                time.sleep(0.5)
+                if process.poll() is not None:
+                    raise RuntimeError(f"Connector did not start. See {log_path}")
+                print(f"Connected {config['name']}. Open {platform_url}/local\nLogs: {log_path}")
+        finally:
+            state.close()
+    except (RuntimeError, ValueError, OSError, aiohttp.ClientError) as exc:
+        print(f"reef connect: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None

--- a/reef/service/connector/__main__.py
+++ b/reef/service/connector/__main__.py
@@ -1,0 +1,3 @@
+from reef.service.connector import main
+
+main()

--- a/reef/service/connector/runtime.py
+++ b/reef/service/connector/runtime.py
@@ -1,0 +1,179 @@
+"""Translate the small connector command vocabulary into native Reef calls."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import math
+from typing import Any
+from urllib.parse import quote, urlsplit
+
+import aiohttp
+
+BODY_LIMIT = 192 * 1024
+
+
+class HTTPFailure(RuntimeError):
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+
+
+def endpoint_url(value: str) -> str:
+    parsed = urlsplit(value)
+    hostname = parsed.hostname or ""
+    try:
+        loopback = ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        loopback = hostname == "localhost" or hostname.endswith(".localhost")
+    if parsed.scheme != "https" and not (parsed.scheme == "http" and loopback):
+        raise ValueError("Use HTTPS, or HTTP on localhost")
+    if not hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("Endpoint URLs cannot contain credentials, a query, or a fragment")
+    _ = parsed.port
+    return value.rstrip("/")
+
+
+class JSONClient:
+    """HTTP boundary with bounded responses, no cookies, redirects, or implicit retries."""
+
+    def __init__(self, session: aiohttp.ClientSession, base_url: str, token: str = ""):
+        self.session = session
+        self.base_url = endpoint_url(base_url)
+        self.token = token
+
+    async def request(
+        self, path: str, *, body: dict[str, Any] | None = None, scenario: str | None = None, timeout: float = 15
+    ) -> dict[str, Any]:
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        if scenario:
+            headers["x-reef-scenario"] = scenario
+        async with self.session.request(
+            "GET" if body is None else "POST",
+            self.base_url + path,
+            headers=headers,
+            json=body,
+            timeout=aiohttp.ClientTimeout(total=timeout),
+            allow_redirects=False,
+        ) as response:
+            chunks = bytearray()
+            async for chunk in response.content.iter_chunked(8192):
+                chunks.extend(chunk)
+                if len(chunks) > 2 * 1024 * 1024:
+                    raise HTTPFailure(502, "Response exceeds the connector size limit")
+            if response.status < 200 or response.status >= 300:
+                # Do not upload runtime error bodies: they can contain credentials, paths, or provider payloads.
+                raise HTTPFailure(response.status, f"HTTP {response.status}")
+            import json
+
+            try:
+                result = json.loads(chunks)
+            except (ValueError, UnicodeDecodeError) as exc:
+                raise HTTPFailure(502, "Expected a JSON object") from exc
+            if not isinstance(result, dict):
+                raise HTTPFailure(502, "Expected a JSON object")
+            return result
+
+
+class ReefRuntime:
+    def __init__(self, client: JSONClient):
+        self.client = client
+
+    async def snapshot(self) -> dict[str, Any]:
+        try:
+            listing, status = await asyncio.gather(
+                self.client.request("/reef/scenarios", timeout=5), self.client.request("/reef/status", timeout=5)
+            )
+            entries = listing.get("scenarios")
+            if not isinstance(entries, list) or len(entries) > 200:
+                raise ValueError("Expected at most 200 scenarios")
+            scenarios = []
+            for item in entries:
+                name = scenario_name(item.get("scenario"))
+                row = {"scenario": name}
+                if isinstance(item.get("release_id"), str):
+                    row["release_id"] = item["release_id"][:180]
+                mode = status.get("scenarios", {}).get(name, {}).get("training_mode")
+                if mode in ("auto", "manual", "hybrid"):
+                    row["training_mode"] = mode
+                scenarios.append(row)
+            return {"reachable": True, "scenarios": scenarios}
+        except (aiohttp.ClientError, TimeoutError, ValueError, HTTPFailure, TypeError, AttributeError):
+            return {
+                "reachable": False,
+                "scenarios": [],
+                "error": "Cannot read Reef. Check the local URL, service token and runtime status.",
+            }
+
+    async def execute(self, command: dict[str, Any]) -> dict[str, Any]:
+        action = command.get("action")
+        if action == "refresh":
+            return await self.snapshot()
+        name = scenario_name(command.get("scenario"))
+        path = "/reef/scenarios/" + quote(name, safe="")
+        if action == "releases":
+            result = await self.client.request(path + "/releases")
+            rows = result.get("releases")
+            if not isinstance(rows, list):
+                raise ValueError("Reef did not return a release list")
+            return {"releases": [release_summary(row) for row in rows[:100]], "truncated": len(rows) > 100}
+        if action == "create_scenario":
+            await self.client.request("/reef/scenarios", body={"name": name}, timeout=60)
+        elif action == "set_training_mode":
+            mode = command.get("training_mode")
+            if mode not in ("auto", "manual", "hybrid"):
+                raise ValueError("Invalid training mode")
+            await self.client.request(path + "/update", body={"training_mode": mode}, timeout=60)
+        elif action in ("promote", "rollback"):
+            release_id = command.get("release_id")
+            if not isinstance(release_id, str) or not release_id or len(release_id) > 180:
+                raise ValueError("Invalid release ID")
+            await self.client.request(path + "/" + action, body={"release_id": release_id}, timeout=60)
+        elif action == "train":
+            instruction = command.get("text")
+            if not isinstance(instruction, str) or not instruction.strip() or len(instruction) > 4000:
+                raise ValueError("Invalid training instruction")
+            await self.client.request(
+                "/reef/train", scenario=name, body={"text": instruction, "agent_record_id": command["id"]}, timeout=60
+            )
+            return {"scenario": name, "agent_record_id": command["id"]}
+        else:
+            raise ValueError("Unsupported connector action")
+        return {"scenario": name}
+
+
+def scenario_name(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 180
+        or value in (".", "..")
+        or any(character in value for character in ("/", "\\", "\r", "\n", "\0"))
+    ):
+        raise ValueError("Invalid scenario name")
+    return value
+
+
+def release_summary(row: Any) -> dict[str, Any]:
+    """Only publish catalog identifiers and numeric gate results, never artifact files or prompts."""
+    if not isinstance(row, dict):
+        raise ValueError("Invalid release row")
+    result: dict[str, Any] = {}
+    for key in ("release_id", "parent_release_id", "content_id", "operation", "rollback_target_release_id"):
+        if isinstance(row.get(key), str):
+            result[key] = row[key][:180]
+    for key in ("current", "pending", "restorable", "checkpoint"):
+        if isinstance(row.get(key), bool):
+            result[key] = row[key]
+    if isinstance(row.get("recorded_at"), (int, float)) and math.isfinite(row["recorded_at"]):
+        result["recorded_at"] = row["recorded_at"]
+    metrics = row.get("metrics")
+    if isinstance(metrics, dict):
+        result["metrics"] = {
+            key: metrics[key]
+            for key in ("selected", "wins", "losses", "ties", "candidate_score", "current_score")
+            if isinstance(metrics.get(key), (bool, int, float)) and math.isfinite(metrics[key])
+        }
+        if metrics.get("skipped"):
+            result["metrics"]["skipped"] = True
+    return result

--- a/reef/service/connector/state.py
+++ b/reef/service/connector/state.py
@@ -1,0 +1,100 @@
+"""Private connector configuration and a durable record of dispatched commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+
+class ConnectorState:
+    """Keep credentials on this machine and never re-execute a recorded command."""
+
+    def __init__(self, directory: Path):
+        self.directory = directory
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+        self.config_path = directory / "connection.json"
+        self.db = sqlite3.connect(directory / "commands.sqlite3")
+        os.chmod(directory / "commands.sqlite3", 0o600)
+        self.db.execute("PRAGMA synchronous=FULL")
+        self.db.execute(
+            "CREATE TABLE IF NOT EXISTS commands (id TEXT PRIMARY KEY, result TEXT, acknowledged INTEGER DEFAULT 0)"
+        )
+        self.db.commit()
+
+    def load(self) -> dict[str, Any]:
+        if not self.config_path.exists():
+            return {}
+        return json.loads(self.config_path.read_text())
+
+    def save(self, config: dict[str, Any]) -> None:
+        temporary = self.directory / "connection.tmp"
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "w") as stream:
+            json.dump(config, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, self.config_path)
+
+    @contextmanager
+    def lock(self):
+        """OS locks release on crashes; a PID file alone cannot prove ownership."""
+        stream = (self.directory / "connector.lock").open("a+b")
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                stream.write(b"0")
+                stream.flush()
+                stream.seek(0)
+                msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            stream.close()
+            raise RuntimeError("A connector is already running for this instance") from exc
+        try:
+            yield
+        finally:
+            stream.close()
+
+    def recover(self) -> None:
+        self.db.execute(
+            "UPDATE commands SET result=? WHERE result IS NULL",
+            (
+                json.dumps(
+                    {"state": "unknown", "error": "Connector restarted after dispatch. Check Reef before retrying."}
+                ),
+            ),
+        )
+        self.db.commit()
+
+    def start(self, command_id: str) -> bool:
+        cursor = self.db.execute("INSERT OR IGNORE INTO commands (id) VALUES (?)", (command_id,))
+        self.db.commit()
+        return cursor.rowcount == 1
+
+    def finish(self, command_id: str, result: dict[str, Any]) -> None:
+        self.db.execute("UPDATE commands SET result=?, acknowledged=0 WHERE id=?", (json.dumps(result), command_id))
+        self.db.commit()
+
+    def pending(self) -> list[tuple[str, dict[str, Any]]]:
+        return [
+            (row[0], json.loads(row[1]))
+            for row in self.db.execute(
+                "SELECT id,result FROM commands WHERE acknowledged=0 AND result IS NOT NULL LIMIT 20"
+            )
+        ]
+
+    def acknowledge(self, command_id: str) -> None:
+        self.db.execute("UPDATE commands SET acknowledged=1 WHERE id=?", (command_id,))
+        self.db.commit()
+
+    def close(self) -> None:
+        self.db.close()

--- a/reef/service/cors.py
+++ b/reef/service/cors.py
@@ -1,0 +1,85 @@
+"""Opt-in browser access to a Reef service from explicitly trusted consoles."""
+
+from collections.abc import Iterable
+from urllib.parse import urlsplit
+
+from aiohttp import web
+
+_METHODS = frozenset({"GET", "POST", "DELETE"})
+_HEADERS = frozenset({"authorization", "content-type", "x-reef-scenario"})
+_EXPOSE = "x-reef-agent-record-id, x-reef-release-id, x-reef-artifact-version"
+
+
+def console_origins(values: Iterable[str]) -> tuple[str, ...]:
+    """Validate exact HTTP(S) origins; wildcards and URL paths are not origins."""
+    if isinstance(values, str):
+        raise ValueError("reef.console_origins must be a list of origins")
+    origins: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            raise ValueError("reef.console_origins must contain only origins")
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme not in ("http", "https")
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+            or "*" in value
+            or any(character.isspace() for character in value)
+            or value != f"{parsed.scheme}://{parsed.netloc}"
+        ):
+            raise ValueError("reef.console_origins must contain exact HTTP(S) origins without paths or wildcards")
+        # Force validation of an explicitly supplied port.
+        _ = parsed.port
+        origins.append(value)
+    return tuple(dict.fromkeys(origins))
+
+
+def configure_browser_access(app: web.Application, origins: Iterable[str]) -> None:
+    """Allow CORS preflights before authentication, retaining auth for actual calls.
+
+    Streamed responses prepare headers inside their handler, so CORS headers
+    are attached with on_response_prepare, including for authentication errors.
+    Unlisted browser origins are refused before a handler can change state.
+    Non-browser clients without an Origin header retain their existing behavior.
+    """
+    allowed = frozenset(console_origins(origins))
+    if not allowed:
+        return
+
+    @web.middleware
+    async def browser_access(request: web.Request, handler):
+        origin = request.headers.get("Origin")
+        if origin is None:
+            return await handler(request)
+        if origin not in allowed:
+            raise web.HTTPForbidden(text="console origin is not allowed")
+        if request.method == "OPTIONS" and "Access-Control-Request-Method" in request.headers:
+            method = request.headers["Access-Control-Request-Method"]
+            headers = {
+                value.strip().lower()
+                for value in request.headers.get("Access-Control-Request-Headers", "").split(",")
+                if value.strip()
+            }
+            if method not in _METHODS or not headers.issubset(_HEADERS):
+                raise web.HTTPForbidden(text="console request method or headers are not allowed")
+            response = web.Response(status=204)
+            response.headers["Access-Control-Allow-Methods"] = ", ".join(sorted(_METHODS))
+            response.headers["Access-Control-Allow-Headers"] = ", ".join(sorted(_HEADERS))
+            response.headers["Access-Control-Max-Age"] = "600"
+            if request.headers.get("Access-Control-Request-Private-Network") == "true":
+                response.headers["Access-Control-Allow-Private-Network"] = "true"
+            return response
+        return await handler(request)
+
+    async def prepare(request: web.Request, response: web.StreamResponse) -> None:
+        response.headers.add("Vary", "Origin")
+        if request.headers.get("Origin") in allowed:
+            response.headers["Access-Control-Allow-Origin"] = request.headers["Origin"]
+            response.headers["Access-Control-Expose-Headers"] = _EXPOSE
+
+    app.middlewares.insert(0, browser_access)
+    app.on_response_prepare.append(prepare)

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -2,8 +2,9 @@
 
 ``reef serve`` configs are YAML with two interpolation passes: ``${VAR}``
 against the process environment at load time (with ``REEF_PYTHON`` defaulting
-to the current interpreter), and ``${dotted.path}`` against the config itself
-when a service command or setting is materialized.
+to the current interpreter and ``${VAR:?}`` requiring a non-empty value), and
+``${dotted.path}`` against the config itself when a service command or setting
+is materialized.
 """
 
 from __future__ import annotations
@@ -28,22 +29,46 @@ except ImportError as exc:  # pragma: no cover - environment-dependent
     raise DeployConfigError("PyYAML is required: pip install pyyaml") from exc
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
-_ENV_VAR_RE = re.compile(r"\$\{(\w+)\}")
+_ENV_VAR_RE = re.compile(r"\$\{(\w+)(:\?)?\}")
 _CFG_VAR_RE = re.compile(r"\$\{([\w.-]+)\}")
 
 
-def _interp_env(value: str, environ: Mapping[str, str]) -> str:
-    return _ENV_VAR_RE.sub(lambda m: environ.get(m.group(1), ""), value)
-
-
-def _deep_interp_env(obj: Any, environ: Mapping[str, str]) -> Any:
+def _deep_interp_env(obj: Any, environ: Mapping[str, str], missing: dict[str, list[str]], location: str = "") -> Any:
     if isinstance(obj, dict):
-        return {key: _deep_interp_env(item, environ) for key, item in obj.items()}
+        return {
+            key: _deep_interp_env(item, environ, missing, f"{location}.{key}" if location else str(key))
+            for key, item in obj.items()
+        }
     if isinstance(obj, list):
-        return [_deep_interp_env(item, environ) for item in obj]
+        return [_deep_interp_env(item, environ, missing, f"{location}[{index}]") for index, item in enumerate(obj)]
     if isinstance(obj, str):
-        return _interp_env(obj, environ)
+
+        def replace(match: re.Match[str]) -> str:
+            name = match.group(1)
+            value = environ.get(name, "")
+            if match.group(2) and not value.strip():
+                locations = missing.setdefault(name, [])
+                if location not in locations:
+                    locations.append(location)
+            return value
+
+        return _ENV_VAR_RE.sub(replace, obj)
     return obj
+
+
+def interpolate_environment(config: Mapping[str, Any], config_path: str | Path) -> dict[str, Any]:
+    """Expand environment references, reporting every missing required variable."""
+    environ = dict(os.environ)
+    environ.setdefault("REEF_PYTHON", sys.executable)
+    missing: dict[str, list[str]] = {}
+    resolved = _deep_interp_env(dict(config), environ, missing)
+    if missing:
+        details = "\n".join(f"  {name} ({', '.join(locations)})" for name, locations in missing.items())
+        raise DeployConfigError(
+            f"config {config_path}: missing or empty required environment variables:\n{details}\n"
+            "Set these variables before running reef serve, or override the corresponding config fields."
+        )
+    return resolved
 
 
 def config_value(
@@ -86,7 +111,8 @@ def interpolate_config(config: Mapping[str, Any], value: str) -> str:
     raise DeployConfigError("config interpolation exceeded 64 levels")
 
 
-def load_config(config_path: str | Path) -> dict[str, Any]:
+def load_config(config_path: str | Path, *, interpolate_env: bool = True) -> dict[str, Any]:
+    """Read a deployment config; defer interpolation when applying CLI overrides."""
     path = Path(config_path)
     if not path.is_absolute():
         path = PROJECT_ROOT / path
@@ -101,9 +127,7 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
         config = {}
     if not isinstance(config, dict):
         raise DeployConfigError(f"config {path} must be a YAML object at the root, not {type(config).__name__}")
-    environ = dict(os.environ)
-    environ.setdefault("REEF_PYTHON", sys.executable)
-    return _deep_interp_env(config, environ)
+    return interpolate_environment(config, path) if interpolate_env else config
 
 
 def recipe_source_root(config: Mapping[str, Any], config_path: str | Path) -> Path | None:

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -32,6 +32,7 @@ from reef.service.deploy.config import (
     PROJECT_ROOT,
     config_value,
     interpolate_config,
+    interpolate_environment,
     load_config,
     recipe_source_root,
     resolve_model_paths,
@@ -369,9 +370,10 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
     resolved_config_path = Path(config_path)
     if not resolved_config_path.is_absolute():
         resolved_config_path = PROJECT_ROOT / resolved_config_path
-    config = load_config(resolved_config_path)
+    config = load_config(resolved_config_path, interpolate_env=False)
     if overrides:
         config = _apply_overrides(config, overrides)
+    config = interpolate_environment(config, resolved_config_path)
     # Structure first, so a bad stack fails before a model download, a run dir, or a child process.
     services = validate_services(config, resolved_config_path)
     # Resolved against the operator's config, before any override copy

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from reef.service.cors import console_origins
 from reef.service.deploy.config import config_value, interpolate_config, load_config
 
 _DESCRIPTION = """reef serve — start a stack from a config.
@@ -72,6 +73,7 @@ class ServiceSettings:
     host: str = "0.0.0.0"
     port: int = 8900
     tokens: tuple[str, ...] = ()
+    console_origins: tuple[str, ...] = ()
     ray_address: str | None = None
     ray_namespace: str = "reef"
     ray_actor_name: str = "reef-train-bridge"
@@ -189,6 +191,15 @@ def _service_tokens(config: Mapping[str, Any]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(tokens))
 
 
+def _console_origins(config: Mapping[str, Any]) -> tuple[str, ...]:
+    listed = _config_service_mapping(config, "reef").get("console_origins", ())
+    if isinstance(listed, str) or not isinstance(listed, Sequence):
+        raise ValueError("reef.console_origins must be a list of origins")
+    if not all(isinstance(value, str) for value in listed):
+        raise ValueError("reef.console_origins must contain only origins")
+    return console_origins(tuple(interpolate_config(config, value) for value in listed))
+
+
 def service_settings_from_config(config: Mapping[str, Any]) -> ServiceSettings:
     """Translate the config's ``reef`` section into HTTP service settings."""
     selected_recipe = _config_service_value(config, "reef", "recipe")
@@ -201,6 +212,7 @@ def service_settings_from_config(config: Mapping[str, Any]) -> ServiceSettings:
         host=_config_service_value(config, "reef", "host", default="0.0.0.0"),
         port=int(_config_service_value(config, "reef", "port", default="8900")),
         tokens=_service_tokens(config),
+        console_origins=_console_origins(config),
         recipe=selected_recipe,
         ray_address=_config_service_value(config, "reef", "ray_address"),
         ray_namespace=_config_service_value(config, "reef", "ray_namespace", default="reef"),

--- a/tests/reef_service/test_connector.py
+++ b/tests/reef_service/test_connector.py
@@ -1,0 +1,367 @@
+"""Connector contracts: bounded access, private credentials and durable command outcomes."""
+
+import asyncio
+import json
+import os
+import signal
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from reef.cli import main
+from reef.service.connector import Connector, _running, authorize
+from reef.service.connector.runtime import HTTPFailure, JSONClient, ReefRuntime, endpoint_url, release_summary
+from reef.service.connector.state import ConnectorState
+
+
+def test_connection_state_survives_restart_without_replay(tmp_path):
+    first, second = str(uuid.uuid4()), str(uuid.uuid4())
+    state = ConnectorState(tmp_path)
+    state.save({"connector_token": "private-test-token", "instance_id": first})
+    assert state.start(first)
+    assert state.start(second)
+    state.finish(second, {"state": "succeeded", "value": {"scenario": "original"}})
+    state.close()
+    state = ConnectorState(tmp_path)
+    try:
+        assert state.load()["instance_id"] == first
+        state.recover()
+        results = dict(state.pending())
+        assert results[first]["state"] == "unknown"
+        assert results[second]["state"] == "succeeded"
+        assert not state.start(first)
+        state.acknowledge(first)
+        assert first not in dict(state.pending())
+        with state.lock(), pytest.raises(RuntimeError, match="already running"), state.lock():
+            pass
+        if os.name != "nt":
+            assert tmp_path.stat().st_mode & 0o777 == 0o700
+            assert state.config_path.stat().st_mode & 0o777 == 0o600
+            assert (tmp_path / "commands.sqlite3").stat().st_mode & 0o777 == 0o600
+    finally:
+        state.close()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com",
+        "https://user:secret@example.com",
+        "https://example.com?token=secret",
+        "file:///tmp/a",
+        "http://127.0.0.1:bad",
+        "https://example.com/#secret",
+    ],
+)
+def test_endpoint_rejects_insecure_or_credential_urls(url):
+    with pytest.raises(ValueError):
+        endpoint_url(url)
+
+
+def test_snapshots_and_releases_strip_private_data():
+    async def run():
+        client = AsyncMock()
+        client.request.side_effect = [
+            {"scenarios": [{"scenario": "original", "release_id": "seed", "token": "private"}]},
+            {"scenarios": {"original": {"training_mode": "manual", "provider_key": "private"}}, "config": "private"},
+        ]
+        snapshot = await ReefRuntime(client).snapshot()
+        assert snapshot == {
+            "reachable": True,
+            "scenarios": [{"scenario": "original", "release_id": "seed", "training_mode": "manual"}],
+        }
+        client.request.side_effect = HTTPFailure(401, "private")
+        failed = await ReefRuntime(client).snapshot()
+        assert failed["reachable"] is False and "private" not in json.dumps(failed)
+
+    asyncio.run(run())
+    row = release_summary(
+        {
+            "release_id": "seed",
+            "current": True,
+            "artifact": "private",
+            "metrics": {
+                "wins": 3,
+                "selected": True,
+                "training_request": {"text": "private"},
+                "mutation": "private",
+                "skipped": "private reason",
+            },
+        }
+    )
+    assert row == {"release_id": "seed", "current": True, "metrics": {"wins": 3, "selected": True, "skipped": True}}
+
+
+def test_commands_use_original_scenarios_and_stable_training_receipts():
+    async def run():
+        client = AsyncMock()
+        client.request.return_value = {"secret": "private"}
+        runtime = ReefRuntime(client)
+        command = {"id": str(uuid.uuid4()), "action": "train", "scenario": "existing a", "text": "improve tests"}
+        result = await runtime.execute(command)
+        client.request.assert_awaited_once_with(
+            "/reef/train",
+            scenario="existing a",
+            body={"text": "improve tests", "agent_record_id": command["id"]},
+            timeout=60,
+        )
+        assert result == {"scenario": "existing a", "agent_record_id": command["id"]}
+        await runtime.execute({"action": "promote", "scenario": "existing a", "release_id": "candidate"})
+        assert client.request.call_args.args == ("/reef/scenarios/existing%20a/promote",)
+        count = client.request.await_count
+        for command in [
+            {"action": "http", "scenario": "original", "url": "http://localhost/secret"},
+            {"action": "train", "scenario": "../other", "text": "x"},
+            {"action": "set_training_mode", "scenario": "original", "training_mode": "invalid"},
+        ]:
+            with pytest.raises(ValueError):
+                await runtime.execute(command)
+        assert client.request.await_count == count
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "failure,expected",
+    [
+        (HTTPFailure(400, "private"), "failed"),
+        (HTTPFailure(500, "private"), "unknown"),
+        (TimeoutError("private"), "unknown"),
+    ],
+)
+def test_execution_outcomes_are_not_repeated(tmp_path, failure, expected):
+    async def run():
+        state = ConnectorState(tmp_path)
+        runtime, platform = AsyncMock(), AsyncMock()
+        runtime.execute.side_effect = failure
+        connector = Connector(platform, runtime, state)
+        command = {"id": str(uuid.uuid4()), "action": "train"}
+        try:
+            await connector.execute(command)
+            await connector.execute(command)
+            assert runtime.execute.await_count == 1
+            result = dict(state.pending())[command["id"]]
+            assert result["state"] == expected and "private" not in json.dumps(result)
+            platform.request.side_effect = aiohttp.ClientConnectionError()
+            with pytest.raises(aiohttp.ClientConnectionError):
+                await connector.flush_results()
+            assert state.pending()
+            platform.request.side_effect = None
+            await connector.flush_results()
+            assert not state.pending()
+        finally:
+            state.close()
+
+    asyncio.run(run())
+
+
+def test_success_reports_snapshot_atomically_and_cancel_is_unknown(tmp_path):
+    async def run():
+        state = ConnectorState(tmp_path)
+        runtime = AsyncMock()
+        runtime.execute.return_value = {"scenario": "new"}
+        runtime.snapshot.return_value = {"reachable": True, "scenarios": [{"scenario": "new"}]}
+        connector = Connector(AsyncMock(), runtime, state)
+        first, second = str(uuid.uuid4()), str(uuid.uuid4())
+        try:
+            await connector.execute({"id": first, "action": "create_scenario"})
+            assert dict(state.pending())[first]["snapshot"]["scenarios"] == [{"scenario": "new"}]
+            runtime.execute.side_effect = asyncio.CancelledError
+            with pytest.raises(asyncio.CancelledError):
+                await connector.execute({"id": second, "action": "train"})
+            assert dict(state.pending())[second]["state"] == "unknown"
+        finally:
+            state.close()
+
+    asyncio.run(run())
+
+
+def test_http_boundary_keeps_tokens_separate_and_blocks_redirects():
+    async def run():
+        seen = []
+
+        async def handler(request):
+            seen.append((request.path, request.headers.get("Authorization"), request.headers.get("Cookie")))
+            if request.path == "/redirect":
+                raise web.HTTPFound("/secret")
+            if request.path == "/invalid":
+                return web.Response(text="accepted, but not JSON")
+            if request.path == "/large":
+                return web.Response(body=b"x" * (2 * 1024 * 1024 + 1))
+            return web.json_response({"ok": True}, headers={"Set-Cookie": "private=value"})
+
+        app = web.Application()
+        app.router.add_route("*", "/{path:.*}", handler)
+        async with TestServer(app) as server, aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar()) as session:
+            platform = JSONClient(session, str(server.make_url("")).rstrip("/"), "platform-test-token")
+            local = JSONClient(session, platform.base_url, "local-test-token")
+            await platform.request("/cloud", body={"ready": True})
+            await local.request("/reef/status")
+            for path in ("/redirect", "/invalid", "/large"):
+                with pytest.raises(HTTPFailure):
+                    await local.request(path)
+            assert seen[:2] == [
+                ("/cloud", "Bearer platform-test-token", None),
+                ("/reef/status", "Bearer local-test-token", None),
+            ]
+            assert not any(path == "/secret" for path, _, _ in seen)
+
+    asyncio.run(run())
+
+
+def test_pairing_saves_only_after_approval_and_reuses_identity(tmp_path, monkeypatch, capsys):
+    async def run():
+        state = ConnectorState(tmp_path)
+        calls = []
+
+        async def handler(request):
+            calls.append((request.method, request.headers.get("Authorization")))
+            if request.method == "POST":
+                body = await request.json()
+                assert body == {"protocol": 1, "instance_id": "stable-id", "name": "my-machine"}
+                return web.json_response(
+                    {
+                        "verification_uri": str(server.make_url("/local/authorize")),
+                        "device_token": "platform-test-token",
+                        "user_code": "ABCD-EF12-3456",
+                        "expires_in": 30,
+                    }
+                )
+            return web.json_response({"status": "approved", "runtime_id": "runtime-id"})
+
+        app = web.Application()
+        app.router.add_route("*", "/api/connector/pair", handler)
+        try:
+            async with TestServer(app) as server:
+                config = {
+                    "platform_url": str(server.make_url("")).rstrip("/"),
+                    "instance_id": "stable-id",
+                    "name": "my-machine",
+                    "reef_token": "local-test-token",
+                }
+                await authorize(config, state, no_browser=True)
+            assert state.load()["connector_token"] == "platform-test-token"
+            assert calls == [("POST", None), ("GET", "Bearer platform-test-token")]
+            output = capsys.readouterr().out
+            assert "test-token" not in output
+            assert "Device code: ABCD-EF12-3456" in output
+            assert "Paste this code into the page" in output
+            assert "/local/authorize" in output
+            assert "/local/connect/ABCD" not in output
+        finally:
+            state.close()
+
+    asyncio.run(run())
+
+
+def test_connect_cli_is_dispatched_without_starting_a_deployment(capsys):
+    with pytest.raises(SystemExit) as result:
+        main(["connect", "--help"])
+    assert result.value.code == 0
+    output = capsys.readouterr().out
+    assert "--foreground" in output and "--reef-token-env" in output and "--stop" in output
+
+
+def test_release_summary_is_valid_json_with_nonfinite_scores():
+    summary = release_summary(
+        {
+            "release_id": "seed",
+            "recorded_at": float("inf"),
+            "metrics": {"candidate_score": float("nan"), "current_score": 0.5},
+        }
+    )
+    assert summary == {"release_id": "seed", "metrics": {"current_score": 0.5}}
+    json.dumps(summary, allow_nan=False)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX background process lifecycle")
+def test_background_cli_stops_restarts_without_pairing_and_exits_on_revocation(tmp_path):
+    async def run():
+        counts = {"pair": 0, "poll": 0}
+        revoked = False
+
+        async def handler(request):
+            if request.path == "/api/connector/pair":
+                if request.method == "POST":
+                    counts["pair"] += 1
+                    return web.json_response(
+                        {
+                            "device_token": "background-test-token",
+                            "user_code": "ABCD-EF12-3456",
+                            "verification_uri": str(server.make_url("/local/authorize")),
+                            "expires_in": 60,
+                        }
+                    )
+                return web.json_response({"status": "approved", "runtime_id": "runtime-id"})
+            if request.path == "/api/connector/poll":
+                counts["poll"] += 1
+                assert request.headers["Authorization"] == "Bearer background-test-token"
+                if revoked:
+                    return web.json_response({"error": "revoked"}, status=401)
+                return web.json_response({"protocol": 1, "command": None})
+            if request.path == "/reef/scenarios":
+                return web.json_response({"scenarios": [{"scenario": "original"}]})
+            return web.json_response({"scenarios": {"original": {"training_mode": "manual"}}})
+
+        app = web.Application()
+        app.router.add_route("*", "/{path:.*}", handler)
+        state = ConnectorState(tmp_path)
+
+        async def wait_for_running(expected):
+            for _ in range(100):
+                if _running(state) is expected:
+                    return
+                await asyncio.sleep(0.1)
+            raise AssertionError("Connector process did not reach expected state")
+
+        try:
+            async with TestServer(app) as server:
+
+                async def cli(*options):
+                    process = await asyncio.create_subprocess_exec(
+                        sys.executable,
+                        "-m",
+                        "reef.cli",
+                        "connect",
+                        "--no-browser",
+                        "--platform",
+                        str(server.make_url("")).rstrip("/"),
+                        "--url",
+                        str(server.make_url("")).rstrip("/"),
+                        "--state-dir",
+                        str(tmp_path),
+                        *options,
+                        cwd=Path(__file__).resolve().parents[2],
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                    stdout, stderr = await asyncio.wait_for(process.communicate(), 15)
+                    assert process.returncode == 0, stderr.decode()
+                    return stdout.decode()
+
+                assert "Connected" in await cli()
+                await wait_for_running(True)
+                identity = state.load()["instance_id"]
+                assert "running" in await cli("--status")
+                await cli("--stop")
+                await wait_for_running(False)
+                await cli()
+                await wait_for_running(True)
+                assert state.load()["instance_id"] == identity and counts["pair"] == 1
+                revoked = True
+                await wait_for_running(False)
+                assert counts["poll"] >= 2
+                assert "background-test-token" not in (tmp_path / "connector.log").read_text()
+        finally:
+            if _running(state):
+                os.kill(int((tmp_path / "connector.pid").read_text()), signal.SIGTERM)
+                await wait_for_running(False)
+            state.close()
+
+    asyncio.run(run())

--- a/tests/reef_service/test_console_cors.py
+++ b/tests/reef_service/test_console_cors.py
@@ -1,0 +1,189 @@
+"""Browser access must preserve authentication and protect state-changing routes."""
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from reef.dispatcher import build_default_dispatcher
+from reef.service import assembly
+from reef.service.auth import create_authentication_middleware
+from reef.service.cors import configure_browser_access
+from reef.service.deploy.settings import service_settings_from_config
+
+ORIGIN = "https://api.reefinfra.ai"
+
+
+def make_client(origins=(ORIGIN,)):
+    app = web.Application(middlewares=[create_authentication_middleware("local-secret")])
+    calls = []
+
+    async def mutation(request):
+        calls.append(request.path)
+        return web.json_response({"scenario": request.headers.get("x-reef-scenario")})
+
+    async def stream(request):
+        response = web.StreamResponse(headers={"content-type": "text/event-stream", "x-reef-release-id": "release-1"})
+        await response.prepare(request)
+        await response.write(b"data: hello\n\n")
+        await response.write_eof()
+        return response
+
+    app.router.add_post("/reef/train", mutation)
+    app.router.add_get("/stream", stream)
+    configure_browser_access(app, origins)
+    return TestClient(TestServer(app)), calls
+
+
+def test_preflight_needs_no_token_but_actual_request_does():
+    async def run():
+        client, calls = make_client()
+        async with client:
+            headers = {
+                "Origin": ORIGIN,
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "Authorization, Content-Type, X-Reef-Scenario",
+                "Access-Control-Request-Private-Network": "true",
+            }
+            preflight = await client.options("/reef/train", headers=headers)
+            assert preflight.status == 204
+            assert preflight.headers["Access-Control-Allow-Origin"] == ORIGIN
+            assert preflight.headers["Access-Control-Allow-Private-Network"] == "true"
+            assert "Access-Control-Allow-Credentials" not in preflight.headers
+            denied = await client.post("/reef/train", headers={"Origin": ORIGIN})
+            assert denied.status == 401
+            assert denied.headers["Access-Control-Allow-Origin"] == ORIGIN
+            assert calls == []
+            accepted = await client.post(
+                "/reef/train",
+                headers={"Origin": ORIGIN, "Authorization": "Bearer local-secret", "x-reef-scenario": "mine"},
+            )
+            assert accepted.status == 200
+            assert await accepted.json() == {"scenario": "mine"}
+            assert len(calls) == 1
+
+    asyncio.run(run())
+
+
+def test_untrusted_origins_cannot_execute_even_simple_requests():
+    async def run():
+        client, calls = make_client()
+        async with client:
+            for origin in ("https://evil.example", "https://api.reefinfra.ai.evil.example", "null"):
+                response = await client.post(
+                    "/reef/train", headers={"Origin": origin, "Authorization": "Bearer local-secret"}
+                )
+                assert response.status == 403
+                assert "Access-Control-Allow-Origin" not in response.headers
+            assert calls == []
+            # Existing SDKs have no Origin and retain their prior behavior.
+            response = await client.post("/reef/train", headers={"Authorization": "Bearer local-secret"})
+            assert response.status == 200
+            assert "Access-Control-Allow-Origin" not in response.headers
+
+    asyncio.run(run())
+
+
+def test_preflight_rejects_unlisted_headers_and_methods():
+    async def run():
+        client, calls = make_client()
+        async with client:
+            for method, header in (("PATCH", "authorization"), ("POST", "x-forwarded-host")):
+                response = await client.options(
+                    "/reef/train",
+                    headers={
+                        "Origin": ORIGIN,
+                        "Access-Control-Request-Method": method,
+                        "Access-Control-Request-Headers": header,
+                    },
+                )
+                assert response.status == 403
+                assert "Access-Control-Allow-Methods" not in response.headers
+            assert calls == []
+
+    asyncio.run(run())
+
+
+def test_streaming_responses_and_errors_have_cors_headers():
+    async def run():
+        client, _ = make_client()
+        async with client:
+            response = await client.get("/stream", headers={"Origin": ORIGIN, "Authorization": "Bearer local-secret"})
+            assert response.status == 200
+            assert response.headers["Access-Control-Allow-Origin"] == ORIGIN
+            assert "x-reef-release-id" in response.headers["Access-Control-Expose-Headers"]
+            assert "Origin" in response.headers.getall("Vary")
+            assert await response.text() == "data: hello\n\n"
+            response = await client.get("/missing", headers={"Origin": ORIGIN, "Authorization": "Bearer local-secret"})
+            assert response.status == 404
+            assert response.headers["Access-Control-Allow-Origin"] == ORIGIN
+
+    asyncio.run(run())
+
+
+def test_browser_access_is_disabled_by_default():
+    async def run():
+        client, _ = make_client(())
+        async with client:
+            response = await client.options(
+                "/reef/train", headers={"Origin": ORIGIN, "Access-Control-Request-Method": "POST"}
+            )
+            assert response.status == 401
+            assert "Access-Control-Allow-Origin" not in response.headers
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "origins",
+    [
+        ["*"],
+        ["null"],
+        ["https://api.reefinfra.ai/"],
+        ["https://name:secret@example.com"],
+        ["https://example.com?a=1"],
+        ["https://example.com#fragment"],
+        ["https://example.com:bad"],
+        [12],
+        ORIGIN,
+    ],
+)
+def test_config_rejects_non_origins(origins):
+    with pytest.raises(ValueError):
+        service_settings_from_config({"reef": {"recipe": "recipe", "console_origins": origins}})
+
+
+def test_config_defaults_and_explicit_origins():
+    assert service_settings_from_config({"reef": {"recipe": "recipe"}}).console_origins == ()
+    assert service_settings_from_config(
+        {"reef": {"recipe": "recipe", "console_origins": [ORIGIN, "http://localhost:3000", ORIGIN]}}
+    ).console_origins == (ORIGIN, "http://localhost:3000")
+
+
+def test_serve_settings_enable_browser_access_on_real_scenario_routes(monkeypatch):
+    dispatcher = build_default_dispatcher()
+    dispatcher.get_or_create_scenario("existing-local")
+    monkeypatch.setattr(assembly, "build_dispatcher", lambda *args, **kwargs: dispatcher)
+    settings = service_settings_from_config(
+        {"reef": {"recipe": "recipe", "tokens": ["local-secret"], "console_origins": [ORIGIN]}}
+    )
+
+    async def run():
+        async with TestClient(TestServer(assembly.build_app(settings))) as client:
+            preflight = await client.options(
+                "/reef/scenarios",
+                headers={"Origin": ORIGIN, "Access-Control-Request-Method": "GET"},
+            )
+            assert preflight.status == 204
+            assert preflight.headers["Access-Control-Allow-Origin"] == ORIGIN
+            denied = await client.get("/reef/scenarios", headers={"Origin": ORIGIN})
+            assert denied.status == 401
+            response = await client.get(
+                "/reef/scenarios", headers={"Origin": ORIGIN, "Authorization": "Bearer local-secret"}
+            )
+            assert response.status == 200
+            assert response.headers["Access-Control-Allow-Origin"] == ORIGIN
+            assert [row["scenario"] for row in (await response.json())["scenarios"]] == ["existing-local"]
+
+    asyncio.run(run())

--- a/tests/reef_service/test_deploy_config_validation.py
+++ b/tests/reef_service/test_deploy_config_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 import reef.service.deploy.orchestrator as orchestrator
 from reef.cli import main as cli_main
-from reef.service.deploy.config import PROJECT_ROOT, DeployConfigError, load_config, validate_services
+from reef.service.deploy.config import DeployConfigError, load_config, validate_services
 from reef.service.deploy.process import _command_argv
 
 VALID = "services:\n  - name: worker\n    command: python -c 'print(1)'\n"
@@ -100,7 +100,8 @@ def test_tutorial_missing_environment_fails_before_launch_without_traceback(tuto
 
     monkeypatch.setattr(orchestrator, "resolve_model_paths", must_not_run)
     monkeypatch.setattr(orchestrator, "_Stack", must_not_run)
-    path = PROJECT_ROOT / "tutorials" / tutorial / "configs" / "deployment.yaml"
+    # The tutorial belongs to the checkout even when Reef is imported from an installed wheel.
+    path = Path(__file__).resolve().parents[2] / "tutorials" / tutorial / "configs" / "deployment.yaml"
     with pytest.raises(SystemExit) as caught:
         cli_main(["serve", "-c", str(path)])
     assert caught.value.code == 2

--- a/tests/reef_service/test_deploy_config_validation.py
+++ b/tests/reef_service/test_deploy_config_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 import reef.service.deploy.orchestrator as orchestrator
 from reef.cli import main as cli_main
-from reef.service.deploy.config import DeployConfigError, load_config, validate_services
+from reef.service.deploy.config import PROJECT_ROOT, DeployConfigError, load_config, validate_services
 from reef.service.deploy.process import _command_argv
 
 VALID = "services:\n  - name: worker\n    command: python -c 'print(1)'\n"
@@ -39,6 +39,77 @@ def test_non_object_root_is_a_config_error(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_empty_file_loads_as_an_empty_config(tmp_path: Path) -> None:
     assert load_config(_write(tmp_path, "")) == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [None, "", " \t "])
+def test_required_environment_variables_report_all_missing_fields(tmp_path: Path, monkeypatch, value) -> None:
+    for name in ("REEF_TEST_URL", "REEF_TEST_MODEL"):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+    monkeypatch.setenv("REEF_TEST_KEY", "secret-value-must-not-appear")
+    path = _write(
+        tmp_path,
+        "reef:\n"
+        "  upstream_url: ${REEF_TEST_URL:?}\n"
+        "  upstream_model: ${REEF_TEST_MODEL:?}\n"
+        "  upstream_api_key: ${REEF_TEST_KEY}\n"
+        "services:\n"
+        "  - env:\n"
+        "      MODEL: ${REEF_TEST_MODEL:?}\n",
+    )
+    with pytest.raises(DeployConfigError, match="missing or empty required environment variables") as caught:
+        load_config(path)
+    message = str(caught.value)
+    assert str(path) in message
+    assert "REEF_TEST_URL (reef.upstream_url)" in message
+    assert "REEF_TEST_MODEL (reef.upstream_model, services[0].env.MODEL)" in message
+    assert "secret-value-must-not-appear" not in message
+
+
+@pytest.mark.unit
+def test_required_environment_values_resolve_and_optional_values_can_be_empty(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("REEF_TEST_MODEL", "provider/model")
+    monkeypatch.delenv("REEF_TEST_KEY", raising=False)
+    config = load_config(
+        _write(
+            tmp_path,
+            "reef:\n"
+            "  upstream_model: ${REEF_TEST_MODEL:?}\n"
+            "  upstream_api_key: ${REEF_TEST_KEY}\n"
+            "  endpoint: http://127.0.0.1:${reef.port}\n",
+        )
+    )
+    assert config["reef"] == {
+        "upstream_model": "provider/model",
+        "upstream_api_key": "",
+        "endpoint": "http://127.0.0.1:${reef.port}",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tutorial", ["evolve-your-harness", "harness-requests"])
+def test_tutorial_missing_environment_fails_before_launch_without_traceback(tutorial, monkeypatch, capsys) -> None:
+    for name in ("REEF_UPSTREAM_URL", "REEF_UPSTREAM_MODEL", "REEF_UPSTREAM_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+    def must_not_run(*args, **kwargs):
+        pytest.fail("missing environment variables must fail before model downloads or processes")
+
+    monkeypatch.setattr(orchestrator, "resolve_model_paths", must_not_run)
+    monkeypatch.setattr(orchestrator, "_Stack", must_not_run)
+    path = PROJECT_ROOT / "tutorials" / tutorial / "configs" / "deployment.yaml"
+    with pytest.raises(SystemExit) as caught:
+        cli_main(["serve", "-c", str(path)])
+    assert caught.value.code == 2
+    output = capsys.readouterr()
+    assert not output.out
+    assert "REEF_UPSTREAM_URL (reef.upstream_url)" in output.err
+    assert "REEF_UPSTREAM_MODEL (reef.upstream_model)" in output.err
+    assert "REEF_UPSTREAM_API_KEY" not in output.err
+    assert "Traceback" not in output.err
 
 
 @pytest.mark.unit
@@ -140,7 +211,8 @@ def test_invalid_stack_never_downloads_or_launches(tmp_path: Path, monkeypatch) 
 
 
 @pytest.mark.unit
-def test_orchestrator_uses_exactly_the_declared_services(tmp_path: Path, monkeypatch) -> None:
+@pytest.mark.parametrize("override_required_env", [False, True])
+def test_orchestrator_uses_exactly_the_declared_services(tmp_path: Path, monkeypatch, override_required_env) -> None:
     captured: dict[str, object] = {}
 
     class StackStub:
@@ -148,6 +220,8 @@ def test_orchestrator_uses_exactly_the_declared_services(tmp_path: Path, monkeyp
 
         def __init__(self, config, services, run_dir, ready_timeout_default, config_path, source_root=None):
             captured["services"] = services
+            captured["config"] = config
+            captured["child_config"] = load_config(config_path)
 
         def start(self):
             pass
@@ -160,11 +234,17 @@ def test_orchestrator_uses_exactly_the_declared_services(tmp_path: Path, monkeyp
 
     monkeypatch.setattr(orchestrator, "_Stack", StackStub)
     monkeypatch.setattr(orchestrator, "resolve_model_paths", lambda config: False)
+    monkeypatch.delenv("REEF_TEST_URL", raising=False)
+    monkeypatch.delenv("REEF_TEST_MODEL", raising=False)
+    upstream_fields = (
+        "  upstream_url: ${REEF_TEST_URL:?}\n  upstream_model: ${REEF_TEST_MODEL:?}\n" if override_required_env else ""
+    )
     path = _write(
         tmp_path,
         f"run_dir: {tmp_path / 'run'}\n"
         "reef:\n"
         "  recipe: recipe\n"
+        f"{upstream_fields}"
         "services:\n"
         "  - name: model\n"
         "    command: model-server\n"
@@ -173,7 +253,16 @@ def test_orchestrator_uses_exactly_the_declared_services(tmp_path: Path, monkeyp
         "    depends_on: [model]\n",
     )
 
-    assert orchestrator._run_orchestrator(str(path)) == 0
+    overrides = (
+        {"reef.upstream_url": "http://127.0.0.1:8000/v1", "upstream_model": "provider/model"}
+        if override_required_env
+        else None
+    )
+    assert orchestrator._run_orchestrator(str(path), overrides) == 0
+    if override_required_env:
+        for key in ("config", "child_config"):
+            assert captured[key]["reef"]["upstream_url"] == "http://127.0.0.1:8000/v1"
+            assert captured[key]["reef"]["upstream_model"] == "provider/model"
     services = captured["services"]
     assert isinstance(services, list)
     assert services == [

--- a/tests/reef_service/test_sao_configs.py
+++ b/tests/reef_service/test_sao_configs.py
@@ -149,6 +149,8 @@ _MEGATRON_ONLY_FLAGS = frozenset(
 # setting them here makes the generated command testable without a GPU stack.
 _CONFIG_ENV = {
     "REEF_TOKEN": "config-test-token",
+    "REEF_UPSTREAM_URL": "http://127.0.0.1:8000/v1",
+    "REEF_UPSTREAM_MODEL": "config-test-model",
     "TTTD_CHECKPOINT_INTERVAL": "2",
     "TTTD_CUDA_GRAPH_MAX_BS": "8",
     "TTTD_GLOBAL_BATCH_SIZE": "8",

--- a/tutorials/evolve-your-harness/configs/deployment.yaml
+++ b/tutorials/evolve-your-harness/configs/deployment.yaml
@@ -74,8 +74,8 @@ reef:
   port: 8901
   recipe: deployment
   token: reef-local
-  upstream_url: ${REEF_UPSTREAM_URL}
-  upstream_model: ${REEF_UPSTREAM_MODEL}
+  upstream_url: ${REEF_UPSTREAM_URL:?}
+  upstream_model: ${REEF_UPSTREAM_MODEL:?}
   upstream_api_key: ${REEF_UPSTREAM_API_KEY}
   agent_record_dir: tutorials/evolve-your-harness/work/deployment/agent-record
   artifact_repository: tutorials/evolve-your-harness/work/deployment/artifacts.git

--- a/tutorials/harness-requests/configs/deployment.yaml
+++ b/tutorials/harness-requests/configs/deployment.yaml
@@ -80,8 +80,8 @@ reef:
   port: 8901
   recipe: deployment
   token: reef-local
-  upstream_url: ${REEF_UPSTREAM_URL}
-  upstream_model: ${REEF_UPSTREAM_MODEL}
+  upstream_url: ${REEF_UPSTREAM_URL:?}
+  upstream_model: ${REEF_UPSTREAM_MODEL:?}
   upstream_api_key: ${REEF_UPSTREAM_API_KEY}
   agent_record_dir: tutorials/harness-requests/work/deployment/agent-record
   artifact_repository: tutorials/harness-requests/work/deployment/artifacts.git


### PR DESCRIPTION
## Motivation

Users running Reef locally need to authorize it once and manage scenarios and versions from the API platform without exposing a public runtime port. The CLI now prints a device code that must be entered in the console, and keeps service credentials on the local machine.

## Changes

- Add `reef connect` with outbound pairing/polling, background or foreground operation, status/stop commands, and reconnect handling.
- Translate a bounded set of platform commands to native Reef APIs; persist execution IDs and completed results in local SQLite so reconnects retry reporting without repeating operations.
- Sync filtered scenario/version summaries and retain unknown outcomes for interrupted commands.
- Add opt-in browser CORS with explicit allowed origins for the console's direct connection mode.
- Report missing required environment variables before downloading models or launching processes. The harness deployment examples require upstream URL/model values, retain optional API keys, and allow command-line overrides.

## Compatibility and operational impact

Adds connector protocol v1 and private local connection state under `~/.reef/connections/`. The platform and runtime must both support this protocol. Only loopback platform URLs allow plain HTTP; normal connections use outbound HTTPS.

Existing serving behavior and authentication remain unchanged unless browser origins are explicitly configured. No new package dependency is added. Configuration supports `${VAR:?}` for required values; existing `${VAR}` interpolation remains compatible.

This feature introduces a new connection protocol and local persisted state; no accepted RFC is linked.

## Verification

- `pre-commit run --all-files`: passed.
- Installed-wheel regression tests from outside the checkout: 75 passed (deployment config validation, CLI overrides, connector, and CORS). Tutorial fixtures resolve from the checkout even when Reef is installed in site-packages.
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null .venv/bin/python -m pytest tests/ -q`: 2,888 passed, 30 skipped (341 seconds).
- Browser and CLI integration: passed (device code entry, authorization, heartbeat, promote/create/train, revocation, recovery, and mobile management).
- `.venv/bin/python -m mypy`: four existing errors in the unchanged Slime `lora_transport.py` and `checkpoint.py` adapters; no errors reported in changed files.
- Reproduced the user's missing-environment command: exits 2 and names `REEF_UPSTREAM_URL` / `REEF_UPSTREAM_MODEL` without starting a child or printing a traceback.

## AI assistance

Codex assisted with implementation, documentation, tests, and PR preparation. The author remains responsible for reviewing and validating the change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes.
- [x] Public interface changes include contract tests.
- [x] Affected user and developer documentation is updated.
- [x] Root README content is unaffected.
- [ ] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above.

