### PR TITLE
fix(harness): reef-pi doctor probes the release catalog, the route the API platform exposes

### DIFF
--- a/reef/harness/client/wrapper.py
+++ b/reef/harness/client/wrapper.py
@@ -935,6 +935,7 @@ def doctor(scenario: str, adapter: str, compose_dir: str, binary: str) -> int:
     warning, a route error); this is the one place that runs them all and
     says which failed."""
     rows: list[tuple[bool, str, str]] = []
+    catalog: list[Mapping[str, Any]] | None = None
     try:
         import reef
 
@@ -951,15 +952,19 @@ def doctor(scenario: str, adapter: str, compose_dir: str, binary: str) -> int:
     else:
         upstream = _strip_v1(upstream)
         token = _reef_token(adapter, compose_dir)
-        req = urllib.request.Request(f"{upstream}/reef/status", headers=_reef_headers(scenario, token))
+        # The release catalog, not /reef/status: every client of a harness can read it, direct or through the
+        # API platform, which does not expose the service wide status.
+        req = urllib.request.Request(f"{upstream}/reef/harness/releases", headers=_reef_headers(scenario, token))
         try:
-            with urllib.request.urlopen(req, timeout=10):
-                rows.append((True, "service", f"{upstream} answers, token {'accepted' if token else 'not needed'}"))
+            with urllib.request.urlopen(req, timeout=10) as response:
+                listed = json.loads(response.read()).get("releases")
+            catalog = [row for row in listed if isinstance(row, Mapping)] if isinstance(listed, list) else []
+            rows.append((True, "service", f"{upstream} answers, token {'accepted' if token else 'not needed'}"))
         except urllib.error.HTTPError as exc:
             rows.append(
                 (False, "service", f"{upstream} answered {exc.code}: {exc.read().decode(errors='replace')[:120]}")
             )
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
             rows.append((False, "service", f"{upstream} unreachable: {exc}"))
     if Path(binary).is_file():
         try:
@@ -984,23 +989,18 @@ def doctor(scenario: str, adapter: str, compose_dir: str, binary: str) -> int:
                 f"no {HARNESS_RELEASE_FILE} beside the tree; this tree did not come through the install",
             )
         )
-    elif upstream is not None and rows[1][0]:
-        try:
-            catalog = _catalog(upstream, scenario, adapter, _reef_token(adapter, compose_dir))
-        except SystemExit as exc:
-            rows.append((False, "release", f"installed {installed[:8]}; catalog unreadable: {exc.code}"))
+    elif catalog is not None:
+        head = next((row.get("release_id") for row in reversed(catalog) if not row.get("pending")), None)
+        if head == installed:
+            rows.append((True, "release", f"{installed[:8]} installed, the served head"))
         else:
-            head = next((row.get("release_id") for row in reversed(catalog) if not row.get("pending")), None)
-            if head == installed:
-                rows.append((True, "release", f"{installed[:8]} installed, the served head"))
-            else:
-                rows.append(
-                    (
-                        True,
-                        "release",
-                        f"{installed[:8]} installed; served head {str(head)[:8]}, the next session offers it",
-                    )
+            rows.append(
+                (
+                    True,
+                    "release",
+                    f"{installed[:8]} installed; served head {str(head)[:8]}, the next session offers it",
                 )
+            )
     else:
         rows.append((True, "release", f"{installed[:8]} installed"))
     for ok, label, value in rows:

--- a/tests/reef_service/test_harness_wrapper.py
+++ b/tests/reef_service/test_harness_wrapper.py
@@ -1540,7 +1540,7 @@ def test_main_passes_release_to_setup_only_when_named(tmp_path) -> None:
 
 
 class _DoctorReef:
-    """A reef whose status route checks the bearer and whose catalog names one served head."""
+    """A reef that serves only the harness routes, checks the bearer on them, and names one served head."""
 
     def __init__(self, token: str, head: str) -> None:
         import http.server
@@ -1548,9 +1548,9 @@ class _DoctorReef:
 
         class Handler(http.server.BaseHTTPRequestHandler):
             def do_GET(self):
-                if self.path == "/reef/status":
-                    ok = self.headers.get("Authorization") == f"Bearer {token}"
-                    code, payload = (200, {"scenarios": {}}) if ok else (401, {"error": "invalid service token"})
+                # Only the harness routes, the ones the API platform exposes too; no service wide status.
+                if self.headers.get("Authorization") != f"Bearer {token}":
+                    code, payload = 401, {"error": "invalid service token"}
                 elif self.path == "/reef/harness/releases":
                     code, payload = 200, {"releases": [{"release_id": head, "pending": False}]}
                 else:


### PR DESCRIPTION
## Motivation

`reef-pi doctor` checked the service with `GET /reef/status`. The API platform (api.reefinfra.ai) does not expose that route, so on a harness installed through the platform the service line read `!! service ... answered 404` while everything else worked. Found while walking the harness evolve path on api.reefinfra.ai.

Closes #404.

## Changes

- `doctor` probes `GET /reef/harness/releases` instead. Every client of a harness can read it, direct or through the platform, and it also checks the token. The release line reads the served head from the same answer, so `doctor` makes one request to the service instead of two.
- The doctor test's fake reef serves only the harness routes and checks the bearer on them, which is what the platform does.

## Compatibility and operational impact

None beyond `doctor`'s own output.

## Verification

- Against a harness installed from api.reefinfra.ai with a workspace key, `reef-pi doctor` printed six `ok` lines (service answers, token accepted; release 9c298669 installed, the served head) and exited 0. Before the change the service line was a 404.
- Against a local deployment with a token, the same six lines; with a wrong `REEF_TOKEN` in the shell the service line reads 401 and the exit is 1.

## AI assistance

Claude Code provided code assistance.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.

