### PR TITLE
test(native): wait for mount event after manifest retry

### DIFF
--- a/tests/reef_service/test_native_serve.py
+++ b/tests/reef_service/test_native_serve.py
@@ -479,7 +479,12 @@ def test_a_manifest_fetch_that_times_out_is_retried_by_the_next_poll(tmp_path: P
         log = server.sessions_dir / serve.SERVE_LOG
         reef.hang_manifest_s = 0.6
         reef.release("r2", [_tool("one"), _tool("two")], parent="r1")
-        _wait(lambda: server.status()["release_id"] == "r2", timeout_s=10.0)
+        # The release ID changes before installation and the mount log write finish.
+        _wait(
+            lambda: any(m["release_id"] == "r2" for m in _typed(_events(log), "harness/mount")),
+            timeout_s=10.0,
+        )
+        assert server.status()["release_id"] == "r2"
         failed = _typed(_events(log), "harness/mount-failed")
         assert [f["release_id"] for f in failed] == ["r2"] and "timed out" in failed[0]["error"]
         assert [m["release_id"] for m in _typed(_events(log), "harness/mount")] == ["r1", "r2"]


### PR DESCRIPTION
## Motivation

The Python 3.11 package job in #382 failed because the manifest retry test observed `release_id == "r2"` before the corresponding `harness/mount` event was written. The server updates the release ID, installs the manifest, and then logs the mount, so checking the log immediately after the status changes races with the background mount.

Failure: https://github.com/Human-Agent-Society/reef/actions/runs/34676644039/job/103507595874

## Changes

Wait for the `r2` mount event before checking the release status and event history. Preserve the existing assertions that the first fetch times out and that the successful mounts are exactly `r1`, then `r2`.

## Compatibility and operational impact

None. Only the test synchronization changes; production code and the existing 10-second wait deadline are unchanged.

## Verification

- A temporary pytest plugin delayed `Server._install` by 0.2 seconds: the original test reproduced the CI assertion failure, and the fixed test passed with the same delay. The plugin is outside the repository and is not part of this change.
- Before rebase, `NO_PROXY='*' no_proxy='*' .venv/bin/python -m pytest tests/reef_service/test_native_serve.py -q --tb=short`: 26 passed.
- After rebase, `pre-commit run --all-files`: passed.
- After rebase, `.venv/bin/python -m mypy`: 4 existing errors in `lora_transport.py` and `checkpoint.py` under the Slime weight updater integration. These files match `origin/main`; this test-only change does not modify them.
- After rebase, `NO_PROXY='*' no_proxy='*' GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null .venv/bin/python -m pytest tests/ -n 4 --dist loadfile --tb=short`: **3076 passed, 48 skipped**, 17 warnings. Proxy bypass avoids local proxy responses interfering with connection-refusal tests.

## AI assistance

OpenAI Codex inspected the CI logs, reproduced the race with temporary delay injection, implemented the test synchronization fix, ran verification, and prepared this pull request. The human contributor remains responsible for reviewing and understanding the change.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
