### PR TITLE
fix(tttd): preserve training timeout errors

### DIFF
--- a/recipes/tttd/examples/guidance_ttt/harness/run_controller.py
+++ b/recipes/tttd/examples/guidance_ttt/harness/run_controller.py
@@ -31,6 +31,10 @@ class GuidanceRunStateError(RuntimeError):
     """The Guidance archive and Reef's durable training state do not align."""
 
 
+class GuidanceTrainingTimeoutError(RuntimeError):
+    """Reef did not commit a Guidance-TTT training step before its deadline."""
+
+
 @dataclass(frozen=True)
 class GuidanceRunIdentity:
     """Settings a resumed run must reproduce exactly."""
@@ -156,7 +160,7 @@ def wait_for_training_step(
                 return last_health
         if poll_interval_s:
             time.sleep(poll_interval_s)
-    raise TimeoutError(
+    raise GuidanceTrainingTimeoutError(
         f"training rollout {expected_rollout_id} did not complete after {timeout_s:g}s: "
         f"bridge={last_health}; reef={last_status}"
     )
@@ -422,6 +426,7 @@ __all__ = [
     "GuidanceRunOutcome",
     "GuidanceRunStateError",
     "GuidanceRunStateStore",
+    "GuidanceTrainingTimeoutError",
     "RayTrainingBridge",
     "atomic_copy",
     "failed_training_step",

--- a/recipes/tttd/examples/tttd/harness/run_controller.py
+++ b/recipes/tttd/examples/tttd/harness/run_controller.py
@@ -20,6 +20,10 @@ class TTTDRunStateError(RuntimeError):
     """The search archive and Reef's durable training state do not align."""
 
 
+class TTTDTrainingTimeoutError(RuntimeError):
+    """Reef did not commit a TTTD training step before its deadline."""
+
+
 @dataclass(frozen=True)
 class TTTDRunIdentity:
     scenario: str
@@ -411,7 +415,7 @@ class TTTDRunController:
                     # weights after checkpoint recovery.
                     return last
             self._sleep(self.poll_interval_s)
-        raise TimeoutError(
+        raise TTTDTrainingTimeoutError(
             f"Reef scenario did not restore step {expected_step} after {self.train_timeout_s:g}s: {last}"
         )
 
@@ -438,4 +442,5 @@ __all__ = [
     "TTTDRunOutcome",
     "TTTDRunStateError",
     "TTTDRunStateStore",
+    "TTTDTrainingTimeoutError",
 ]

--- a/tests/test_guidance_ttt.py
+++ b/tests/test_guidance_ttt.py
@@ -35,6 +35,7 @@ from recipes.tttd.examples.guidance_ttt.harness.run_controller import (
     GuidanceRunIdentity,
     GuidanceRunStateError,
     GuidanceRunStateStore,
+    GuidanceTrainingTimeoutError,
     RayTrainingBridge,
     read_json,
     require_step_success,
@@ -462,6 +463,31 @@ def test_training_wait_fails_on_reef_training_error() -> None:
             timeout_s=0.01,
             poll_interval_s=0,
         )
+
+
+def test_training_wait_deadline_is_not_a_builtin_timeout(monkeypatch) -> None:
+    monotonic = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(
+        "recipes.tttd.examples.guidance_ttt.harness.run_controller.time.monotonic",
+        lambda: next(monotonic),
+    )
+    blocked_status = _reef_status()["scenarios"]["guidance-run"]
+    blocked_status["checkpoint_storage"] = {
+        "blocked": True,
+        "reasons": ["protected checkpoints plus reservation exceed the managed storage cap"],
+    }
+
+    with pytest.raises(GuidanceTrainingTimeoutError, match="rollout 11 did not complete after 1s") as raised:
+        wait_for_training_step(
+            health=lambda: _bridge_health(completed_train_steps=0, last_train_rollout_id=None),
+            status=lambda: blocked_status,
+            expected_completed_steps=1,
+            expected_rollout_id=11,
+            timeout_s=1,
+            poll_interval_s=0,
+        )
+
+    assert not isinstance(raised.value, TimeoutError)
 
 
 def _reef_status(

--- a/tests/test_tttd_run_controller.py
+++ b/tests/test_tttd_run_controller.py
@@ -14,6 +14,7 @@ from recipes.tttd.examples.tttd.harness.run_controller import (
     TTTDRunIdentity,
     TTTDRunStateError,
     TTTDRunStateStore,
+    TTTDTrainingTimeoutError,
 )
 
 
@@ -294,3 +295,27 @@ def test_controller_fails_fast_when_reef_discards_a_mixed_artifact_step(tmp_path
 
     with pytest.raises(TTTDRunStateError, match="mixed_release_ids"):
         controller.run(1)
+
+
+@pytest.mark.unit
+def test_controller_training_deadline_is_not_a_builtin_timeout(tmp_path, monkeypatch) -> None:
+    store = TTTDRunStateStore(tmp_path / "state.json", _identity())
+    store.save_pending(next_step=1, previous_runtime_load_id="v0", archive={"steps": [0]})
+    controller = TTTDRunController(
+        _Harness([]),
+        _StatusReader([_status(0, "v0")]),
+        store,
+        train_timeout_s=1,
+        poll_interval_s=0.01,
+        sleep=lambda _seconds: None,
+    )
+    monotonic = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(
+        "recipes.tttd.examples.tttd.harness.run_controller.time.monotonic",
+        lambda: next(monotonic),
+    )
+
+    with pytest.raises(TTTDTrainingTimeoutError, match="did not restore step 1 after 1s") as raised:
+        controller.run(1)
+
+    assert not isinstance(raised.value, TimeoutError)


### PR DESCRIPTION
## Motivation

Closes #383.

The ordinary TTTD and Guidance-TTT controllers used Python's built-in `TimeoutError` when Reef did not commit a training step before the controller deadline. Because `asyncio.TimeoutError` aliases that built-in exception, Harbor could catch the inner Reef failure as though Harbor's outer agent timer had expired and replace the real 14400-second diagnostic with its configured 604800-second timeout.

## Changes

- Raise a self-contained `RuntimeError` subclass from each TTTD example when its Reef training deadline expires.
- Preserve the existing deadline, polling, checkpoint-storage retry behavior, and diagnostic text.
- Add regression tests for ordinary TTTD and Guidance-TTT that verify the domain error is not a built-in `TimeoutError`.

## Compatibility and operational impact

The exception type for these two example-controller deadlines changes from built-in `TimeoutError` to a named `RuntimeError` subclass. This is intentional so enclosing timeout managers do not claim Reef's inner deadline. Configuration, persisted state, checkpoint behavior, and resource usage are unchanged.

## Verification

```text
$ python -m pytest tests/test_tttd_run_controller.py tests/test_guidance_ttt.py -q
36 passed in 0.49s

$ pre-commit run --files recipes/tttd/examples/tttd/harness/run_controller.py recipes/tttd/examples/guidance_ttt/harness/run_controller.py tests/test_tttd_run_controller.py tests/test_guidance_ttt.py
All hooks passed

$ python -m mypy
Success: no issues found in 244 source files
```

Checks ran on macOS with Python 3.13.1 in a clean checkout and isolated virtual environment.

## AI assistance

OpenAI Codex was used to inspect the failure path, implement the focused change and regression tests, run the checks above, and draft the issue and pull-request text. The author is responsible for reviewing and understanding every submitted line and claim.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the [maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md) for review and merge requirements.
