### PR TITLE
feat(harness): reef serve prints the install line, the install refuses an interpreter without reef, reef-pi doctor

### DIFF
--- a/docs/user-guide/evolve-your-harness.rst
+++ b/docs/user-guide/evolve-your-harness.rst
@@ -463,7 +463,10 @@ no endpoint or credential, and the binding takes its token from
 through the interpreter that imported reef when the script ran and reads the
 token back from the binding, so the shell that runs it later needs neither
 on its own. The wrapper keeps
-the receipts from a run, so ``report`` only needs the result. Pinning,
+the receipts from a run, so ``report`` only needs the result. ``reef-pi doctor`` prints one line per thing the install needs
+(the interpreter and its imports, the service and its token, the binary,
+the tools on PATH, the installed release against the served head) and exits
+0 when they all hold. Pinning,
 rollback, and the raw manifest routes are in `HTTP API
 <../reference/http-api.rst#harness-artifacts>`__.
 

--- a/reef/harness/client/wrapper.py
+++ b/reef/harness/client/wrapper.py
@@ -27,6 +27,14 @@ When invoked with ``harness`` (e.g. ``reef-pi harness "text me when you are bloc
   feedback report; the merged ``requires`` list rides ``training_request``
   in the commit's metrics.
 
+When invoked with ``doctor`` (e.g. ``reef-pi doctor``):
+
+  Prints one line per thing an install needs and exits 0 when they all hold:
+  the interpreter behind the wrapper and whether it imports reef and
+  reef-client, the service address and whether the token is accepted, the
+  agent binary and its version, the tools the adapter wants on PATH, and the
+  installed release against the served head.
+
 When invoked with ``setup`` (e.g. ``reef-pi setup``, ``reef-pi setup --yes``,
 ``reef-pi setup --mark <name>``, ``reef-pi setup --release <id>``):
 
@@ -916,6 +924,90 @@ def setup(
     return 0
 
 
+def _doctor_row(ok: bool, label: str, value: str) -> str:
+    return f"{'ok' if ok else '!!'}  {label:<12} {value}"
+
+
+def doctor(scenario: str, adapter: str, compose_dir: str, binary: str) -> int:
+    """One line per thing an install needs; 0 when every line holds, 1 otherwise.
+
+    Every check exists somewhere already (an install warning, a run time
+    warning, a route error); this is the one place that runs them all and
+    says which failed."""
+    rows: list[tuple[bool, str, str]] = []
+    try:
+        import reef
+
+        rows.append((True, "interpreter", f"{sys.executable} (reef {reef.__version__}, reef-client importable)"))
+    except Exception as exc:  # pragma: no cover - the wrapper itself imports both
+        rows.append((False, "interpreter", f"{sys.executable} does not import reef: {exc}"))
+    try:
+        upstream = _extract_reef_url(adapter, Path(compose_dir))
+    except WrapperError as exc:
+        upstream = None
+        rows.append((False, "service", f"binding unreadable: {exc}"))
+    if upstream is None:
+        rows.append((False, "service", "no Reef URL in the tree's model binding files"))
+    else:
+        upstream = _strip_v1(upstream)
+        token = _reef_token(adapter, compose_dir)
+        req = urllib.request.Request(f"{upstream}/reef/status", headers=_reef_headers(scenario, token))
+        try:
+            with urllib.request.urlopen(req, timeout=10):
+                rows.append((True, "service", f"{upstream} answers, token {'accepted' if token else 'not needed'}"))
+        except urllib.error.HTTPError as exc:
+            rows.append(
+                (False, "service", f"{upstream} answered {exc.code}: {exc.read().decode(errors='replace')[:120]}")
+            )
+        except OSError as exc:
+            rows.append((False, "service", f"{upstream} unreachable: {exc}"))
+    if Path(binary).is_file():
+        try:
+            version = subprocess.run([binary, "--version"], capture_output=True, text=True, timeout=20)
+            first = (version.stdout or version.stderr).strip().splitlines()
+            rows.append((version.returncode == 0, "binary", f"{binary} ({first[0] if first else 'no output'})"))
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            rows.append((False, "binary", f"{binary} did not run: {exc}"))
+    else:
+        rows.append((False, "binary", f"{binary} missing; rerun the install"))
+    for command, package in get_adapter(adapter).client_tools:
+        found = shutil.which(command)
+        rows.append(
+            (found is not None, "tool", f"{command} {'at ' + found if found else 'missing: install ' + package}")
+        )
+    installed = _installed_release(compose_dir)
+    if installed is None:
+        rows.append(
+            (
+                False,
+                "release",
+                f"no {HARNESS_RELEASE_FILE} beside the tree; this tree did not come through the install",
+            )
+        )
+    elif upstream is not None and rows[1][0]:
+        try:
+            catalog = _catalog(upstream, scenario, adapter, _reef_token(adapter, compose_dir))
+        except SystemExit as exc:
+            rows.append((False, "release", f"installed {installed[:8]}; catalog unreadable: {exc.code}"))
+        else:
+            head = next((row.get("release_id") for row in reversed(catalog) if not row.get("pending")), None)
+            if head == installed:
+                rows.append((True, "release", f"{installed[:8]} installed, the served head"))
+            else:
+                rows.append(
+                    (
+                        True,
+                        "release",
+                        f"{installed[:8]} installed; served head {str(head)[:8]}, the next session offers it",
+                    )
+                )
+    else:
+        rows.append((True, "release", f"{installed[:8]} installed"))
+    for ok, label, value in rows:
+        print(_doctor_row(ok, label, value))
+    return 0 if all(ok for ok, _, _ in rows) else 1
+
+
 def main() -> None:
     binary = os.environ.get("REEF_HARNESS_BINARY")
     compose = os.environ.get("REEF_HARNESS_COMPOSE")
@@ -945,6 +1037,9 @@ def main() -> None:
         parser.add_argument("request", nargs=argparse.REMAINDER, help="what the harness should do, in plain words")
         ns = parser.parse_args(args[1:])
         harness(scenario, adapter, compose, " ".join(ns.request))
+    elif args and args[0] == "doctor":
+        argparse.ArgumentParser(prog=f"reef-{adapter} doctor").parse_args(args[1:])
+        sys.exit(doctor(scenario, adapter, compose, binary))
     elif args and args[0] == "setup":
         parser = argparse.ArgumentParser(prog=f"reef-{adapter} setup")
         parser.add_argument("--yes", action="store_true", help="run every check without asking (for scripts)")

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -291,6 +291,9 @@ class _Stack:
             self.shutdown()
             raise
         _log(f"stack up. logs: {self.run_dir}/*.log")
+        hint = install_hint(self.config)
+        if hint is not None:
+            _log(f"install the harness in another terminal: {hint}")
 
     def _watchdog(self) -> None:
         while not self._stopping.is_set():
@@ -364,6 +367,29 @@ class _Stack:
     @property
     def exit_code(self) -> int:
         return int(self._unexpected_exit.is_set())
+
+
+def install_hint(config: Mapping[str, Any]) -> str | None:
+    """The one line that installs a harness evolution deployment's harness, or None for a deployment without one.
+
+    Printed when the stack is up so nobody copies it from a README: the
+    address the service listens on (loopback when it binds every interface),
+    the adapter the deployment evolves, and the token the config holds."""
+    evolution = config.get("evolution")
+    adapter = evolution.get("adapter") if isinstance(evolution, Mapping) else None
+    if not isinstance(adapter, str) or not adapter:
+        return None
+    host = str(config_value(config, "reef", "host", default="127.0.0.1"))
+    if host in ("0.0.0.0", "::", ""):
+        host = "127.0.0.1"
+    port = config_value(config, "reef", "port", default="8900")
+    token = config_value(config, "reef", "token", default=None)
+    if token is None:
+        tokens = config.get("reef", {}).get("tokens") if isinstance(config.get("reef"), Mapping) else None
+        if isinstance(tokens, list) and tokens:
+            token = str(tokens[0])
+    header = f"-H 'Authorization: Bearer {token}' " if token else ""
+    return f"curl -fsS {header}'http://{host}:{port}/reef/harness/install?adapter={adapter}' | bash"
 
 
 def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None) -> int:

--- a/reef/service/install_script.py
+++ b/reef/service/install_script.py
@@ -160,7 +160,7 @@ def _wrapper_lines(
         f'# Usage: {wrapper_name} -p "fix the bug"     # run the agent (receipts captured)',
         f'#        {wrapper_name} report --score 0 --feedback "..."  # report last run\'s receipts',
         f'#        {wrapper_name} harness "what the harness should do"  # ask reef for a change',
-        f"#        {wrapper_name} setup  # check off what the newest release requires of you",
+        f"#        {wrapper_name} doctor  # check the install: interpreter, service, binary, tools, release",
         "# Runs the python3 the install resolved; rerun the install from another shell to change it.",
         'export REEF_HARNESS_BINARY="$BINARY_ABS"',
         'export REEF_HARNESS_COMPOSE="$COMPOSE_ABS"',
@@ -189,9 +189,28 @@ def _wrapper_lines(
     ]
 
 
+def _import_check_lines(wrapper_name: str) -> list[str]:
+    """Refuse, before anything is installed or written, an interpreter that cannot import what the wrapper runs.
+
+    The check takes ``$SAFE_PATH`` so the working directory cannot stand in
+    for an installed package: run from a checkout, it would pass for an
+    interpreter that has no reef at all. Nothing is installed on the person's
+    behalf: the one line that would is printed for them to run. The
+    distribution is ``reef-infra``; the import package is ``reef``.
+    """
+    return [
+        f"# reef-client (the capture proxy) and reef (the wrapper) must import in $PYTHON, which {wrapper_name} runs.",
+        "if ! \"$PYTHON\" $SAFE_PATH -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null; then",
+        f'    echo "reef: reef-client and reef-infra are not importable by $PYTHON, which {wrapper_name} runs; install them there:" >&2',
+        '    echo "    \\"$PYTHON\\" -m pip install reef-client \\"reef-infra @ git+https://github.com/Human-Agent-Society/reef.git\\"" >&2',
+        '    echo "or rerun this script from a shell whose python3 has them" >&2',
+        "    exit 1",
+        "fi",
+    ]
+
+
 def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) -> list[str]:
     """The vendor-delegating install step: check the pin, else install through the vendor's channel."""
-    wrapper_name = f"reef-{descriptor.name}"
     prelude: list[str] = []
     # Extra condition the "already installed" gate ands onto the binary check.
     gate = ""
@@ -255,27 +274,6 @@ def _ensure_binary_lines(descriptor: AdapterDescriptor, install: InstallSpec) ->
         "        ;;",
         "esac",
         "",
-        "# Ensure reef-client (capture proxy) and reef (harness wrapper) are importable by $PYTHON, the",
-        f"# interpreter {wrapper_name} runs.",
-        # The distribution is `reef-infra`; naming it `reef` here makes pip
-        # reject the requirement ("produced metadata for project name
-        # reef-infra") on every run. The install stays best effort - a managed
-        # interpreter (PEP 668) refuses it too - so the import is rechecked
-        # after and the wrapper's own failure is named here rather than
-        # surfacing later as a bare ModuleNotFoundError from the launcher.
-        # The check takes $SAFE_PATH so the working directory cannot stand in
-        # for an installed package: run from a checkout, it would pass for an
-        # interpreter that has no reef at all.
-        (
-            "\"$PYTHON\" $SAFE_PATH -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || "
-            'spin "installing reef-client and reef-infra for $PYTHON" '
-            '"$PYTHON" -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" || true'
-        ),
-        (
-            "\"$PYTHON\" $SAFE_PATH -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || "
-            f'echo "reef: warning: reef-client and reef-infra are not importable by $PYTHON, which {wrapper_name} runs; '
-            'install them there, or rerun this script from a shell whose python3 has them" >&2'
-        ),
         *(
             f'command -v {command} >/dev/null 2>&1 || echo "reef: warning: {descriptor.binary} wants {package} '
             f"({command}) on PATH and otherwise downloads it from GitHub at first start, which GitHub rate-limits; "
@@ -551,6 +549,8 @@ def render_install_script(
         "fi",
         "",
         *_python_lines(),
+        "",
+        *_import_check_lines(wrapper_name),
         "",
         *_release_info_tool_lines(wrapper_name),
         "",

--- a/tests/reef_service/test_harness_channel.py
+++ b/tests/reef_service/test_harness_channel.py
@@ -699,6 +699,10 @@ def _source_env(shim: Path, home: Path) -> dict:
     the suite out of the developer's, where a test's link would replace the
     reef-pi they use."""
     repo_root = str(Path(__file__).resolve().parents[2])
+    # The script's python3 is the interpreter running the tests, never the machine's: a fixture that
+    # writes its own shim keeps it, the others get this one.
+    if not (shim / "python3").exists():
+        _write_executable(shim / "python3", f'#!/bin/sh\nexec "{sys.executable}" "$@"\n')
     return {
         **os.environ,
         "HOME": str(home),
@@ -813,6 +817,14 @@ if "$PYTHON" -P -c '' 2>/dev/null; then
     SAFE_PATH="-P"
 fi
 
+# reef-client (the capture proxy) and reef (the wrapper) must import in $PYTHON, which reef-pi runs.
+if ! "$PYTHON" $SAFE_PATH -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null; then
+    echo "reef: reef-client and reef-infra are not importable by $PYTHON, which reef-pi runs; install them there:" >&2
+    echo "    \"$PYTHON\" -m pip install reef-client \"reef-infra @ git+https://github.com/Human-Agent-Society/reef.git\"" >&2
+    echo "or rerun this script from a shell whose python3 has them" >&2
+    exit 1
+fi
+
 # The release file's requires bookkeeping (reef-pi setup's check offs): JSON is no job for sed.
 release_info_tool() {
     "$PYTHON" - "$@" <<'REEF_RELEASE_INFO_TOOL_EOF'
@@ -905,10 +917,6 @@ case " $installed " in
         ;;
 esac
 
-# Ensure reef-client (capture proxy) and reef (harness wrapper) are importable by $PYTHON, the
-# interpreter reef-pi runs.
-"$PYTHON" $SAFE_PATH -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || spin "installing reef-client and reef-infra for $PYTHON" "$PYTHON" -m pip install --quiet --user reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git" || true
-"$PYTHON" $SAFE_PATH -c 'import reef_client.serve, reef.harness.client.wrapper' 2>/dev/null || echo "reef: warning: reef-client and reef-infra are not importable by $PYTHON, which reef-pi runs; install them there, or rerun this script from a shell whose python3 has them" >&2
 command -v rg >/dev/null 2>&1 || echo "reef: warning: pi wants ripgrep (rg) on PATH and otherwise downloads it from GitHub at first start, which GitHub rate-limits; install ripgrep with your package manager" >&2
 command -v fd >/dev/null 2>&1 || echo "reef: warning: pi wants fd (fd) on PATH and otherwise downloads it from GitHub at first start, which GitHub rate-limits; install fd with your package manager" >&2
 
@@ -977,7 +985,7 @@ wrapper_text() {
 # Usage: reef-pi -p "fix the bug"     # run the agent (receipts captured)
 #        reef-pi report --score 0 --feedback "..."  # report last run's receipts
 #        reef-pi harness "what the harness should do"  # ask reef for a change
-#        reef-pi setup  # check off what the newest release requires of you
+#        reef-pi doctor  # check the install: interpreter, service, binary, tools, release
 # Runs the python3 the install resolved; rerun the install from another shell to change it.
 export REEF_HARNESS_BINARY="$BINARY_ABS"
 export REEF_HARNESS_COMPOSE="$COMPOSE_ABS"
@@ -1185,6 +1193,32 @@ def test_install_refuses_a_python3_that_prints_at_startup_instead_of_baking_garb
     assert result.returncode == 1
     assert "reef: python3 did not name its interpreter" in result.stderr
     assert not (dest / "reef-pi").exists()
+
+
+@pytest.mark.unit
+def test_install_refuses_an_interpreter_without_reef_and_installs_nothing_on_its_own(tmp_path) -> None:
+    """The import check runs before the gate and the vendor install: an interpreter that cannot import reef and
+    reef-client stops the script with the line that installs them there, and nothing is written or run."""
+    script, dest, prefix, env = _install_fixture(
+        tmp_path, binary_version=None, npm='#!/bin/sh\necho npm >> "$0.log"\nexit 0\n', scenario="code-repair"
+    )
+    _write_executable(
+        tmp_path / "shim" / "python3",
+        '#!/bin/sh\nif [ "$1" = -m ] && [ "$2" = pip ]; then echo "pip called" >&2; exit 1; fi\n'
+        # It names itself as the interpreter, so every later call still goes through it.
+        'if [ "$1" = "-c" ] && [ "$2" = "import sys; print(sys.executable)" ]; then printf \'%s\\n\' "$0"; exit 0; fi\n'
+        'case "$*" in *reef_client.serve*) exit 1;; esac\n'
+        f'exec "{sys.executable}" "$@"\n',
+    )
+    result = _run_install(script, dest, prefix, env)
+    assert result.returncode == 1
+    assert "reef: reef-client and reef-infra are not importable by" in result.stderr
+    assert (
+        '-m pip install reef-client "reef-infra @ git+https://github.com/Human-Agent-Society/reef.git"'
+        in result.stderr
+    )
+    assert "pip called" not in result.stderr
+    assert not dest.exists() and not (tmp_path / "shim" / "npm.log").exists()
 
 
 @pytest.mark.unit
@@ -1769,11 +1803,12 @@ def test_git_install_kind_clones_the_pinned_ref_into_a_venv_when_the_binary_is_a
     script, dest, prefix, env, log = _git_install_fixture(tmp_path, binary_version=None)
     result = _run_install(script, dest, prefix, env)
     assert result.returncode == 0, result.stderr
-    # The first two python3 calls are the install's: the sys.executable resolution of the interpreter it
-    # pins, then the -P probe of it; the vendor steps follow.
-    resolve, probe, *calls = log.read_text().splitlines()
+    # The first three python3 calls are the install's: the sys.executable resolution of the interpreter it
+    # pins, the -P probe of it, then the import check; the vendor steps follow.
+    resolve, probe, check, *calls = log.read_text().splitlines()
     assert resolve == "python3 -c import sys; print(sys.executable)"
     assert probe == "python3 -P -c "
+    assert check == "python3 -P -c import reef_client.serve, reef.harness.client.wrapper"
     assert calls[0] == (
         f"git clone --quiet --depth 1 --branch v2026.8.31 https://github.com/NousResearch/hermes-agent {prefix}/src"
     )
@@ -2040,7 +2075,7 @@ def test_install_script_embeds_requires_with_hostile_text_and_refuses_a_bad_list
     expected = json.dumps([{"name": "notify", "kind": "permission", "check": check}])
     assert f"REQUIRES='{expected.replace(chr(39), chr(39) + chr(92) + chr(39) * 2)}'" in script
     assert '"requires": [' in script and '"extra"' not in script
-    assert "reef-pi setup  # check off what the newest release requires of you" in script
+    assert "reef-pi doctor  # check the install: interpreter, service, binary, tools, release" in script
     with pytest.raises(ValueError, match=r"requires\[0\]\.kind must be one of"):
         render_install_script(
             descriptor=get_adapter("pi"),

--- a/tests/reef_service/test_harness_wrapper.py
+++ b/tests/reef_service/test_harness_wrapper.py
@@ -1534,3 +1534,69 @@ def test_main_passes_release_to_setup_only_when_named(tmp_path) -> None:
         main()
     assert exited.value.code == 0
     assert called == [(("setup-scenario", "pi", str(tmp_path)), {"yes": False, "marks": (), "release": "v4"})]
+
+
+# -- reef-<adapter> doctor: one report of what the install needs ---------------------------------
+
+
+class _DoctorReef:
+    """A reef whose status route checks the bearer and whose catalog names one served head."""
+
+    def __init__(self, token: str, head: str) -> None:
+        import http.server
+        import threading
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == "/reef/status":
+                    ok = self.headers.get("Authorization") == f"Bearer {token}"
+                    code, payload = (200, {"scenarios": {}}) if ok else (401, {"error": "invalid service token"})
+                elif self.path == "/reef/harness/releases":
+                    code, payload = 200, {"releases": [{"release_id": head, "pending": False}]}
+                else:
+                    code, payload = 404, {}
+                raw = json.dumps(payload).encode()
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def log_message(self, *args):
+                pass
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+        self.port = self._server.server_address[1]
+
+    def close(self) -> None:
+        self._server.shutdown()
+
+
+@pytest.mark.unit
+def test_doctor_reports_every_line_and_exits_by_the_worst_of_them(tmp_path, capsys, monkeypatch) -> None:
+    from reef.harness.client.wrapper import doctor
+
+    reef = _DoctorReef(token="dummy", head="rel-3")
+    compose, _ = _ask_tree(tmp_path, reef.port)  # models.json binds the token dummy; release file names rel-3
+    binary = tmp_path / "fake-pi"
+    binary.write_text("#!/bin/sh\necho 0.84.2\n")
+    binary.chmod(0o755)
+    monkeypatch.delenv("REEF_TOKEN", raising=False)
+    monkeypatch.setattr("shutil.which", lambda command: f"/usr/bin/{command}" if command == "rg" else None)
+    assert doctor("doc-scenario", "pi", compose, str(binary)) == 1  # fd is missing
+    out = capsys.readouterr().out.splitlines()
+    assert any(line.startswith("ok  interpreter") and "reef " in line for line in out)
+    assert any(line.startswith("ok  service") and "token accepted" in line for line in out)
+    assert any(line.startswith("ok  binary") and "0.84.2" in line for line in out)
+    assert any(line.startswith("ok  tool") and "rg at /usr/bin/rg" in line for line in out)
+    assert any(line.startswith("!!  tool") and "fd missing: install fd" in line for line in out)
+    assert any(line.startswith("ok  release") and "rel-3 installed, the served head" in line for line in out)
+    monkeypatch.setattr("shutil.which", lambda command: f"/usr/bin/{command}")
+    assert doctor("doc-scenario", "pi", compose, str(binary)) == 0
+    # A wrong token in the shell wins over the binding's, and the service says so.
+    monkeypatch.setenv("REEF_TOKEN", "wrong")
+    assert doctor("doc-scenario", "pi", compose, str(binary)) == 1
+    out = capsys.readouterr().out
+    assert "!!  service" in out and "401" in out
+    reef.close()

--- a/tests/reef_service/test_orchestrator_overrides.py
+++ b/tests/reef_service/test_orchestrator_overrides.py
@@ -104,3 +104,22 @@ def test_cli_exits_with_status_2_before_starting_services_for_an_invalid_path(tm
 
     assert excinfo.value.code == 2
     assert "reef.artifact_dir" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_the_install_hint_is_the_one_line_that_installs_the_deployments_harness() -> None:
+    """Printed once the stack is up: the loopback address when the service binds every interface, the adapter the
+    deployment evolves, and the token the config holds; a deployment without a harness gets no line."""
+    from reef.service.deploy.orchestrator import install_hint
+
+    config = {"evolution": {"adapter": "pi"}, "reef": {"host": "0.0.0.0", "port": 8901, "token": "reef-local"}}
+    assert install_hint(config) == (
+        "curl -fsS -H 'Authorization: Bearer reef-local' 'http://127.0.0.1:8901/reef/harness/install?adapter=pi' | bash"
+    )
+    assert install_hint({"evolution": {"adapter": "opencode"}, "reef": {"tokens": ["a", "b"]}}) == (
+        "curl -fsS -H 'Authorization: Bearer a' 'http://127.0.0.1:8900/reef/harness/install?adapter=opencode' | bash"
+    )
+    assert install_hint({"evolution": {"adapter": "pi"}, "reef": {"host": "127.0.0.1", "port": 8900}}) == (
+        "curl -fsS 'http://127.0.0.1:8900/reef/harness/install?adapter=pi' | bash"
+    )
+    assert install_hint({"reef": {"recipe": "recipe"}}) is None


### PR DESCRIPTION
## Motivation

After `reef serve` is up, a person still copies the install line from the README, and when the install or the first run fails the reason is spread over a bash error, an install warning, a run time warning and a route error. The install script also ran `pip install --user` from GitHub on its own when its import check failed, which nobody asked for and which changed the person's user site without a word. Closes #378.

## Changes

- `reef serve` prints the install line once the stack is up, for a deployment that evolves a harness: the loopback address, the adapter, and the token when the config has one. Copy it, nothing to retype.
- The install script checks that the resolved `python3` imports reef and reef-client before it installs or writes anything. If it cannot, the script prints the interpreter and the one `pip install` line that would fix it, and exits 1. It no longer runs pip itself.
- Added `reef-pi doctor`. It prints one line per thing the install needs and exits 0 when they all hold: the interpreter behind the wrapper and its imports, the service address and whether the token is accepted, the agent binary and its version, the tools the adapter wants on PATH, and the installed release against the served head.
- The wrapper's usage header lists `doctor` instead of `setup`; `setup` only matters when a release carries `requires`, and the install script's refusal and the update notice already name it then.
- Every install test now runs the script with the test interpreter as `python3`, so the suite behaves the same on a developer machine and on CI.

## Compatibility and operational impact

The generated install script changes in two ways: it stops early on an interpreter without reef instead of warning and going on, and it never runs pip. A machine that relied on that silent install gets the line to run instead. The wrapper gains a subcommand; the others are unchanged.

## Verification

- With the harness-requests tutorial deployment running, the serve log ended with `install the harness in another terminal: curl -fsS -H 'Authorization: Bearer reef-local' 'http://127.0.0.1:8901/reef/harness/install?adapter=pi' | bash`.
- From an empty environment with cwd `/`, `reef-pi doctor` printed six `ok` lines (interpreter, service with the token accepted, pi 0.84.2, rg, fd, the installed release as the served head) and exited 0; with a wrong `REEF_TOKEN` in the shell it printed `!!  service ... answered 401: invalid service token` and exited 1.
- New tests: the install hint for four config shapes, the install refusing an interpreter without reef and running neither pip nor npm, and `doctor` against a fake service that checks the bearer and names a served head.

## AI assistance

Claude Code provided code assistance.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
