### PR TITLE
refactor(config): unify service CLI and YAML parsing

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -34,6 +34,39 @@ a bare ``--model_path /models/demo`` targets the ``reef`` section, and a dotted
 ``--training.checkpoint_dir /tmp/ckpt`` targets any other. Each process writes a
 log under ``/tmp/reef-stack/``; set ``run_dir`` to move it.
 
+Public service settings use the same argument parser for YAML and CLI values.
+Their types, defaults, and help are declared on ``ServiceSettings``. Explicit
+CLI values override YAML values; omitted values use the setting's default.
+Run ``reef serve --help`` to see these options. Hyphenated names such as
+``--upstream-model`` and existing underscore names such as ``--upstream_model``
+are aliases, as are their dotted ``--reef.upstream_model`` forms. The last
+explicit CLI spelling of a setting wins. ``--recipe`` still selects a launcher
+profile; ``--reef.recipe`` overrides the deployment's recipe setting.
+
+String settings retain their text: ``--upstream-model 00123`` remains ``00123``.
+Numeric and boolean settings are parsed according to their declared type;
+invalid values fail before model downloads or process startup. Booleans accept
+an explicit value or a bare flag; a negative flag can disable a YAML setting:
+
+.. code:: bash
+
+   reef serve -c stack.yaml --port 9000 --no-allow-implicit-scenario-creation
+
+List and object options take one quoted JSON/YAML value. Empty lists and
+objects are preserved, and an explicit container replaces the YAML value:
+
+.. code:: bash
+
+   reef serve -c stack.yaml --tokens '[]' \
+     --inference-backend-config '{"tool_call_parser": "qwen25"}'
+
+The parsed public values are also supplied to service commands and the HTTP
+child's config. Existing empty/null service values retain their defaulting
+behavior. ``reef.token`` and ``reef.tokens`` remain distinct inputs whose
+credentials are combined. Recipe-owned fields and arbitrary custom-stack
+overrides keep their existing parsers and YAML coercion; this change does not
+replace the ``services`` layout or introduce a new configuration format.
+
 If a service exits before readiness or exceeds its ``ready_timeout``, Reef
 stops the stack and reports the service, the failure reason, and the local
 log directory. An exited service's message includes its exit code. CLI

--- a/reef/service/deploy/arguments.py
+++ b/reef/service/deploy/arguments.py
@@ -1,0 +1,162 @@
+"""Typed argparse definitions shared by deployment YAML and command-line input.
+
+Only declared settings pass through this adapter. Custom service stacks and
+recipe-owned mappings keep their existing parsers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import dataclasses
+import json
+import math
+import types
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, NoReturn, Union, get_args, get_origin, get_type_hints
+
+import yaml
+
+
+def config_metadata(help: str, *, path: tuple[str, ...] = ()) -> dict[str, Any]:
+    """Describe a public setting; an omitted path means ``reef.<field>``."""
+    return {"config_help": help, "config_path": path}
+
+
+def config_option(default: Any = dataclasses.MISSING, *, help: str) -> Any:
+    """Declare a setting's default and CLI help beside its type."""
+    return dataclasses.field(default=default, metadata=config_metadata(help))
+
+
+class ConfigArgumentParser(argparse.ArgumentParser):
+    """Library parsing reports errors without printing input values or exiting."""
+
+    def error(self, message: str) -> NoReturn:
+        raise ValueError(message)
+
+
+@dataclass(frozen=True)
+class ConfigArgument:
+    """One setting's YAML path, CLI aliases, default and value parser."""
+
+    name: str
+    path: tuple[str, ...]
+    kind: str
+    nullable: bool
+    default: Any
+    help: str
+
+    @property
+    def destination(self) -> str:
+        """Keep the config's recipe separate from the launcher's profile."""
+        return "config_recipe" if self.name == "recipe" else self.name
+
+    @property
+    def flags(self) -> tuple[str, ...]:
+        dotted = ".".join(self.path)
+        names = [dotted.replace("_", "-"), dotted]
+        # The launcher owns --recipe; the setting remains --reef.recipe.
+        if self.path[0] == "reef" and self.name != "recipe":
+            names = [self.name.replace("_", "-"), self.name, *names]
+        return tuple(dict.fromkeys(f"--{name}" for name in names))
+
+    @property
+    def negative_flags(self) -> tuple[str, ...]:
+        return tuple(f"--no-{flag[2:]}" for flag in self.flags) if self.kind == "bool" else ()
+
+    def parse(self, raw: str) -> Any:
+        """Convert either source with the same rules; never echo credentials."""
+        try:
+            if self.kind == "str":
+                return raw
+            if self.nullable and raw == "null":
+                return None
+            if self.kind == "int":
+                return int(raw)
+            if self.kind == "float":
+                value = float(raw)
+                if not math.isfinite(value):
+                    raise ValueError("non-finite number")
+                return value
+            if self.kind == "bool":
+                if raw.lower() in {"true", "yes", "on", "1"}:
+                    return True
+                if raw.lower() in {"false", "no", "off", "0"}:
+                    return False
+                raise ValueError("invalid boolean")
+            value = yaml.safe_load(raw)
+            if self.kind == "object" and isinstance(value, dict):
+                return value
+            if self.kind == "strings" and isinstance(value, list) and all(isinstance(item, str) for item in value):
+                return tuple(value)
+        except (ValueError, TypeError, yaml.YAMLError):
+            pass
+        expected = {"object": "an object", "strings": "a list of strings"}.get(self.kind, f"a valid {self.kind}")
+        raise argparse.ArgumentTypeError(f"{'.'.join(self.path)} must be {expected}")
+
+    def add_to(self, parser: argparse.ArgumentParser) -> None:
+        options: dict[str, Any] = {
+            "dest": self.destination,
+            "type": self.parse,
+            "default": copy.deepcopy(self.default),
+            "help": self.help,
+        }
+        if self.kind == "bool":
+            options.update(nargs="?", const="true")
+        parser.add_argument(*self.flags, **options)
+        if self.negative_flags:
+            parser.add_argument(
+                *self.negative_flags,
+                dest=self.destination,
+                action="store_const",
+                const=False,
+                default=argparse.SUPPRESS,
+                help=f"Disable {'.'.join(self.path)}.",
+            )
+
+    def encode(self, value: Any) -> str:
+        """Convert a YAML value to an argv value without losing empty containers."""
+        if isinstance(value, str):
+            return value
+        if self.kind in {"strings", "object"}:
+            try:
+                return json.dumps(value)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(f"{'.'.join(self.path)} must contain JSON-compatible values") from exc
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+
+def config_arguments(settings_type: type) -> tuple[ConfigArgument, ...]:
+    """Read the declared fields of a settings dataclass, not runtime objects."""
+    annotations = get_type_hints(settings_type)
+    arguments = []
+    for field in dataclasses.fields(settings_type):
+        if "config_help" not in field.metadata:
+            continue
+        annotation = annotations[field.name]
+        nullable = False
+        if get_origin(annotation) in (Union, types.UnionType):
+            members = get_args(annotation)
+            nullable = type(None) in members
+            annotation = next(member for member in members if member is not type(None))
+        kinds = {str: "str", int: "int", float: "float", bool: "bool", tuple: "strings", Mapping: "object"}
+        kind = kinds.get(get_origin(annotation) or annotation)
+        if kind is None:
+            raise TypeError(f"unsupported config field type: {field.name}")
+        default = field.default
+        if default is dataclasses.MISSING:
+            default = field.default_factory() if field.default_factory is not dataclasses.MISSING else None
+        arguments.append(
+            ConfigArgument(
+                field.name,
+                field.metadata["config_path"] or ("reef", field.name),
+                kind,
+                nullable,
+                default,
+                field.metadata["config_help"],
+            )
+        )
+    return tuple(arguments)

--- a/reef/service/deploy/orchestrator.py
+++ b/reef/service/deploy/orchestrator.py
@@ -42,7 +42,7 @@ from reef.service.deploy.config import (
     validate_services,
 )
 from reef.service.deploy.execution import service_executor_config, service_executor_selection
-from reef.service.deploy.settings import build_parser
+from reef.service.deploy.settings import build_parser, normalize_service_config, service_override
 from reef.service.profiles import PROFILES_DIR, UnknownProfileError, profile_names, profile_path
 
 _DEFAULT_GRACE_TIMEOUT = 30
@@ -76,22 +76,30 @@ def _parse_overrides(extras: list[str]) -> dict[str, str]:
         if not token.startswith("--"):
             raise InvalidOverrideError(f"unrecognized argument: {token!r}")
         key = token[2:]
+        has_value = True
         if "=" in key:
             key, value = key.split("=", 1)
-            if not key:
-                raise InvalidOverrideError(f"override is missing a name: {token!r}")
-            overrides[key] = value
             i += 1
         elif i + 1 < len(extras) and not extras[i + 1].startswith("--"):
-            if not key:
-                raise InvalidOverrideError(f"override is missing a name: {token!r}")
-            overrides[key] = extras[i + 1]
+            value = extras[i + 1]
             i += 2
         else:
-            if not key:
-                raise InvalidOverrideError(f"override is missing a name: {token!r}")
-            overrides[key] = "true"
+            value = "true"
+            has_value = False
             i += 1
+        if not key:
+            raise InvalidOverrideError(f"override is missing a name: {token!r}")
+        declared = service_override(key, value)
+        if declared is not None:
+            argument, _ = declared
+            if not has_value and argument.kind != "bool":
+                raise InvalidOverrideError(f"argument --{key} requires a value")
+            if has_value and f"--{key}" in argument.negative_flags:
+                raise InvalidOverrideError(f"argument --{key} does not take a value")
+        # Preserve the last occurrence's position as well as its value, so
+        # a repeated spelling can still override an intervening alias.
+        overrides.pop(key, None)
+        overrides[key] = value
     return overrides
 
 
@@ -111,7 +119,11 @@ def _apply_overrides(config: dict[str, Any], overrides: dict[str, str]) -> dict[
     """
     config = copy.deepcopy(config)
     for key, raw_value in overrides.items():
-        if "." not in key:
+        declared = service_override(key, raw_value)
+        if declared is not None:
+            argument, raw_value = declared
+            key = ".".join(argument.path)
+        if "." not in key and declared is None:
             key = f"reef.{key}"
         parts = key.split(".")
         node: dict[str, Any] = config
@@ -123,7 +135,9 @@ def _apply_overrides(config: dict[str, Any], overrides: dict[str, str]) -> dict[
                 prefix = ".".join(parts[: index + 1])
                 raise InvalidOverrideError(f"override path {prefix!r} is not a section")
             node = existing
-        node[parts[-1]] = _coerce_value(raw_value)
+        # Public fields are converted by argparse, just like YAML values.
+        # Keep generic recipe/custom-stack overrides on their legacy path.
+        node[parts[-1]] = raw_value if declared is not None else _coerce_value(raw_value)
     return config
 
 
@@ -416,6 +430,17 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
     if overrides:
         config = _apply_overrides(config, overrides)
     config = interpolate_environment(config, resolved_config_path)
+    cli_paths = frozenset(
+        declared[0].path
+        for key, value in (overrides or {}).items()
+        if (declared := service_override(key, value)) is not None
+    )
+    try:
+        normalized_config = normalize_service_config(config, cli_paths=cli_paths)
+    except ValueError as exc:
+        raise DeployConfigError(f"config {resolved_config_path}: {exc}") from exc
+    settings_changed = normalized_config != config
+    config = normalized_config
     # Structure first, so a bad stack fails before a model download, a run dir, or a child process.
     services = validate_services(config, resolved_config_path)
     # Resolved against the operator's config, before any override copy
@@ -427,7 +452,7 @@ def _run_orchestrator(config_path: str, overrides: dict[str, str] | None = None)
             sys.path.append(str(source_root))
     paths_changed = resolve_model_paths(config)
     temp_config_path: Path | None = None
-    if overrides or paths_changed:
+    if overrides or paths_changed or settings_changed:
         temp_config_path = _write_override_config(config)
         resolved_config_path = temp_config_path
     run_dir = Path(config_value(config, "run_dir", default="/tmp/reef-stack") or "/tmp/reef-stack")
@@ -529,11 +554,11 @@ def _prepare_profile(recipe: str, model: str | None, environ: MutableMapping[str
     environ["REEF_CHECKOUT"] = str(PROJECT_ROOT)
 
 
-def build_serve_parser() -> argparse.ArgumentParser:
+def build_serve_parser(*, service_arguments: bool = True) -> argparse.ArgumentParser:
     """``reef serve``'s own arguments: the service child's parser plus the profile and model flags.
 
     Only the launcher takes them; ``python -m reef.service`` still refuses ``--recipe``."""
-    parser = build_parser()
+    parser = build_parser(service_arguments=service_arguments)
     parser.add_argument(
         "--recipe",
         default=None,
@@ -550,7 +575,12 @@ def build_serve_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    parser = build_serve_parser()
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if "--help" in argv or "-h" in argv:
+        build_serve_parser().parse_args(argv)
+    # Discover the file/profile without applying defaults or converting
+    # public values before YAML and environment references are available.
+    parser = build_serve_parser(service_arguments=False)
     args, extras = parser.parse_known_args(argv)
     try:
         overrides = _parse_overrides(extras)

--- a/reef/service/deploy/settings.py
+++ b/reef/service/deploy/settings.py
@@ -11,14 +11,23 @@ orchestrator that starts the surrounding stack lives in
 from __future__ import annotations
 
 import argparse
+import copy
 import dataclasses
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 from reef.service.cors import console_origins
+from reef.service.deploy.arguments import (
+    ConfigArgument,
+    ConfigArgumentParser,
+    config_arguments,
+    config_metadata,
+    config_option,
+)
 from reef.service.deploy.config import config_value, interpolate_config, load_config
 from reef.storage.postgres import postgres_url, validate_postgres_schema
 from reef.storage.records import RecordRetention
@@ -35,22 +44,26 @@ The Reef HTTP child is an internal service process configured from the same
 YAML file. Public startup is always config-driven.
 
 Config overrides:
-  Any ``--key value`` pair not recognized as a flag is applied as a config
-  override. Bare keys target the ``reef`` section; use dotted notation for
-  other sections. Values are YAML-coerced (ints, bools, etc.).
+  Public settings below share type conversion with YAML. Explicit CLI
+  values override YAML; omitted settings use the dataclass defaults.
+  Both --upstream-model and legacy --upstream_model spellings work.
+  Lists and objects take one quoted JSON/YAML value, including [] or {}.
+  Recipe and custom-stack overrides retain their existing YAML coercion:
+  bare keys target ``reef``; dotted keys target other sections.
 
   Examples:
-    reef serve --model_path Qwen2.5-1.5B-Instruct
+    reef serve -c stack.yaml --model-path Qwen/Qwen2.5-1.5B-Instruct
     reef serve -c path/to/local-sglang.yaml --port 9000
     reef serve --training.checkpoint_dir /tmp/ckpt
 """
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser(*, service_arguments: bool = False) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="reef serve",
         description=_DESCRIPTION,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
     )
     parser.add_argument(
         "-c",
@@ -58,6 +71,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Config file path, relative to the working directory (default: $REEF_CONFIG or ./reef.yaml).",
     )
+    if service_arguments:
+        for argument in service_config_arguments():
+            argument.add_to(parser)
     return parser
 
 
@@ -71,50 +87,64 @@ class ServiceSettings:
     ``WeightTrainingRecipe.service_config``, so their defaults live with the recipe.
     """
 
-    recipe: str
-    host: str = "0.0.0.0"
-    port: int = 8900
-    tokens: tuple[str, ...] = ()
-    console_origins: tuple[str, ...] = ()
-    ray_address: str | None = None
-    ray_namespace: str = "reef"
-    ray_actor_name: str = "reef-train-bridge"
-    inference_url: str | None = None
-    model_path: str | None = None
+    recipe: str = config_option(help="Recipe implementation or named deployment preset (the launcher owns --recipe).")
+    host: str = config_option("0.0.0.0", help="HTTP bind address.")
+    port: int = config_option(8900, help="HTTP bind port.")
+    tokens: tuple[str, ...] = config_option((), help="Accepted bearer tokens as a JSON/YAML list.")
+    console_origins: tuple[str, ...] = config_option((), help="Allowed console origins as a JSON/YAML list.")
+    ray_address: str | None = config_option(None, help="Ray cluster address.")
+    ray_namespace: str = config_option("reef", help="Ray namespace for the training bridge.")
+    ray_actor_name: str = config_option("reef-train-bridge", help="Training bridge actor name.")
+    inference_url: str | None = config_option(None, help="Local inference endpoint.")
+    model_path: str | None = config_option(None, help="Local model directory or Hugging Face repository ID.")
     #: The OpenAI-compatible provider no-update recipes proxy to (no ``/v1``
     #: suffix), its credential, and the model name to request from it. The
     #: only place the upstream is named: the HTTP service forwards to it, and
     #: the training side derives the model binding it hands to methods and
     #: evaluation episodes from it. ``upstream_model`` is a provider model
     #: name, unlike ``model_path``, which is local weights for training.
-    upstream_url: str | None = None
-    upstream_api_key: str | None = None
-    upstream_model: str | None = None
+    upstream_url: str | None = config_option(None, help="Upstream provider base URL.")
+    upstream_api_key: str | None = config_option(None, help="Upstream provider credential.")
+    upstream_model: str | None = config_option(None, help="Model name requested from the upstream provider.")
     #: The provider's API dialect: ``openai`` (default), ``responses``, or ``anthropic``.
-    upstream_api: str = "openai"
-    inference_timeout_s: float = 300.0
-    train_timeout_s: float | None = None
-    inference_backend_factory: str | None = None
-    inference_backend_config: Mapping[str, Any] = field(default_factory=dict)
-    inference_retry_initial_s: float = 0.05
-    inference_retry_max_s: float = 1.0
-    inference_retry_timeout_s: float = 300.0
-    artifact_repository: str = ".reef/artifacts.git"
-    artifact_work_dir: str = ".reef/artifact-work"
-    artifact_cache_dir: str = ".reef/artifact-cache"
-    agent_record_dir: str = ".reef/agent-record"
-    record_backend: str = "sqlite"
-    record_database_url: str | None = field(default=None, repr=False)
-    record_database_schema: str = "reef_records"
-    agent_record_retention_days: float = 7.0
-    agent_record_retention_max_bytes: int = 20 * 1024**3
-    allow_implicit_scenario_creation: bool = True
+    upstream_api: str = config_option("openai", help="Provider API dialect.")
+    inference_timeout_s: float = config_option(300.0, help="Inference request timeout in seconds.")
+    train_timeout_s: float | None = config_option(None, help="Training request timeout in seconds.")
+    inference_backend_factory: str | None = config_option(None, help="Dotted inference backend factory.")
+    inference_backend_config: Mapping[str, Any] = field(
+        default_factory=dict, metadata=config_metadata("Inference backend options as a JSON/YAML object.")
+    )
+    inference_retry_initial_s: float = config_option(0.05, help="Initial inference retry delay in seconds.")
+    inference_retry_max_s: float = config_option(1.0, help="Maximum inference retry delay in seconds.")
+    inference_retry_timeout_s: float = config_option(
+        300.0, help="Retry deadline in seconds; defaults to the inference timeout."
+    )
+    artifact_repository: str = config_option(".reef/artifacts.git", help="Artifact repository location.")
+    artifact_work_dir: str = config_option(".reef/artifact-work", help="Artifact working directory.")
+    artifact_cache_dir: str = config_option(".reef/artifact-cache", help="Artifact cache directory.")
+    agent_record_dir: str = config_option(".reef/agent-record", help="Agent record directory.")
+    record_backend: str = config_option("sqlite", help="Record storage backend.")
+    record_database_url: str | None = field(
+        default=None, repr=False, metadata=config_metadata("PostgreSQL connection URL.")
+    )
+    record_database_schema: str = config_option("reef_records", help="PostgreSQL schema.")
+    agent_record_retention_days: float = config_option(7.0, help="Record retention in days.")
+    agent_record_retention_max_bytes: int = config_option(20 * 1024**3, help="Maximum retained record bytes.")
+    allow_implicit_scenario_creation: bool = config_option(True, help="Allow requests to create scenarios implicitly.")
     #: Deployment-level experiment provider settings, sourced from
     #: ``observability.wandb``.
-    wandb_config: Mapping[str, Any] = field(default_factory=dict)
-    training_settings: Mapping[str, Any] = field(default_factory=dict)
+    wandb_config: Mapping[str, Any] = field(
+        default_factory=dict,
+        metadata=config_metadata("W&B settings as a JSON/YAML object.", path=("observability", "wandb")),
+    )
+    training_settings: Mapping[str, Any] = field(
+        default_factory=dict, metadata=config_metadata("Training settings as a JSON/YAML object.", path=("training",))
+    )
     #: Optional pre-publication checkpoint evaluator and selection plugin.
-    evaluation_settings: Mapping[str, Any] | None = None
+    evaluation_settings: Mapping[str, Any] | None = field(
+        default=None,
+        metadata=config_metadata("Candidate evaluation settings as a JSON/YAML object.", path=("evaluation",)),
+    )
     #: The flat ``reef`` config section, interpolated; recipes read their own
     #: config fields from it (see the class docstring).
     recipe_settings: Mapping[str, Any] = field(default_factory=dict, repr=False)
@@ -148,20 +178,6 @@ def _config_service_mapping(config: Mapping[str, Any], *path: str) -> Mapping[st
     return {} if value is None else value
 
 
-def _config_optional_mapping(config: Mapping[str, Any], *path: str) -> Mapping[str, Any] | None:
-    """Return an optional object while rejecting a present non-object value."""
-    value: Any = config
-    for key in path:
-        if not isinstance(value, Mapping) or key not in value:
-            return None
-        value = value[key]
-    if value is None:
-        return None
-    if not isinstance(value, Mapping):
-        raise ValueError(f"{'.'.join(path)} must be an object")
-    return value
-
-
 def _reef_section(config: Mapping[str, Any]) -> dict[str, Any]:
     """The flat ``reef`` section with per-value interpolation applied."""
     section = config.get("reef")
@@ -184,6 +200,84 @@ def service_owned_keys() -> frozenset[str]:
         for settings_field in dataclasses.fields(ServiceSettings)
         if settings_field.name not in non_reef_fields
     ) | frozenset(SERVICE_CONFIG_ALIASES)
+
+
+@lru_cache(maxsize=1)
+def service_config_arguments() -> tuple[ConfigArgument, ...]:
+    """Public settings derive their types and defaults from ServiceSettings."""
+    return (
+        *config_arguments(ServiceSettings),
+        ConfigArgument("token", ("reef", "token"), "str", True, None, "One accepted bearer token."),
+    )
+
+
+def service_override(key: str, value: str) -> tuple[ConfigArgument, str] | None:
+    """Identify a declared option, retaining legacy names and dotted paths."""
+    flag = f"--{key}"
+    for argument in service_config_arguments():
+        if flag in argument.flags:
+            return argument, value
+        if flag in argument.negative_flags:
+            return argument, "false"
+    return None
+
+
+def _argument_value(config: Mapping[str, Any], argument: ConfigArgument) -> Any:
+    node: Any = config
+    for key in argument.path:
+        if not isinstance(node, Mapping):
+            raise ValueError(f"{'.'.join(argument.path[:-1])} must be an object")
+        node = node.get(key)
+        if node is None:
+            return None
+    if isinstance(node, str):
+        return os.path.expanduser(interpolate_config(config, node.strip())) if node.strip() else None
+    if argument.kind == "strings" and isinstance(node, (list, tuple)):
+        return [interpolate_config(config, item) if isinstance(item, str) else item for item in node]
+    return node
+
+
+def parse_service_arguments(
+    config: Mapping[str, Any], *, cli_paths: frozenset[tuple[str, ...]] = frozenset()
+) -> dict[str, Any]:
+    """Parse YAML arguments followed by explicit CLI values with one parser.
+
+    The caller has already replaced overridden environment references and
+    expanded the effective config. CLI paths identify the values to append
+    last; containers are encoded as objects, never flattened into shell text.
+    """
+    parser = ConfigArgumentParser(prog="reef serve", add_help=False, allow_abbrev=False)
+    yaml_args: list[str] = []
+    cli_args: list[str] = []
+    for argument in service_config_arguments():
+        argument.add_to(parser)
+        value = _argument_value(config, argument)
+        if value is not None:
+            target = cli_args if argument.path in cli_paths else yaml_args
+            target.append(f"{argument.flags[0]}={argument.encode(value)}")
+    values = vars(parser.parse_args([*yaml_args, *cli_args]))
+    return {argument.name: values[argument.destination] for argument in service_config_arguments()}
+
+
+def normalize_service_config(
+    config: Mapping[str, Any], *, cli_paths: frozenset[tuple[str, ...]] = frozenset()
+) -> dict[str, Any]:
+    """Validate explicit public settings and pass the same values to children.
+
+    Do not add defaults to the deployment mapping: recipes must still know
+    which of their fields the operator supplied, and custom stacks may have
+    no Reef HTTP child at all.
+    """
+    values = parse_service_arguments(config, cli_paths=cli_paths)
+    normalized = copy.deepcopy(dict(config))
+    for argument in service_config_arguments():
+        if _argument_value(config, argument) is None:
+            continue
+        node = normalized
+        for key in argument.path[:-1]:
+            node = node[key]
+        node[argument.path[-1]] = values[argument.name]
+    return normalized
 
 
 def _service_tokens(config: Mapping[str, Any]) -> tuple[str, ...]:
@@ -210,103 +304,17 @@ def _service_tokens(config: Mapping[str, Any]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(tokens))
 
 
-def _console_origins(config: Mapping[str, Any]) -> tuple[str, ...]:
-    listed = _config_service_mapping(config, "reef").get("console_origins", ())
-    if isinstance(listed, str) or not isinstance(listed, Sequence):
-        raise ValueError("reef.console_origins must be a list of origins")
-    if not all(isinstance(value, str) for value in listed):
-        raise ValueError("reef.console_origins must contain only origins")
-    return console_origins(tuple(interpolate_config(config, value) for value in listed))
-
-
 def service_settings_from_config(config: Mapping[str, Any]) -> ServiceSettings:
     """Translate the config's ``reef`` section into HTTP service settings."""
-    selected_recipe = _config_service_value(config, "reef", "recipe")
-    if not isinstance(selected_recipe, str) or not selected_recipe:
+    values = parse_service_arguments(config)
+    if not isinstance(values["recipe"], str) or not values["recipe"]:
         raise ValueError("config must declare a non-empty reef.recipe")
-    inference_timeout_s = float(_config_service_value(config, "reef", "inference_timeout_s", default="300"))
-    train_timeout_raw = _config_service_value(config, "reef", "train_timeout_s")
-    train_timeout_s = float(train_timeout_raw) if train_timeout_raw is not None else None
-    return ServiceSettings(
-        host=_config_service_value(config, "reef", "host", default="0.0.0.0"),
-        port=int(_config_service_value(config, "reef", "port", default="8900")),
-        tokens=_service_tokens(config),
-        console_origins=_console_origins(config),
-        recipe=selected_recipe,
-        ray_address=_config_service_value(config, "reef", "ray_address"),
-        ray_namespace=_config_service_value(config, "reef", "ray_namespace", default="reef"),
-        ray_actor_name=_config_service_value(
-            config,
-            "reef",
-            "ray_actor_name",
-            default="reef-train-bridge",
-        ),
-        inference_url=_config_service_value(config, "reef", "inference_url"),
-        model_path=_config_service_value(config, "reef", "model_path"),
-        upstream_url=_config_service_value(config, "reef", "upstream_url"),
-        upstream_api_key=_config_service_value(config, "reef", "upstream_api_key"),
-        upstream_model=_config_service_value(config, "reef", "upstream_model"),
-        upstream_api=_config_service_value(config, "reef", "upstream_api", default="openai"),
-        inference_timeout_s=inference_timeout_s,
-        train_timeout_s=train_timeout_s,
-        inference_backend_factory=_config_service_value(
-            config,
-            "reef",
-            "inference_backend_factory",
-        ),
-        inference_backend_config=_config_service_mapping(
-            config,
-            "reef",
-            "inference_backend_config",
-        ),
-        inference_retry_initial_s=float(
-            _config_service_value(config, "reef", "inference_retry_initial_s", default="0.05")
-        ),
-        inference_retry_max_s=float(_config_service_value(config, "reef", "inference_retry_max_s", default="1")),
-        inference_retry_timeout_s=float(
-            _config_service_value(config, "reef", "inference_retry_timeout_s", default=inference_timeout_s)
-        ),
-        artifact_repository=_config_service_value(
-            config,
-            "reef",
-            "artifact_repository",
-            default=".reef/artifacts.git",
-        ),
-        artifact_work_dir=_config_service_value(
-            config,
-            "reef",
-            "artifact_work_dir",
-            default=".reef/artifact-work",
-        ),
-        artifact_cache_dir=_config_service_value(
-            config,
-            "reef",
-            "artifact_cache_dir",
-            default=".reef/artifact-cache",
-        ),
-        agent_record_dir=_config_service_value(
-            config,
-            "reef",
-            "agent_record_dir",
-            default=".reef/agent-record",
-        ),
-        agent_record_retention_days=float(
-            _config_service_value(config, "reef", "agent_record_retention_days", default=7.0)
-        ),
-        record_backend=_config_service_value(config, "reef", "record_backend", default="sqlite"),
-        record_database_url=_config_service_value(config, "reef", "record_database_url"),
-        record_database_schema=_config_service_value(config, "reef", "record_database_schema", default="reef_records"),
-        agent_record_retention_max_bytes=int(
-            _config_service_value(config, "reef", "agent_record_retention_max_bytes", default=20 * 1024**3)
-        ),
-        allow_implicit_scenario_creation=bool(
-            _config_service_value(config, "reef", "allow_implicit_scenario_creation", default=True)
-        ),
-        wandb_config=_config_service_mapping(config, "observability", "wandb"),
-        training_settings=_config_service_mapping(config, "training"),
-        evaluation_settings=_config_optional_mapping(config, "evaluation"),
-        recipe_settings=_reef_section(config),
-    )
+    values["tokens"] = _service_tokens({"reef": {"token": values.pop("token"), "tokens": values["tokens"]}})
+    values["console_origins"] = console_origins(values["console_origins"])
+    # The legacy retry deadline follows the request timeout unless supplied.
+    if _config_service_value(config, "reef", "inference_retry_timeout_s") is None:
+        values["inference_retry_timeout_s"] = values["inference_timeout_s"]
+    return ServiceSettings(**values, recipe_settings=_reef_section(config))
 
 
 def run_service(config_path: str | Path | None = None) -> int:

--- a/tests/reef_service/test_serve_profile.py
+++ b/tests/reef_service/test_serve_profile.py
@@ -61,11 +61,12 @@ def test_the_serve_parser_takes_recipe_and_model_and_the_service_parser_still_do
     args, extras = build_serve_parser().parse_known_args(
         ["--recipe", "harness-evolve", "--model", "ollama/gemma4:26b", "--port", "8901"]
     )
-    assert (args.config, args.recipe, args.model, extras) == (
+    assert (args.config, args.recipe, args.model, args.port, extras) == (
         None,
         "harness-evolve",
         "ollama/gemma4:26b",
-        ["--port", "8901"],
+        8901,
+        [],
     )
     with pytest.raises(SystemExit):
         build_parser().parse_args(["--recipe", "harness-evolve"])

--- a/tests/reef_service/test_service_config_arguments.py
+++ b/tests/reef_service/test_service_config_arguments.py
@@ -1,0 +1,279 @@
+"""Public deployment settings share one parser for CLI and YAML values."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reef.cli import main as cli_main
+from reef.service.deploy import orchestrator
+from reef.service.deploy.config import interpolate_environment, load_config
+from reef.service.deploy.orchestrator import _apply_overrides, _parse_overrides, build_serve_parser
+from reef.service.deploy.settings import (
+    ServiceSettings,
+    normalize_service_config,
+    parse_service_arguments,
+    service_config_arguments,
+    service_settings_from_config,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "yaml_value", "cli_value"),
+    [
+        ("port", 9123, "9123"),
+        ("inference_timeout_s", 12.5, "12.5"),
+        ("upstream_model", "00123", "00123"),
+        ("upstream_model", "true", "true"),
+        ("upstream_model", "null", "null"),
+        ("allow_implicit_scenario_creation", False, "false"),
+        ("tokens", ["first", "second"], '["first", "second"]'),
+        ("tokens", [], "[]"),
+        (
+            "inference_backend_config",
+            {"nested": {"enabled": False, "ids": [1, 2]}},
+            '{"nested": {"enabled": false, "ids": [1, 2]}}',
+        ),
+        ("inference_backend_config", {}, "{}"),
+    ],
+)
+def test_yaml_and_cli_use_the_same_field_types(name, yaml_value, cli_value):
+    yaml_values = parse_service_arguments({"reef": {name: yaml_value}})
+    cli_values = vars(build_serve_parser().parse_args([f"--{name.replace('_', '-')}={cli_value}"]))
+    assert yaml_values[name] == cli_values[name]
+    assert type(yaml_values[name]) is type(cli_values[name])
+
+
+def test_parser_defaults_come_from_settings():
+    defaults = parse_service_arguments({})
+    for argument in service_config_arguments():
+        if argument.name in {"token", "recipe"}:
+            continue
+        field = next(field for field in fields(ServiceSettings) if field.name == argument.name)
+        assert defaults[argument.name] == getattr(ServiceSettings(recipe="recipe"), field.name)
+
+
+def test_recipe_setting_and_launcher_profile_are_independent_arguments():
+    args = build_serve_parser().parse_args(["--recipe", "harness-evolve", "--reef.recipe", "custom-preset"])
+    assert args.recipe == "harness-evolve"
+    assert args.config_recipe == "custom-preset"
+    assert parse_service_arguments({"reef": {"recipe": "custom-preset"}})["recipe"] == "custom-preset"
+
+
+@pytest.mark.parametrize("flag", ["--port", "--reef.port"])
+def test_cli_beats_yaml_and_omitted_cli_leaves_yaml_value(flag):
+    config = {"reef": {"recipe": "recipe", "port": 9123}}
+    assert service_settings_from_config(config).port == 9123
+    updated = _apply_overrides(config, _parse_overrides([flag, "8123"]))
+    assert service_settings_from_config(normalize_service_config(updated)).port == 8123
+    assert config["reef"]["port"] == 9123
+
+
+def test_last_cli_alias_wins_even_when_a_previous_spelling_is_repeated():
+    overrides = _parse_overrides(["--port", "7000", "--reef.port", "8000", "--port", "9000"])
+    config = _apply_overrides({"reef": {"recipe": "recipe", "port": 6000}}, overrides)
+    assert service_settings_from_config(config).port == 9000
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--host"],
+        ["--port", "--tokens", "[]"],
+        ["--no-allow-implicit-scenario-creation=false"],
+        ["--no-allow-implicit-scenario-creation", "true"],
+    ],
+)
+def test_declared_cli_options_reject_missing_or_unexpected_values(arguments):
+    with pytest.raises(ValueError, match="value"):
+        _parse_overrides(arguments)
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        (["--allow-implicit-scenario-creation"], True),
+        (["--allow_implicit_scenario_creation", "false"], False),
+        (["--no-allow-implicit-scenario-creation"], False),
+        (["--no-allow-implicit-scenario-creation", "--allow-implicit-scenario-creation"], True),
+    ],
+)
+def test_boolean_flags_can_enable_and_disable_yaml_settings(arguments, expected):
+    config = _apply_overrides(
+        {"reef": {"recipe": "recipe", "allow_implicit_scenario_creation": not expected}}, _parse_overrides(arguments)
+    )
+    assert service_settings_from_config(config).allow_implicit_scenario_creation is expected
+
+
+def test_empty_container_overrides_replace_yaml_values_and_survive_child_serialization():
+    config = _apply_overrides(
+        {"reef": {"recipe": "recipe", "tokens": ["old"], "inference_backend_config": {"old": 1}}},
+        {"tokens": "[]", "inference-backend-config": "{}"},
+    )
+    normalized = normalize_service_config(config)
+    child = yaml.safe_load(yaml.safe_dump(normalized))
+    settings = service_settings_from_config(child)
+    assert settings.tokens == ()
+    assert settings.inference_backend_config == {}
+
+
+def test_override_replaces_required_environment_reference_before_validation(monkeypatch):
+    monkeypatch.delenv("REEF_CONFIG_TEST_PORT", raising=False)
+    config = _apply_overrides(
+        {
+            "reef": {
+                "recipe": "recipe",
+                "port": "${REEF_CONFIG_TEST_PORT:?}",
+                "inference_url": "http://localhost:${reef.port}",
+            }
+        },
+        {"port": "9000"},
+    )
+    config = interpolate_environment(config, "stack.yaml")
+    settings = service_settings_from_config(normalize_service_config(config))
+    assert settings.port == 9000
+    assert settings.inference_url == "http://localhost:9000"
+
+
+def test_string_lists_resolve_config_references():
+    config = {"reef": {"recipe": "recipe", "tokens": ["${auth.current}"]}, "auth": {"current": "credential"}}
+    assert service_settings_from_config(config).tokens == ("credential",)
+
+
+def test_non_reef_objects_and_generic_recipe_overrides_keep_their_ownership():
+    config = _apply_overrides(
+        {"reef": {"recipe": "recipe"}},
+        {
+            "training": '{"global_batch_size": 2}',
+            "evaluation": '{"module": "example:Evaluator"}',
+            "observability.wandb": '{"enabled": false}',
+            "batch_size": "4",
+            "execution.services.backend": "uni",
+        },
+    )
+    normalized = normalize_service_config(config)
+    settings = service_settings_from_config(normalized)
+    assert settings.training_settings == {"global_batch_size": 2}
+    assert settings.evaluation_settings == {"module": "example:Evaluator"}
+    assert settings.wandb_config == {"enabled": False}
+    assert settings.recipe_settings["batch_size"] == "4"
+    assert "batch_size" not in parse_service_arguments(normalized)
+    assert normalized["execution"] == {"services": {"backend": "uni"}}
+
+
+def test_retry_deadline_still_follows_inference_timeout():
+    config = {"reef": {"recipe": "recipe", "inference_timeout_s": 42}}
+    assert service_settings_from_config(normalize_service_config(config)).inference_retry_timeout_s == 42
+    config["reef"]["inference_retry_timeout_s"] = 12
+    assert service_settings_from_config(config).inference_retry_timeout_s == 12
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("port", "secret-invalid-integer"),
+        ("port", "1.5"),
+        ("port", True),
+        ("inference_timeout_s", "nan"),
+        ("allow_implicit_scenario_creation", "maybe"),
+        ("tokens", [123]),
+        ("inference_backend_config", [1]),
+    ],
+)
+def test_invalid_public_values_report_the_field_without_echoing_values(name, value):
+    with pytest.raises(ValueError, match=name) as caught:
+        service_settings_from_config({"reef": {"recipe": "recipe", name: value}})
+    assert "secret-invalid-integer" not in str(caught.value)
+
+
+def test_cli_help_exposes_public_fields_without_optional_runtimes():
+    import subprocess
+    import sys
+
+    code = (
+        "import sys\n"
+        "from reef.service.deploy.orchestrator import build_serve_parser\n"
+        "print(build_serve_parser().format_help())\n"
+        "assert not any(name in sys.modules for name in ('torch', 'slime', 'sglang'))\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+    assert "--upstream-model" in result.stdout
+    assert "--no-allow-implicit-scenario-creation" in result.stdout
+
+
+def test_launcher_passes_typed_cli_values_to_commands_and_child(tmp_path: Path, monkeypatch):
+    captured = {}
+
+    class StackStub:
+        exit_code = 0
+
+        def __init__(self, config, services, run_dir, ready_timeout_default, config_path, source_root=None):
+            captured["parent"] = config
+            captured["child"] = load_config(config_path)
+
+        def start(self):
+            pass
+
+        def block(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    path = tmp_path / "stack.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "reef": {"recipe": "recipe", "port": 9000, "upstream_model": "old", "tokens": ["old"]},
+                "services": [{"name": "reef", "command": ["python", "-m", "reef.service"]}],
+                "run_dir": str(tmp_path / "run"),
+            }
+        )
+    )
+    monkeypatch.setattr(orchestrator, "_Stack", StackStub)
+    monkeypatch.setattr(orchestrator, "resolve_model_paths", lambda config: False)
+    with pytest.raises(SystemExit) as caught:
+        cli_main(
+            [
+                "serve",
+                "-c",
+                str(path),
+                "--port",
+                "8123",
+                "--upstream-model",
+                "001",
+                "--tokens",
+                "[]",
+                "--inference-backend-config",
+                json.dumps({"nested": [1, False]}),
+            ]
+        )
+    assert caught.value.code == 0
+    for config in captured.values():
+        settings = service_settings_from_config(config)
+        assert settings.port == 8123
+        assert settings.upstream_model == "001"
+        assert settings.tokens == ()
+        assert settings.inference_backend_config == {"nested": [1, False]}
+
+
+def test_invalid_cli_setting_fails_before_download_or_spawn(tmp_path, monkeypatch, capsys):
+    def unexpected(*args, **kwargs):
+        pytest.fail("invalid settings reached a side effect")
+
+    monkeypatch.setattr(orchestrator, "resolve_model_paths", unexpected)
+    monkeypatch.setattr(orchestrator, "_Stack", unexpected)
+    path = tmp_path / "stack.yaml"
+    path.write_text("reef: {recipe: recipe}\nservices: [{name: reef, command: worker}]\n")
+    with pytest.raises(SystemExit) as caught:
+        cli_main(["serve", "-c", str(path), "--port", "credential-like-invalid-port"])
+    assert caught.value.code == 2
+    error = capsys.readouterr().err
+    assert "reef.port" in error
+    assert "credential-like-invalid-port" not in error
+    assert "Traceback" not in error


### PR DESCRIPTION
## Motivation

Service configuration currently has separate CLI override coercion and YAML-to-settings conversion. That duplicates types and defaults and can make equivalent inputs behave differently. This change gives public service fields one argument definition and makes explicit CLI values take precedence over YAML, with defaults applied afterward.

Implements the first parsing phase of #414. The broader startup RFC remains open; this PR is a draft pending a recorded RFC decision.

## Changes

- Define public field types, defaults, configuration paths, and help with `ServiceSettings`, and generate argparse options from those definitions.
- Normalize YAML values and explicit CLI overrides through the same argument parser. Apply overrides before environment interpolation so an overridden `${VAR:?}` value does not fail startup.
- Support kebab-case, underscore, and dotted aliases; the last explicit occurrence wins. Add boolean disable flags and typed list/object values, including empty containers.
- Normalize the configuration passed to child services and reject invalid public values before downloading models or spawning processes.
- Add 38 configuration contract test cases and update CLI help coverage and configuration documentation.

## Compatibility and operational impact

Existing YAML files, profiles, generic recipe overrides, and custom service configuration remain supported. Launcher `--recipe` still selects a profile; `--reef.recipe` selects the configured recipe. Legacy token combination and retry-timeout fallback remain in place.

Public string fields preserve literal values such as `001` and `true`; invalid public types and non-finite numbers now fail consistently. Boolean flags support explicit false values and `--no-...`; lists and objects are supplied as one quoted JSON/YAML argument.

This phase does not introduce a new YAML format, migrate recipe-specific argument parsing, or add configuration-free startup. No dependencies, persisted formats, or service topology change.

## Verification

Python 3.12.9 on macOS:

- `pre-commit run --all-files` — passed. `pre-commit run --files reef/service/deploy/arguments.py tests/reef_service/test_service_config_arguments.py` also passed for the files that were new at verification time.
- `.venv/bin/python -m mypy reef/service/deploy/arguments.py reef/service/deploy/settings.py reef/service/deploy/orchestrator.py` — passed.
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null .venv/bin/python -m pytest tests/ -n 4 --dist loadfile -q --tb=short --durations=5` — **3165 passed, 48 skipped, 1 failed**. The failure is `test_bridge_catalogs_paired_checkpoint_metrics_and_blocks_before_second_optimizer` in `tests/reef_service/test_slime_bridge.py`: the first result is `storage_blocked` with no training job ID. The same failure was reproduced in a clean archive of the unchanged baseline. That baseline has the same tracked tree as the merged #413/main base of this PR.
- `.venv/bin/python -m mypy` — **4 existing errors** in `lora_transport.py` (lines 42, 96, 129) and `checkpoint.py` (line 247). Replacing the changed existing modules with their baseline versions via mypy shadow files produced the same errors.
- `git diff --check` — passed. GPU deployment was not exercised; lifecycle tests stub downloads and process launches.

## AI assistance

OpenAI Codex assisted with the design research, implementation, documentation, contract tests, verification, and PR preparation. The human contributor remains responsible for reviewing and understanding the submitted changes and results.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [ ] An accepted RFC is linked, or this change does not require an RFC.
- [ ] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.

The unchecked items reflect the pending RFC decision and the baseline failures documented above.

## Review and merge

The Merge Oncall is assigned automatically. See the
[maintenance model](https://github.com/Human-Agent-Society/reef/blob/main/.github/MAINTAINER.md)
for review and merge requirements.
