### PR TITLE
docs(profiles): say what selection always does in the harness-evolve profile

### DIFF
--- a/reef/service/profiles/harness-evolve.yaml
+++ b/reef/service/profiles/harness-evolve.yaml
@@ -17,7 +17,7 @@ evolution:
   version_check: true
   # An evolved extension runs in pi's process with the person's privileges: held until promoted.
   review_kinds: [code_extension]
-  # A workflow change does not move the seed tasks, so a candidate that does not lose is published.
+  # Every candidate whose evaluation ran is published; the gate scores are recorded for the step page, not enforced.
   selection: always
   step_record_dir: .reef/harness-evolve/steps
   proposals_dir: .reef/harness-evolve/proposals


### PR DESCRIPTION
## Motivation

The comment above `selection: always` in the harness-evolve profile said a candidate that does not lose is published. The always policy publishes every candidate whose evaluation ran, whatever the gate scores say; a step through api.reefinfra.ai scored 3.0 against 2.0 and was published. A reader of the profile expects a losing candidate to be rejected.

Closes #408.

## Changes

- The comment says what the policy does: every evaluated candidate is published, and the gate scores are recorded for the step page, not enforced.

## Compatibility and operational impact

None. A comment changed.

## Verification

- `AlwaysSelectMixin.decide` in `reef/train/evaluation/evaluators.py` returns select for every evaluated candidate; the new comment matches it.

## AI assistance

Claude Code provided code assistance.

## Checklist

- [x] The change is scoped to one issue.
- [x] Tests are not affected; a comment changed.
- [x] Docs already describe the policy this way in the skillclaw guide.
