### PR TITLE
docs: add GEPA package README

### DIFF
--- a/recipes/gepa/README.md
+++ b/recipes/gepa/README.md
@@ -1,0 +1,24 @@
+# gepa
+
+Reproduction of [GEPA](https://arxiv.org/abs/2507.19457) as a Reef harness-evolution recipe. GEPA keeps an archive of candidate prompts, Pareto-samples a parent, and reflects on its training-minibatch traces to rewrite one component. A child survives only if it beats its parent on that minibatch, then receives a full validation pass; Reef serves the candidate with the best mean validation score. The package holds the method; the loop that validates it lives in [examples/aime](examples/aime/README.md).
+
+- Paper: [arXiv:2507.19457](https://arxiv.org/abs/2507.19457)
+- Pins: upstream GEPA v0.1.2 (`92dadfffbe98c8ecf508179a1cab09c1bb85cd32`), Pi `0.84.2`, task model `gpt-4.1-mini-2025-04-14`, and reflection model `gpt-5-2025-08-07`; the example pins and hash-checks the 45/45/150 AIME train/validation/test split and uses a 150-metric-call search budget. The method has no upstream GEPA runtime dependency.
+- Claim scope: the [AIME-2025 validation contract](examples/aime/README.md#the-validation-contract) pairs two seeds with upstream GEPA under the same models, split, budget, scorer, and worker count. Mean held-out improvement is +16.00 percentage points for this method and +12.67 for upstream; the selected-score difference changes sign between seeds, so this is method validation, not evidence of superiority. Deterministic tests cover the scorer and driver, with an upstream fidelity comparison when GEPA is installed.
+
+## Layout
+
+```text
+gepa/
+  archive.py      candidates, Pareto fronts, seeded sampling, and search budget
+  backend.py      committed algorithm state and the post-commit archive mirror
+  components.py   harness components as prompt texts and mutations
+  method.py       reflection proposals, minibatch acceptance, and selection
+  reflection.py   attributed upstream reflection prompt and record formatting
+  recipe.py       GEPARecipe: configuration and evolution backend binding
+  examples/aime/  the runnable validation loop: harness, gepa.yaml, and results
+```
+
+## Where the rest is documented
+
+[The gepa recipe page](../../docs/user-guide/recipes/gepa.rst) covers the algorithm and configuration, [Evolve your harness](../../docs/user-guide/evolve-your-harness.rst) describes the evolution engine, and the [example README](examples/aime/README.md) records setup, implementation details, distance from the upstream protocol, and the completed validation.

--- a/recipes/gepa/README.md
+++ b/recipes/gepa/README.md
@@ -4,7 +4,7 @@ Reproduction of [GEPA](https://arxiv.org/abs/2507.19457) as a Reef harness-evolu
 
 - Paper: [arXiv:2507.19457](https://arxiv.org/abs/2507.19457)
 - Pins: upstream GEPA v0.1.2 (`92dadfffbe98c8ecf508179a1cab09c1bb85cd32`), Pi `0.84.2`, task model `gpt-4.1-mini-2025-04-14`, and reflection model `gpt-5-2025-08-07`; the example pins and hash-checks the 45/45/150 AIME train/validation/test split and uses a 150-metric-call search budget. The method has no upstream GEPA runtime dependency.
-- Claim scope: the [AIME-2025 validation contract](examples/aime/README.md#the-validation-contract) pairs two seeds with upstream GEPA under the same models, split, budget, scorer, and worker count. Mean held-out improvement is +16.00 percentage points for this method and +12.67 for upstream; the selected-score difference changes sign between seeds, so this is method validation, not evidence of superiority. Deterministic tests cover the scorer and driver, with an upstream fidelity comparison when GEPA is installed.
+- Claim scope: the [AIME-2025 validation contract](examples/aime/README.md#the-validation-contract) pairs two seeds with upstream GEPA under the same models, split, budget, scorer, and worker count. Mean held-out improvement is +16.00 percentage points for this method and +12.67 for upstream; the selected-score difference changes sign between seeds, so these results validate the method but do not establish superiority. Deterministic tests cover the scorer and driver, with an upstream fidelity comparison when GEPA is installed.
 
 ## Layout
 


### PR DESCRIPTION
## Motivation

The GEPA catalog's code link opens a package without a README. Closes #431.

## Changes

- Add the package README in the same shape as SAO, including the paper, implementation pins, bounded AIME-2025 validation claim, and module layout.
- Link to the recipe guide and runnable AIME example for configuration, setup, protocol deviations, and results.

## Compatibility and operational impact

None. Documentation only.

## Verification

- `uv tool run pre-commit run --all-files`: passed, including README translation pairing.
- `git diff --cached --check`: passed.
- Docs CI commands with Node.js 22: `npm ci`, `npm run check:docs`, `npm run lint`, and `npm run build` all passed.
- Checked pins and result claims against the existing AIME example and retained records.

## AI assistance

Codex drafted the README, checked its claims against repository sources, and ran verification.

## Checklist

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests cover behavior changes, or this pull request does not change behavior.
- [x] Public interface changes include contract tests, or no public interface changes are present.
- [x] Affected user and developer documentation is updated, or no documentation update is required.
- [x] Root README changes update both languages and `README.i18n.yaml`, or do not affect README content.
- [x] An accepted RFC is linked, or this change does not require an RFC.
- [x] Relevant pre-commit and test checks pass.
- [x] Non-trivial AI assistance is disclosed above, or none was used.
