### PR TITLE
fix(docs): load site fonts with next/font

### DIFF
--- a/docs/site/app/globals.css
+++ b/docs/site/app/globals.css
@@ -34,9 +34,9 @@
   --callout-warn-ink: #7a1f1a;
   --shadow-sm: 0 1px 1px rgba(20, 17, 14, .03);
   --shadow-lg: 0 24px 64px rgba(20, 17, 14, .07);
-  --font-sans: "DM Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-serif: "Source Serif 4", Georgia, "Times New Roman", serif;
-  --font-mono: "DM Mono", ui-monospace, monospace;
+  --font-sans: var(--font-dm-sans), ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-serif: var(--font-source-serif), Georgia, "Times New Roman", serif;
+  --font-mono: var(--font-dm-mono), ui-monospace, monospace;
 }
 
 html { color-scheme: light; scroll-padding-top: 128px; } /* auto scroll: smooth raced the late-mounting diagrams and landed deep links hundreds of px off */

--- a/docs/site/app/layout.tsx
+++ b/docs/site/app/layout.tsx
@@ -1,10 +1,33 @@
 import type { Metadata } from "next";
+import { DM_Mono, DM_Sans, Source_Serif_4 } from "next/font/google";
 import { Header } from "@/components/header";
 import { RouteFocus } from "@/components/route-focus";
 import { ThemeSync } from "@/components/theme-sync";
 import { getSearchDocuments, navigation } from "@/lib/docs";
 import { siteConfig } from "@/lib/site";
 import "./globals.css";
+
+const dmSans = DM_Sans({
+  weight: ["400", "500", "600", "800"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-dm-sans",
+});
+
+const sourceSerif = Source_Serif_4({
+  // Keep optical sizing available across the site's heading sizes.
+  axes: ["opsz"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-source-serif",
+});
+
+const dmMono = DM_Mono({
+  weight: ["400", "500"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-dm-mono",
+});
 
 export const metadata: Metadata = {
   title: { default: siteConfig.title, template: `%s | Reef Docs` },
@@ -32,13 +55,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
   const searchDocuments = getSearchDocuments();
 
   return (
-    <html lang="en" suppressHydrationWarning>
-      <head>
-        {/* Linked here, not imported from the stylesheet, so the browser fetches the fonts in parallel with the CSS. */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;600;800&family=Source+Serif+4:opsz,wght@8..60,500;8..60,600&display=swap" />
-      </head>
+    <html lang="en" className={`${dmSans.variable} ${sourceSerif.variable} ${dmMono.variable}`} suppressHydrationWarning>
       <body>
         {/* Inline so it runs at parse time, before first paint. */}
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />


### PR DESCRIPTION
## Motivation

The Google Fonts stylesheet link in the App Router root layout triggers `@next/next/no-page-custom-font`, even though that layout is shared across the site. Use Next.js font loading to remove the warning and serve font assets from the site.

Searched existing issues and PRs for overlapping font work. This updates the font loading introduced in #253; the independent static deck in #392 is unaffected.

## Changes

- Load DM Sans, DM Mono, and Source Serif 4 with `next/font/google` in the root layout and remove the external stylesheet and preconnect links.
- Connect the generated font variables to the existing sans, serif, and monospace CSS variables, including diagram typography.
- Keep the existing DM Sans and DM Mono weights and `display: swap`. Use variable Source Serif 4 with the optical-size axis, retaining the existing 500/600 weights within its supported range.

## Compatibility and operational impact

No public API, route, content, dependency, or persisted-format changes. Fonts are downloaded during builds and served as static assets from the deployment; builds need access to Google Fonts, while page visits no longer request fonts from Google. The Source Serif 4 variable font includes its full weight range and Next.js adds adjusted fallback fonts. No user-facing configuration or documentation changes are required.

## Verification

Using Node.js 22.22.1:

- Before the change, `./node_modules/.bin/eslint app/layout.tsx` reproduced the single custom-font warning.
- `npm ci`: passed; existing ESLint peer dependency warnings were emitted.
- `npm run check:docs`: passed (150 Markdown files, 38 RST files, and 24 Reef routes).
- `npm run lint`: passed with no warnings.
- `npm run build`: passed, including TypeScript and static export.
- Inspected generated output with a Node script: 36 content pages have font classes; the `/docs` redirect is handled separately; all three font variables and 12 bundled WOFF2 files are present; exported HTML has no Google Fonts URLs.
- `pre-commit run --files docs/site/app/layout.tsx docs/site/app/globals.css`: passed all applicable hooks.
- `git diff --check`: passed.

No browser visual comparison or new automated regression test was added. Python suites were not run for this docs-site-only change. The branch was rebased onto the latest main; its only intervening change was the unrelated record-store fix in #394.

## AI assistance

OpenAI Codex investigated the lint rule, implemented the font migration, ran the checks above, and prepared this pull request at the contributor's request. The human contributor remains responsible for reviewing and understanding the change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [ ] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
