### PR TITLE
perf(ci): parallelize tests and cache Python dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ permissions:
   contents: read
 
 env:
-  UV_CACHE_DIR: ${{ runner.temp }}/uv-cache
+  UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+  UV_INSTALL_DIR: ${{ github.workspace }}/.ci-uv
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -27,13 +28,19 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      # Use GitHub-owned actions to comply with the repository allowlist.
-      - name: Install uv
-        run: python -m pip install uv==0.12.13
+      # Cache uv itself as well as packages; only a cold cache needs pip.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: uv-cache
         with:
-          path: ${{ env.UV_CACHE_DIR }}
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+            ${{ env.UV_INSTALL_DIR }}
           key: uv-${{ runner.os }}-${{ runner.arch }}-lint-3.12-${{ hashFiles('pyproject.toml', '.github/workflows/ci.yml') }}
+      - name: Install uv on a cache miss
+        if: steps.uv-cache.outputs.cache-hit != 'true'
+        run: python -m pip install --no-deps --ignore-installed --prefix "$UV_INSTALL_DIR" uv==0.12.13
+      - name: Add uv to PATH
+        run: echo "$UV_INSTALL_DIR/bin" >> "$GITHUB_PATH"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
@@ -90,13 +97,19 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      # Use GitHub-owned actions to comply with the repository allowlist.
-      - name: Install uv
-        run: python -m pip install uv==0.12.13
+      # Cache uv itself as well as packages; only a cold cache needs pip.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: uv-cache
         with:
-          path: ${{ env.UV_CACHE_DIR }}
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+            ${{ env.UV_INSTALL_DIR }}
           key: uv-${{ runner.os }}-${{ runner.arch }}-test-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'third_party/reef-client/pyproject.toml', '.github/workflows/ci.yml') }}
+      - name: Install uv on a cache miss
+        if: steps.uv-cache.outputs.cache-hit != 'true'
+        run: python -m pip install --no-deps --ignore-installed --prefix "$UV_INSTALL_DIR" uv==0.12.13
+      - name: Add uv to PATH
+        run: echo "$UV_INSTALL_DIR/bin" >> "$GITHUB_PATH"
       # huggingface_hub is a declared core dependency (pyproject.toml); the
       # rest are test-only: NumPy for the Erdos TTTD example, httpx for the
       # OPD teacher-client tests, and ray for the slime bridge suites; keeping
@@ -177,13 +190,19 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      # Use GitHub-owned actions to comply with the repository allowlist.
-      - name: Install uv
-        run: python -m pip install uv==0.12.13
+      # Cache uv itself as well as packages; only a cold cache needs pip.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: uv-cache
         with:
-          path: ${{ env.UV_CACHE_DIR }}
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+            ${{ env.UV_INSTALL_DIR }}
           key: uv-${{ runner.os }}-${{ runner.arch }}-package-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'third_party/reef-client/pyproject.toml', '.github/workflows/ci.yml') }}
+      - name: Install uv on a cache miss
+        if: steps.uv-cache.outputs.cache-hit != 'true'
+        run: python -m pip install --no-deps --ignore-installed --prefix "$UV_INSTALL_DIR" uv==0.12.13
+      - name: Add uv to PATH
+        run: echo "$UV_INSTALL_DIR/bin" >> "$GITHUB_PATH"
       - run: uv pip install --system --python python build twine
       # Full build (sdist, then wheel from the sdist) validates the sdist is
       # complete too; twine check validates the metadata. reef-client is a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,18 +137,18 @@ jobs:
       # 3.10. The guard is gone in 3.12, and 3.12 is already the only leg whose
       # coverage.xml is uploaded, so the other legs were paying the risk for a
       # report nothing reads.
-      # Two workers share the runner; keep each file together so module fixtures
-      # and expensive imports are reused. Both workers contribute to coverage.
+      # Four workers share the runner; keep each file together so module fixtures
+      # and expensive imports are reused. All workers contribute to coverage.
       - name: Run tests
         if: matrix.python-version != '3.12'
-        run: python -m pytest tests -n 2 --dist loadfile
+        run: python -m pytest tests -n 4 --dist loadfile
         env:
           GIT_CONFIG_GLOBAL: /dev/null
           GIT_CONFIG_SYSTEM: /dev/null
       - name: Run tests with coverage
         if: matrix.python-version == '3.12'
         run: >
-          python -m pytest tests -n 2 --dist loadfile
+          python -m pytest tests -n 4 --dist loadfile
           --cov=reef --cov-report=term --cov-report=xml
         env:
           GIT_CONFIG_GLOBAL: /dev/null
@@ -327,7 +327,7 @@ jobs:
       - run: ln -s "${{ github.workspace }}/recipes" "${{ runner.temp }}/recipes"
       - run: >
           python -m pytest ${{ github.workspace }}/tests/reef_service
-          -n 2 --dist loadfile
+          -n 4 --dist loadfile
           --ignore=${{ github.workspace }}/tests/reef_service/test_slime_bridge.py
           --ignore=${{ github.workspace }}/tests/reef_service/test_slime_hf_autofill.py
           --ignore=${{ github.workspace }}/tests/reef_service/test_sao_bridge.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.13"
+          enable-cache: true
+          cache-suffix: lint-3.12
+          cache-dependency-glob: |
+            pyproject.toml
+            .github/workflows/ci.yml
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
@@ -52,7 +60,7 @@ jobs:
       # Type check the service package, including its training-runtime adapters.
       # huggingface_hub is a declared core dependency (pyproject.toml);
       # without it installed mypy degrades its call sites to Any.
-      - run: python -m pip install mypy aiohttp "alembic>=1.13,<2" pyyaml huggingface_hub "sqlalchemy>=2.0,<3" tomli-w
+      - run: uv pip install --system --python python mypy aiohttp "alembic>=1.13,<2" pyyaml huggingface_hub "sqlalchemy>=2.0,<3" tomli-w
       - run: python -m mypy
 
   test:
@@ -80,24 +88,33 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.13"
+          enable-cache: true
+          cache-suffix: test-${{ matrix.python-version }}
+          cache-dependency-glob: |
+            pyproject.toml
+            third_party/reef-client/pyproject.toml
+            .github/workflows/ci.yml
       # huggingface_hub is a declared core dependency (pyproject.toml); the
       # rest are test-only: NumPy for the Erdos TTTD example, httpx for the
       # OPD teacher-client tests, and ray for the slime bridge suites; keeping
       # them here avoids expanding Reef's minimal service dependencies.
-      - run: python -m pip install pytest pytest-cov aiohttp "alembic>=1.13,<2" pyyaml huggingface_hub "sqlalchemy>=2.0,<3" tomli-w numpy ray httpx
+      - run: uv pip install --system --python python pytest pytest-cov pytest-xdist==3.8.0 aiohttp "alembic>=1.13,<2" pyyaml huggingface_hub "sqlalchemy>=2.0,<3" tomli-w numpy ray httpx
       # Install the pinned training runtime without its GPU dependencies: the
       # tests need it importable, not its GPU stack, and the
       # full requirements pull CUDA torch and the nvidia wheels, which
       # exhausts the runner disk and trips the checkpoint free-space floor.
-      - run: python -m pip install --no-deps --group runtime
+      - run: uv pip install --system --python python --no-deps --group runtime
       # reef-client is a separate distribution (Human-Agent-Society/reef-client);
       # install the submodule pin so coordinated protocol changes are tested
       # before the matching client release reaches PyPI.
-      - run: python -m pip install ./third_party/reef-client
+      - run: uv pip install --system --python python ./third_party/reef-client
       # Exercise the CPU-only Megatron LoRA helpers without making Torch a
       # dependency of the Reef wheel. Production Torch remains owned by the
       # Slime image.
-      - run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - run: uv pip install --system --python python torch --index-url https://download.pytorch.org/whl/cpu
       # Directory-driven selection: run everything under tests/ so a new suite
       # cannot be silently dropped from CI. Nothing is ignored today — what
       # genuinely needs Megatron carries its own importorskip and reports as
@@ -120,16 +137,18 @@ jobs:
       # 3.10. The guard is gone in 3.12, and 3.12 is already the only leg whose
       # coverage.xml is uploaded, so the other legs were paying the risk for a
       # report nothing reads.
+      # Two workers share the runner; keep each file together so module fixtures
+      # and expensive imports are reused. Both workers contribute to coverage.
       - name: Run tests
         if: matrix.python-version != '3.12'
-        run: python -m pytest tests
+        run: python -m pytest tests -n 2 --dist loadfile
         env:
           GIT_CONFIG_GLOBAL: /dev/null
           GIT_CONFIG_SYSTEM: /dev/null
       - name: Run tests with coverage
         if: matrix.python-version == '3.12'
         run: >
-          python -m pytest tests
+          python -m pytest tests -n 2 --dist loadfile
           --cov=reef --cov-report=term --cov-report=xml
         env:
           GIT_CONFIG_GLOBAL: /dev/null
@@ -158,14 +177,23 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install build twine
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.13"
+          enable-cache: true
+          cache-suffix: package-${{ matrix.python-version }}
+          cache-dependency-glob: |
+            pyproject.toml
+            third_party/reef-client/pyproject.toml
+            .github/workflows/ci.yml
+      - run: uv pip install --system --python python build twine
       # Full build (sdist, then wheel from the sdist) validates the sdist is
       # complete too; twine check validates the metadata. reef-client is a
       # separate distribution installed from the matching submodule pin below.
       - run: python -m build
       - run: python -m twine check dist/*
-      - run: python -m pip install ./third_party/reef-client
-      - run: python -m pip install dist/reef_infra-[0-9]*.whl
+      - run: uv pip install --system --python python ./third_party/reef-client
+      - run: uv pip install --system --python python dist/reef_infra-[0-9]*.whl
       - name: Check distribution and dependency boundaries
         working-directory: ${{ runner.temp }}
         run: |
@@ -292,13 +320,14 @@ jobs:
       # repo so the source tree cannot shadow them. Excluded: tests that
       # import the slime package (the wheel does not bundle it) or Slime's
       # optional dependencies.
-      - run: python -m pip install pytest
+      - run: uv pip install --system --python python pytest pytest-xdist==3.8.0
       # Exercise the repository cookbook as an external consumer of the
       # installed Reef wheel. Linking only recipes/ keeps the source reef/
       # package off sys.path, so it cannot shadow the wheel under test.
       - run: ln -s "${{ github.workspace }}/recipes" "${{ runner.temp }}/recipes"
       - run: >
           python -m pytest ${{ github.workspace }}/tests/reef_service
+          -n 2 --dist loadfile
           --ignore=${{ github.workspace }}/tests/reef_service/test_slime_bridge.py
           --ignore=${{ github.workspace }}/tests/reef_service/test_slime_hf_autofill.py
           --ignore=${{ github.workspace }}/tests/reef_service/test_sao_bridge.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_CACHE_DIR: ${{ runner.temp }}/uv-cache
+
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -24,14 +27,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      # Use GitHub-owned actions to comply with the repository allowlist.
+      - name: Install uv
+        run: python -m pip install uv==0.12.13
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          version: "0.12.13"
-          enable-cache: true
-          cache-suffix: lint-3.12
-          cache-dependency-glob: |
-            pyproject.toml
-            .github/workflows/ci.yml
+          path: ${{ env.UV_CACHE_DIR }}
+          key: uv-${{ runner.os }}-${{ runner.arch }}-lint-3.12-${{ hashFiles('pyproject.toml', '.github/workflows/ci.yml') }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
@@ -88,15 +90,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      # Use GitHub-owned actions to comply with the repository allowlist.
+      - name: Install uv
+        run: python -m pip install uv==0.12.13
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          version: "0.12.13"
-          enable-cache: true
-          cache-suffix: test-${{ matrix.python-version }}
-          cache-dependency-glob: |
-            pyproject.toml
-            third_party/reef-client/pyproject.toml
-            .github/workflows/ci.yml
+          path: ${{ env.UV_CACHE_DIR }}
+          key: uv-${{ runner.os }}-${{ runner.arch }}-test-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'third_party/reef-client/pyproject.toml', '.github/workflows/ci.yml') }}
       # huggingface_hub is a declared core dependency (pyproject.toml); the
       # rest are test-only: NumPy for the Erdos TTTD example, httpx for the
       # OPD teacher-client tests, and ray for the slime bridge suites; keeping
@@ -177,15 +177,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      # Use GitHub-owned actions to comply with the repository allowlist.
+      - name: Install uv
+        run: python -m pip install uv==0.12.13
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          version: "0.12.13"
-          enable-cache: true
-          cache-suffix: package-${{ matrix.python-version }}
-          cache-dependency-glob: |
-            pyproject.toml
-            third_party/reef-client/pyproject.toml
-            .github/workflows/ci.yml
+          path: ${{ env.UV_CACHE_DIR }}
+          key: uv-${{ runner.os }}-${{ runner.arch }}-package-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'third_party/reef-client/pyproject.toml', '.github/workflows/ci.yml') }}
       - run: uv pip install --system --python python build twine
       # Full build (sdist, then wheel from the sdist) validates the sdist is
       # complete too; twine check validates the metadata. reef-client is a

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -17,6 +17,25 @@ Run it in the supported container environment. Many torch-dependent tests use
 collection. Without the training dependencies, pytest cannot collect the full
 suite.
 
+CI runs source and installed-wheel tests on Python 3.10, 3.11, and 3.12 with
+two pytest workers. Tests in the same file stay in one worker, preserving
+module fixture reuse. In an activated development environment, install the same
+test runner plugin and reproduce the parallel run:
+
+.. code:: bash
+
+   uv pip install pytest-xdist==3.8.0
+   GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+     pytest tests/ -n 2 --dist loadfile
+
+Use ``-n 0`` for a serial run when diagnosing a failure. Tests in different
+files may run at the same time; use temporary directories and dynamically
+allocated ports for their external resources.
+
+CI installs dependencies with ``uv pip`` and caches downloads and built wheels
+separately for each job and Python version. It still creates a fresh installed
+environment on each runner, including the CPU-only package boundary checks.
+
 Run one area
 ------------
 
@@ -35,13 +54,14 @@ Markers
 Coverage
 --------
 
-CI runs the suite under coverage, and ``[tool.coverage.report] fail_under`` in
+CI measures coverage on Python 3.12, combining both workers' results, and
+``[tool.coverage.report] fail_under`` in
 ``pyproject.toml`` is a gate: the run exits non-zero when total coverage falls
 below the floor. Reproduce it the way CI does:
 
 .. code:: bash
 
-   pytest tests --cov=reef --cov-report=term
+   pytest tests -n 2 --dist loadfile --cov=reef --cov-report=term
 
 ``pytest-cov`` ships in the ``dev`` extra. The floor applies to the whole
 package, so a partial run reports far less than CI does; measure against the

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -18,7 +18,7 @@ collection. Without the training dependencies, pytest cannot collect the full
 suite.
 
 CI runs source and installed-wheel tests on Python 3.10, 3.11, and 3.12 with
-two pytest workers. Tests in the same file stay in one worker, preserving
+four pytest workers. Tests in the same file stay in one worker, preserving
 module fixture reuse. In an activated development environment, install the same
 test runner plugin and reproduce the parallel run:
 
@@ -26,7 +26,7 @@ test runner plugin and reproduce the parallel run:
 
    uv pip install pytest-xdist==3.8.0
    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
-     pytest tests/ -n 2 --dist loadfile
+     pytest tests/ -n 4 --dist loadfile
 
 Use ``-n 0`` for a serial run when diagnosing a failure. Tests in different
 files may run at the same time; use temporary directories and dynamically
@@ -54,14 +54,14 @@ Markers
 Coverage
 --------
 
-CI measures coverage on Python 3.12, combining both workers' results, and
+CI measures coverage on Python 3.12, combining all workers' results, and
 ``[tool.coverage.report] fail_under`` in
 ``pyproject.toml`` is a gate: the run exits non-zero when total coverage falls
 below the floor. Reproduce it the way CI does:
 
 .. code:: bash
 
-   pytest tests -n 2 --dist loadfile --cov=reef --cov-report=term
+   pytest tests -n 4 --dist loadfile --cov=reef --cov-report=term
 
 ``pytest-cov`` ships in the ``dev`` extra. The floor applies to the whole
 package, so a partial run reports far less than CI does; measure against the

--- a/tests/reef_service/test_serve_profile.py
+++ b/tests/reef_service/test_serve_profile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from dataclasses import replace
 from pathlib import Path
 
@@ -26,6 +27,23 @@ from reef.train.cordis_backend.recipe import CordisRecipe
 REPO_ROOT = Path(__file__).resolve().parents[2]
 #: The profile's proposer lives in the tutorial: the wheel alone (the package job) cannot start it.
 IN_CHECKOUT = (PROJECT_ROOT / "tutorials" / "evolve-your-harness" / "harness" / "evolution.py").is_file()
+
+
+@pytest.fixture
+def isolated_harness_package() -> Iterator[None]:
+    # Examples share this package name, but their modules belong to different
+    # directories. Restore the worker's previous imports after this test.
+    previous = {
+        name: module for name, module in sys.modules.items() if name == "harness" or name.startswith("harness.")
+    }
+    for name in previous:
+        sys.modules.pop(name)
+    try:
+        yield
+    finally:
+        for name in [name for name in sys.modules if name == "harness" or name.startswith("harness.")]:
+            sys.modules.pop(name)
+        sys.modules.update(previous)
 
 
 @pytest.mark.unit
@@ -112,6 +130,7 @@ def test_a_profile_sets_its_directory_and_the_checkout_for_the_service() -> None
 
 @pytest.mark.unit
 @pytest.mark.skipif(not IN_CHECKOUT, reason="the harness-evolve profile runs from a reef checkout")
+@pytest.mark.usefixtures("isolated_harness_package")
 def test_the_harness_evolve_profile_loads_and_boots_its_recipe(monkeypatch, tmp_path) -> None:
     """The profile is the stack config and the preset in one file: it validates as a stack, the registry reads it
     back by the name it carries, and the recipe it builds is the tutorial's proposer over pi in hybrid mode."""

--- a/tests/slime_backend/test_weight_update_recovery.py
+++ b/tests/slime_backend/test_weight_update_recovery.py
@@ -80,6 +80,13 @@ def _install_updater_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     http_utils.is_port_available = lambda _port: True  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "slime.utils.http_utils", http_utils)
 
+    # Recovery tests must provide their own CPU-only transport imports rather
+    # than inherit a LoRA test's cached module in the same pytest worker.
+    sglang = types.ModuleType("slime.backends.megatron_utils.sglang")
+    sglang.FlattenedTensorBucket = object  # type: ignore[attr-defined]
+    sglang.MultiprocessingSerializer = object  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.sglang", sglang)
+
     megatron_to_hf = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
     megatron_to_hf.convert_to_hf = lambda *_args, **_kwargs: []  # type: ignore[attr-defined]
     monkeypatch.setitem(
@@ -165,6 +172,13 @@ def _load_module(monkeypatch: pytest.MonkeyPatch, filename: str):
     base = importlib.util.module_from_spec(base_spec)
     monkeypatch.setitem(sys.modules, base_name, base)
     base_spec.loader.exec_module(base)
+
+    transport_name = f"{package}.lora_transport"
+    transport_spec = importlib.util.spec_from_file_location(transport_name, root / "lora_transport.py")
+    assert transport_spec is not None and transport_spec.loader is not None
+    transport = importlib.util.module_from_spec(transport_spec)
+    monkeypatch.setitem(sys.modules, transport_name, transport)
+    transport_spec.loader.exec_module(transport)
 
     distributed_name = f"{package}.distributed"
     distributed_spec = importlib.util.spec_from_file_location(distributed_name, root / "distributed.py")


### PR DESCRIPTION
## Motivation

Recent CI runs spend roughly four to six minutes executing tests serially inside each Python job. Dependency installation also starts without a persistent Python package cache.

## Changes

- Run source and installed-wheel suites with `pytest-xdist==3.8.0`, four workers, and `--dist loadfile` so each test file stays in one process.
- Cache both the pinned uv installation and its package download/build cache separately by job and Python version. Install uv through pip only on a cache miss; warm runs restore the executable and skip installation.
- Use SHA-pinned GitHub-owned `actions/cache` for the uv cache, compatible with the repository Actions allowlist.
- Make weight-update recovery tests install their own SGLang import stubs and restore the LoRA transport module after each test. Isolate the serve-profile test from other examples' cached `harness` packages so worker scheduling does not change the result.
- Document parallel reproduction, serial debugging, and combined coverage.

## Compatibility and operational impact

No public API or package dependency changes. Keep Python 3.10/3.11/3.12, existing test selection and required job names, CPU-only Torch, Slime's `--no-deps` installation, and the Python 3.12 coverage gate. Jobs use four test processes; installed environments are still fresh and package dependency boundary checks remain intact. Preserve the SQLAlchemy/Alembic dependencies newly added on main.

## Verification

- [GitHub Actions run 34630049883](https://github.com/Human-Agent-Society/reef/actions/runs/34630049883) passed on commit `3a038db`: lint and all source/installed-wheel jobs on Python 3.10, 3.11, and 3.12. The complete CI workflow took **3 minutes 11 seconds**.
- Python 3.12 with four workers and coverage: **2,992 passed, 30 skipped**, **147.39 seconds** for pytest; **88.32% coverage**, above the unchanged 80% floor.
- Local pre-commit checks passed for the changed fixtures; workflow syntax passed actionlint 1.7.12. Four-worker validation ran in GitHub Actions, without another local full-suite benchmark.
- Earlier local Python 3.12 two-worker baseline: 2,982 passed, 33 skipped in 179.35 seconds, with 88.25% coverage. This preceded main's SQLAlchemy merge and ran on macOS, so it is not a controlled comparison to the Linux CI timings.

## AI assistance

OpenAI Codex inspected Actions timings, implemented the workflow/documentation changes, ran local checks, and prepared this PR under the contributor's direction. The human contributor remains responsible for reviewing and understanding the change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
