### PR TITLE
feat: retain compacted traces with automatic retention limits

### DIFF
--- a/docs/advanced_topics/state-model.rst
+++ b/docs/advanced_topics/state-model.rst
@@ -11,8 +11,8 @@ or artifact identifier used for serving).
 
 Compaction retires records from training while retaining their bodies for audit.
 It retires only rows the processor marks releasable, and Reef recomputes that
-set from current state on every read. Physical deletion requires a separate,
-explicit purge of compacted bodies.
+set from current state on every read. Separate retention maintenance physically
+purges old compacted bodies while keeping retry hashes and commit metadata.
 
 With a database path configured, the SQLite store uses WAL journalling and
 synchronous = FULL. The default in-memory database is for tests and does not

--- a/docs/advanced_topics/state-model.rst
+++ b/docs/advanced_topics/state-model.rst
@@ -9,9 +9,10 @@ It includes a record id, a scenario, an inference payload (for inference
 exchange) or feedback (for report), and necessary metadata (e.g. request type
 or artifact identifier used for serving).
 
-Compaction is the only operation that deletes records. It deletes only rows
-the processor marks releasable, and Reef recomputes that set from current state
-on every read.
+Compaction retires records from training while retaining their bodies for audit.
+It retires only rows the processor marks releasable, and Reef recomputes that
+set from current state on every read. Physical deletion requires a separate,
+explicit purge of compacted bodies.
 
 With a database path configured, the SQLite store uses WAL journalling and
 synchronous = FULL. The default in-memory database is for tests and does not
@@ -68,7 +69,7 @@ Commit ordering
 
 Each scenario has an append-only JSONL commit log, and the fsynced append is the
 commit point. A committed step records its step number, artifact ref, checkpoint
-flag, algorithm state, record high-water mark, compaction deletions, and
+flag, algorithm state, record high-water mark, compaction retirements, and
 metrics. Every other store is derived from that log, and the ordering around the
 append is fixed per step kind, so a crash in any gap replays cleanly.
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -129,7 +129,7 @@ This is a retained-body budget, not a hard disk quota. Incoming compaction can
 exceed the budget between sweeps; active records, indexes, hashes, commit logs,
 and WAL files take additional space. SQLite reuses pages freed by cleanup but
 does not automatically shrink the database file. Allow additional disk headroom.
-Standalone Python stores do not start a maintenance task; see :doc:`python-api`
+Standalone Python stores do not start a maintenance task; see `Python API <python-api.rst>`__
 for explicit retention and purge methods.
 
 Existing stores gain ``compacted_at`` and ``body_bytes`` columns when opened.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -94,6 +94,8 @@ persistent.
    reef.artifact_work_dir | .reef/artifact-work | materialization scratch
    reef.artifact_cache_dir | .reef/artifact-cache | fetched artifact cache
    reef.agent_record_dir | .reef/agent-record | the record store
+   reef.agent_record_retention_days | 7.0 | compacted trace bodies expire this many days after compaction
+   reef.agent_record_retention_max_bytes | 21474836480 | 20 GiB shared across compacted trace bodies in the record directory
 
 .. warning::
 
@@ -102,11 +104,27 @@ persistent.
 
 The record store keeps trace bodies after training compaction. Compaction marks
 records as retired from training; it does not remove their requests, responses,
-or feedback from SQLite. No automatic expiry is enabled. Operators can apply a
-retention period with the explicit, bounded ``RecordStore.purge_compacted``
-method described in :doc:`python-api`. Allow disk space for retained traces.
+or feedback from SQLite immediately. The HTTP service starts retention cleanup
+at startup and repeats it every 60 seconds, outside the inference and training
+request paths. It first removes bodies older than 7 days, then the oldest
+remaining bodies until their total fits within 20 GiB. Both limits are
+configurable above and must be positive; the time limit must also be finite.
 
-Existing stores gain a nullable ``compacted_at`` column when opened. Already
+The byte budget counts UTF-8 JSON payloads, references, and artifact references
+across all scenario databases, including databases under ``archived/``. It is
+shared across the directory, not allocated separately to each scenario. Deletes
+commit in batches of 256. Active records, retry hashes, and commit/receipt
+metadata are retained. Cleanup failures are logged and retried on the next sweep.
+
+This is a retained-body budget, not a hard disk quota. Incoming compaction can
+exceed the budget between sweeps; active records, indexes, hashes, commit logs,
+and WAL files take additional space. SQLite reuses pages freed by cleanup but
+does not automatically shrink the database file. Allow additional disk headroom.
+Standalone Python stores do not start a maintenance task; see :doc:`python-api`
+for explicit retention and purge methods.
+
+Existing stores gain ``compacted_at`` and ``body_bytes`` columns when opened.
+The migration measures retained JSON byte sizes once. Already
 deleted bodies cannot be recovered by this migration. Older Reef versions do
 not filter that column: stop the service and restore a pre-upgrade backup for
 rollback, or purge all compacted bodies with the new version before downgrading.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -100,6 +100,18 @@ persistent.
    On ephemeral storage, a restart loses the record store, the commit logs, and
    every version.
 
+The record store keeps trace bodies after training compaction. Compaction marks
+records as retired from training; it does not remove their requests, responses,
+or feedback from SQLite. No automatic expiry is enabled. Operators can apply a
+retention period with the explicit, bounded ``RecordStore.purge_compacted``
+method described in :doc:`python-api`. Allow disk space for retained traces.
+
+Existing stores gain a nullable ``compacted_at`` column when opened. Already
+deleted bodies cannot be recovered by this migration. Older Reef versions do
+not filter that column: stop the service and restore a pre-upgrade backup for
+rollback, or purge all compacted bodies with the new version before downgrading.
+Do not share a migrated store between old and new writers.
+
 Recipe settings such as ``batch_size`` sit beside these in the same section,
 along with any others the recipe declares with ``config_field``. When
 ``reef.recipe`` is a dotted weight-training class, keys the service does not

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -419,9 +419,10 @@ counted twice.
 Training compaction retires records without deleting their original payloads.
 Reef's explicit Python audit reads can inspect retained requests, responses,
 references, and compaction timestamps; ordinary training reads exclude retired
-records. There is no new HTTP record-query endpoint. Physical deletion is a
-separate, explicit purge operation; see :doc:`python-api` for the audit and
-purge methods. A compaction timestamp alone does not prove that a record was
+records. There is no new HTTP record-query endpoint. Separate background
+retention limits compacted bodies to 7 days and a shared 20 GiB by default;
+see :doc:`configuration` for scope and :doc:`python-api` for audit and purge
+methods. A compaction timestamp alone does not prove that a record was
 used for learning: per-step ``consumed_ids`` in the commit log identifies that
 relationship.
 

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -416,6 +416,15 @@ conflict rather than overwriting. Reef keeps track of consumed records so
 retried reports and late reports whose references already trained are not
 counted twice.
 
+Training compaction retires records without deleting their original payloads.
+Reef's explicit Python audit reads can inspect retained requests, responses,
+references, and compaction timestamps; ordinary training reads exclude retired
+records. There is no new HTTP record-query endpoint. Physical deletion is a
+separate, explicit purge operation; see :doc:`python-api` for the audit and
+purge methods. A compaction timestamp alone does not prove that a record was
+used for learning: per-step ``consumed_ids`` in the commit log identifies that
+relationship.
+
 Receiving an update
 -------------------
 

--- a/docs/reference/http-api.rst
+++ b/docs/reference/http-api.rst
@@ -421,8 +421,8 @@ Reef's explicit Python audit reads can inspect retained requests, responses,
 references, and compaction timestamps; ordinary training reads exclude retired
 records. There is no new HTTP record-query endpoint. Separate background
 retention limits compacted bodies to 7 days and a shared 20 GiB by default;
-see :doc:`configuration` for scope and :doc:`python-api` for audit and purge
-methods. A compaction timestamp alone does not prove that a record was
+see `Configuration <configuration.rst>`__ for scope and `Python API <python-api.rst>`__
+for audit and purge methods. A compaction timestamp alone does not prove that a record was
 used for learning: per-step ``consumed_ids`` in the commit log identifies that
 relationship.
 

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -215,6 +215,59 @@ The same type serves both sides: a producer constructs it and calls
 ``to_dict()``; a processor receives the parsed instance as
 ``context.parsed_report``.
 
+Record storage and audit
+------------------------
+
+``reef.records.RecordStore`` separates the training record set from retained
+trace history. ``compact(scenario, ids)`` sets ``compacted_at`` and keeps the
+original payload, response, references, and artifact reference. Hash tombstones
+and optional compaction receipts are committed atomically with that transition.
+Repeated compaction preserves the first timestamp.
+
+``get``, ``replay``, ``replay_page``, and ``count`` expose only records whose
+``compacted_at`` is ``None``. Training and restart recovery continue to use
+those methods. Use these explicit methods for audit and retention work:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Method
+     - Result
+   * - ``get_for_audit(scenario, agent_record_id)``
+     - A ``StoredRecord``, or ``None`` if no body is retained in that scenario.
+   * - ``audit_page(scenario, after_sequence=0, limit=256)``
+     - A bounded tuple of ``StoredRecord`` entries, in append order, including
+       compacted bodies. Advance the cursor using the last entry's ``sequence``.
+   * - ``purge_compacted(scenario, before=timestamp, limit=256)``
+     - The number of bodies physically deleted, at most ``limit``. Only records
+       with ``compacted_at < before`` are eligible. The cutoff must be a finite
+       Unix timestamp and the limit a positive integer.
+
+``StoredRecord`` contains ``sequence``, ``item`` (the original ``AgentRecord``),
+and ``compacted_at`` (a Unix timestamp or ``None``). Audit reads never restore a
+record to the training set. A missing body may have been purged or never stored;
+the read API does not guess which. Compaction includes terminal or excluded
+records as well as trained records. Use the commit log's per-step
+``consumed_ids`` to determine learning participation.
+
+For example, inspect one trace without making it available to training again:
+
+.. code:: python
+
+   entry = scenario.records.get_for_audit(scenario.name, record_id)
+   if entry is not None:
+       payload = entry.item.payload
+       references = entry.item.references
+       retired_at = entry.compacted_at
+
+No purge runs automatically. Operators choose retention and invoke purge
+separately; it preserves active records, retry hashes, and compaction receipts.
+An identical retry after purge still deduplicates, and conflicting content
+still fails. SQLite may reuse freed pages, but purging does not shrink the
+database file. HTTP audit routes and scheduled retention are separate
+integrations. See :doc:`configuration` for migration and rollback constraints.
+
 Processor
 ---------
 

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -261,12 +261,26 @@ For example, inspect one trace without making it available to training again:
        references = entry.item.references
        retired_at = entry.compacted_at
 
-No purge runs automatically. Operators choose retention and invoke purge
-separately; it preserves active records, retry hashes, and compaction receipts.
+The HTTP service runs background retention at startup and every 60 seconds.
+It removes bodies older than 7 days, then the oldest remaining bodies to meet
+a shared 20 GiB budget across scenario databases in ``agent_record_dir``,
+including ``archived/``. The budget measures UTF-8 JSON payloads, references,
+and artifact references. Limits are configurable in :doc:`configuration`.
+
+For embedded Python deployments, use
+``dispatcher.prune_record_archives(RecordRetention(days=7, max_bytes=20 * 1024**3))``
+with ``RecordRetention`` imported from ``reef.records``. This runs one sweep
+and serializes it with scenario file moves. Standalone ``RecordStore`` and
+``Dispatcher`` construction do not start a maintenance task. ``create_app``
+accepts ``record_retention=RecordRetention(...)`` to enable service maintenance.
+
+Retention preserves active records, retry hashes, and compaction receipts.
 An identical retry after purge still deduplicates, and conflicting content
-still fails. SQLite may reuse freed pages, but purging does not shrink the
-database file. HTTP audit routes and scheduled retention are separate
-integrations. See :doc:`configuration` for migration and rollback constraints.
+still fails. Deletes commit in batches of 256. Concurrent compaction can exceed
+the budget until the next sweep. SQLite may reuse freed pages, but purging does
+not shrink the database file; active records, indexes, and other metadata also
+use disk space. HTTP audit routes remain a separate integration. See
+:doc:`configuration` for migration and rollback constraints.
 
 Processor
 ---------

--- a/docs/reference/python-api.rst
+++ b/docs/reference/python-api.rst
@@ -265,7 +265,7 @@ The HTTP service runs background retention at startup and every 60 seconds.
 It removes bodies older than 7 days, then the oldest remaining bodies to meet
 a shared 20 GiB budget across scenario databases in ``agent_record_dir``,
 including ``archived/``. The budget measures UTF-8 JSON payloads, references,
-and artifact references. Limits are configurable in :doc:`configuration`.
+and artifact references. Limits are configurable in `Configuration <configuration.rst>`__.
 
 For embedded Python deployments, use
 ``dispatcher.prune_record_archives(RecordRetention(days=7, max_bytes=20 * 1024**3))``
@@ -280,7 +280,7 @@ still fails. Deletes commit in batches of 256. Concurrent compaction can exceed
 the budget until the next sweep. SQLite may reuse freed pages, but purging does
 not shrink the database file; active records, indexes, and other metadata also
 use disk space. HTTP audit routes remain a separate integration. See
-:doc:`configuration` for migration and rollback constraints.
+`Configuration <configuration.rst>`__ for migration and rollback constraints.
 
 Processor
 ---------

--- a/reef/dispatcher.py
+++ b/reef/dispatcher.py
@@ -34,6 +34,7 @@ from reef.observability import (
     TrainingExperimentEvent,
 )
 from reef.recipe.base import Recipe
+from reef.records import RecordRetention
 from reef.runtime.base import RuntimeContractError, TrainingRuntime
 from reef.scenario.checkpoint_strategy import CheckpointStrategy, EveryNVersions
 from reef.scenario.registry import ScenarioRegistry
@@ -149,6 +150,7 @@ class Dispatcher:
         experiment_tracker: ExperimentTracker | None = None,
     ) -> None:
         self._recipe = recipe
+        self._record_retention_lock = Lock()
         self._experiment_tracker = experiment_tracker if experiment_tracker is not None else NullExperimentTracker()
         self._registry = ScenarioRegistry(
             recipe,
@@ -216,6 +218,12 @@ class Dispatcher:
     def list_scenarios(self) -> tuple[dict[str, Any], ...]:
         return self._registry.list()
 
+    def prune_record_archives(self, retention: RecordRetention) -> int:
+        """Apply deployment-wide retention without racing scenario file moves."""
+        with self._record_retention_lock:
+            directory = self._registry.agent_record_dir
+            return 0 if directory is None else retention.prune(directory)
+
     def delete_scenario(self, scenario: str) -> dict[str, Any]:
         """Remove a scenario from this deployment and move its own state aside.
 
@@ -228,7 +236,7 @@ class Dispatcher:
         """
         if "/" in scenario or scenario in ("", ".", ".."):
             raise UnknownScenario(f"unknown scenario {scenario!r}")
-        with self._registry.lock_for(scenario):
+        with self._record_retention_lock, self._registry.lock_for(scenario):
             if not self._registry.has(scenario):
                 raise UnknownScenario(f"unknown scenario {scenario!r}")
             dropped = self._registry.remove(scenario)

--- a/reef/records.py
+++ b/reef/records.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import sqlite3
 import time
 from collections.abc import Mapping
@@ -45,6 +46,19 @@ class AppendResult:
     inserted: bool
 
 
+@dataclass(frozen=True)
+class StoredRecord:
+    """A retained record and its storage state, for audit reads only.
+
+    ``compacted_at`` marks retirement from training, not proof of learning.
+    The commit log's ``consumed_ids`` identifies which records a step consumed.
+    """
+
+    sequence: int
+    item: AgentRecord
+    compacted_at: float | None
+
+
 class RecordStore:
     """Store scenario records in append order.
 
@@ -55,6 +69,9 @@ class RecordStore:
     Passing a filesystem path makes the store durable. The default in-memory
     database keeps standalone/test construction lightweight; production callers
     should always pass a path.
+
+    Training reads hide compacted rows. Explicit audit reads retain access to
+    their bodies until :meth:`purge_compacted` physically removes them.
     """
 
     _SQLITE_ID_CHUNK_SIZE = 900
@@ -82,6 +99,8 @@ class RecordStore:
             if self._database != ":memory:":
                 self._connection.execute("PRAGMA journal_mode = WAL")
                 self._connection.execute("PRAGMA synchronous = FULL")
+            # Serialize schema inspection and upgrade across store openers.
+            self._connection.execute("BEGIN IMMEDIATE")
             self._connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS agent_record (
@@ -92,10 +111,14 @@ class RecordStore:
                     payload_json TEXT NOT NULL,
                     created_at REAL NOT NULL,
                     references_json TEXT NOT NULL,
-                    artifact_json TEXT
+                    artifact_json TEXT,
+                    compacted_at REAL
                 )
             """
             )
+            columns = {row["name"] for row in self._connection.execute("PRAGMA table_info(agent_record)")}
+            if "compacted_at" not in columns:
+                self._connection.execute("ALTER TABLE agent_record ADD COLUMN compacted_at REAL")
             self._connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS consumed_agent_record (
@@ -110,6 +133,18 @@ class RecordStore:
             self._connection.execute(
                 "CREATE INDEX IF NOT EXISTS agent_record_scenario_type_sequence "
                 "ON agent_record (scenario, request_type, sequence)"
+            )
+            self._connection.execute(
+                "CREATE INDEX IF NOT EXISTS agent_record_active_sequence "
+                "ON agent_record (scenario, sequence) WHERE compacted_at IS NULL"
+            )
+            self._connection.execute(
+                "CREATE INDEX IF NOT EXISTS agent_record_active_type_sequence "
+                "ON agent_record (scenario, request_type, sequence) WHERE compacted_at IS NULL"
+            )
+            self._connection.execute(
+                "CREATE INDEX IF NOT EXISTS agent_record_compacted_at "
+                "ON agent_record (scenario, compacted_at, sequence) WHERE compacted_at IS NOT NULL"
             )
             self._connection.execute(
                 """
@@ -270,9 +305,10 @@ class RecordStore:
             return AppendResult(stored, False)
 
     def get(self, scenario: str, agent_record_id: str) -> AgentRecord | None:
+        """Read a record still visible to training, scoped to its scenario."""
         with self._lock:
             row = self._connection.execute(
-                "SELECT * FROM agent_record WHERE scenario = ? AND agent_record_id = ?",
+                "SELECT * FROM agent_record WHERE scenario = ? AND agent_record_id = ? AND compacted_at IS NULL",
                 (scenario, agent_record_id),
             ).fetchone()
         return None if row is None else self._decode(row)
@@ -290,7 +326,10 @@ class RecordStore:
             raise ValueError("limit must be non-negative")
         if limit == 0:
             return ()
-        sql = "SELECT * FROM agent_record WHERE scenario = ? ORDER BY sequence LIMIT ? OFFSET ?"
+        sql = (
+            "SELECT * FROM agent_record WHERE scenario = ? AND compacted_at IS NULL "
+            "ORDER BY sequence LIMIT ? OFFSET ?"
+        )
         size = -1 if limit is None else limit
         with self._lock:
             rows = self._connection.execute(sql, (scenario, size, offset)).fetchall()
@@ -312,7 +351,7 @@ class RecordStore:
             rows = self._connection.execute(
                 """
                 SELECT * FROM agent_record
-                WHERE scenario = ? AND sequence > ?
+                WHERE scenario = ? AND sequence > ? AND compacted_at IS NULL
                 ORDER BY sequence
                 LIMIT ?
                 """,
@@ -321,10 +360,10 @@ class RecordStore:
         return tuple((int(row["sequence"]), self._decode(row)) for row in rows)
 
     def count(self, scenario: str, *, request_type: RequestType | None = None, after_sequence: int = 0) -> int:
-        """How many records the scenario holds, of one type when given, past ``after_sequence`` only."""
+        """Count training-visible records, optionally by type and after an append sequence."""
         if after_sequence < 0:
             raise ValueError("after_sequence must be non-negative")
-        sql = "SELECT COUNT(*) AS count FROM agent_record WHERE scenario = ? AND sequence > ?"
+        sql = "SELECT COUNT(*) AS count FROM agent_record WHERE scenario = ? AND sequence > ? AND compacted_at IS NULL"
         parameters: list[object] = [scenario, after_sequence]
         if request_type is not None:
             sql += " AND request_type = ?"
@@ -335,6 +374,38 @@ class RecordStore:
             raise RuntimeError("record count query returned no row")
         return int(row["count"])
 
+    def get_for_audit(self, scenario: str, agent_record_id: str) -> StoredRecord | None:
+        """Read a retained record including its compaction state; never reactivate it."""
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT * FROM agent_record WHERE scenario = ? AND agent_record_id = ?",
+                (scenario, agent_record_id),
+            ).fetchone()
+        return None if row is None else self._audit_record(row)
+
+    def audit_page(
+        self,
+        scenario: str,
+        *,
+        after_sequence: int = 0,
+        limit: int = 256,
+    ) -> tuple[StoredRecord, ...]:
+        """Read a bounded append-order page including compacted bodies, scoped to one scenario."""
+        if after_sequence < 0:
+            raise ValueError("after_sequence must be non-negative")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT * FROM agent_record WHERE scenario = ? AND sequence > ? ORDER BY sequence LIMIT ?",
+                (scenario, after_sequence, limit),
+            ).fetchall()
+        return tuple(self._audit_record(row) for row in rows)
+
+    @classmethod
+    def _audit_record(cls, row: sqlite3.Row) -> StoredRecord:
+        return StoredRecord(sequence=int(row["sequence"]), item=cls._decode(row), compacted_at=row["compacted_at"])
+
     def compact(
         self,
         scenario: str,
@@ -343,12 +414,12 @@ class RecordStore:
         receipt_id: str | None = None,
         receipt_metadata: Mapping[str, object] | None = None,
     ) -> None:
-        """Delete payloads while retaining retry-safe idempotency receipts.
+        """Retire records from training while retaining their bodies for audit.
 
-        Compaction is irreversible: deleted rows no longer participate in
-        replay, lookup, or reference availability. Durable receipts preserve
-        append deduplication and reject reports that reference consumed data.
-        Callers must ensure the payloads are no longer needed.
+        Compacted rows no longer participate in training replay, lookup, or
+        reference availability. Durable receipts preserve append deduplication
+        and refuse reports that reference retired data. Repeated compaction
+        preserves the first retirement time. Physical deletion is separate.
         """
         if (receipt_id is None) != (receipt_metadata is None):
             raise ValueError("compaction receipt_id and receipt_metadata must be provided together")
@@ -358,6 +429,7 @@ class RecordStore:
             return
         compacted_ids_json = self._json(sorted(agent_record_ids))
         metadata_json = self._json(dict(receipt_metadata or {}))
+        compacted_at = time.time()
         with self._lock, self._connection:
             if receipt_id is not None:
                 # A receipt is identified by (scenario, receipt_id, compacted ids), the
@@ -389,7 +461,8 @@ class RecordStore:
                     chunk = sorted_ids[start : start + self._SQLITE_ID_CHUNK_SIZE]
                     placeholders = ",".join("?" for _ in chunk)
                     rows = self._connection.execute(
-                        f"SELECT * FROM agent_record WHERE scenario = ? AND agent_record_id IN ({placeholders})",
+                        "SELECT * FROM agent_record WHERE scenario = ? AND compacted_at IS NULL "
+                        f"AND agent_record_id IN ({placeholders})",
                         (scenario, *chunk),
                     ).fetchall()
                     self._connection.executemany(
@@ -400,11 +473,35 @@ class RecordStore:
                         ((row["agent_record_id"], self._content_sha256(self._row_content(row))) for row in rows),
                     )
                     self._connection.execute(
-                        f"DELETE FROM agent_record WHERE scenario = ? AND agent_record_id IN ({placeholders})",
-                        (scenario, *chunk),
+                        "UPDATE agent_record SET compacted_at = ? WHERE scenario = ? AND compacted_at IS NULL "
+                        f"AND agent_record_id IN ({placeholders})",
+                        (compacted_at, scenario, *chunk),
                     )
         for agent_record_id in agent_record_ids:
             self._live_records.pop(agent_record_id, None)
+
+    def purge_compacted(self, scenario: str, *, before: float, limit: int = 256) -> int:
+        """Delete at most ``limit`` bodies retired before a finite Unix timestamp.
+
+        This explicit operation is irreversible. Active records, retry hashes,
+        and compaction receipts are retained. No automatic purge is scheduled.
+        """
+        if not math.isfinite(before):
+            raise ValueError("before must be a finite Unix timestamp")
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValueError("limit must be a positive integer")
+        with self._lock, self._connection:
+            cursor = self._connection.execute(
+                """
+                DELETE FROM agent_record WHERE sequence IN (
+                    SELECT sequence FROM agent_record
+                    WHERE scenario = ? AND compacted_at < ?
+                    ORDER BY compacted_at, sequence LIMIT ?
+                )
+                """,
+                (scenario, before, limit),
+            )
+            return cursor.rowcount
 
     def compaction_receipts(self, scenario: str) -> tuple[dict[str, object], ...]:
         """Return durable, ordered metadata for explicitly recorded compactions."""

--- a/reef/records.py
+++ b/reef/records.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import heapq
 import json
 import math
 import sqlite3
 import time
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
@@ -112,13 +114,20 @@ class RecordStore:
                     created_at REAL NOT NULL,
                     references_json TEXT NOT NULL,
                     artifact_json TEXT,
-                    compacted_at REAL
+                    compacted_at REAL,
+                    body_bytes INTEGER NOT NULL DEFAULT 0
                 )
             """
             )
             columns = {row["name"] for row in self._connection.execute("PRAGMA table_info(agent_record)")}
             if "compacted_at" not in columns:
                 self._connection.execute("ALTER TABLE agent_record ADD COLUMN compacted_at REAL")
+            if "body_bytes" not in columns:
+                self._connection.execute("ALTER TABLE agent_record ADD COLUMN body_bytes INTEGER NOT NULL DEFAULT 0")
+                self._connection.execute(
+                    "UPDATE agent_record SET body_bytes = length(CAST(payload_json AS BLOB)) "
+                    "+ length(CAST(references_json AS BLOB)) + COALESCE(length(CAST(artifact_json AS BLOB)), 0)"
+                )
             self._connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS consumed_agent_record (
@@ -145,6 +154,10 @@ class RecordStore:
             self._connection.execute(
                 "CREATE INDEX IF NOT EXISTS agent_record_compacted_at "
                 "ON agent_record (scenario, compacted_at, sequence) WHERE compacted_at IS NOT NULL"
+            )
+            self._connection.execute(
+                "CREATE INDEX IF NOT EXISTS agent_record_retention "
+                "ON agent_record (compacted_at, sequence, body_bytes) WHERE compacted_at IS NOT NULL"
             )
             self._connection.execute(
                 """
@@ -282,10 +295,10 @@ class RecordStore:
                 """
                 INSERT OR IGNORE INTO agent_record (
                     agent_record_id, scenario, request_type, created_at,
-                    payload_json, references_json, artifact_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    payload_json, references_json, artifact_json, body_bytes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                encoded,
+                (*encoded, sum(len(value.encode("utf-8")) for value in encoded[4:] if value is not None)),
             )
             if cursor.rowcount == 1:
                 self._live_records[item.agent_record_id] = item
@@ -484,7 +497,7 @@ class RecordStore:
         """Delete at most ``limit`` bodies retired before a finite Unix timestamp.
 
         This explicit operation is irreversible. Active records, retry hashes,
-        and compaction receipts are retained. No automatic purge is scheduled.
+        and compaction receipts are retained. This call schedules no further maintenance.
         """
         if not math.isfinite(before):
             raise ValueError("before must be a finite Unix timestamp")
@@ -534,3 +547,108 @@ class RecordStore:
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
         self.close()
+
+
+@dataclass(frozen=True)
+class RecordRetention:
+    """Deployment-wide limits on compacted JSON bodies, applied by service maintenance.
+
+    The byte budget excludes active records, indexes, tombstones, and WAL pages.
+    Cleanup reuses SQLite pages; it does not impose a physical file-size limit.
+    """
+
+    days: float = 7.0
+    max_bytes: int = 20 * 1024**3
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.days, bool)
+            or not isinstance(self.days, (int, float))
+            or not math.isfinite(self.days)
+            or self.days <= 0
+        ):
+            raise ValueError("agent_record_retention_days must be positive and finite")
+        if isinstance(self.max_bytes, bool) or not isinstance(self.max_bytes, int) or self.max_bytes <= 0:
+            raise ValueError("agent_record_retention_max_bytes must be a positive integer")
+
+    def prune(self, directory: Path) -> int:
+        """Purge expired bodies, then the oldest bodies across this directory to meet the budget.
+
+        The caller must serialize this sweep with scenario file moves. Deletes
+        commit in batches of 256 and never touch active records or retry metadata.
+        Concurrent compaction may exceed the budget until the next sweep.
+        """
+        cutoff = time.time() - self.days * 86400
+        paths = sorted((*directory.glob("*.sqlite3"), *(directory / "archived").rglob("*.sqlite3")))
+        purged = 0
+        total = 0
+        retained_paths: list[str] = []
+        for database_path in paths:
+            with closing(self._connect(str(database_path))) as connection:
+                columns = {row[1] for row in connection.execute("PRAGMA table_info(agent_record)")}
+                if not {"compacted_at", "body_bytes"} <= columns:
+                    # Old stores have no retained compacted bodies; migration belongs to RecordStore.
+                    continue
+                retained_paths.append(str(database_path))
+                while True:
+                    with connection:
+                        count = connection.execute(
+                            "DELETE FROM agent_record WHERE sequence IN ("
+                            "SELECT sequence FROM agent_record WHERE compacted_at < ? "
+                            "ORDER BY compacted_at, sequence LIMIT 256)",
+                            (cutoff,),
+                        ).rowcount
+                    purged += count
+                    if count < 256:
+                        break
+
+                total += connection.execute(
+                    "SELECT COALESCE(SUM(body_bytes), 0) FROM agent_record WHERE compacted_at IS NOT NULL"
+                ).fetchone()[0]
+        if total <= self.max_bytes:
+            return purged
+        pending: dict[str, list[int]] = {path: [] for path in retained_paths}
+        rows = heapq.merge(*(self._rows(path) for path in retained_paths))
+        for _, path, sequence, size in rows:
+            pending[path].append(sequence)
+            total -= size
+            if len(pending[path]) == 256:
+                purged += self._delete(path, pending[path])
+                pending[path].clear()
+            if total <= self.max_bytes:
+                break
+        for path, sequences in pending.items():
+            if sequences:
+                purged += self._delete(path, sequences)
+        return purged
+
+    @staticmethod
+    def _connect(path: str) -> sqlite3.Connection:
+        return sqlite3.connect(Path(path).resolve().as_uri() + "?mode=rw", uri=True, timeout=30)
+
+    @classmethod
+    def _rows(cls, path: str) -> Iterator[tuple[float, str, int, int]]:
+        after_time: float = -math.inf
+        after_sequence = 0
+        while True:
+            with closing(cls._connect(path)) as connection:
+                rows = connection.execute(
+                    "SELECT compacted_at, sequence, body_bytes FROM agent_record "
+                    "WHERE compacted_at IS NOT NULL AND (compacted_at, sequence) > (?, ?) "
+                    "ORDER BY compacted_at, sequence LIMIT 256",
+                    (after_time, after_sequence),
+                ).fetchall()
+            if not rows:
+                return
+            for compacted_at, sequence, size in rows:
+                yield compacted_at, path, sequence, size
+            after_time, after_sequence = rows[-1][:2]
+
+    @classmethod
+    def _delete(cls, path: str, sequences: list[int]) -> int:
+        placeholders = ",".join("?" for _ in sequences)
+        with closing(cls._connect(path)) as connection, connection:
+            return connection.execute(
+                f"DELETE FROM agent_record WHERE compacted_at IS NOT NULL AND sequence IN ({placeholders})",
+                sequences,
+            ).rowcount

--- a/reef/scenario/commit_log.py
+++ b/reef/scenario/commit_log.py
@@ -55,7 +55,7 @@ class CommitRecord:
     ``step``, ``artifact_ref`` and ``algorithm_state`` advance together or not
     at all; ``record_progress`` pins the record high-water mark the step
     consumed, the rows its batch consumed, and the rows its compaction
-    deleted, so the record store and processor memory can be re-derived after
+    retired, so the record store and processor memory can be re-derived after
     a crash.
     """
 

--- a/reef/service/app.py
+++ b/reef/service/app.py
@@ -1,16 +1,35 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Iterable
 
 from aiohttp import web
 
 from reef.dispatcher import Dispatcher, build_default_dispatcher
+from reef.records import RecordRetention
 from reef.runtime.inference import InferenceBackend
 from reef.service.auth import create_authentication_middleware
 from reef.service.errors import translate_errors
 from reef.service.request_service import InferenceRetryPolicy, RequestService
 from reef.service.routes import register_routes
+
+logger = logging.getLogger(__name__)
+_RECORD_RETENTION_INTERVAL_SECONDS = 60.0
+
+
+async def _maintain_records(dispatcher: Dispatcher, retention: RecordRetention, stopped: asyncio.Event) -> None:
+    while not stopped.is_set():
+        try:
+            purged = await asyncio.to_thread(dispatcher.prune_record_archives, retention)
+            if purged:
+                logger.info("purged %d compacted trace bodies under record retention limits", purged)
+        except Exception:
+            logger.exception("record retention failed; will retry on the next sweep")
+        try:
+            await asyncio.wait_for(stopped.wait(), timeout=_RECORD_RETENTION_INTERVAL_SECONDS)
+        except asyncio.TimeoutError:
+            continue
 
 
 def create_app(
@@ -20,6 +39,7 @@ def create_app(
     inference_backend: InferenceBackend | None = None,
     inference_retry_policy: InferenceRetryPolicy | None = None,
     close_dispatcher: bool = False,
+    record_retention: RecordRetention | None = None,
 ):
     request_service = RequestService(
         dispatcher or build_default_dispatcher(),
@@ -33,6 +53,19 @@ def create_app(
         request_service=request_service,
         inference_backend=inference_backend,
     )
+    if record_retention is not None:
+
+        async def maintain_records(app: web.Application):
+            stopped = asyncio.Event()
+            task = asyncio.create_task(_maintain_records(request_service.dispatcher, record_retention, stopped))
+            try:
+                yield
+            finally:
+                # Let an in-flight SQLite batch finish before closing the dispatcher.
+                stopped.set()
+                await task
+
+        app.cleanup_ctx.append(maintain_records)
     if dispatcher is None or close_dispatcher:
 
         async def cleanup(app: web.Application) -> None:

--- a/reef/service/assembly.py
+++ b/reef/service/assembly.py
@@ -21,6 +21,7 @@ from reef.observability import build_experiment_tracker
 from reef.recipe import Recipe, WeightTrainingRecipe
 from reef.recipe.config_fields import resolve_config_field_values
 from reef.recipe.registry import build_named_recipe, build_recipe, recipe_class_for
+from reef.records import RecordRetention
 from reef.runtime.adapters.inference_proxy import InferenceProxyRuntime
 from reef.runtime.base import InferenceRuntime, TrainingRuntime
 from reef.runtime.inference import InferenceBackendFactory
@@ -237,6 +238,7 @@ def build_dispatcher(
 
 
 def build_app(settings: ServiceSettings, *, environ: Mapping[str, str] | None = None, connector: Any = None) -> Any:
+    record_retention = RecordRetention(settings.agent_record_retention_days, settings.agent_record_retention_max_bytes)
     retry_policy = InferenceRetryPolicy(
         initial_s=settings.inference_retry_initial_s,
         max_s=settings.inference_retry_max_s,
@@ -251,6 +253,7 @@ def build_app(settings: ServiceSettings, *, environ: Mapping[str, str] | None = 
             tokens=settings.tokens,
             inference_retry_policy=retry_policy,
             close_dispatcher=True,
+            record_retention=record_retention,
         )
     except BaseException:
         with suppress(Exception):

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from reef.records import RecordRetention
 from reef.service.deploy.config import config_value, interpolate_config, load_config
 
 _DESCRIPTION = """reef serve — start a stack from a config.
@@ -99,6 +100,8 @@ class ServiceSettings:
     artifact_work_dir: str = ".reef/artifact-work"
     artifact_cache_dir: str = ".reef/artifact-cache"
     agent_record_dir: str = ".reef/agent-record"
+    agent_record_retention_days: float = 7.0
+    agent_record_retention_max_bytes: int = 20 * 1024**3
     allow_implicit_scenario_creation: bool = True
     #: Deployment-level experiment provider settings, sourced from
     #: ``observability.wandb``.
@@ -109,6 +112,9 @@ class ServiceSettings:
     #: The flat ``reef`` config section, interpolated; recipes read their own
     #: config fields from it (see the class docstring).
     recipe_settings: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        RecordRetention(self.agent_record_retention_days, self.agent_record_retention_max_bytes)
 
 
 def _config_service_value(config: Mapping[str, Any], *path: str, default: Any = None, expand: bool = True) -> Any:
@@ -258,6 +264,12 @@ def service_settings_from_config(config: Mapping[str, Any]) -> ServiceSettings:
             "reef",
             "agent_record_dir",
             default=".reef/agent-record",
+        ),
+        agent_record_retention_days=float(
+            _config_service_value(config, "reef", "agent_record_retention_days", default=7.0)
+        ),
+        agent_record_retention_max_bytes=int(
+            _config_service_value(config, "reef", "agent_record_retention_max_bytes", default=20 * 1024**3)
         ),
         allow_implicit_scenario_creation=bool(
             _config_service_value(config, "reef", "allow_implicit_scenario_creation", default=True)

--- a/reef/train/trainer.py
+++ b/reef/train/trainer.py
@@ -451,7 +451,7 @@ class Trainer:
             self._pending = None
 
     def apply_compaction(self, compacted_ids: frozenset[str]) -> None:
-        """Physically delete the rows a prepared commit marked disposable."""
+        """Retire disposable rows from training while preserving their audit bodies."""
         if not compacted_ids:
             return
         with self._lock:

--- a/tests/reef_service/test_commit_log.py
+++ b/tests/reef_service/test_commit_log.py
@@ -657,7 +657,7 @@ def test_recovery_resumes_record_progress_without_retraining(tmp_path) -> None:
     first.accept_record(sft_report("r1", "i1"))
     wait_for_step(first, 1)
     assert first_runtime.trained_batches == [["i1"]]
-    # Nothing was compacted: the consumed pair is still physically present.
+    # Nothing was compacted: the consumed pair is still visible to training reads.
     assert first.get_or_create_scenario("math").records.get("math", "i1") is not None
 
     second_runtime = RecordingRuntime()

--- a/tests/reef_service/test_record_retention.py
+++ b/tests/reef_service/test_record_retention.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from threading import Event
+
+import pytest
+from aiohttp import web
+
+from reef.core import AgentRecord, RequestType
+from reef.dispatcher import build_default_dispatcher
+from reef.records import RecordConflict, RecordRetention, RecordStore
+from reef.service import assembly
+from reef.service.deploy.settings import ServiceSettings, service_settings_from_config
+
+
+def trace(record_id: str, scenario: str = "math") -> AgentRecord:
+    return AgentRecord.create(
+        agent_record_id=record_id, scenario=scenario, request_type=RequestType.INFERENCE, payload={"text": "海"}
+    )
+
+
+BODY_BYTES = len('{"text":"海"}[]'.encode())
+
+
+def test_retention_uses_one_budget_across_scenarios_and_archived_databases(tmp_path, monkeypatch):
+    archive = tmp_path / "archived" / "removed" / "archived.sqlite3"
+    oldest = trace("old")
+    with RecordStore(tmp_path / "a.sqlite3") as first, RecordStore(tmp_path / "b.sqlite3") as second:
+        with RecordStore(archive) as removed:
+            for clock, store, record in (
+                (10.0, first, oldest),
+                (15.0, removed, trace("archived")),
+                (20.0, second, trace("middle", "code")),
+                (30.0, first, trace("new")),
+            ):
+                monkeypatch.setattr("reef.records.time.time", lambda clock=clock: clock)
+                store.append(record)
+                store.compact(record.scenario, frozenset({record.agent_record_id}))
+        first.append(replace(trace("active"), payload={"text": "x" * 4096}))
+        monkeypatch.setattr("reef.records.time.time", lambda: 40.0)
+        assert RecordRetention(max_bytes=2 * BODY_BYTES).prune(tmp_path) == 2
+        assert first.get_for_audit("math", "old") is None
+        assert first.get_for_audit("math", "new") is not None
+        assert second.get_for_audit("code", "middle") is not None
+        assert first.get("math", "active") is not None
+        assert first.append_result(oldest).inserted is False
+        with pytest.raises(RecordConflict):
+            first.append(replace(oldest, payload={"text": "changed"}))
+        assert (
+            first.append_result(replace(trace("late"), request_type=RequestType.REPORT, references=("old",))).inserted
+            is False
+        )
+    with RecordStore(archive) as removed:
+        assert removed.get_for_audit("math", "archived") is None
+
+
+def test_retention_expires_bodies_in_batches_and_preserves_boundary_and_receipts(tmp_path, monkeypatch):
+    with RecordStore(tmp_path / "records.sqlite3") as records:
+        for index in range(257):
+            records.append(trace(f"old-{index}"))
+        monkeypatch.setattr("reef.records.time.time", lambda: 99.0)
+        records.compact(
+            "math",
+            frozenset(f"old-{index}" for index in range(257)),
+            receipt_id="batch",
+            receipt_metadata={"outcome": "stale"},
+        )
+        records.append(trace("boundary"))
+        monkeypatch.setattr("reef.records.time.time", lambda: 100.0)
+        records.compact("math", frozenset({"boundary"}))
+        monkeypatch.setattr("reef.records.time.time", lambda: 7 * 86400 + 100.0)
+        assert RecordRetention().prune(tmp_path) == 257
+        assert [entry.item.agent_record_id for entry in records.audit_page("math")] == ["boundary"]
+        assert records.compaction_receipts("math")[0]["receipt_id"] == "batch"
+        assert RecordRetention().prune(tmp_path) == 0
+
+
+def test_budget_purge_pages_across_equal_timestamps_without_skipping_rows(tmp_path, monkeypatch):
+    with RecordStore(tmp_path / "records.sqlite3") as records:
+        for index in range(600):
+            records.append(trace(str(index)))
+        monkeypatch.setattr("reef.records.time.time", lambda: 100.0)
+        records.compact("math", frozenset(str(index) for index in range(600)))
+        assert RecordRetention(max_bytes=3 * BODY_BYTES).prune(tmp_path) == 597
+        assert [entry.item.agent_record_id for entry in records.audit_page("math")] == ["597", "598", "599"]
+
+
+def test_retention_skips_unmigrated_stores_and_empty_directories(tmp_path):
+    assert RecordRetention().prune(tmp_path) == 0
+    with sqlite3.connect(tmp_path / "legacy.sqlite3") as connection:
+        connection.execute("CREATE TABLE agent_record (sequence INTEGER PRIMARY KEY, payload_json TEXT)")
+        connection.execute("INSERT INTO agent_record VALUES (1, 'original')")
+    assert RecordRetention().prune(tmp_path) == 0
+    with sqlite3.connect(tmp_path / "legacy.sqlite3") as connection:
+        assert connection.execute("SELECT payload_json FROM agent_record").fetchone() == ("original",)
+
+
+@pytest.mark.parametrize("days", [0, -1, float("nan"), float("inf"), True])
+def test_retention_rejects_invalid_days(days):
+    with pytest.raises(ValueError, match="retention_days"):
+        RecordRetention(days=days)
+
+
+@pytest.mark.parametrize("size", [0, -1, 1.5, True])
+def test_retention_rejects_invalid_budgets(size):
+    with pytest.raises(ValueError, match="retention_max_bytes"):
+        RecordRetention(max_bytes=size)
+
+
+def test_service_config_defaults_to_seven_days_and_twenty_gib_and_accepts_overrides():
+    defaults = service_settings_from_config({"reef": {"recipe": "recipe"}})
+    assert defaults.agent_record_retention_days == 7
+    assert defaults.agent_record_retention_max_bytes == 20 * 1024**3
+    settings = service_settings_from_config(
+        {"reef": {"recipe": "recipe", "agent_record_retention_days": 3, "agent_record_retention_max_bytes": 1024}}
+    )
+    assert settings.agent_record_retention_days == 3
+    assert settings.agent_record_retention_max_bytes == 1024
+    assert "agent_record_retention_days" not in assembly._recipe_owned_settings(settings)
+    with pytest.raises(ValueError, match="retention_max_bytes"):
+        service_settings_from_config({"reef": {"recipe": "recipe", "agent_record_retention_max_bytes": 0}})
+
+
+def test_service_runs_retention_retries_failure_and_stops_on_cleanup(tmp_path, monkeypatch, caplog):
+    dispatcher = build_default_dispatcher(agent_record_dir=tmp_path)
+    monkeypatch.setattr(assembly, "build_dispatcher", lambda *args, **kwargs: dispatcher)
+    monkeypatch.setattr("reef.service.app._RECORD_RETENTION_INTERVAL_SECONDS", 0.005)
+    original = dispatcher.prune_record_archives
+    attempts = []
+
+    def flaky(retention):
+        attempts.append(retention)
+        if len(attempts) == 1:
+            raise sqlite3.OperationalError("temporary storage failure")
+        return original(retention)
+
+    monkeypatch.setattr(dispatcher, "prune_record_archives", flaky)
+    with RecordStore(tmp_path / "records.sqlite3") as records:
+        records.append(trace("expired"))
+        with monkeypatch.context() as clock:
+            clock.setattr("reef.records.time.time", lambda: 1.0)
+            records.compact("math", frozenset({"expired"}))
+
+        async def run():
+            app = assembly.build_app(ServiceSettings(recipe="recipe", agent_record_dir=str(tmp_path)))
+            runner = web.AppRunner(app)
+            await runner.setup()
+            try:
+
+                async def wait_for_purge():
+                    while records.get_for_audit("math", "expired") is not None:
+                        await asyncio.sleep(0.005)
+
+                await asyncio.wait_for(wait_for_purge(), timeout=2)
+            finally:
+                await runner.cleanup()
+            count = len(attempts)
+            await asyncio.sleep(0.02)
+            assert len(attempts) == count
+
+        asyncio.run(run())
+    assert len(attempts) >= 2
+    assert attempts[0] == RecordRetention(days=7, max_bytes=20 * 1024**3)
+    assert "record retention failed" in caplog.text
+
+
+def test_retention_serializes_with_scenario_file_archival(tmp_path, monkeypatch):
+    dispatcher = build_default_dispatcher(agent_record_dir=tmp_path)
+    dispatcher.get_or_create_scenario("math")
+    started, release, deleting = Event(), Event(), Event()
+    original = RecordRetention.prune
+
+    def held(retention, directory):
+        started.set()
+        assert release.wait(3)
+        return original(retention, directory)
+
+    def remove():
+        deleting.set()
+        return dispatcher.delete_scenario("math")
+
+    monkeypatch.setattr(RecordRetention, "prune", held)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            pruning = executor.submit(dispatcher.prune_record_archives, RecordRetention())
+            assert started.wait(3)
+            deletion = executor.submit(remove)
+            try:
+                assert deleting.wait(3)
+                assert not deletion.done()
+                assert list(tmp_path.glob("*.sqlite3"))
+            finally:
+                release.set()
+            assert pruning.result(timeout=3) == 0
+            assert deletion.result(timeout=3)["archived"]
+    finally:
+        dispatcher.close()

--- a/tests/reef_service/test_records.py
+++ b/tests/reef_service/test_records.py
@@ -8,7 +8,7 @@ import pytest
 
 from reef.artifact import ArtifactRef, LiveWeightArtifactRef
 from reef.core import AgentRecord, RequestType
-from reef.records import RecordConflict, RecordStore
+from reef.records import RecordConflict, RecordRetention, RecordStore
 
 
 def item(
@@ -432,6 +432,9 @@ def test_old_schema_migrates_without_losing_live_records_or_reviving_deleted_bod
     with RecordStore(database) as records:
         assert records.get("math", "live") is None
         assert records.get_for_audit("math", "live").item == item("live", "math")
+        assert RecordRetention(max_bytes=1).prune(tmp_path) == 1
+        assert records.get_for_audit("math", "live") is None
+        assert records.get("math", "next") is not None
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_records.py
+++ b/tests/reef_service/test_records.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
 import pytest
 
 from reef.artifact import ArtifactRef, LiveWeightArtifactRef
@@ -155,12 +159,19 @@ def test_compact_hides_records_but_retains_retry_tombstones(tmp_path) -> None:
         assert [record.agent_record_id for record in records.replay("math")] == ["retained"]
         assert records.get("math", "inference") is None
         assert records.get("math", "retained") is not None
+        archived = records.get_for_audit("math", "inference")
+        assert archived is not None and archived.item == inference
+        assert archived.compacted_at is not None
+        assert records.get_for_audit("code", "inference") is None
 
     with RecordStore(database) as recovered:
         assert recovered.append_result(inference).inserted is False
         late = item("late", "math", RequestType.REPORT, references=("inference",))
         assert recovered.append_result(late).inserted is False
         assert recovered.count("math") == 1
+        assert recovered.get_for_audit("math", "inference") == archived
+        assert recovered.get_for_audit("math", "report").item == report
+        assert recovered.existing_receipt(inference).agent_record_id == inference.agent_record_id
 
 
 @pytest.mark.unit
@@ -238,10 +249,13 @@ def test_compact_fingerprints_large_id_sets_in_bounded_queries() -> None:
 
     assert records.count("math") == 0
     assert records.append_result(items[-1]).inserted is False
+    archived = records.audit_page("math", limit=1001)
+    assert len(archived) == 1001
+    assert all(record.compacted_at is not None for record in archived)
 
 
 @pytest.mark.unit
-def test_compaction_receipt_is_atomic_with_payload_deletion_and_persists(tmp_path) -> None:
+def test_compaction_receipt_is_atomic_with_retirement_and_persists(tmp_path) -> None:
     database = tmp_path / "records.sqlite3"
     with RecordStore(database) as records:
         records.append(item("inference", "math"))
@@ -274,6 +288,7 @@ def test_compaction_receipt_is_atomic_with_payload_deletion_and_persists(tmp_pat
             },
         }
         assert isinstance(receipts[0]["recorded_at"], float)
+        assert all(record.compacted_at is not None for record in recovered.audit_page("math"))
 
 
 @pytest.mark.unit
@@ -300,3 +315,198 @@ def test_compaction_receipt_is_idempotent_and_conflicting_content_fails() -> Non
         receipt_metadata=metadata,
     )
     assert len(records.compaction_receipts("math")) == 2
+
+
+@pytest.mark.unit
+def test_audit_reads_preserve_trace_content_without_reactivating_it() -> None:
+    trace = AgentRecord.create(
+        agent_record_id="trace",
+        scenario="code",
+        request_type=RequestType.INFERENCE,
+        created_at=10.0,
+        payload={
+            "messages": [{"role": "user", "content": "修复登录重试"}],
+            "response": {"choices": [{"message": {"role": "assistant", "content": "先复现失败。"}}]},
+        },
+        artifact_ref=ArtifactRef("artifact", "release", "initial"),
+    )
+    report = replace(item("feedback", "code", RequestType.REPORT, references=("trace",)), payload={"score": 0.2})
+    with RecordStore() as records:
+        records.append(trace)
+        records.append(report)
+        records.compact("code", frozenset({"trace", "feedback"}))
+
+        page = records.audit_page("code")
+        assert [entry.item for entry in page] == [trace, report]
+        assert all(entry.compacted_at is not None for entry in page)
+        assert records.get_for_audit("code", "feedback").item.references == ("trace",)
+        assert records.count("code") == 0
+        assert records.replay("code") == ()
+        assert records.replay_page("code") == ()
+        assert records.get("code", "trace") is None
+        assert records.append_result(trace).inserted is False
+        assert records.append_result(item("late", "code", RequestType.REPORT, references=("trace",))).inserted is False
+        assert records.count("code") == 0
+
+
+@pytest.mark.unit
+def test_training_pages_skip_compacted_gaps_and_audit_pages_include_them() -> None:
+    with RecordStore() as records:
+        for record in (
+            item("a", "code"),
+            item("other", "math"),
+            item("b", "code", RequestType.REPORT),
+            item("c", "code"),
+            item("d", "code"),
+            item("e", "code", RequestType.REPORT),
+        ):
+            records.append(record)
+        records.compact("code", frozenset({"a", "c", "other"}))
+        assert records.get("math", "other") is not None
+        first = records.replay_page("code", limit=1)
+        second = records.replay_page("code", after_sequence=first[0][0], limit=1)
+        assert [row.agent_record_id for _, row in first] == ["b"]
+        assert [row.agent_record_id for _, row in second] == ["d"]
+        assert [row.agent_record_id for row in records.replay("code", offset=1, limit=1)] == ["d"]
+        assert records.count("code") == 3
+        assert records.count("code", request_type=RequestType.INFERENCE) == 1
+        assert records.count("code", request_type=RequestType.REPORT, after_sequence=first[0][0]) == 1
+        audit_first = records.audit_page("code", limit=2)
+        audit_second = records.audit_page("code", after_sequence=audit_first[-1].sequence, limit=2)
+        assert [row.item.agent_record_id for row in audit_first] == ["a", "b"]
+        assert [row.item.agent_record_id for row in audit_second] == ["c", "d"]
+        assert audit_first[0].compacted_at is not None
+        assert audit_first[1].compacted_at is None
+        assert records.audit_page("missing") == ()
+
+
+@pytest.mark.unit
+def test_repeated_compaction_preserves_the_first_retirement_time(monkeypatch) -> None:
+    with RecordStore() as records:
+        records.append(item("a", "math"))
+        monkeypatch.setattr("reef.records.time.time", lambda: 100.0)
+        records.compact("math", frozenset({"a"}))
+        first = records.get_for_audit("math", "a")
+        monkeypatch.setattr("reef.records.time.time", lambda: 200.0)
+        records.compact("math", frozenset({"a"}))
+        assert records.get_for_audit("math", "a") == first
+        assert first.compacted_at == 100.0
+
+
+@pytest.mark.unit
+def test_old_schema_migrates_without_losing_live_records_or_reviving_deleted_bodies(tmp_path) -> None:
+    database = tmp_path / "legacy.sqlite3"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE agent_record (
+                sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_record_id TEXT NOT NULL UNIQUE, scenario TEXT NOT NULL,
+                request_type TEXT NOT NULL, payload_json TEXT NOT NULL,
+                created_at REAL NOT NULL, references_json TEXT NOT NULL, artifact_json TEXT
+            );
+            CREATE TABLE consumed_agent_record (
+                agent_record_id TEXT PRIMARY KEY, content_sha256 TEXT NOT NULL
+            );
+            INSERT INTO agent_record VALUES (7, 'live', 'math', 'inference', '{"value":"live"}', 4, '[]', NULL);
+            INSERT INTO consumed_agent_record VALUES ('deleted', 'legacy-fingerprint');
+            """
+        )
+
+    def open_store(_: int) -> None:
+        with RecordStore(database) as records:
+            assert records.get("math", "live") == item("live", "math")
+            entry = records.get_for_audit("math", "live")
+            assert entry.sequence == 7 and entry.compacted_at is None
+            assert records.get_for_audit("math", "deleted") is None
+
+    # Concurrent openers must see one atomic, idempotent schema upgrade.
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        tuple(executor.map(open_store, range(3)))
+    with RecordStore(database) as records:
+        late = item("late", "math", RequestType.REPORT, references=("deleted",))
+        assert records.append_result(late).inserted is False
+        records.append(item("next", "math"))
+        assert records.get_for_audit("math", "next").sequence > 7
+        records.compact("math", frozenset({"live"}))
+    with RecordStore(database) as records:
+        assert records.get("math", "live") is None
+        assert records.get_for_audit("math", "live").item == item("live", "math")
+
+
+@pytest.mark.unit
+def test_compaction_failure_rolls_back_body_state_hashes_and_receipt(tmp_path) -> None:
+    database = tmp_path / "records.sqlite3"
+    with RecordStore(database) as records:
+        records.append(item("a", "math"))
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                "CREATE TRIGGER reject_compaction BEFORE UPDATE OF compacted_at ON agent_record "
+                "BEGIN SELECT RAISE(ABORT, 'injected compaction failure'); END"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="injected compaction failure"):
+            records.compact("math", frozenset({"a"}), receipt_id="batch", receipt_metadata={"outcome": "stale"})
+        assert records.get("math", "a") is not None
+        assert records.get_for_audit("math", "a").compacted_at is None
+        assert records.compaction_receipts("math") == ()
+        assert records.append_result(item("report", "math", RequestType.REPORT, references=("a",))).inserted is True
+
+
+@pytest.mark.unit
+def test_purge_is_bounded_scoped_and_preserves_retry_and_receipt_contracts(tmp_path, monkeypatch) -> None:
+    database = tmp_path / "records.sqlite3"
+    original = item("a", "math")
+    with RecordStore(database) as records:
+        for record in (
+            original,
+            item("b", "math"),
+            item("newer", "math"),
+            item("active", "math"),
+            item("other", "code"),
+        ):
+            records.append(record)
+        monkeypatch.setattr("reef.records.time.time", lambda: 100.0)
+        records.compact("math", frozenset({"a", "b"}), receipt_id="batch", receipt_metadata={"outcome": "stale"})
+        records.compact("code", frozenset({"other"}))
+        monkeypatch.setattr("reef.records.time.time", lambda: 200.0)
+        records.compact("math", frozenset({"newer"}))
+        assert records.purge_compacted("math", before=100.0) == 0
+        assert records.purge_compacted("math", before=150.0, limit=1) == 1
+        assert records.get_for_audit("math", "a") is None
+        assert records.get_for_audit("math", "b") is not None
+        assert records.purge_compacted("math", before=150.0) == 1
+        assert records.purge_compacted("math", before=150.0) == 0
+        assert records.get_for_audit("math", "newer") is not None
+        assert records.get("math", "active") is not None
+        assert records.get_for_audit("code", "other") is not None
+
+    with RecordStore(database) as records:
+        assert records.append_result(original).inserted is False
+        assert records.existing_receipt(original).agent_record_id == "a"
+        with pytest.raises(RecordConflict):
+            records.append(replace(original, payload={"value": "changed"}))
+        assert records.append_result(item("late", "math", RequestType.REPORT, references=("a",))).inserted is False
+        assert records.get_for_audit("math", "a") is None
+        assert records.compaction_receipts("math")[0]["receipt_id"] == "batch"
+        assert records.count("math") == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("before", [float("nan"), float("inf"), float("-inf")])
+def test_purge_rejects_non_finite_cutoffs(before: float) -> None:
+    with RecordStore() as records, pytest.raises(ValueError, match="finite"):
+        records.purge_compacted("math", before=before)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("limit", [0, -1, True, 1.5])
+def test_purge_rejects_invalid_limits(limit) -> None:
+    with RecordStore() as records, pytest.raises(ValueError, match="positive integer"):
+        records.purge_compacted("math", before=100.0, limit=limit)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("options", [{"after_sequence": -1}, {"limit": 0}, {"limit": -1}])
+def test_audit_page_rejects_invalid_bounds(options) -> None:
+    with RecordStore() as records, pytest.raises(ValueError):
+        records.audit_page("math", **options)

--- a/tests/reef_service/test_trainer.py
+++ b/tests/reef_service/test_trainer.py
@@ -689,7 +689,7 @@ def test_trainer_restores_algorithm_state_from_metadata() -> None:
 
     # Simulate restart: a fresh trainer is built with the algorithm_state
     # recovered from artifact metadata. the record store on disk retains only the
-    # untrained prefix (compaction removed i1/r1).
+    # untrained prefix (compaction retired i1/r1 from training reads).
     recovered_state = first.algorithm_state_dict()
     second = Trainer.build(
         "math",
@@ -712,7 +712,7 @@ def test_trainer_restores_algorithm_state_from_metadata() -> None:
 
 
 @pytest.mark.unit
-def test_commit_compacts_consumed_payloads_physically(tmp_path) -> None:
+def test_commit_retires_consumed_payloads_and_retains_audit_history(tmp_path) -> None:
     database = tmp_path / "records.sqlite3"
     first_inference = positioned_inference(1)
     first_report = positioned_report(2, first_inference.agent_record_id, 1.0)
@@ -738,6 +738,8 @@ def test_commit_compacts_consumed_payloads_physically(tmp_path) -> None:
 
         assert first_store.get("math", first_inference.agent_record_id) is None
         assert first_store.get("math", first_report.agent_record_id) is None
+        assert first_store.get_for_audit("math", first_inference.agent_record_id).item == first_inference
+        assert first_store.get_for_audit("math", first_report.agent_record_id).item == first_report
         assert [item.agent_record_id for item in first_store.replay("math")] == [
             second_inference.agent_record_id,
             second_report.agent_record_id,
@@ -761,6 +763,10 @@ def test_commit_compacts_consumed_payloads_physically(tmp_path) -> None:
         second.commit(prepared)
         second.apply_compaction(prepared.compacted_ids)
         assert second_store.count("math") == 0
+        archived = second_store.audit_page("math")
+        assert [entry.item for entry in archived] == [first_inference, first_report, second_inference, second_report]
+        assert all(entry.compacted_at is not None for entry in archived)
+        assert second.reserve_training_batch() is None
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Motivation

Training compaction currently deletes inference and report bodies from SQLite, so a learning step can retain its consumed record IDs while the corresponding traces are unavailable to the evolution dashboard. This change retains those bodies for explicit audit reads while keeping compacted records out of training, with automatic retention capped at 7 days and a shared 20 GiB by default.

Related RFC: #365. This PR remains a draft pending acceptance of the persistence and retention change.

## Changes

- Migrate existing stores transactionally to `compacted_at` and measured JSON `body_bytes` columns, with partial indexes for active reads, metadata accounting, and purge selection.
- Mark compacted records instead of deleting them, preserving the first retirement timestamp, content-hash tombstones, atomic compaction receipts, and processor memory release.
- Keep `get`, `replay`, `replay_page`, and `count` restricted to active records. Add scenario-scoped `get_for_audit` and paginated `audit_page` methods that return the original record, append sequence, and compaction timestamp.
- Add explicit, bounded `purge_compacted(scenario, before=..., limit=...)` for physical deletion of old compacted bodies. Active records, retry hashes, and receipts remain intact.
- Run background retention at service startup and every 60 seconds. First expire old compacted bodies, then purge the oldest remaining bodies across all scenario databases (including `archived/`) to meet the shared byte budget. Use 256-row transactions and metadata pages; serialize cleanup with scenario file moves and retry failures on the next sweep.
- Cover migration, restart recovery, trace preservation, pagination, retry/conflict behavior, atomic failure rollback, scenario isolation, global age/size retention, background retries/shutdown, and archival concurrency. Update storage and API documentation.

`compacted_at` indicates retirement from training, which also includes excluded records. Learning lineage still comes from the commit log's per-step `consumed_ids`.

## Compatibility and operational impact

Existing live rows remain active after migration; historical bodies already deleted by old compaction cannot be restored. Existing training-read signatures, HTTP contracts, and learning/promotion policy are unchanged. Dashboard UI, HTTP audit routes, and learning/promotion policy changes are outside this PR.

New service settings are `reef.agent_record_retention_days: 7.0` and `reef.agent_record_retention_max_bytes: 21474836480`. The byte budget counts UTF-8 JSON payloads, references, and artifact references shared across the record directory. Standalone Python stores start no background task; embedded callers can invoke `dispatcher.prune_record_archives(RecordRetention(...))`.

This is a retained-body budget, not a hard disk quota. Compaction can exceed the budget between sweeps, and active records, indexes, retry hashes, commit logs, and WAL files take additional space. Purging allows SQLite to reuse pages but does not shrink the database file. Operators still need disk headroom.

Older Reef versions do not filter `compacted_at`. Before downgrading, stop the service and restore a pre-upgrade backup, or purge all compacted bodies with the new version. Do not mix old and new writers against the migrated store.

## Verification

- From `docs/site` with Node.js 22: `npm ci --no-audit --no-fund`, `npm run check:docs`, `npm run lint`, and `NEXT_TELEMETRY_DISABLED=1 npm run build`: **passed** (lint reports one existing font warning).

- `.venv/bin/python -m pytest tests/reef_service/test_record_retention.py tests/reef_service/test_records.py tests/reef_service/test_console_cors.py tests/reef_service/test_connector.py tests/reef_service/test_deploy_config_validation.py tests/reef_service/test_training_server.py tests/reef_service/test_executor_runtime.py -q --disable-warnings --durations=5`: **178 passed**.
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --all-files`: **passed**.
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null .venv/bin/python -m pytest tests/ -q --disable-warnings --durations=10`: **2920 passed, 30 skipped, 16 warnings** in 307.04 seconds.
- `.venv/bin/python -m mypy`: **4 existing errors in 2 unchanged Slime weight updater files** (`lora_transport.py` and `checkpoint.py`). Running the same command against a clean worktree at base commit `db2a0f0` produced the same four errors; no new type errors were reported.
- SQLite `EXPLAIN QUERY PLAN` confirms archive accounting and metadata paging use the covering retention index; training paging uses the active-row index.
- `git diff --check`: **passed**.

## AI assistance

OpenAI Codex implemented the storage changes, tests, and documentation, and ran the verification commands. The human contributor remains responsible for reviewing and understanding the submitted change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [ ] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.


