### PR TITLE
fix(deploy): resolve local configs and report startup failures

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -42,12 +42,12 @@ startup failures exit with status 1; invalid configuration exits with status
 Interrupting startup with SIGINT or SIGTERM also stops the services already
 launched, including when they are still loading a model.
 
-The basic and SAO example ``run.sh`` launchers also bound their HTTP readiness
-waits and stop when the Reef process exits. Their defaults are 300 seconds
-and 3600 seconds respectively; set ``REEF_STARTUP_TIMEOUT_S`` to a positive
-integer to change the wait. On failure they print the last 100 lines of
-``work/reef.log`` and stop the process they started. Each HTTP probe has a
-timeout, so a stalled endpoint cannot leave the script waiting indefinitely.
+The basic and SAO example ``run.sh`` launchers wait for the HTTP health
+endpoint and stop waiting if Reef exits. Startup deadlines are configured
+through the deployment YAML's ``ready_timeout``; the scripts do not add a
+second deadline. Each HTTP probe has a five-second timeout. Startup errors
+are recorded in ``work/reef.log``, and exiting the script stops the Reef
+process it started.
 
 Use ``${VAR:?}`` for a required environment variable, for example
 ``upstream_model: ${REEF_UPSTREAM_MODEL:?}``. If it is unset, empty, or only

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -5,6 +5,14 @@ A deployment config is one YAML file. ``reef serve -c <file>`` reads it, starts
 every process in its ``services`` list in dependency order, and hands the
 ``reef`` section to the HTTP service.
 
+Relative config paths, including ``REEF_CONFIG``, resolve from the directory
+where you run the command. With no ``-c`` or ``--recipe``, Reef reads
+``REEF_CONFIG`` if set, otherwise ``./reef.yaml`` in that directory. It does
+not search the Reef installation for your config. From outside a checkout,
+pass an absolute path to a cookbook config. Relative state paths still use
+the launch directory, and an explicit ``services[].cwd`` controls that
+service's working directory.
+
 .. code:: yaml
 
    reef:
@@ -25,6 +33,21 @@ itself with ``${dotted.path}``. Any value can be overridden on the command line:
 a bare ``--model_path /models/demo`` targets the ``reef`` section, and a dotted
 ``--training.checkpoint_dir /tmp/ckpt`` targets any other. Each process writes a
 log under ``/tmp/reef-stack/``; set ``run_dir`` to move it.
+
+If a service exits before readiness or exceeds its ``ready_timeout``, Reef
+stops the stack and reports the service, the failure reason, and the local
+log directory. An exited service's message includes its exit code. CLI
+startup failures exit with status 1; invalid configuration exits with status
+2. Child output is retained in the logs and forwarded to the terminal.
+Interrupting startup with SIGINT or SIGTERM also stops the services already
+launched, including when they are still loading a model.
+
+The basic and SAO example ``run.sh`` launchers also bound their HTTP readiness
+waits and stop when the Reef process exits. Their defaults are 300 seconds
+and 3600 seconds respectively; set ``REEF_STARTUP_TIMEOUT_S`` to a positive
+integer to change the wait. On failure they print the last 100 lines of
+``work/reef.log`` and stop the process they started. Each HTTP probe has a
+timeout, so a stalled endpoint cannot leave the script waiting indefinitely.
 
 Use ``${VAR:?}`` for a required environment variable, for example
 ``upstream_model: ${REEF_UPSTREAM_MODEL:?}``. If it is unset, empty, or only

--- a/recipes/basic/run.sh
+++ b/recipes/basic/run.sh
@@ -2,6 +2,12 @@
 # Serve + run. Setup (once): see README. State and logs go to ./work.
 set -e
 cd "$(dirname "$0")"
+
+startup_timeout=${REEF_STARTUP_TIMEOUT_S:-300}
+if [[ ! "$startup_timeout" =~ ^[1-9][0-9]*$ ]]; then
+    echo "run.sh: REEF_STARTUP_TIMEOUT_S must be a positive integer" >&2
+    exit 2
+fi
 mkdir -p work
 
 # Start Reef from the external-provider stack, with the local example's
@@ -16,10 +22,37 @@ PYTHONPATH=../.. python3 -m reef serve -c "$PWD/external-provider.yaml" \
     --artifact_work_dir work/artifact-work \
     --artifact_cache_dir work/artifact-cache \
     > work/reef.log 2>&1 &
-trap 'kill %1' EXIT
+reef_pid=$!
+cleanup() {
+    kill "$reef_pid" 2>/dev/null || true
+    wait "$reef_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-# Wait until Reef answers. If this never returns, check work/reef.log.
-while ! curl -sf http://127.0.0.1:8900/healthz > /dev/null; do
+# Bound both the overall wait and each HTTP probe; stop if the stack exits.
+ready_deadline=$((SECONDS + startup_timeout))
+while true; do
+    if ! kill -0 "$reef_pid" 2>/dev/null; then
+        exit_code=0
+        wait "$reef_pid" || exit_code=$?
+        echo "run.sh: Reef exited before ready (exit code $exit_code). Log: $PWD/work/reef.log" >&2
+        tail -n 100 work/reef.log >&2
+        (( exit_code != 0 )) || exit_code=1
+        exit "$exit_code"
+    fi
+    remaining=$((ready_deadline - SECONDS))
+    if (( remaining <= 0 )); then
+        echo "run.sh: Reef did not become ready within ${startup_timeout}s. Log: $PWD/work/reef.log" >&2
+        tail -n 100 work/reef.log >&2
+        exit 1
+    fi
+    probe_timeout=$((remaining < 5 ? remaining : 5))
+    if curl -sf --connect-timeout "$probe_timeout" --max-time "$probe_timeout" \
+        http://127.0.0.1:8900/healthz > /dev/null && kill -0 "$reef_pid" 2>/dev/null; then
+        break
+    fi
     sleep 1
 done
 

--- a/recipes/basic/run.sh
+++ b/recipes/basic/run.sh
@@ -3,11 +3,6 @@
 set -e
 cd "$(dirname "$0")"
 
-startup_timeout=${REEF_STARTUP_TIMEOUT_S:-300}
-if [[ ! "$startup_timeout" =~ ^[1-9][0-9]*$ ]]; then
-    echo "run.sh: REEF_STARTUP_TIMEOUT_S must be a positive integer" >&2
-    exit 2
-fi
 mkdir -p work
 
 # Start Reef from the external-provider stack, with the local example's
@@ -23,37 +18,18 @@ PYTHONPATH=../.. python3 -m reef serve -c "$PWD/external-provider.yaml" \
     --artifact_cache_dir work/artifact-cache \
     > work/reef.log 2>&1 &
 reef_pid=$!
-cleanup() {
-    kill "$reef_pid" 2>/dev/null || true
-    wait "$reef_pid" 2>/dev/null || true
-}
-trap cleanup EXIT
+trap 'kill "$reef_pid" 2>/dev/null || true; wait "$reef_pid" 2>/dev/null || true' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-# Bound both the overall wait and each HTTP probe; stop if the stack exits.
-ready_deadline=$((SECONDS + startup_timeout))
-while true; do
-    if ! kill -0 "$reef_pid" 2>/dev/null; then
-        exit_code=0
-        wait "$reef_pid" || exit_code=$?
-        echo "run.sh: Reef exited before ready (exit code $exit_code). Log: $PWD/work/reef.log" >&2
-        tail -n 100 work/reef.log >&2
-        (( exit_code != 0 )) || exit_code=1
-        exit "$exit_code"
-    fi
-    remaining=$((ready_deadline - SECONDS))
-    if (( remaining <= 0 )); then
-        echo "run.sh: Reef did not become ready within ${startup_timeout}s. Log: $PWD/work/reef.log" >&2
-        tail -n 100 work/reef.log >&2
-        exit 1
-    fi
-    probe_timeout=$((remaining < 5 ? remaining : 5))
-    if curl -sf --connect-timeout "$probe_timeout" --max-time "$probe_timeout" \
-        http://127.0.0.1:8900/healthz > /dev/null && kill -0 "$reef_pid" 2>/dev/null; then
-        break
-    fi
+# Reef enforces the YAML ready_timeout and exits if startup fails.
+while kill -0 "$reef_pid" 2>/dev/null; do
+    curl -sf --max-time 5 http://127.0.0.1:8900/healthz > /dev/null && break
     sleep 1
 done
+if ! kill -0 "$reef_pid" 2>/dev/null; then
+    echo "Reef failed to start. See $PWD/work/reef.log" >&2
+    exit 1
+fi
 
 python3 run.py

--- a/recipes/sao/examples/sao/README.md
+++ b/recipes/sao/examples/sao/README.md
@@ -145,13 +145,19 @@ paths must mean the same thing to the host docker daemon.
 ./run.sh
 ```
 
+The launcher waits up to 3600 seconds for Reef, with a timeout on each HTTP
+probe. Set `REEF_STARTUP_TIMEOUT_S` to a positive integer to change the wait.
+If the stack exits or the deadline expires, it prints the reason and the last
+100 lines of `work/reef.log`, stops its Reef process, and exits without starting
+the workload. Normal completion and interruption also stop the Reef process.
+
 `run.sh` starts `reef serve -c serve.yaml` with its state under `./work`,
 waits for `/healthz`, and runs `run.py`. `serve.yaml` describes a two-GPU
 stack: one Megatron actor with the critic colocated on it, and one SGLang
 rollout engine, serving `Qwen2.5-1.5B-Instruct`. On the first start Reef
 loads the Hugging Face weights directly and writes the Megatron checkpoint
 that later starts load. Ray, Slime, Megatron, and SGLang take minutes to come
-up; `work/reef.log` has the service log if the wait never ends.
+up; `work/reef.log` has the service log if startup fails.
 
 Reef starts and stops the shared Ray runtime automatically; no `ray start`
 or fixed Ray port is needed. `run.sh` defaults the local cluster's GPU pool to

--- a/recipes/sao/examples/sao/README.md
+++ b/recipes/sao/examples/sao/README.md
@@ -145,11 +145,10 @@ paths must mean the same thing to the host docker daemon.
 ./run.sh
 ```
 
-The launcher waits up to 3600 seconds for Reef, with a timeout on each HTTP
-probe. Set `REEF_STARTUP_TIMEOUT_S` to a positive integer to change the wait.
-If the stack exits or the deadline expires, it prints the reason and the last
-100 lines of `work/reef.log`, stops its Reef process, and exits without starting
-the workload. Normal completion and interruption also stop the Reef process.
+The launcher waits for Reef's health endpoint and stops waiting if Reef
+exits. Configure service startup deadlines with `ready_timeout` in
+`serve.yaml`; startup errors are in `work/reef.log`. Exiting or interrupting
+the script also stops its Reef process.
 
 `run.sh` starts `reef serve -c serve.yaml` with its state under `./work`,
 waits for `/healthz`, and runs `run.py`. `serve.yaml` describes a two-GPU

--- a/recipes/sao/examples/sao/run.sh
+++ b/recipes/sao/examples/sao/run.sh
@@ -3,6 +3,12 @@
 set -e
 cd "$(dirname "$0")"
 
+startup_timeout=${REEF_STARTUP_TIMEOUT_S:-3600}
+if [[ ! "$startup_timeout" =~ ^[1-9][0-9]*$ ]]; then
+    echo "run.sh: REEF_STARTUP_TIMEOUT_S must be a positive integer" >&2
+    exit 2
+fi
+
 # Limit the locally managed Ray cluster to this training stack's GPU pool.
 # On an external cluster, its node configuration determines GPU visibility.
 export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1}
@@ -10,12 +16,38 @@ mkdir -p work
 
 # Start the Reef training stack, stop it again when this script exits.
 python3 -m reef serve -c "$PWD/serve.yaml" > work/reef.log 2>&1 &
-trap 'kill %1' EXIT
+reef_pid=$!
+cleanup() {
+    kill "$reef_pid" 2>/dev/null || true
+    wait "$reef_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-# Ray + Slime/Megatron + SGLang take minutes to come up.
-# If this never returns, check work/reef.log.
-while ! curl -s http://127.0.0.1:8900/healthz > /dev/null; do
-    sleep 5
+# Bound both the overall wait and each HTTP probe; stop if the stack exits.
+ready_deadline=$((SECONDS + startup_timeout))
+while true; do
+    if ! kill -0 "$reef_pid" 2>/dev/null; then
+        exit_code=0
+        wait "$reef_pid" || exit_code=$?
+        echo "run.sh: Reef exited before ready (exit code $exit_code). Log: $PWD/work/reef.log" >&2
+        tail -n 100 work/reef.log >&2
+        (( exit_code != 0 )) || exit_code=1
+        exit "$exit_code"
+    fi
+    remaining=$((ready_deadline - SECONDS))
+    if (( remaining <= 0 )); then
+        echo "run.sh: Reef did not become ready within ${startup_timeout}s. Log: $PWD/work/reef.log" >&2
+        tail -n 100 work/reef.log >&2
+        exit 1
+    fi
+    probe_timeout=$((remaining < 5 ? remaining : 5))
+    if curl -sf --connect-timeout "$probe_timeout" --max-time "$probe_timeout" \
+        http://127.0.0.1:8900/healthz > /dev/null && kill -0 "$reef_pid" 2>/dev/null; then
+        break
+    fi
+    sleep 1
 done
 
 python3 run.py

--- a/recipes/sao/examples/sao/run.sh
+++ b/recipes/sao/examples/sao/run.sh
@@ -3,12 +3,6 @@
 set -e
 cd "$(dirname "$0")"
 
-startup_timeout=${REEF_STARTUP_TIMEOUT_S:-3600}
-if [[ ! "$startup_timeout" =~ ^[1-9][0-9]*$ ]]; then
-    echo "run.sh: REEF_STARTUP_TIMEOUT_S must be a positive integer" >&2
-    exit 2
-fi
-
 # Limit the locally managed Ray cluster to this training stack's GPU pool.
 # On an external cluster, its node configuration determines GPU visibility.
 export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1}
@@ -17,37 +11,18 @@ mkdir -p work
 # Start the Reef training stack, stop it again when this script exits.
 python3 -m reef serve -c "$PWD/serve.yaml" > work/reef.log 2>&1 &
 reef_pid=$!
-cleanup() {
-    kill "$reef_pid" 2>/dev/null || true
-    wait "$reef_pid" 2>/dev/null || true
-}
-trap cleanup EXIT
+trap 'kill "$reef_pid" 2>/dev/null || true; wait "$reef_pid" 2>/dev/null || true' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-# Bound both the overall wait and each HTTP probe; stop if the stack exits.
-ready_deadline=$((SECONDS + startup_timeout))
-while true; do
-    if ! kill -0 "$reef_pid" 2>/dev/null; then
-        exit_code=0
-        wait "$reef_pid" || exit_code=$?
-        echo "run.sh: Reef exited before ready (exit code $exit_code). Log: $PWD/work/reef.log" >&2
-        tail -n 100 work/reef.log >&2
-        (( exit_code != 0 )) || exit_code=1
-        exit "$exit_code"
-    fi
-    remaining=$((ready_deadline - SECONDS))
-    if (( remaining <= 0 )); then
-        echo "run.sh: Reef did not become ready within ${startup_timeout}s. Log: $PWD/work/reef.log" >&2
-        tail -n 100 work/reef.log >&2
-        exit 1
-    fi
-    probe_timeout=$((remaining < 5 ? remaining : 5))
-    if curl -sf --connect-timeout "$probe_timeout" --max-time "$probe_timeout" \
-        http://127.0.0.1:8900/healthz > /dev/null && kill -0 "$reef_pid" 2>/dev/null; then
-        break
-    fi
+# Reef enforces the YAML ready_timeout and exits if startup fails.
+while kill -0 "$reef_pid" 2>/dev/null; do
+    curl -sf --max-time 5 http://127.0.0.1:8900/healthz > /dev/null && break
     sleep 1
 done
+if ! kill -0 "$reef_pid" 2>/dev/null; then
+    echo "Reef failed to start. See $PWD/work/reef.log" >&2
+    exit 1
+fi
 
 python3 run.py

--- a/reef/cli.py
+++ b/reef/cli.py
@@ -68,7 +68,7 @@ def main(argv=None):
         _connect_main(rest)
         return
 
-    from reef.service.deploy import DeployConfigError
+    from reef.service.deploy import DeployConfigError, DeployStartupError
     from reef.service.deploy import main as _serve_main
 
     try:
@@ -77,6 +77,9 @@ def main(argv=None):
         # Deploy config errors are typed library errors; the CLI owns the exit.
         print(f"[reef] ERROR: {exc}", file=sys.stderr)
         sys.exit(2)
+    except DeployStartupError as exc:
+        print(f"[reef] ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/reef/service/deploy/__init__.py
+++ b/reef/service/deploy/__init__.py
@@ -11,7 +11,7 @@ settings.
 
 from reef.artifact.git_lfs import GitLFSRepositoryBackend
 from reef.service.deploy.config import PROJECT_ROOT, DeployConfigError, load_config
-from reef.service.deploy.orchestrator import main
+from reef.service.deploy.orchestrator import DeployStartupError, main
 from reef.service.deploy.settings import ServiceSettings, build_parser, run_service, service_settings_from_config
 
 
@@ -30,6 +30,7 @@ def build_dispatcher(settings, **kwargs):
 __all__ = [
     "PROJECT_ROOT",
     "DeployConfigError",
+    "DeployStartupError",
     "GitLFSRepositoryBackend",
     "ServiceSettings",
     "build_app",

--- a/reef/service/deploy/config.py
+++ b/reef/service/deploy/config.py
@@ -112,10 +112,8 @@ def interpolate_config(config: Mapping[str, Any], value: str) -> str:
 
 
 def load_config(config_path: str | Path, *, interpolate_env: bool = True) -> dict[str, Any]:
-    """Read a deployment config; defer interpolation when applying CLI overrides."""
-    path = Path(config_path)
-    if not path.is_absolute():
-        path = PROJECT_ROOT / path
+    """Read a config relative to the working directory; optionally defer interpolation."""
+    path = Path(config_path).expanduser().resolve()
     if not path.exists():
         raise DeployConfigError(f"config not found: {path}\n  pass a deployment stack with: reef serve -c <path>")
     try:
@@ -123,6 +121,8 @@ def load_config(config_path: str | Path, *, interpolate_env: bool = True) -> dic
             config = yaml.safe_load(handle)
     except yaml.YAMLError as exc:
         raise DeployConfigError(f"config {path} is not valid YAML: {exc}") from exc
+    except OSError as exc:
+        raise DeployConfigError(f"cannot read config {path}: {exc.strerror}") from exc
     if config is None:
         config = {}
     if not isinstance(config, dict):

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -19,6 +19,7 @@ import threading
 import time
 from collections.abc import Mapping, MutableMapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from contextlib import suppress
 from pathlib import Path
 from types import FrameType
 from typing import Any
@@ -54,6 +55,10 @@ def _log(msg: str) -> None:
 
 class InvalidOverrideError(ValueError):
     """A leftover ``reef serve`` argument is not a valid ``--key`` override."""
+
+
+class DeployStartupError(RuntimeError):
+    """A deployment failed to start; includes its reason and local log location."""
 
 
 def _parse_overrides(extras: list[str]) -> dict[str, str]:
@@ -177,8 +182,18 @@ class _Stack:
         while not self._stopping.is_set():
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise TimeoutError(f"service {service['name']!r} did not become ready")
-            ready = executor.rpc(0, "probe", args=(service["name"], min(5, remaining)), timeout=min(5, remaining) + 2)
+                timeout = service.get("ready_timeout", self.ready_timeout_default)
+                raise TimeoutError(f"service {service['name']!r} did not become ready within {timeout}s")
+            try:
+                ready = executor.rpc(
+                    0, "probe", args=(service["name"], min(5, remaining)), timeout=min(5, remaining) + 2
+                )
+            except Exception:
+                # A failed probe can be the first observation of a child's exit.
+                # Preserve its last output without replacing the startup error.
+                with suppress(Exception):
+                    self._drain_log(service["name"])
+                raise
             self._drain_log(service["name"])
             if ready:
                 return
@@ -396,9 +411,7 @@ def install_hint(config: Mapping[str, Any]) -> str | None:
 
 
 def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None) -> int:
-    resolved_config_path = Path(config_path)
-    if not resolved_config_path.is_absolute():
-        resolved_config_path = PROJECT_ROOT / resolved_config_path
+    resolved_config_path = Path(config_path).expanduser().resolve()
     config = load_config(resolved_config_path, interpolate_env=False)
     if overrides:
         config = _apply_overrides(config, overrides)
@@ -429,15 +442,25 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
         resolved_config_path,
         source_root=source_root,
     )
+
+    def interrupt_startup(signum: int, frame: FrameType | None) -> None:
+        _log("received signal during startup, shutting down")
+        raise KeyboardInterrupt
+
+    # block() installs the steady-state handler only after every service is
+    # ready. Until then, interruption must unwind start() and stop its peers.
+    previous_sigterm = signal.signal(signal.SIGTERM, interrupt_startup)
     try:
-        stack.start()
+        try:
+            stack.start()
+        except Exception as exc:
+            raise DeployStartupError(f"deployment startup failed: {exc}\n  logs: {run_dir.resolve()}/*.log") from exc
         stack.block()
     except KeyboardInterrupt:
-        # SIGINT during startup (before block() registers its handler) still
-        # triggers the default KeyboardInterrupt; shutdown ran via finally.
-        # Swallow it so the operator sees a clean exit, not a traceback.
+        # Startup signals unwind the launch tasks before final cleanup.
         stack._stopping.set()
     finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
         stack.shutdown()
         if temp_config_path is not None:
             temp_config_path.unlink(missing_ok=True)
@@ -485,7 +508,7 @@ def _resolve_config(config: str | None, recipe: str | None, environ: Mapping[str
             raise DeployConfigError(str(exc)) from exc
     if environ.get("REEF_CONFIG"):
         return environ["REEF_CONFIG"]
-    if (PROJECT_ROOT / "reef.yaml").is_file():
+    if Path("reef.yaml").is_file():
         return "reef.yaml"
     raise DeployConfigError(
         "no config: pass one with -c <file>, or start a recipe's profile with --recipe <name>; "

--- a/reef/service/deploy/process.py
+++ b/reef/service/deploy/process.py
@@ -116,14 +116,17 @@ class ProcessWorker:
         log_fp = open(self._log_file(name), "a")  # noqa: SIM115
         self._log_fps[name] = log_fp
         # Logs stay on the worker node and are tailed through Executor RPC.
-        proc = self._spawn(
-            command,
-            env=env,
-            cwd=interpolate_config(self.config, svc["cwd"]) if svc.get("cwd") else None,
-            stdout=log_fp,
-            stderr=subprocess.STDOUT,
-            start_new_session=os.name == "posix",
-        )
+        try:
+            proc = self._spawn(
+                command,
+                env=env,
+                cwd=interpolate_config(self.config, svc["cwd"]) if svc.get("cwd") else None,
+                stdout=log_fp,
+                stderr=subprocess.STDOUT,
+                start_new_session=os.name == "posix",
+            )
+        except OSError as exc:
+            raise OSError(exc.errno, f"service {name!r} could not start: {exc.strerror}", exc.filename) from exc
         self._procs[name] = proc
         if os.name == "posix":
             self._process_groups[name] = proc.pid
@@ -266,7 +269,9 @@ class ProcessWorker:
     def probe(self, name: str, timeout: float = 5.0) -> bool:
         service = next(svc for svc in self.services if svc["name"] == name)
         if not self._is_alive(name):
-            raise RuntimeError(f"service {name!r} exited before ready")
+            proc = self._procs.get(name)
+            exit_status = f" (exit code {proc.returncode})" if proc is not None else ""
+            raise RuntimeError(f"service {name!r} exited before ready{exit_status}")
         ready = service.get("ready")
         if not ready:
             return True

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -56,7 +56,7 @@ def build_parser() -> argparse.ArgumentParser:
         "-c",
         "--config",
         default=None,
-        help="Config file path (default: reef.yaml or $REEF_CONFIG).",
+        help="Config file path, relative to the working directory (default: $REEF_CONFIG or ./reef.yaml).",
     )
     return parser
 

--- a/tests/reef_service/test_deploy_config_validation.py
+++ b/tests/reef_service/test_deploy_config_validation.py
@@ -22,6 +22,63 @@ def _write(tmp_path: Path, text: str) -> Path:
 
 
 @pytest.mark.unit
+def test_relative_config_uses_working_directory_not_installation(tmp_path: Path, monkeypatch) -> None:
+    installed = tmp_path / "installed"
+    installed.mkdir()
+    _write(installed, "reef: {recipe: wrong}\n")
+    _write(tmp_path, "reef: {recipe: selected}\n")
+    monkeypatch.setattr("reef.service.deploy.config.PROJECT_ROOT", installed)
+    monkeypatch.chdir(tmp_path)
+
+    assert load_config("stack.yaml")["reef"]["recipe"] == "selected"
+    (tmp_path / "stack.yaml").unlink()
+    with pytest.raises(DeployConfigError, match="config not found") as caught:
+        load_config("stack.yaml")
+    assert str(tmp_path / "stack.yaml") in str(caught.value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("source", ["argument", "environment", "default"])
+def test_cli_config_paths_and_child_config_follow_working_directory(tmp_path: Path, monkeypatch, source) -> None:
+    captured = {}
+
+    class StackStub:
+        exit_code = 0
+
+        def __init__(self, config, services, run_dir, ready_timeout_default, config_path, source_root=None):
+            captured["path"] = config_path
+            captured["config"] = load_config(config_path)
+            captured["run_dir"] = run_dir.resolve()
+
+        def start(self):
+            pass
+
+        def block(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("REEF_CONFIG", raising=False)
+    monkeypatch.setattr(orchestrator, "_Stack", StackStub)
+    monkeypatch.setattr(orchestrator, "resolve_model_paths", lambda config: False)
+    path = tmp_path / ("reef.yaml" if source == "default" else "stack.yaml")
+    path.write_text("run_dir: work/stack\n" + VALID)
+    if source == "environment":
+        monkeypatch.setenv("REEF_CONFIG", path.name)
+    arguments = ["serve", "-c", path.name] if source == "argument" else ["serve"]
+
+    with pytest.raises(SystemExit) as caught:
+        cli_main(arguments)
+
+    assert caught.value.code == 0
+    assert captured["path"] == path
+    assert captured["config"]["services"][0]["name"] == "worker"
+    assert captured["run_dir"] == tmp_path / "work" / "stack"
+
+
+@pytest.mark.unit
 def test_malformed_yaml_is_a_config_error_naming_the_path(tmp_path: Path) -> None:
     path = _write(tmp_path, "services: [unclosed\n")
     with pytest.raises(DeployConfigError, match="not valid YAML") as caught:
@@ -39,6 +96,16 @@ def test_non_object_root_is_a_config_error(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_empty_file_loads_as_an_empty_config(tmp_path: Path) -> None:
     assert load_config(_write(tmp_path, "")) == {}
+
+
+@pytest.mark.unit
+def test_directory_is_reported_as_an_unreadable_config(tmp_path: Path, capsys) -> None:
+    with pytest.raises(SystemExit) as caught:
+        cli_main(["serve", "-c", str(tmp_path)])
+    assert caught.value.code == 2
+    message = capsys.readouterr().err
+    assert f"cannot read config {tmp_path}" in message
+    assert "Traceback" not in message
 
 
 @pytest.mark.unit

--- a/tests/reef_service/test_deployment_startup.py
+++ b/tests/reef_service/test_deployment_startup.py
@@ -1,0 +1,122 @@
+"""CLI startup failures name the failed service and preserve its final output."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reef.cli import main as cli_main
+
+
+@pytest.mark.parametrize("failure", ["exit", "timeout", "missing-command"])
+def test_startup_failure_reports_reason_and_logs_then_stops_processes(tmp_path: Path, capfd, failure) -> None:
+    pid_file = tmp_path / "worker.pid"
+    command = [
+        sys.executable,
+        "-u",
+        "-c",
+        "import os,time; from pathlib import Path; "
+        f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+        "print('worker startup output', flush=True); "
+        + ("raise SystemExit(7)" if failure == "exit" else "time.sleep(120)"),
+    ]
+    if failure == "missing-command":
+        command = [str(tmp_path / "missing-program")]
+    run_dir = tmp_path / "logs"
+    config_path = tmp_path / "stack.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "run_dir": str(run_dir),
+                "services": [
+                    {"name": "model", "command": command, "ready": "false", "ready_timeout": 1},
+                    {
+                        "name": "api",
+                        "command": [sys.executable, "-c", "raise RuntimeError('must not start')"],
+                        "depends_on": ["model"],
+                    },
+                ],
+            }
+        )
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        cli_main(["serve", "-c", str(config_path)])
+
+    assert caught.value.code == 1
+    output = capfd.readouterr()
+    assert "model" in output.err
+    assert str(run_dir) in output.err
+    assert "Traceback" not in output.err
+    if failure == "exit":
+        assert "exit code 7" in output.err
+    elif failure == "timeout":
+        assert "did not become ready within 1s" in output.err
+    else:
+        assert "missing-program" in output.err
+    if failure != "missing-command":
+        assert "worker startup output" in output.out
+        assert "worker startup output" in (run_dir / "model.log").read_text()
+        with pytest.raises(ProcessLookupError):
+            os.kill(int(pid_file.read_text()), 0)
+    assert not (run_dir / "api.worker.json").exists()
+
+
+def test_sigterm_during_startup_stops_the_service_process(tmp_path: Path) -> None:
+    pid_file = tmp_path / "service.pid"
+    path = tmp_path / "stack.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "run_dir": str(tmp_path / "logs"),
+                "services": [
+                    {
+                        "name": "loading-model",
+                        "command": [
+                            sys.executable,
+                            "-c",
+                            "import os,time; from pathlib import Path; "
+                            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); time.sleep(120)",
+                        ],
+                        "ready": "false",
+                        "ready_timeout": 60,
+                    }
+                ],
+            }
+        )
+    )
+    root = Path(__file__).resolve().parents[2]
+    env = {**os.environ, "PYTHONPATH": os.pathsep.join(filter(None, (str(root), os.environ.get("PYTHONPATH"))))}
+    process = subprocess.Popen(
+        [sys.executable, "-m", "reef", "serve", "-c", path.name],
+        cwd=tmp_path,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while not pid_file.exists():
+            assert process.poll() is None
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+        process.terminate()
+        _, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, stderr
+        assert "Traceback" not in stderr
+        with pytest.raises(ProcessLookupError):
+            os.kill(int(pid_file.read_text()), 0)
+    finally:
+        if process.poll() is None:
+            process.kill()
+        process.communicate(timeout=5)
+        if pid_file.exists():
+            with suppress(ProcessLookupError):
+                os.killpg(int(pid_file.read_text()), signal.SIGKILL)

--- a/tests/reef_service/test_serve_profile.py
+++ b/tests/reef_service/test_serve_profile.py
@@ -82,7 +82,11 @@ def test_the_config_is_resolved_explicit_first_then_the_environment_then_reef_ya
         _resolve_config("mine.yaml", "harness-evolve", {})
     with pytest.raises(DeployConfigError, match="recipes with a profile: harness-evolve"):
         _resolve_config(None, "weights", {})
-    monkeypatch.setattr("reef.service.deploy.orchestrator.PROJECT_ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
+    installed = tmp_path / "installed"
+    installed.mkdir()
+    (installed / "reef.yaml").write_text("reef: {}\n")
+    monkeypatch.setattr("reef.service.deploy.orchestrator.PROJECT_ROOT", installed)
     with pytest.raises(DeployConfigError, match="--recipe <name>; recipes with a profile: harness-evolve"):
         _resolve_config(None, None, {})
     (tmp_path / "reef.yaml").write_text("reef: {}\n")

--- a/tests/test_example_startup.py
+++ b/tests/test_example_startup.py
@@ -1,0 +1,129 @@
+"""Run example launchers with lightweight services, without GPUs or provider calls."""
+
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ("recipes/basic", "recipes/sao/examples/sao")
+
+
+def _write_command(directory: Path, name: str, source: str) -> None:
+    path = directory / name
+    path.write_text(f"#!{sys.executable}\n" + source)
+    path.chmod(0o755)
+
+
+@pytest.mark.parametrize("example", EXAMPLES)
+@pytest.mark.parametrize(
+    "mode", ["exit", "exit-success", "timeout", "hanging-probe", "ready", "workload-error", "signal"]
+)
+def test_example_startup_and_cleanup(tmp_path: Path, example: str, mode: str) -> None:
+    script = tmp_path / "run.sh"
+    shutil.copyfile(ROOT / example / "run.sh", script)
+    commands = tmp_path / "bin"
+    commands.mkdir()
+    _write_command(
+        commands,
+        "python3",
+        """import os, signal, sys, time
+from pathlib import Path
+
+mode = os.environ['REEF_TEST_MODE']
+if sys.argv[1:] == ['run.py']:
+    Path('work/workload-started').touch()
+    raise SystemExit(9 if mode == 'workload-error' else 0)
+Path('work/service.pid').write_text(str(os.getpid()))
+print('example startup output', flush=True)
+if mode in ('exit', 'exit-success'):
+    raise SystemExit(7 if mode == 'exit' else 0)
+def stop(signum, frame):
+    Path('work/service-stopped').touch()
+    raise SystemExit(0)
+signal.signal(signal.SIGTERM, stop)
+Path('work/service-started').touch()
+while True:
+    time.sleep(0.01)
+""",
+    )
+    _write_command(
+        commands,
+        "curl",
+        """import os, sys, time
+from pathlib import Path
+
+mode = os.environ['REEF_TEST_MODE']
+if mode == 'hanging-probe':
+    timeout = float(sys.argv[sys.argv.index('--max-time') + 1]) if '--max-time' in sys.argv else 120
+    time.sleep(timeout)
+    raise SystemExit(28)
+time.sleep(0.05)
+raise SystemExit(0 if mode in ('ready', 'workload-error') and Path('work/service-started').exists() else 7)
+""",
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{commands}{os.pathsep}{os.environ['PATH']}",
+        "REEF_TEST_MODE": mode,
+        "REEF_STARTUP_TIMEOUT_S": "1" if mode in ("timeout", "hanging-probe") else "5",
+    }
+    process = subprocess.Popen(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        if mode == "signal":
+            deadline = time.monotonic() + 5
+            while not (tmp_path / "work/service-started").exists():
+                assert process.poll() is None
+                assert time.monotonic() < deadline
+                time.sleep(0.01)
+            process.send_signal(signal.SIGTERM)
+        _, stderr = process.communicate(timeout=8)
+        expected = {"ready": 0, "workload-error": 9, "exit": 7, "signal": 143}.get(mode, 1)
+        assert process.returncode == expected, stderr
+        assert (tmp_path / "work/workload-started").exists() == (mode in ("ready", "workload-error"))
+        if mode not in ("ready", "workload-error", "signal"):
+            assert "example startup output" in stderr
+            assert str(tmp_path / "work/reef.log") in stderr
+            reason = {"exit": "exit code 7", "exit-success": "exit code 0"}.get(mode, "within 1s")
+            assert reason in stderr
+        if mode not in ("exit", "exit-success"):
+            assert (tmp_path / "work/service-stopped").exists()
+        with pytest.raises(ProcessLookupError):
+            os.kill(int((tmp_path / "work/service.pid").read_text()), 0)
+    finally:
+        # The old infinite wait and failed assertions must not leave test workers alive.
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.communicate(timeout=5)
+
+
+@pytest.mark.parametrize("example", EXAMPLES)
+@pytest.mark.parametrize("timeout", ["0", "-1", "abc", "1.5"])
+def test_invalid_startup_timeout_fails_before_launch(tmp_path: Path, example: str, timeout: str) -> None:
+    script = tmp_path / "run.sh"
+    shutil.copyfile(ROOT / example / "run.sh", script)
+    result = subprocess.run(
+        ["bash", str(script)],
+        env={**os.environ, "REEF_STARTUP_TIMEOUT_S": timeout},
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "REEF_STARTUP_TIMEOUT_S must be a positive integer" in result.stderr
+    assert not (tmp_path / "work").exists()

--- a/tests/test_example_startup.py
+++ b/tests/test_example_startup.py
@@ -64,9 +64,19 @@ if mode == 'hanging-probe':
     timeout = float(sys.argv[sys.argv.index('--max-time') + 1]) if '--max-time' in sys.argv else 120
     time.sleep(timeout)
     raise SystemExit(28)
+if mode == 'stale-ready':
+    # Answer only after Reef has exited, independent of process scheduling.
+    while not Path('work/service.pid').exists():
+        time.sleep(0.01)
+    pid = int(Path('work/service.pid').read_text())
+    while True:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            raise SystemExit(0)
+        time.sleep(0.01)
 time.sleep(0.05)
-ready = mode == 'stale-ready' or mode in ('ready', 'workload-error') and Path('work/service-started').exists()
-raise SystemExit(0 if ready else 7)
+raise SystemExit(0 if mode in ('ready', 'workload-error') and Path('work/service-started').exists() else 7)
 """,
     )
     env = {

--- a/tests/test_example_startup.py
+++ b/tests/test_example_startup.py
@@ -23,7 +23,7 @@ def _write_command(directory: Path, name: str, source: str) -> None:
 
 @pytest.mark.parametrize("example", EXAMPLES)
 @pytest.mark.parametrize(
-    "mode", ["exit", "exit-success", "timeout", "hanging-probe", "ready", "workload-error", "signal"]
+    "mode", ["exit", "exit-success", "stale-ready", "hanging-probe", "ready", "workload-error", "signal"]
 )
 def test_example_startup_and_cleanup(tmp_path: Path, example: str, mode: str) -> None:
     script = tmp_path / "run.sh"
@@ -42,8 +42,8 @@ if sys.argv[1:] == ['run.py']:
     raise SystemExit(9 if mode == 'workload-error' else 0)
 Path('work/service.pid').write_text(str(os.getpid()))
 print('example startup output', flush=True)
-if mode in ('exit', 'exit-success'):
-    raise SystemExit(7 if mode == 'exit' else 0)
+if mode in ('exit', 'exit-success', 'stale-ready', 'hanging-probe'):
+    raise SystemExit(0 if mode == 'exit-success' else 7)
 def stop(signum, frame):
     Path('work/service-stopped').touch()
     raise SystemExit(0)
@@ -65,14 +65,14 @@ if mode == 'hanging-probe':
     time.sleep(timeout)
     raise SystemExit(28)
 time.sleep(0.05)
-raise SystemExit(0 if mode in ('ready', 'workload-error') and Path('work/service-started').exists() else 7)
+ready = mode == 'stale-ready' or mode in ('ready', 'workload-error') and Path('work/service-started').exists()
+raise SystemExit(0 if ready else 7)
 """,
     )
     env = {
         **os.environ,
         "PATH": f"{commands}{os.pathsep}{os.environ['PATH']}",
         "REEF_TEST_MODE": mode,
-        "REEF_STARTUP_TIMEOUT_S": "1" if mode in ("timeout", "hanging-probe") else "5",
     }
     process = subprocess.Popen(
         ["bash", str(script)],
@@ -92,15 +92,14 @@ raise SystemExit(0 if mode in ('ready', 'workload-error') and Path('work/service
                 time.sleep(0.01)
             process.send_signal(signal.SIGTERM)
         _, stderr = process.communicate(timeout=8)
-        expected = {"ready": 0, "workload-error": 9, "exit": 7, "signal": 143}.get(mode, 1)
+        expected = {"ready": 0, "workload-error": 9, "signal": 143}.get(mode, 1)
         assert process.returncode == expected, stderr
         assert (tmp_path / "work/workload-started").exists() == (mode in ("ready", "workload-error"))
         if mode not in ("ready", "workload-error", "signal"):
-            assert "example startup output" in stderr
+            assert "Reef failed to start" in stderr
             assert str(tmp_path / "work/reef.log") in stderr
-            reason = {"exit": "exit code 7", "exit-success": "exit code 0"}.get(mode, "within 1s")
-            assert reason in stderr
-        if mode not in ("exit", "exit-success"):
+            assert "example startup output" in (tmp_path / "work/reef.log").read_text()
+        if mode in ("ready", "workload-error", "signal"):
             assert (tmp_path / "work/service-stopped").exists()
         with pytest.raises(ProcessLookupError):
             os.kill(int((tmp_path / "work/service.pid").read_text()), 0)
@@ -109,21 +108,3 @@ raise SystemExit(0 if mode in ('ready', 'workload-error') and Path('work/service
         with suppress(ProcessLookupError):
             os.killpg(process.pid, signal.SIGKILL)
         process.communicate(timeout=5)
-
-
-@pytest.mark.parametrize("example", EXAMPLES)
-@pytest.mark.parametrize("timeout", ["0", "-1", "abc", "1.5"])
-def test_invalid_startup_timeout_fails_before_launch(tmp_path: Path, example: str, timeout: str) -> None:
-    script = tmp_path / "run.sh"
-    shutil.copyfile(ROOT / example / "run.sh", script)
-    result = subprocess.run(
-        ["bash", str(script)],
-        env={**os.environ, "REEF_STARTUP_TIMEOUT_S": timeout},
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=False,
-    )
-    assert result.returncode == 2
-    assert "REEF_STARTUP_TIMEOUT_S must be a positive integer" in result.stderr
-    assert not (tmp_path / "work").exists()


### PR DESCRIPTION
## Motivation

Running `reef serve -c stack.yaml` outside the checkout can select a config under the Reef installation instead of the caller's directory. The basic and SAO launchers can also wait indefinitely after startup fails, leaving users to infer the cause from logs.

Make config selection predictable and startup failures actionable. Related to the deployment discussion in #20; component overrides remain separate work.

## Changes

- Resolve explicit config paths, `REEF_CONFIG`, and the default `./reef.yaml` from the launch directory, and report unreadable configs as configuration errors.
- Report startup failures with the service, reason, exit status where available, and local log location. Preserve the child's final output and clean up the stack, including SIGTERM during startup.
- Keep the basic and SAO launchers small: poll health while Reef is alive, cap each HTTP probe at five seconds, point to the log on failure, and clean up on exit. Service startup deadlines use the existing YAML `ready_timeout`.
- Document the behavior and add regression coverage for config selection, failed launches, timeouts, stalled probes, signals, and cleanup.

## Compatibility and operational impact

Relative config paths now resolve from the caller's working directory, rather than the installation root. Invocations that relied on the previous lookup must use an explicit checkout path or run from that checkout. Relative state paths and explicit service working directories retain their existing behavior.

The examples use the existing per-service `ready_timeout`; there is no additional shell startup timeout setting. CLI startup failures exit with status 1; configuration errors retain status 2. The example launchers return status 1 if Reef exits before readiness and preserve the workload exit status after readiness. No new dependencies, persisted formats, or service topology changes.

## Verification

Local environment: macOS, Python 3.12.9.

- `pre-commit run --all-files` and `git diff --check`: passed.
- `.venv/bin/python -m pytest tests/test_example_startup.py tests/reef_service/test_deployment_startup.py -n 4 -q --tb=short --durations=3`: **18 passed**, covering process exits, stalled probes, an unrelated healthy endpoint after Reef exits, workload completion/failure, signals, and stack cleanup.
- `bash -n recipes/basic/run.sh recipes/sao/examples/sao/run.sh`: passed.
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null .venv/bin/python -m pytest tests/ -n 4 --dist loadfile -q --tb=short --durations=5`: **3126 passed, 48 skipped, 2 failed**. One was the baseline storage failure below; the other exposed a scheduling assumption in the new test stub. The stub now waits for actual process exit, and the final parallel focused run above passes. The full suite was not repeated after that test-only correction.
- The full-suite failure, `test_bridge_catalogs_paired_checkpoint_metrics_and_blocks_before_second_optimizer`, returns `storage_blocked` before the first training job. Reproduced the same failure in a clean archive of base commit `173de82`.
- `.venv/bin/python -m mypy`: **4 existing errors** in `lora_transport.py` and `checkpoint.py` (distributed collective typing and `Work | None`). Confirmed the same errors with baseline versions of the changed Python modules using mypy shadow files.
- Example tests use lightweight process/HTTP stubs; GPU training startup was not exercised.

## AI assistance

OpenAI Codex helped investigate and reproduce the failures, implement the fixes and regression tests, update documentation, run verification, and prepare this PR. The human contributor remains responsible for review and follow-up.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [ ] Relevant pre-commit and test checks pass. (Focused tests and pre-commit pass; baseline full-suite and mypy failures are recorded above.)
- [x] Non-trivial AI assistance is disclosed above, or none was used.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
