### PR TITLE
feat(serve): the harness evolve recipe carries a profile that reef serve --recipe starts

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Last human-confirmed consistent README pair.
 # After updating and reviewing both files, run:
 #   python .github/scripts/check_readme_i18n.py --write
-README.md: e027bcf5028a690d4081631c2f5b10ef82fce987
-README.zh.md: 58c3f60d679d98ff2337166f52c0b4938aa40c4e
+README.md: 878a786d0e9d11bae4465396625cc4b6010aeb6a
+README.zh.md: 05014375fa89eb1bc2d46c4f6f7920e0641b7fa0

--- a/README.md
+++ b/README.md
@@ -195,40 +195,34 @@ current version without restarting Reef.
 
 Improve harness skills using a model API instead of GPUs.
 
-Pass the model at startup using `REEF_UPSTREAM_MODEL`; no YAML edit is needed.
-[deployment.yaml](tutorials/evolve-your-harness/configs/deployment.yaml) uses this
-variable for both serving and evaluation. From your Reef checkout and activated
-Python environment, replace the model ID and API key below with your provider's values:
+The harness evolve recipe carries its own profile, so the model is the one thing
+you name. From your Reef checkout and activated Python environment:
 
 ```bash
-export REEF_UPSTREAM_URL="https://api.openai.com"  # No /v1 suffix
-export REEF_UPSTREAM_MODEL="REPLACE_WITH_YOUR_PROVIDER_MODEL_ID"
-export REEF_UPSTREAM_API_KEY="your-openai-api-key"
-reef serve -c tutorials/evolve-your-harness/configs/deployment.yaml
+reef serve --recipe harness-evolve --model ollama/gemma4:26b
 ```
 
-Use the exact model ID accepted by your provider, not the placeholder above.
-An unset or empty `REEF_UPSTREAM_MODEL` is reported at startup.
+`ollama/` and `openai/` prefixes fill the endpoint and the key (`openai/` reads
+`REEF_UPSTREAM_API_KEY`); any other spelling is the model ID as is, with the
+endpoint from `REEF_UPSTREAM_URL`. The profile listens on `127.0.0.1:8900` with
+no token and keeps its state under `.reef/harness-evolve/`. To change anything
+else, copy [the profile](reef/service/profiles/harness-evolve.yaml) and pass
+your copy with `-c`.
 
-For another provider, use its base URL, model name, and API key. This config deploys Reef on `8901` with `reef-local` as its access token.
-
-In another terminal, install the harness and run a task:
+In another terminal with the same Python environment activated (the install
+bakes that terminal's `python3` into `reef-pi`), install the harness and run a task:
 
 ```bash
-export REEF_TOKEN="reef-local"   # the script writes it into the installed harness's
-                                 # model binding, where reef-pi reads it back
-curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
-  'http://localhost:8901/reef/harness/install?adapter=pi' | bash
+curl -fsS 'http://127.0.0.1:8900/reef/harness/install?adapter=pi' | bash
 reef-pi -p "fix the failing test in auth.py"
 
 # After running your tests, report the actual result:
 reef-pi report --score 0 --feedback "missed the empty-token case"
 ```
 
-If you already installed the harness with `your-model-name`, set `REEF_UPSTREAM_MODEL`,
-stop and restart `reef serve` with the command above, then rerun the harness install
-command before retrying `reef-pi`. Installation writes the model ID into the local
-harness configuration.
+To change the model, restart `reef serve` with another `--model` and rerun the
+install command before `reef-pi`: installation writes the model ID into the
+local harness configuration.
 
 Failed reports trigger a candidate skill update. Reef evaluates it against the
 current harness on the tutorial's three coding tasks and publishes it only if

--- a/README.zh.md
+++ b/README.zh.md
@@ -187,39 +187,28 @@ reef.post(
 
 使用模型 API 改进 harness 技能，无需 GPU。
 
-通过 `REEF_UPSTREAM_MODEL` 在启动时传入模型，无需编辑 YAML。
-[deployment.yaml](tutorials/evolve-your-harness/configs/deployment.yaml) 的推理和评估
-共用这个变量。在 Reef 源码目录及已激活的 Python 环境中运行，
-将下面的模型 ID 和 API key 替换为提供商对应的值：
+harness 进化 recipe 自带 profile，你只需要指定模型。在 Reef checkout 和已激活的 Python 环境中：
 
 ```bash
-export REEF_UPSTREAM_URL="https://api.openai.com"  # No /v1 suffix
-export REEF_UPSTREAM_MODEL="REPLACE_WITH_YOUR_PROVIDER_MODEL_ID"
-export REEF_UPSTREAM_API_KEY="your-openai-api-key"
-reef serve -c tutorials/evolve-your-harness/configs/deployment.yaml
+reef serve --recipe harness-evolve --model ollama/gemma4:26b
 ```
 
-请填写提供商接受的完整模型 ID，不要使用上面的占位符。
-如果未设置 `REEF_UPSTREAM_MODEL` 或其值为空，启动时会报错提示。
+`ollama/` 和 `openai/` 前缀会自动填入端点和密钥（`openai/` 读取
+`REEF_UPSTREAM_API_KEY`）；其他写法按原样作为模型 ID，端点来自 `REEF_UPSTREAM_URL`。
+该 profile 监听 `127.0.0.1:8900`，不设 token，状态保存在 `.reef/harness-evolve/`。
+需要修改其他内容时，复制[该 profile](reef/service/profiles/harness-evolve.yaml) 并用 `-c` 传入你的副本。
 
-如使用其他模型提供商，请填写对应的基础 URL、模型名称和 API key。此配置在 `8901`
-端口部署 Reef，并使用 `reef-local` 作为访问 token。
-
-在另一个终端中安装 harness 并运行任务：
+在另一个已激活同一 Python 环境的终端中（安装会把该终端的 `python3` 写入 `reef-pi`）安装 harness 并运行任务：
 
 ```bash
-export REEF_TOKEN="reef-local"   # the script writes it into the installed harness's
-                                 # model binding, where reef-pi reads it back
-curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
-  'http://localhost:8901/reef/harness/install?adapter=pi' | bash
+curl -fsS 'http://127.0.0.1:8900/reef/harness/install?adapter=pi' | bash
 reef-pi -p "fix the failing test in auth.py"
 
 # After running your tests, report the actual result:
 reef-pi report --score 0 --feedback "missed the empty-token case"
 ```
 
-如果已经使用 `your-model-name` 安装了 harness，请先设置 `REEF_UPSTREAM_MODEL`，停止服务并用上面的
-命令重新启动 `reef serve`，再重新执行 harness 安装命令，最后重试 `reef-pi`。
+要更换模型，用另一个 `--model` 重启 `reef serve`，并在 `reef-pi` 之前重新执行安装命令：
 安装过程会将模型 ID 写入本地 harness 配置。
 
 失败报告会触发候选技能更新。Reef 会在教程的三个编程任务上对候选技能和当前 harness

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -19,8 +19,36 @@ unexpectedly.
 .. config::
 
    -c, --config | the config file. Defaults to ``reef.yaml``, or ``$REEF_CONFIG``.
+   --recipe NAME | start a built in recipe's profile instead of a config file. Today: ``harness-evolve``.
+   --model [PROVIDER/]MODEL | the upstream model. An ``ollama/`` or ``openai/`` prefix fills the endpoint and the key; any other spelling is the model ID as is.
    --help | the command list
    -V, --version | the installed reef version. Takes no command: ``reef --version``.
+
+Starting a recipe's profile
+---------------------------
+
+A built in recipe can carry a profile: one deployment config that is the same
+for every deployment of that recipe except the model. ``--recipe`` starts it
+without a file of your own:
+
+.. code:: bash
+
+   reef serve --recipe harness-evolve --model ollama/gemma4:26b
+
+The config is chosen in this order: ``-c`` or ``--recipe`` (one of the two),
+else ``$REEF_CONFIG``, else ``reef.yaml`` in the checkout; with none of them,
+``reef serve`` names the recipes that carry a profile and stops. This is a
+default of the recipe, not of reef: nothing starts without a recipe or a
+config named. ``ollama/`` fills ``http://127.0.0.1:11434`` and a placeholder
+key; ``openai/`` fills ``https://api.openai.com`` and reads the key from
+``REEF_UPSTREAM_API_KEY``; a spelling with another prefix (``Qwen/Qwen3-8B``)
+or none is the model ID as is, with the endpoint from ``REEF_UPSTREAM_URL``.
+An explicit ``--upstream_url`` or ``--upstream_api_key`` override wins over
+the prefix. The ``harness-evolve`` profile points at the tutorial's proposer
+and evaluator, so it runs from a reef checkout; it listens on
+``127.0.0.1:8900`` with no token and keeps its state under
+``.reef/harness-evolve/``. To change anything else, copy
+``reef/service/profiles/harness-evolve.yaml`` and pass the copy with ``-c``.
 
 Overriding config values
 ------------------------

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -215,6 +215,10 @@ set the variable outright.
 
 ``REEF_RECIPE_CONFIG_DIR`` is the directory preset YAML is read from, and it has
 **no default**: a bare recipe name resolves to a preset only when it is set.
+The one kind of preset reef bundles is a recipe's profile under
+``reef/service/profiles/``: ``reef serve --recipe <name>`` points this
+variable at that directory and reads the profile as both the deployment
+config and the preset (see `the CLI reference <cli.rst>`__).
 
 A preset is read as-is. ``${VAR}`` interpolates in a deployment config, never
 in a preset. A preset carries its own ``implementation``, ``model``, and

--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -368,6 +368,18 @@ From a Reef checkout:
    cd tutorials/evolve-your-harness
    ./run.sh
 
+To run the same recipe as a plain deployment, without the example's driver,
+start its profile and name the model:
+
+.. code:: bash
+
+   reef serve --recipe harness-evolve --model ollama/gemma4:26b
+
+The profile is the harness evolve recipe's own default (loopback, port 8900,
+no token, state under ``.reef/harness-evolve/``); it points at this
+tutorial's proposer and evaluator, so it runs from a reef checkout. `The CLI
+reference <../reference/cli.rst>`__ has the ``--model`` spellings.
+
 ``serve.yaml`` holds the endpoint (``http://127.0.0.1:8000``, no ``/v1``
 suffix), the model (``qwen3-8b``), and the service token as literals; edit
 them there to point at your own. The model name appears twice, as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ fallback_version = "0.0.0.dev0"
 include = ["reef", "reef.*"]
 
 [tool.setuptools.package-data]
-reef = ["harness/adapters/*/descriptor.yaml", "harness/adapters/*/version_check.ts", "harness/adapters/*/requests.ts", "harness/adapters/*/pi_extension_api.md"]
+reef = ["harness/adapters/*/descriptor.yaml", "harness/adapters/*/version_check.ts", "harness/adapters/*/requests.ts", "harness/adapters/*/pi_extension_api.md", "service/profiles/*.yaml"]
 
 [tool.isort]
 profile = "black"  # black-compatible

--- a/reef/recipe/registry.py
+++ b/reef/recipe/registry.py
@@ -77,8 +77,9 @@ def build_named_recipe(
 
     ``name`` is a YAML preset ``<name>.yaml`` under ``config_directory``
     (defaulting to ``REEF_RECIPE_CONFIG_DIR``), or the reserved core name
-    ``recipe``. Reef bundles no presets — they are deployment data (see
-    ``docs/reference/configuration.rst``). A preset's ``runtime`` section builds the recipe's
+    ``recipe``. Presets are deployment data (see ``docs/reference/configuration.rst``);
+    the one kind reef bundles is a recipe's profile under ``reef.service.profiles``,
+    which ``reef serve --recipe`` points this directory at. A preset's ``runtime`` section builds the recipe's
     runtime; without one the recipe gets ``default_runtime`` and may omit
     ``model.path`` to use that runtime's model. Dotted references are
     not names: they are operator configuration for :func:`build_recipe`, so a

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -469,13 +469,13 @@ def _resolve_config(config: str | None, recipe: str | None, environ: Mapping[str
 
 def _prepare_profile(recipe: str, model: str | None, environ: MutableMapping[str, str]) -> None:
     """What a profile needs from the environment before it loads: its own directory, the checkout, a model."""
+    if not model and not environ.get("REEF_UPSTREAM_MODEL", "").strip():
+        raise DeployConfigError(f"--recipe {recipe} needs the model: pass --model <provider>/<model>")
     method = _PROFILE_METHODS.get(recipe)
     if method is not None and not (PROJECT_ROOT / method).is_file():
         raise DeployConfigError(
             f"the {recipe} profile runs from a reef checkout: its proposer is {method}, not found under {PROJECT_ROOT}"
         )
-    if not model and not environ.get("REEF_UPSTREAM_MODEL", "").strip():
-        raise DeployConfigError(f"--recipe {recipe} needs the model: pass --model <provider>/<model>")
     environ["REEF_RECIPE_CONFIG_DIR"] = str(PROFILES_DIR)
     environ["REEF_CHECKOUT"] = str(PROJECT_ROOT)
 

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -8,6 +8,7 @@ lives in :mod:`reef.service.deploy.settings` and :mod:`reef.service.assembly`.
 
 from __future__ import annotations
 
+import argparse
 import copy
 import json
 import os
@@ -16,7 +17,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from pathlib import Path
 from types import FrameType
@@ -30,6 +31,7 @@ from reef.runtime.executor.ray import RayExecutor
 from reef.runtime.executor.ray_runtime import RayRuntimeLease, acquire_ray_runtime
 from reef.service.deploy.config import (
     PROJECT_ROOT,
+    DeployConfigError,
     config_value,
     interpolate_config,
     interpolate_environment,
@@ -40,6 +42,7 @@ from reef.service.deploy.config import (
 )
 from reef.service.deploy.execution import service_executor_config, service_executor_selection
 from reef.service.deploy.settings import build_parser
+from reef.service.profiles import PROFILES_DIR, UnknownProfileError, profile_names, profile_path
 
 _DEFAULT_GRACE_TIMEOUT = 30
 _WATCHDOG_INTERVAL = 5
@@ -415,12 +418,99 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
     return stack.exit_code
 
 
-def main(argv: Sequence[str] | None = None) -> None:
+#: ``--model <provider>/<model>``: the upstream URL and the key a provider prefix stands for. A key of None
+#: comes from ``REEF_UPSTREAM_API_KEY`` and is required; ollama ignores its key, so any word will do.
+_PROVIDERS: dict[str, tuple[str, str | None]] = {
+    "ollama": ("http://127.0.0.1:11434", "ollama"),
+    "openai": ("https://api.openai.com", None),
+}
+
+#: The tutorial method the harness-evolve profile points at; the profile runs from the checkout that holds it.
+_PROFILE_METHODS = {"harness-evolve": Path("tutorials/evolve-your-harness/harness/evolution.py")}
+
+
+def _model_overrides(spec: str, environ: Mapping[str, str]) -> dict[str, str]:
+    """The ``reef.*`` overrides ``--model`` stands for.
+
+    A known provider prefix fills the URL and the key; any other spelling,
+    a prefix of another kind included (``Qwen/Qwen3-8B``), is the model id
+    alone and the URL comes from the config or the environment."""
+    provider, _, model = spec.partition("/")
+    if provider not in _PROVIDERS or not model:
+        return {"upstream_model": spec}
+    url, key = _PROVIDERS[provider]
+    if key is None:
+        key = environ.get("REEF_UPSTREAM_API_KEY", "").strip()
+        if not key:
+            raise DeployConfigError(f"--model {spec}: set REEF_UPSTREAM_API_KEY to the {provider} key")
+    return {"upstream_url": url, "upstream_model": model, "upstream_api_key": key}
+
+
+def _resolve_config(config: str | None, recipe: str | None, environ: Mapping[str, str]) -> str:
+    """The config ``reef serve`` runs: ``-c`` or ``--recipe``, else ``REEF_CONFIG``, else ``reef.yaml``."""
+    if config and recipe:
+        raise DeployConfigError("pass -c <file> or --recipe <name>, not both")
+    if config:
+        return config
+    if recipe:
+        try:
+            return str(profile_path(recipe))
+        except UnknownProfileError as exc:
+            raise DeployConfigError(str(exc)) from exc
+    if environ.get("REEF_CONFIG"):
+        return environ["REEF_CONFIG"]
+    if (PROJECT_ROOT / "reef.yaml").is_file():
+        return "reef.yaml"
+    raise DeployConfigError(
+        "no config: pass one with -c <file>, or start a recipe's profile with --recipe <name>; "
+        f"recipes with a profile: {', '.join(profile_names())}"
+    )
+
+
+def _prepare_profile(recipe: str, model: str | None, environ: MutableMapping[str, str]) -> None:
+    """What a profile needs from the environment before it loads: its own directory, the checkout, a model."""
+    method = _PROFILE_METHODS.get(recipe)
+    if method is not None and not (PROJECT_ROOT / method).is_file():
+        raise DeployConfigError(
+            f"the {recipe} profile runs from a reef checkout: its proposer is {method}, not found under {PROJECT_ROOT}"
+        )
+    if not model and not environ.get("REEF_UPSTREAM_MODEL", "").strip():
+        raise DeployConfigError(f"--recipe {recipe} needs the model: pass --model <provider>/<model>")
+    environ["REEF_RECIPE_CONFIG_DIR"] = str(PROFILES_DIR)
+    environ["REEF_CHECKOUT"] = str(PROJECT_ROOT)
+
+
+def build_serve_parser() -> argparse.ArgumentParser:
+    """``reef serve``'s own arguments: the service child's parser plus the profile and model flags.
+
+    Only the launcher takes them; ``python -m reef.service`` still refuses ``--recipe``."""
     parser = build_parser()
+    parser.add_argument(
+        "--recipe",
+        default=None,
+        metavar="NAME",
+        help="Start a built in recipe's profile instead of a config file (harness-evolve).",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        metavar="[PROVIDER/]MODEL",
+        help="The upstream model; a known provider prefix (ollama, openai) fills the URL and the key.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_serve_parser()
     args, extras = parser.parse_known_args(argv)
-    config_path = args.config or os.environ.get("REEF_CONFIG", "reef.yaml")
     try:
         overrides = _parse_overrides(extras)
+        if args.model:
+            # An explicit --key beats what the provider prefix fills in.
+            overrides = {**_model_overrides(args.model, os.environ), **overrides}
+        config_path = _resolve_config(args.config, args.recipe, os.environ)
+        if args.recipe:
+            _prepare_profile(args.recipe, args.model, os.environ)
         exit_code = _run_orchestrator(config_path, overrides)
     except InvalidOverrideError as exc:
         parser.error(str(exc))

--- a/reef/service/profiles/__init__.py
+++ b/reef/service/profiles/__init__.py
@@ -1,0 +1,35 @@
+"""The profiles ``reef serve --recipe <name>`` starts without a config file.
+
+A profile is one deployment yaml a built in recipe carries, read both as the
+stack config and as the named preset ``reef.recipe`` selects, so the recipe's
+sections and the service's sections live in one file. ``REEF_RECIPE_CONFIG_DIR``
+still names a directory of the operator's own presets; a profile is only ever
+selected by name on the command line.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from reef.core.errors import ReefError
+
+PROFILES_DIR = Path(__file__).resolve().parent
+
+
+class UnknownProfileError(ReefError):
+    """``--recipe`` named a recipe that carries no profile."""
+
+
+def profile_names() -> tuple[str, ...]:
+    """The recipes that carry a profile, by name, sorted."""
+    return tuple(sorted(path.stem for path in PROFILES_DIR.glob("*.yaml")))
+
+
+def profile_path(name: str) -> Path:
+    """The profile file of ``name``, or an error naming the recipes that have one."""
+    path = PROFILES_DIR / f"{name}.yaml"
+    if "/" in name or not path.is_file():
+        raise UnknownProfileError(
+            f"no profile for recipe {name!r}; recipes with a profile: {', '.join(profile_names())}"
+        )
+    return path

--- a/reef/service/profiles/harness-evolve.yaml
+++ b/reef/service/profiles/harness-evolve.yaml
@@ -1,0 +1,80 @@
+# The harness evolve recipe's profile: what `reef serve --recipe harness-evolve --model <provider>/<model>`
+# starts. One file in two roles: the stack config reef serve reads, and the preset the recipe registry
+# reads back by name. The person decides the model; everything else here is the same for every
+# deployment of this recipe, and a deployment that outgrows it copies this file and passes it with -c.
+#
+# The proposer and the evaluator are the tutorial's (tutorials/evolve-your-harness/harness/evolution.py):
+# reef serve puts that package on the service's PYTHONPATH from the checkout it runs in, so this profile
+# runs from a reef checkout.
+implementation: reef.train.cordis_backend.recipe:CordisRecipe
+
+evolution:
+  adapter: pi
+  propose: harness.evolution:propose
+  evaluate: harness.evolution:evaluate
+  # A person asks for a change with /reef-harness; the next session is offered the install.
+  requests: true
+  version_check: true
+  # An evolved extension runs in pi's process with the person's privileges: held until promoted.
+  review_kinds: [code_extension]
+  # A workflow change does not move the seed tasks, so a candidate that does not lose is published.
+  selection: always
+  step_record_dir: .reef/harness-evolve/steps
+  proposals_dir: .reef/harness-evolve/proposals
+  tasks:
+    - '[sieve] Write and mentally run a prime sieve: how many primes are below 100000?
+      Reply with the count as a plain integer alone on the last line.'
+    - '[fib] With fib(1) = 1 and fib(2) = 1, compute fib(90) exactly (memoize, do not
+      approximate). Reply with the value as a plain integer alone on the last line.'
+    - '[csv] Compute the median of the value column in this csv:
+      id,value
+      1,12
+      2,47
+      3,3
+      4,88
+      5,21
+      6,56
+      7,9
+      8,74
+      9,30
+      Reply with the median as a plain integer alone on the last line.'
+  seed:
+    - id: answer-style
+      name: skill
+      config:
+        name: answer-style
+        text: '# answer-style
+          Starter skill. The evolution loop replaces this placeholder with
+          concrete guidance learned from failing tasks.
+          '
+
+data:
+  batch_size: 1
+  max_score: 0.0
+  # Failure reports and asks both start steps.
+  training_mode: hybrid
+
+reef:
+  host: 127.0.0.1
+  port: 8900
+  recipe: harness-evolve
+  # No token: the service listens on loopback only. Add one here in a copy of this file for anything else.
+  upstream_url: ${REEF_UPSTREAM_URL:?}
+  upstream_model: ${REEF_UPSTREAM_MODEL:?}
+  upstream_api_key: ${REEF_UPSTREAM_API_KEY}
+  agent_record_dir: .reef/harness-evolve/agent-record
+  artifact_repository: .reef/harness-evolve/artifacts.git
+  artifact_work_dir: .reef/harness-evolve/artifact-work
+  artifact_cache_dir: .reef/harness-evolve/artifact-cache
+
+run_dir: .reef/harness-evolve/stack
+
+services:
+  - name: reef
+    command: ["${REEF_PYTHON}", "-m", "reef.service"]
+    env:
+      # reef serve sets both when it starts a profile: the registry reads this file back from here,
+      # and the tutorial's method package imports from the checkout.
+      REEF_RECIPE_CONFIG_DIR: "${REEF_RECIPE_CONFIG_DIR}"
+      PYTHONPATH: "${REEF_CHECKOUT}/tutorials/evolve-your-harness:${REEF_CHECKOUT}"
+    ready: curl -sf http://127.0.0.1:${reef.port}/healthz

--- a/tests/reef_service/test_serve_profile.py
+++ b/tests/reef_service/test_serve_profile.py
@@ -1,0 +1,159 @@
+"""``reef serve --recipe <name> --model <provider>/<model>``: a recipe's profile starts without a config file."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from reef.records import RecordStore
+from reef.service.deploy.config import DeployConfigError, load_config, validate_services
+from reef.service.deploy.orchestrator import _model_overrides, _prepare_profile, _resolve_config, build_serve_parser
+from reef.service.deploy.settings import build_parser, service_settings_from_config
+from reef.service.profiles import PROFILES_DIR, UnknownProfileError, profile_names, profile_path
+from reef.train.cordis_backend.recipe import CordisRecipe
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.unit
+def test_the_harness_evolve_recipe_carries_the_one_profile() -> None:
+    assert profile_names() == ("harness-evolve",)
+    assert profile_path("harness-evolve") == PROFILES_DIR / "harness-evolve.yaml"
+    with pytest.raises(UnknownProfileError, match="recipes with a profile: harness-evolve"):
+        profile_path("weights")
+    with pytest.raises(UnknownProfileError):
+        profile_path("../harness-evolve")
+
+
+@pytest.mark.unit
+def test_the_serve_parser_takes_recipe_and_model_and_the_service_parser_still_does_not() -> None:
+    args, extras = build_serve_parser().parse_known_args(
+        ["--recipe", "harness-evolve", "--model", "ollama/gemma4:26b", "--port", "8901"]
+    )
+    assert (args.config, args.recipe, args.model, extras) == (
+        None,
+        "harness-evolve",
+        "ollama/gemma4:26b",
+        ["--port", "8901"],
+    )
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--recipe", "harness-evolve"])
+
+
+@pytest.mark.unit
+def test_the_config_is_resolved_explicit_first_then_the_environment_then_reef_yaml(tmp_path, monkeypatch) -> None:
+    """``-c`` or ``--recipe`` is the person's choice and wins; ``REEF_CONFIG`` and ``reef.yaml`` are the defaults behind them."""
+    profile = str(PROFILES_DIR / "harness-evolve.yaml")
+    assert _resolve_config("mine.yaml", None, {"REEF_CONFIG": "env.yaml"}) == "mine.yaml"
+    assert _resolve_config(None, "harness-evolve", {"REEF_CONFIG": "env.yaml"}) == profile
+    assert _resolve_config(None, None, {"REEF_CONFIG": "env.yaml"}) == "env.yaml"
+    with pytest.raises(DeployConfigError, match="not both"):
+        _resolve_config("mine.yaml", "harness-evolve", {})
+    with pytest.raises(DeployConfigError, match="recipes with a profile: harness-evolve"):
+        _resolve_config(None, "weights", {})
+    monkeypatch.setattr("reef.service.deploy.orchestrator.PROJECT_ROOT", tmp_path)
+    with pytest.raises(DeployConfigError, match="--recipe <name>; recipes with a profile: harness-evolve"):
+        _resolve_config(None, None, {})
+    (tmp_path / "reef.yaml").write_text("reef: {}\n")
+    assert _resolve_config(None, None, {}) == "reef.yaml"
+
+
+@pytest.mark.unit
+def test_the_model_flag_fills_the_provider_preset_and_leaves_other_spellings_alone() -> None:
+    assert _model_overrides("ollama/gemma4:26b", {}) == {
+        "upstream_url": "http://127.0.0.1:11434",
+        "upstream_model": "gemma4:26b",
+        "upstream_api_key": "ollama",
+    }
+    assert _model_overrides("openai/gpt-5.6", {"REEF_UPSTREAM_API_KEY": "sk-1"}) == {
+        "upstream_url": "https://api.openai.com",
+        "upstream_model": "gpt-5.6",
+        "upstream_api_key": "sk-1",
+    }
+    with pytest.raises(DeployConfigError, match="set REEF_UPSTREAM_API_KEY to the openai key"):
+        _model_overrides("openai/gpt-5.6", {})
+    # A prefix that is not a provider is part of the model id, and a bare id is just the id.
+    assert _model_overrides("Qwen/Qwen3-8B", {}) == {"upstream_model": "Qwen/Qwen3-8B"}
+    assert _model_overrides("qwen3-8b", {}) == {"upstream_model": "qwen3-8b"}
+    assert _model_overrides("ollama/openai/gpt-oss-20b", {})["upstream_model"] == "openai/gpt-oss-20b"
+
+
+@pytest.mark.unit
+def test_a_profile_needs_the_checkout_and_a_model_before_it_loads(tmp_path, monkeypatch) -> None:
+    env: dict[str, str] = {}
+    with pytest.raises(DeployConfigError, match="pass --model <provider>/<model>"):
+        _prepare_profile("harness-evolve", None, env)
+    _prepare_profile("harness-evolve", "ollama/gemma4:26b", env)
+    assert env == {"REEF_RECIPE_CONFIG_DIR": str(PROFILES_DIR), "REEF_CHECKOUT": str(REPO_ROOT)}
+    env = {"REEF_UPSTREAM_MODEL": "qwen3-8b"}
+    _prepare_profile("harness-evolve", None, env)  # the environment names the model as before
+    monkeypatch.setattr("reef.service.deploy.orchestrator.PROJECT_ROOT", tmp_path)
+    with pytest.raises(DeployConfigError, match="runs from a reef checkout"):
+        _prepare_profile("harness-evolve", "ollama/gemma4:26b", {})
+
+
+@pytest.mark.unit
+def test_the_harness_evolve_profile_loads_and_boots_its_recipe(monkeypatch, tmp_path) -> None:
+    """The profile is the stack config and the preset in one file: it validates as a stack, the registry reads it
+    back by the name it carries, and the recipe it builds is the tutorial's proposer over pi in hybrid mode."""
+    from reef.recipe.registry import build_named_recipe
+    from reef.service.assembly import _upstream_runtime
+
+    env: dict[str, str] = {}
+    _prepare_profile("harness-evolve", "ollama/gemma4:26b", env)
+    for key, value in {
+        **env,
+        "REEF_UPSTREAM_URL": "http://127.0.0.1:11434",
+        "REEF_UPSTREAM_MODEL": "gemma4:26b",
+        "REEF_UPSTREAM_API_KEY": "ollama",
+        "REEF_PYTHON": sys.executable,
+    }.items():
+        monkeypatch.setenv(key, value)
+    path = profile_path("harness-evolve")
+    config = load_config(path)
+    validate_services(config, path)
+    reef_service = next(service for service in config["services"] if service["name"] == "reef")
+    assert reef_service["env"]["REEF_RECIPE_CONFIG_DIR"] == str(PROFILES_DIR)
+    method_root = Path(reef_service["env"]["PYTHONPATH"].split(os.pathsep)[0])
+    assert (method_root / "harness" / "evolution.py").is_file()
+    assert config["reef"]["recipe"] == "harness-evolve" and config["reef"]["port"] == 8900
+    assert "token" not in config["reef"]  # loopback only; a copy of the file adds one
+    for key in ("agent_record_dir", "artifact_repository", "artifact_work_dir", "artifact_cache_dir"):
+        assert config["reef"][key].startswith(".reef/harness-evolve/")
+    assert config["run_dir"].startswith(".reef/harness-evolve/")
+    monkeypatch.syspath_prepend(str(method_root))
+    service = service_settings_from_config(config)
+    monkeypatch.delenv("REEF_UPSTREAM_MODEL")
+    built = build_named_recipe("harness-evolve", dict(os.environ), default_runtime=_upstream_runtime(service))
+    assert isinstance(built, CordisRecipe) and built.adapter == "pi" and built.training_mode == "hybrid"
+    assert built.model_binding().model == "gemma4:26b"
+    records = RecordStore()
+    trainer = replace(built, binary=str(tmp_path / "fake-pi")).build("demo", records)
+    assert trainer.training_mode == "hybrid"
+    trainer.close()
+    records.close()
+
+
+@pytest.mark.unit
+def test_serve_without_a_config_names_the_recipes_with_a_profile(tmp_path) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "REEF_CONFIG"}
+    result = subprocess.run(
+        [sys.executable, "-m", "reef.cli", "serve"], cwd=tmp_path, env=env, capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 2
+    assert "recipes with a profile: harness-evolve" in result.stderr
+    result = subprocess.run(
+        [sys.executable, "-m", "reef.cli", "serve", "--recipe", "harness-evolve"],
+        cwd=tmp_path,
+        env={k: v for k, v in env.items() if k != "REEF_UPSTREAM_MODEL"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 2
+    assert "pass --model <provider>/<model>" in result.stderr

--- a/tests/reef_service/test_serve_profile.py
+++ b/tests/reef_service/test_serve_profile.py
@@ -12,12 +12,20 @@ import pytest
 
 from reef.records import RecordStore
 from reef.service.deploy.config import DeployConfigError, load_config, validate_services
-from reef.service.deploy.orchestrator import _model_overrides, _prepare_profile, _resolve_config, build_serve_parser
+from reef.service.deploy.orchestrator import (
+    PROJECT_ROOT,
+    _model_overrides,
+    _prepare_profile,
+    _resolve_config,
+    build_serve_parser,
+)
 from reef.service.deploy.settings import build_parser, service_settings_from_config
 from reef.service.profiles import PROFILES_DIR, UnknownProfileError, profile_names, profile_path
 from reef.train.cordis_backend.recipe import CordisRecipe
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+#: The profile's proposer lives in the tutorial: the wheel alone (the package job) cannot start it.
+IN_CHECKOUT = (PROJECT_ROOT / "tutorials" / "evolve-your-harness" / "harness" / "evolution.py").is_file()
 
 
 @pytest.mark.unit
@@ -84,20 +92,26 @@ def test_the_model_flag_fills_the_provider_preset_and_leaves_other_spellings_alo
 
 
 @pytest.mark.unit
-def test_a_profile_needs_the_checkout_and_a_model_before_it_loads(tmp_path, monkeypatch) -> None:
-    env: dict[str, str] = {}
+def test_a_profile_needs_a_model_and_the_checkout_before_it_loads(tmp_path, monkeypatch) -> None:
     with pytest.raises(DeployConfigError, match="pass --model <provider>/<model>"):
-        _prepare_profile("harness-evolve", None, env)
-    _prepare_profile("harness-evolve", "ollama/gemma4:26b", env)
-    assert env == {"REEF_RECIPE_CONFIG_DIR": str(PROFILES_DIR), "REEF_CHECKOUT": str(REPO_ROOT)}
-    env = {"REEF_UPSTREAM_MODEL": "qwen3-8b"}
-    _prepare_profile("harness-evolve", None, env)  # the environment names the model as before
+        _prepare_profile("harness-evolve", None, {})
     monkeypatch.setattr("reef.service.deploy.orchestrator.PROJECT_ROOT", tmp_path)
     with pytest.raises(DeployConfigError, match="runs from a reef checkout"):
         _prepare_profile("harness-evolve", "ollama/gemma4:26b", {})
 
 
 @pytest.mark.unit
+@pytest.mark.skipif(not IN_CHECKOUT, reason="the harness-evolve profile runs from a reef checkout")
+def test_a_profile_sets_its_directory_and_the_checkout_for_the_service() -> None:
+    env: dict[str, str] = {}
+    _prepare_profile("harness-evolve", "ollama/gemma4:26b", env)
+    assert env == {"REEF_RECIPE_CONFIG_DIR": str(PROFILES_DIR), "REEF_CHECKOUT": str(PROJECT_ROOT)}
+    env = {"REEF_UPSTREAM_MODEL": "qwen3-8b"}
+    _prepare_profile("harness-evolve", None, env)  # the environment names the model as before
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not IN_CHECKOUT, reason="the harness-evolve profile runs from a reef checkout")
 def test_the_harness_evolve_profile_loads_and_boots_its_recipe(monkeypatch, tmp_path) -> None:
     """The profile is the stack config and the preset in one file: it validates as a stack, the registry reads it
     back by the name it carries, and the recipe it builds is the tutorial's proposer over pi in hybrid mode."""
@@ -141,7 +155,10 @@ def test_the_harness_evolve_profile_loads_and_boots_its_recipe(monkeypatch, tmp_
 
 @pytest.mark.unit
 def test_serve_without_a_config_names_the_recipes_with_a_profile(tmp_path) -> None:
+    # The subprocess runs away from the checkout, so reef must reach it through PYTHONPATH as the suite's own
+    # interpreter has it; in the package job reef is installed and the entry is harmless.
     env = {k: v for k, v in os.environ.items() if k != "REEF_CONFIG"}
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (str(REPO_ROOT), env.get("PYTHONPATH", ""))))
     result = subprocess.run(
         [sys.executable, "-m", "reef.cli", "serve"], cwd=tmp_path, env=env, capture_output=True, text=True, timeout=60
     )


### PR DESCRIPTION
## Motivation

`reef serve` only starts from a config file. The only harness evolution config in the repo is the tutorial's `deployment.yaml`, so to run the recipe on your own model you copy that file and change one value in it, the model. Closes #379.

## Changes

- Added `reef/service/profiles/harness-evolve.yaml`, the default deployment of the harness evolve recipe. It has the same content as the tutorial's `deployment.yaml`: it uses the tutorial's proposer and evaluator, runs in hybrid mode, listens on `127.0.0.1:8900` without a token, and keeps its state under `.reef/harness-evolve/`. The recipe registry reads the recipe sections from this same file, so there is no second preset file.
- Added `--recipe <name>` to `reef serve`. It starts the profile of that recipe instead of a config file. `python -m reef.service` does not accept the flag.
- Added `--model [provider/]model` to `reef serve`. `ollama/` sets the local ollama URL and a placeholder key. `openai/` sets the OpenAI URL and reads the key from `REEF_UPSTREAM_API_KEY`. Any other string is used as the model ID unchanged.
- `reef serve` picks the config from `-c` or `--recipe` first, then `REEF_CONFIG`, then `reef.yaml`. With none of these it lists the recipes that have a profile and exits. There is no default for reef itself.
- The wheel includes the profile. The CLI reference, the configuration reference, the harness guide and both READMEs describe the two commands.

## Compatibility and operational impact

`-c` and `REEF_CONFIG` work as before, and an explicit config always wins over a profile. The profile imports the proposer from `tutorials/evolve-your-harness/harness/evolution.py`, so it only runs inside a reef checkout; elsewhere `reef serve` stops with a message that says so. Nothing changes on the wire or in stored data.

## Verification

- With a local ollama, `reef serve --recipe harness-evolve --model ollama/gemma4:26b` answered `/healthz` after 2 s and `/reef/status` without a token. From a shell that has the checkout's venv on PATH, `curl -fsS 'http://127.0.0.1:8900/reef/harness/install?adapter=pi' | bash` installed a tree whose `models.json` names `gemma4:26b`. From an empty environment with cwd `/`, `reef-pi setup` reported `requires nothing` and `reef-pi --version` printed `0.84.2`.
- The built wheel contains `reef/service/profiles/harness-evolve.yaml`.
- `tests/reef_service/test_serve_profile.py` covers the profile lookup, the two parsers, the config order, the `--model` spellings, the profile's preconditions, loading and booting the profile through the registry, and `reef serve` with no config.

## AI assistance

Claude Code provided code assistance.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
